### PR TITLE
ci: remove redundant push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Remove `push: branches: [main]` trigger from CI workflow
- Branch protection now requires PRs to merge into main, making push-triggered CI redundant
- Prevents double CI runs (one on PR, another on merge)

## Test plan
- [x] Verify this PR triggers CI correctly
- [x] Verify no CI runs on the merge commit to main