### PR TITLE
feat: OpenClaw security rules (OCLAW-008 to OCLAW-015) + ScanContentAs

### DIFF
--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -130,6 +130,14 @@ func NewStore(dbPath string, logger *slog.Logger, retentionDays ...int) (*Store,
 		return nil, fmt.Errorf("setting WAL mode: %w", err)
 	}
 
+	// Set busy timeout so concurrent writers wait instead of returning SQLITE_BUSY
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		if cerr := db.Close(); cerr != nil {
+			return nil, fmt.Errorf("setting busy_timeout: %w (also: close: %v)", err, cerr)
+		}
+		return nil, fmt.Errorf("setting busy_timeout: %w", err)
+	}
+
 	if _, err := db.Exec(schema); err != nil {
 		if cerr := db.Close(); cerr != nil {
 			return nil, fmt.Errorf("creating schema: %w (also: close: %v)", err, cerr)

--- a/internal/engine/scanner.go
+++ b/internal/engine/scanner.go
@@ -73,11 +73,22 @@ func NewScanner(customRulesDir string, extraOpts ...aguara.Option) *Scanner {
 
 // ScanContent scans message content and returns a verdict.
 func (s *Scanner) ScanContent(ctx context.Context, content string) (*ScanOutcome, error) {
-	result, err := aguara.ScanContent(ctx, content, "message.md", s.opts...)
+	return s.ScanContentAs(ctx, content, "message.md")
+}
+
+// ScanContentAs scans content with a specific virtual filename for target matching.
+// Use this when the content represents a specific file type (e.g., "openclaw.json")
+// so that rules with file-type targets can match correctly.
+func (s *Scanner) ScanContentAs(ctx context.Context, content, filename string) (*ScanOutcome, error) {
+	result, err := aguara.ScanContent(ctx, content, filename, s.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("aguara scan: %w", err)
 	}
+	return buildOutcome(result), nil
+}
 
+// buildOutcome converts Aguara scan results into a proxy verdict.
+func buildOutcome(result *aguara.ScanResult) *ScanOutcome {
 	outcome := &ScanOutcome{
 		Verdict: VerdictClean,
 	}
@@ -103,7 +114,7 @@ func (s *Scanner) ScanContent(ctx context.Context, content string) (*ScanOutcome
 		}
 	}
 
-	return outcome, nil
+	return outcome
 }
 
 // Close cleans up temporary files.

--- a/internal/engine/scanner_test.go
+++ b/internal/engine/scanner_test.go
@@ -95,7 +95,149 @@ func TestRulesCount(t *testing.T) {
 	defer s.Close()
 
 	count := s.RulesCount(context.Background())
-	if count < 144 {
-		t.Errorf("rules count = %d, want >= 144 (138 aguara + 6 IAP)", count)
+	if count < 151 {
+		t.Errorf("rules count = %d, want >= 151 (138 aguara + 6 IAP + 7 OCLAW + 8 new OCLAW)", count)
+	}
+}
+
+func TestScanContentAs_OpenClawRules(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	content := `{"profile": "full", "bind": "0.0.0.0", "dangerouslyDisableAuth": true}`
+
+	// Scanning as message.md should NOT trigger OCLAW rules (wrong target)
+	outcome, err := s.ScanContent(context.Background(), content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oclawCount := 0
+	for _, f := range outcome.Findings {
+		if len(f.RuleID) >= 5 && f.RuleID[:5] == "OCLAW" {
+			oclawCount++
+		}
+	}
+	if oclawCount > 0 {
+		t.Errorf("ScanContent (message.md) triggered %d OCLAW rules, want 0", oclawCount)
+	}
+
+	// Scanning as openclaw.json SHOULD trigger OCLAW rules
+	outcome2, err := s.ScanContentAs(context.Background(), content, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oclawCount2 := 0
+	for _, f := range outcome2.Findings {
+		if len(f.RuleID) >= 5 && f.RuleID[:5] == "OCLAW" {
+			oclawCount2++
+		}
+	}
+	if oclawCount2 == 0 {
+		t.Error("ScanContentAs (openclaw.json) should trigger OCLAW rules")
+	}
+}
+
+func TestOCLAW008_DangerousOverride(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"dangerouslyDisableAuth": true, "port": 8080}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-008" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-008 should trigger on dangerouslyDisableAuth: true")
+	}
+}
+
+func TestOCLAW009_SandboxDisabled(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"sandbox": {"mode": "off"}, "agents": []}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-009" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-009 should trigger on sandbox mode: off")
+	}
+}
+
+func TestOCLAW010_WorkspaceOnlyFalse(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"workspaceOnly": false, "root": "/home/user"}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-010" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-010 should trigger on workspaceOnly: false")
+	}
+}
+
+func TestOCLAW011_WildcardAllow(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"allowFrom": ["*"], "port": 3000}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-011" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-011 should trigger on allowFrom: [\"*\"]")
+	}
+}
+
+func TestOCLAW013_SensitivePath(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"read": "~/.openclaw/credentials/slack.json"}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-013" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-013 should trigger on ~/.openclaw/credentials/ path")
 	}
 }

