### PR TITLE
docs: fix Docker Sandboxes guide to reflect actual architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker compose up -d
 
 See [`docker-compose.yml`](docker-compose.yml) for the full example.
 
-For running inside **Docker Sandboxes** (isolated micro VMs for AI agents), see the dedicated guide: [Docker Sandboxes deployment](guides/docker-sandboxes.md).
+For using Oktsec alongside **Docker Sandboxes** (isolated micro VMs for AI agents), see the dedicated guide: [Oktsec + Docker Sandboxes](guides/docker-sandboxes.md).
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

The previous Docker Sandboxes guide incorrectly suggested using `--network-proxy` to route sandbox traffic through Oktsec. This doesn't work — Docker's `--network-proxy` expects a standard HTTP forward proxy (CONNECT tunneling, RFC 7230), but Oktsec is a REST API that only accepts `POST /v1/message`.

This PR fixes the guide to document what actually works today:

- **Removed**: `--network-proxy http://host.docker.internal:8080` references
- **Added**: Correct pattern where agents explicitly call Oktsec's `/v1/message` endpoint
- **Added**: "Current limitations" section documenting the transparent proxy gap
- **Added**: "What Oktsec does NOT do" section for the NanoClaw example
- **Replaced**: Generic OpenClaw example with concrete NanoClaw example (matches Docker's own blog post)
- **Fixed**: README link description ("running inside" -> "using alongside")

## Test plan

- [x] Verify all commands in the guide are valid against current CLI
- [x] Confirm no `--network-proxy` references remain in the guide
- [x] Check internal links resolve correctly