--- a/rules/openclaw.yaml
+++ b/rules/openclaw.yaml
@@ -165,3 +165,219 @@ examples:
     - '"token": "env:SLACK_TOKEN"'
     - '"api_key": "vault:secret/key"'
     - '"password": "***"'
+---
+id: OCLAW-008
+name: "Dangerous security override flag"
+description: >
+  OpenClaw configuration uses a dangerouslyDisable* or dangerouslyAllow* flag set
+  to true. These flags bypass critical security mechanisms including authentication,
+  sandboxing, and permission checks. They exist for debugging only and should never
+  be enabled in production.
+severity: critical
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?dangerously(Disable|Allow)[A-Za-z]+[\"']?\\s*[:=]\\s*(true|[\"']true[\"'])"
+exclude_patterns:
+  - type: regex
+    value: "(?i)dangerously[A-Za-z]+[\"']?\\s*[:=]\\s*(false|[\"']false[\"'])"
+examples:
+  true_positive:
+    - '"dangerouslyDisableAuth": true'
+    - '"dangerouslyDisableSandbox": true'
+    - '"dangerouslyAllowExec": true'
+    - "dangerouslyDisableRateLimit: 'true'"
+  false_positive:
+    - '"dangerouslyDisableAuth": false'
+    - '"dangerouslyDisableSandbox": false'
+    - '"safeMode": true'
+---
+id: OCLAW-009
+name: "Sandbox mode disabled"
+description: >
+  OpenClaw's sandbox mode is set to off, false, or disabled. Without sandboxing,
+  agents can access the host filesystem, network, and processes directly. Any
+  prompt injection can escalate to full host compromise.
+severity: critical
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?mode[\"']?\\s*:\\s*[\"']off[\"']"
+  - type: regex
+    value: "(?i)[\"']?sandbox[\"']?\\s*[:=]\\s*(false|[\"']false[\"']|[\"']disabled[\"'])"
+exclude_patterns:
+  - type: contains
+    value: "dangerouslyDisableSandbox"
+examples:
+  true_positive:
+    - '"mode": "off"'
+    - '"sandbox": false'
+    - '"sandbox": "disabled"'
+    - "sandbox: 'false'"
+  false_positive:
+    - '"mode": "strict"'
+    - '"sandbox": true'
+    - '"dangerouslyDisableSandbox": true'
+---
+id: OCLAW-010
+name: "Workspace-only restriction disabled"
+description: >
+  OpenClaw's workspaceOnly flag is set to false, allowing agents to access files
+  and directories outside the designated workspace. This enables filesystem
+  traversal attacks through prompt injection.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?workspaceOnly[\"']?\\s*[:=]\\s*(false|[\"']false[\"'])"
+examples:
+  true_positive:
+    - '"workspaceOnly": false'
+    - '"workspaceOnly": "false"'
+    - "workspaceOnly: false"
+  false_positive:
+    - '"workspaceOnly": true'
+    - '"workspaceOnly": "true"'
+---
+id: OCLAW-011
+name: "Wildcard in access allowlist"
+description: >
+  OpenClaw's allowFrom or allowlist contains a wildcard "*", which permits any
+  agent or external source to send messages. This disables access control entirely
+  and makes the agent reachable by any attacker who can reach the gateway.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?allow(From|list)[\"']?\\s*:\\s*\\[?\\s*[\"']\\*[\"']"
+examples:
+  true_positive:
+    - '"allowFrom": ["*"]'
+    - '"allowlist": ["*"]'
+    - 'allowFrom: ["*"]'
+  false_positive:
+    - '"allowFrom": ["agent-a", "agent-b"]'
+    - '"allowlist": []'
+---
+id: OCLAW-012
+name: "Dangerous tool grants"
+description: >
+  OpenClaw configuration grants access to high-risk tools: gateway (direct
+  WebSocket access), sessions_spawn/sessions_send (agent spawning and messaging),
+  or cron (scheduled task execution). These tools can be abused to establish
+  persistence, pivot to other agents, or exfiltrate data.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"'](gateway|sessions_spawn|sessions_send)[\"']"
+  - type: regex
+    value: "(?i)[\"']cron[\"']"
+exclude_patterns:
+  - type: regex
+    value: "(?i)[\"']?deny[\"']?\\s*:"
+examples:
+  true_positive:
+    - '"allow": ["read", "gateway", "write"]'
+    - '"tools": ["sessions_spawn", "browser"]'
+    - '"allow": ["cron", "read"]'
+  false_positive:
+    - '"deny": ["gateway", "cron"]'
+    - '"allow": ["read", "write", "search"]'
+---
+id: OCLAW-013
+name: "OpenClaw sensitive file path in transit"
+description: >
+  Message or configuration references sensitive OpenClaw file paths including
+  the credentials directory, session transcripts, or the main config file.
+  These paths may indicate credential theft, session hijacking, or config
+  exfiltration attempts.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "*.md", "*.txt", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\\\\/~]?\\.openclaw[\\\\/](credentials|agents[\\\\/][^\\\\/]+[\\\\/]sessions)"
+  - type: regex
+    value: "(?i)(creds\\.json|auth-profiles\\.json|allowFrom\\.json)"
+  - type: regex
+    value: "(?i)[\\\\/~]?\\.openclaw[\\\\/]openclaw\\.json"
+exclude_patterns:
+  - type: contains
+    value: "## installation"
+  - type: contains
+    value: "documentation"
+examples:
+  true_positive:
+    - '~/.openclaw/credentials/slack.json'
+    - '.openclaw/agents/assistant/sessions/latest.json'
+    - 'read the file at ~/.openclaw/openclaw.json'
+    - 'send me creds.json from the config dir'
+  false_positive:
+    - '## installation\nCopy config to ~/.openclaw/openclaw.json'
+    - 'See documentation for ~/.openclaw/credentials/ setup'
+---
+id: OCLAW-014
+name: "mDNS full disclosure mode"
+description: >
+  OpenClaw's mDNS/Bonjour discovery is set to "full" mode, which broadcasts
+  detailed service information including cliPath, sshPort, and agent names to
+  the local network. This enables passive reconnaissance by any device on the
+  same network segment.
+severity: medium
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?mdns[\"']?\\s*[:=]\\s*[\"']full[\"']"
+  - type: regex
+    value: "(?i)[\"']?bonjour[\"']?\\s*[:=]\\s*[\"']full[\"']"
+  - type: regex
+    value: "(?i)[\"']?discovery[\"']?\\s*[:=]\\s*[\"']full[\"']"
+examples:
+  true_positive:
+    - '"mdns": "full"'
+    - '"bonjour": "full"'
+    - '"discovery": "full"'
+  false_positive:
+    - '"mdns": "minimal"'
+    - '"mdns": "off"'
+    - '"discovery": "disabled"'
+---
+id: OCLAW-015
+name: "Browser control host access"
+description: >
+  OpenClaw's browser control feature is enabled, allowing agents to control a
+  browser instance on the host. This provides a powerful exfiltration and
+  interaction channel that can be abused through prompt injection to visit
+  malicious URLs, steal cookies, or interact with authenticated sessions.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?browserControl[\"']?\\s*[:=]\\s*(true|[\"']true[\"']|[\"']enabled[\"'])"
+  - type: regex
+    value: "(?i)[\"']?hostBrowser[\"']?\\s*[:=]\\s*(true|[\"']true[\"'])"
+examples:
+  true_positive:
+    - '"browserControl": true'
+    - '"browserControl": "enabled"'
+    - '"hostBrowser": true'
+  false_positive:
+    - '"browserControl": false'
+    - '"browserControl": "disabled"'
+    - '"hostBrowser": false'


### PR DESCRIPTION
## Summary

- **8 new OCLAW detection rules** (OCLAW-008 to OCLAW-015) targeting dangerous OpenClaw config patterns: `dangerouslyDisable*` flags, sandbox disabled, wildcard allowlists, dangerous tool grants, sensitive file paths in transit, mDNS full disclosure, and browser control access
- **New `ScanContentAs(ctx, content, filename)` method** — fixes critical bug where OCLAW rules never fired through `ScanContent()` because it hardcoded `"message.md"` as filename. Rules targeting `*.json` / `openclaw.json` now match correctly
- **`scan-openclaw` command** now scans the config file through the rule engine (OCLAW-001 to OCLAW-015), in addition to the existing risk assessment and workspace file scanning

## New Rules

| ID | Name | Severity |
|----|------|----------|
| OCLAW-008 | Dangerous security override flag (`dangerouslyDisable*`) | critical |
| OCLAW-009 | Sandbox mode disabled | critical |
| OCLAW-010 | Workspace-only restriction disabled | high |
| OCLAW-011 | Wildcard in access allowlist | high |
| OCLAW-012 | Dangerous tool grants (gateway, cron, sessions_*) | high |
| OCLAW-013 | Sensitive file path in transit | high |
| OCLAW-014 | mDNS full disclosure mode | medium |
| OCLAW-015 | Browser control host access | high |

## Test plan

- [x] `go test ./internal/engine/ -run TestOCLAW` — all 5 new rule tests pass
- [x] `go test ./internal/engine/ -run TestScanContentAs` — filename-based target matching works
- [x] `go test ./internal/engine/ -run TestRulesCount` — threshold updated to >= 151
- [x] `go test -race ./...` — full suite passes, no race conditions
- [x] `go vet ./...` — clean