### PR TITLE
feat: oktsec audit — deployment security checker

### DIFF
--- a/cmd/oktsec/commands/audit.go
+++ b/cmd/oktsec/commands/audit.go
@@ -1,0 +1,517 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity"
+	"github.com/spf13/cobra"
+)
+
+// AuditSeverity represents the severity of an audit finding.
+type AuditSeverity int
+
+const (
+	AuditInfo AuditSeverity = iota
+	AuditLow
+	AuditMedium
+	AuditHigh
+	AuditCritical
+)
+
+func (s AuditSeverity) String() string {
+	switch s {
+	case AuditInfo:
+		return "INFO"
+	case AuditLow:
+		return "LOW"
+	case AuditMedium:
+		return "MEDIUM"
+	case AuditHigh:
+		return "HIGH"
+	case AuditCritical:
+		return "CRITICAL"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// AuditFinding is a single issue found during the audit.
+type AuditFinding struct {
+	Severity AuditSeverity `json:"severity"`
+	CheckID  string        `json:"check_id"`
+	Title    string        `json:"title"`
+	Detail   string        `json:"detail"`
+}
+
+// auditReport is the full audit output.
+type auditReport struct {
+	ConfigPath string         `json:"config_path"`
+	Findings   []AuditFinding `json:"findings"`
+	KeysLoaded int            `json:"keys_loaded"`
+	AgentCount int            `json:"agent_count"`
+	Summary    auditSummary   `json:"summary"`
+}
+
+type auditSummary struct {
+	Critical int `json:"critical"`
+	High     int `json:"high"`
+	Medium   int `json:"medium"`
+	Low      int `json:"low"`
+	Info     int `json:"info"`
+}
+
+type checkFunc func(*config.Config, string) []AuditFinding
+
+func newAuditCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Check deployment security configuration",
+		Long:  "Analyzes the oktsec configuration file and filesystem state, producing a security report with actionable findings.",
+		Example: `  oktsec audit
+  oktsec audit --json
+  oktsec audit --config /path/to/oktsec.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(cfgFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			configDir := filepath.Dir(cfgFile)
+			if configDir == "." {
+				if wd, err := os.Getwd(); err == nil {
+					configDir = wd
+				}
+			}
+
+			findings := runAuditChecks(cfg, configDir)
+
+			// Count keys
+			keysLoaded := 0
+			if cfg.Identity.KeysDir != "" {
+				keysDir := cfg.Identity.KeysDir
+				if !filepath.IsAbs(keysDir) {
+					keysDir = filepath.Join(configDir, keysDir)
+				}
+				ks := identity.NewKeyStore()
+				if err := ks.LoadFromDir(keysDir); err == nil {
+					keysLoaded = ks.Count()
+				}
+			}
+
+			report := auditReport{
+				ConfigPath: cfgFile,
+				Findings:   findings,
+				KeysLoaded: keysLoaded,
+				AgentCount: len(cfg.Agents),
+			}
+			for _, f := range findings {
+				switch f.Severity {
+				case AuditCritical:
+					report.Summary.Critical++
+				case AuditHigh:
+					report.Summary.High++
+				case AuditMedium:
+					report.Summary.Medium++
+				case AuditLow:
+					report.Summary.Low++
+				case AuditInfo:
+					report.Summary.Info++
+				}
+			}
+
+			if jsonOutput {
+				return printAuditJSON(report)
+			}
+			printAuditTerminal(report)
+
+			if report.Summary.Critical > 0 || report.Summary.High > 0 {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
+}
+
+func runAuditChecks(cfg *config.Config, configDir string) []AuditFinding {
+	checks := []checkFunc{
+		checkSignatureDisabled,
+		checkNetworkExposure,
+		checkDefaultPolicyAllow,
+		checkNoAgents,
+		checkWildcardMessaging,
+		checkQuarantineDisabled,
+		checkRateLimitDisabled,
+		checkKeysDirectory,
+		checkNoWebhooks,
+		checkAnomalyThreshold,
+		checkNoBlockedContent,
+		checkRetentionDays,
+		checkNoCustomRules,
+		checkForwardProxyNoScanResponses,
+		checkPrivateKeyPermissions,
+		checkAuditDatabase,
+	}
+
+	var findings []AuditFinding
+	for _, check := range checks {
+		findings = append(findings, check(cfg, configDir)...)
+	}
+	return findings
+}
+
+// --- Checks ---
+
+func checkSignatureDisabled(cfg *config.Config, _ string) []AuditFinding {
+	if !cfg.Identity.RequireSignature {
+		return []AuditFinding{{
+			Severity: AuditCritical,
+			CheckID:  "SIG-001",
+			Title:    "Message signatures not required",
+			Detail:   "require_signature is false — any process can spoof agent identity. Set identity.require_signature: true.",
+		}}
+	}
+	return nil
+}
+
+func checkNetworkExposure(cfg *config.Config, _ string) []AuditFinding {
+	bind := cfg.Server.Bind
+	if bind == "0.0.0.0" || bind == "::" {
+		return []AuditFinding{{
+			Severity: AuditCritical,
+			CheckID:  "NET-001",
+			Title:    "Proxy exposed to all network interfaces",
+			Detail:   fmt.Sprintf("server.bind is %q — the proxy accepts connections from any host. Set server.bind: 127.0.0.1.", bind),
+		}}
+	}
+	return nil
+}
+
+func checkDefaultPolicyAllow(cfg *config.Config, _ string) []AuditFinding {
+	policy := cfg.DefaultPolicy
+	if policy == "" {
+		policy = "allow"
+	}
+	if policy == "allow" && len(cfg.Agents) > 0 {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "ACL-001",
+			Title:    "Default policy is 'allow' with agents defined",
+			Detail:   "Unconfigured agents bypass ACL entirely. Set default_policy: deny.",
+		}}
+	}
+	return nil
+}
+
+func checkNoAgents(cfg *config.Config, _ string) []AuditFinding {
+	if len(cfg.Agents) == 0 {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "ACL-002",
+			Title:    "No agents defined",
+			Detail:   "Without agent definitions there is no access control. Define agents in the config.",
+		}}
+	}
+	return nil
+}
+
+func checkWildcardMessaging(cfg *config.Config, _ string) []AuditFinding {
+	var findings []AuditFinding
+	for name, agent := range cfg.Agents {
+		for _, target := range agent.CanMessage {
+			if target == "*" {
+				findings = append(findings, AuditFinding{
+					Severity: AuditHigh,
+					CheckID:  "ACL-003",
+					Title:    fmt.Sprintf("Agent %q can message everyone", name),
+					Detail:   fmt.Sprintf("Agent %q has can_message: [\"*\"]. Restrict to specific targets.", name),
+				})
+				break
+			}
+		}
+	}
+	return findings
+}
+
+func checkQuarantineDisabled(cfg *config.Config, _ string) []AuditFinding {
+	if !cfg.Quarantine.Enabled {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "RET-001",
+			Title:    "Quarantine queue disabled",
+			Detail:   "Suspicious messages are not held for human review. Set quarantine.enabled: true.",
+		}}
+	}
+	return nil
+}
+
+func checkRateLimitDisabled(cfg *config.Config, _ string) []AuditFinding {
+	if cfg.RateLimit.PerAgent == 0 {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "MON-001",
+			Title:    "No per-agent rate limit",
+			Detail:   "A compromised agent can flood the proxy. Set rate_limit.per_agent to a reasonable value.",
+		}}
+	}
+	return nil
+}
+
+func checkKeysDirectory(cfg *config.Config, configDir string) []AuditFinding {
+	if !cfg.Identity.RequireSignature {
+		return nil
+	}
+
+	keysDir := cfg.Identity.KeysDir
+	if keysDir == "" {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "SIG-002",
+			Title:    "Keys directory not configured",
+			Detail:   "Signatures are required but no keys_dir is set. Set identity.keys_dir.",
+		}}
+	}
+
+	if !filepath.IsAbs(keysDir) {
+		keysDir = filepath.Join(configDir, keysDir)
+	}
+
+	entries, err := os.ReadDir(keysDir)
+	if err != nil {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "SIG-002",
+			Title:    "Keys directory missing or unreadable",
+			Detail:   fmt.Sprintf("Cannot read keys directory %q: %v", cfg.Identity.KeysDir, err),
+		}}
+	}
+
+	pubCount := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".pub") {
+			pubCount++
+		}
+	}
+	if pubCount == 0 {
+		return []AuditFinding{{
+			Severity: AuditHigh,
+			CheckID:  "SIG-002",
+			Title:    "Keys directory is empty",
+			Detail:   fmt.Sprintf("No .pub files in %q. Generate keys with 'oktsec keygen'.", cfg.Identity.KeysDir),
+		}}
+	}
+	return nil
+}
+
+func checkNoWebhooks(cfg *config.Config, _ string) []AuditFinding {
+	if len(cfg.Webhooks) == 0 {
+		return []AuditFinding{{
+			Severity: AuditMedium,
+			CheckID:  "MON-002",
+			Title:    "No webhooks configured",
+			Detail:   "No external alerting for blocked or quarantined messages. Add webhooks for monitoring.",
+		}}
+	}
+	return nil
+}
+
+func checkAnomalyThreshold(cfg *config.Config, _ string) []AuditFinding {
+	if cfg.Anomaly.RiskThreshold == 0 {
+		return []AuditFinding{{
+			Severity: AuditMedium,
+			CheckID:  "MON-003",
+			Title:    "Anomaly detection threshold is zero",
+			Detail:   "No behavioral monitoring. Set anomaly.risk_threshold to enable anomaly detection.",
+		}}
+	}
+	return nil
+}
+
+func checkNoBlockedContent(cfg *config.Config, _ string) []AuditFinding {
+	if len(cfg.Agents) == 0 {
+		return nil
+	}
+	for _, agent := range cfg.Agents {
+		if len(agent.BlockedContent) > 0 {
+			return nil
+		}
+	}
+	return []AuditFinding{{
+		Severity: AuditMedium,
+		CheckID:  "ACL-004",
+		Title:    "No agents have blocked_content rules",
+		Detail:   "Content filtering is not in use. Add blocked_content patterns to agents.",
+	}}
+}
+
+func checkRetentionDays(cfg *config.Config, _ string) []AuditFinding {
+	if cfg.Quarantine.RetentionDays == 0 {
+		return []AuditFinding{{
+			Severity: AuditMedium,
+			CheckID:  "RET-002",
+			Title:    "Audit log retention is unlimited",
+			Detail:   "retention_days is 0 — the audit log will grow indefinitely. Set quarantine.retention_days.",
+		}}
+	}
+	return nil
+}
+
+func checkNoCustomRules(cfg *config.Config, _ string) []AuditFinding {
+	if cfg.CustomRulesDir == "" {
+		return []AuditFinding{{
+			Severity: AuditMedium,
+			CheckID:  "ENG-001",
+			Title:    "No custom rules directory",
+			Detail:   "Only default Aguara rules are applied. Set custom_rules_dir for environment-specific detections.",
+		}}
+	}
+	return nil
+}
+
+func checkForwardProxyNoScanResponses(cfg *config.Config, _ string) []AuditFinding {
+	if cfg.ForwardProxy.Enabled && !cfg.ForwardProxy.ScanResponses {
+		return []AuditFinding{{
+			Severity: AuditMedium,
+			CheckID:  "NET-002",
+			Title:    "Forward proxy does not scan responses",
+			Detail:   "Inbound HTTP bodies are not inspected. Set forward_proxy.scan_responses: true.",
+		}}
+	}
+	return nil
+}
+
+func checkPrivateKeyPermissions(cfg *config.Config, configDir string) []AuditFinding {
+	keysDir := cfg.Identity.KeysDir
+	if keysDir == "" {
+		return nil
+	}
+	if !filepath.IsAbs(keysDir) {
+		keysDir = filepath.Join(configDir, keysDir)
+	}
+
+	entries, err := os.ReadDir(keysDir)
+	if err != nil {
+		return nil
+	}
+
+	var findings []AuditFinding
+	for _, e := range entries {
+		if e.IsDir() || strings.HasSuffix(e.Name(), ".pub") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			findings = append(findings, AuditFinding{
+				Severity: AuditMedium,
+				CheckID:  "SIG-003",
+				Title:    fmt.Sprintf("Private key %q has loose permissions", e.Name()),
+				Detail:   fmt.Sprintf("File mode is %04o — group/world readable. Run: chmod 600 %s", mode, filepath.Join(keysDir, e.Name())),
+			})
+		}
+	}
+	return findings
+}
+
+func checkAuditDatabase(_ *config.Config, configDir string) []AuditFinding {
+	dbPath := filepath.Join(configDir, "oktsec.db")
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return []AuditFinding{{
+			Severity: AuditInfo,
+			CheckID:  "RET-003",
+			Title:    "Audit database not found",
+			Detail:   fmt.Sprintf("No oktsec.db at %s — the proxy has not run yet or uses a different path.", configDir),
+		}}
+	}
+	sizeMB := float64(info.Size()) / (1024 * 1024)
+	return []AuditFinding{{
+		Severity: AuditInfo,
+		CheckID:  "RET-003",
+		Title:    "Audit database present",
+		Detail:   fmt.Sprintf("oktsec.db exists (%.1f MB).", sizeMB),
+	}}
+}
+
+// --- Output ---
+
+func printAuditTerminal(report auditReport) {
+	fmt.Println()
+	fmt.Println("  oktsec audit")
+	fmt.Println("  ────────────────────────────────────────")
+	fmt.Printf("  Config:     %s\n", report.ConfigPath)
+	fmt.Printf("  Agents:     %d\n", report.AgentCount)
+	fmt.Printf("  Keys:       %d loaded\n", report.KeysLoaded)
+
+	bySeverity := map[AuditSeverity][]AuditFinding{}
+	for _, f := range report.Findings {
+		bySeverity[f.Severity] = append(bySeverity[f.Severity], f)
+	}
+
+	for _, sev := range []AuditSeverity{AuditCritical, AuditHigh, AuditMedium, AuditLow, AuditInfo} {
+		group := bySeverity[sev]
+		if len(group) == 0 {
+			continue
+		}
+		fmt.Println()
+		fmt.Printf("  %s (%d)\n", sev, len(group))
+		for _, f := range group {
+			fmt.Printf("    [%s] %s\n", f.CheckID, f.Title)
+			fmt.Printf("              %s\n", f.Detail)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("  ────────────────────────────────────────")
+	fmt.Printf("  Findings: %d critical, %d high, %d medium, %d info\n",
+		report.Summary.Critical, report.Summary.High, report.Summary.Medium, report.Summary.Info)
+	fmt.Println()
+}
+
+func printAuditJSON(report auditReport) error {
+	type jsonFinding struct {
+		Severity string `json:"severity"`
+		CheckID  string `json:"check_id"`
+		Title    string `json:"title"`
+		Detail   string `json:"detail"`
+	}
+	type jsonReport struct {
+		ConfigPath string        `json:"config_path"`
+		Findings   []jsonFinding `json:"findings"`
+		KeysLoaded int           `json:"keys_loaded"`
+		AgentCount int           `json:"agent_count"`
+		Summary    auditSummary  `json:"summary"`
+	}
+
+	jr := jsonReport{
+		ConfigPath: report.ConfigPath,
+		KeysLoaded: report.KeysLoaded,
+		AgentCount: report.AgentCount,
+		Summary:    report.Summary,
+	}
+	for _, f := range report.Findings {
+		jr.Findings = append(jr.Findings, jsonFinding{
+			Severity: f.Severity.String(),
+			CheckID:  f.CheckID,
+			Title:    f.Title,
+			Detail:   f.Detail,
+		})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(jr)
+}
+

--- a/cmd/oktsec/commands/audit_test.go
+++ b/cmd/oktsec/commands/audit_test.go
@@ -1,0 +1,373 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func secureBaseline() *config.Config {
+	return &config.Config{
+		Version: "1",
+		Server: config.ServerConfig{
+			Port: 8080,
+			Bind: "127.0.0.1",
+		},
+		Identity: config.IdentityConfig{
+			KeysDir:          "./keys",
+			RequireSignature: true,
+		},
+		DefaultPolicy: "deny",
+		Agents: map[string]config.Agent{
+			"agent-a": {
+				CanMessage:     []string{"agent-b"},
+				BlockedContent: []string{"password"},
+			},
+			"agent-b": {
+				CanMessage:     []string{"agent-a"},
+				BlockedContent: []string{"secret"},
+			},
+		},
+		Webhooks: []config.Webhook{
+			{URL: "https://hooks.example.com/oktsec", Events: []string{"blocked"}},
+		},
+		CustomRulesDir: "./rules",
+		Quarantine: config.QuarantineConfig{
+			Enabled:       true,
+			ExpiryHours:   24,
+			RetentionDays: 90,
+		},
+		RateLimit: config.RateLimitConfig{
+			PerAgent: 100,
+			WindowS:  60,
+		},
+		Anomaly: config.AnomalyConfig{
+			RiskThreshold: 80,
+			MinMessages:   10,
+		},
+	}
+}
+
+// --- SIG-001 ---
+
+func TestCheckSignatureDisabled(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Identity.RequireSignature = false
+	findings := checkSignatureDisabled(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "SIG-001", findings[0].CheckID)
+	assert.Equal(t, AuditCritical, findings[0].Severity)
+}
+
+func TestCheckSignatureEnabled(t *testing.T) {
+	cfg := secureBaseline()
+	findings := checkSignatureDisabled(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- NET-001 ---
+
+func TestCheckNetworkExposure_Exposed(t *testing.T) {
+	for _, bind := range []string{"0.0.0.0", "::"} {
+		cfg := secureBaseline()
+		cfg.Server.Bind = bind
+		findings := checkNetworkExposure(cfg, "")
+		require.Len(t, findings, 1, "bind=%s", bind)
+		assert.Equal(t, "NET-001", findings[0].CheckID)
+		assert.Equal(t, AuditCritical, findings[0].Severity)
+	}
+}
+
+func TestCheckNetworkExposure_Localhost(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Server.Bind = "127.0.0.1"
+	findings := checkNetworkExposure(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- ACL-001 ---
+
+func TestCheckDefaultPolicyAllow(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.DefaultPolicy = "allow"
+	findings := checkDefaultPolicyAllow(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ACL-001", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+}
+
+func TestCheckDefaultPolicyAllow_EmptyStringIsAllow(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.DefaultPolicy = ""
+	findings := checkDefaultPolicyAllow(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ACL-001", findings[0].CheckID)
+}
+
+func TestCheckDefaultPolicyDeny(t *testing.T) {
+	cfg := secureBaseline()
+	findings := checkDefaultPolicyAllow(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- ACL-002 ---
+
+func TestCheckNoAgents(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Agents = nil
+	findings := checkNoAgents(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ACL-002", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+}
+
+func TestCheckWithAgents(t *testing.T) {
+	cfg := secureBaseline()
+	findings := checkNoAgents(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- ACL-003 ---
+
+func TestCheckWildcardMessaging(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Agents["rogue"] = config.Agent{CanMessage: []string{"*"}}
+	findings := checkWildcardMessaging(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ACL-003", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+	assert.Contains(t, findings[0].Title, "rogue")
+}
+
+// --- RET-001 ---
+
+func TestCheckQuarantineDisabled(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Quarantine.Enabled = false
+	findings := checkQuarantineDisabled(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "RET-001", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+}
+
+// --- MON-001 ---
+
+func TestCheckRateLimitDisabled(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.RateLimit.PerAgent = 0
+	findings := checkRateLimitDisabled(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "MON-001", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+}
+
+// --- SIG-002 ---
+
+func TestCheckKeysDirectory_Missing(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = "/nonexistent/keys"
+	findings := checkKeysDirectory(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "SIG-002", findings[0].CheckID)
+	assert.Equal(t, AuditHigh, findings[0].Severity)
+}
+
+func TestCheckKeysDirectory_WithKeys(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	require.NoError(t, os.Mkdir(keysDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.pub"), []byte("key"), 0o644))
+
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = keysDir
+	findings := checkKeysDirectory(cfg, dir)
+	assert.Empty(t, findings)
+}
+
+func TestCheckKeysDirectory_Empty(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	require.NoError(t, os.Mkdir(keysDir, 0o700))
+
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = keysDir
+	findings := checkKeysDirectory(cfg, dir)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "SIG-002", findings[0].CheckID)
+}
+
+func TestCheckKeysDirectory_SkippedWhenNoSignature(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Identity.RequireSignature = false
+	cfg.Identity.KeysDir = "/nonexistent"
+	findings := checkKeysDirectory(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- MON-002 ---
+
+func TestCheckNoWebhooks(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Webhooks = nil
+	findings := checkNoWebhooks(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "MON-002", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+// --- MON-003 ---
+
+func TestCheckAnomalyThreshold(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Anomaly.RiskThreshold = 0
+	findings := checkAnomalyThreshold(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "MON-003", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+// --- ACL-004 ---
+
+func TestCheckNoBlockedContent(t *testing.T) {
+	cfg := secureBaseline()
+	for name, agent := range cfg.Agents {
+		agent.BlockedContent = nil
+		cfg.Agents[name] = agent
+	}
+	findings := checkNoBlockedContent(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ACL-004", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+func TestCheckNoBlockedContent_NoAgents(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Agents = nil
+	findings := checkNoBlockedContent(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- RET-002 ---
+
+func TestCheckRetentionDays(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.Quarantine.RetentionDays = 0
+	findings := checkRetentionDays(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "RET-002", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+// --- ENG-001 ---
+
+func TestCheckNoCustomRules(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.CustomRulesDir = ""
+	findings := checkNoCustomRules(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "ENG-001", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+// --- NET-002 ---
+
+func TestCheckForwardProxyNoScanResponses(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.ForwardProxy.Enabled = true
+	cfg.ForwardProxy.ScanResponses = false
+	findings := checkForwardProxyNoScanResponses(cfg, "")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "NET-002", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+}
+
+func TestCheckForwardProxyNoScanResponses_Disabled(t *testing.T) {
+	cfg := secureBaseline()
+	cfg.ForwardProxy.Enabled = false
+	findings := checkForwardProxyNoScanResponses(cfg, "")
+	assert.Empty(t, findings)
+}
+
+// --- SIG-003 ---
+
+func TestCheckPrivateKeyPermissions(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	require.NoError(t, os.Mkdir(keysDir, 0o700))
+
+	// Private key with loose permissions
+	keyPath := filepath.Join(keysDir, "agent-a.key")
+	require.NoError(t, os.WriteFile(keyPath, []byte("private"), 0o644))
+
+	// Public key should be ignored
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.pub"), []byte("public"), 0o644))
+
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = keysDir
+	findings := checkPrivateKeyPermissions(cfg, dir)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "SIG-003", findings[0].CheckID)
+	assert.Equal(t, AuditMedium, findings[0].Severity)
+	assert.Contains(t, findings[0].Title, "agent-a.key")
+}
+
+func TestCheckPrivateKeyPermissions_Secure(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	require.NoError(t, os.Mkdir(keysDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.key"), []byte("private"), 0o600))
+
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = keysDir
+	findings := checkPrivateKeyPermissions(cfg, dir)
+	assert.Empty(t, findings)
+}
+
+// --- RET-003 ---
+
+func TestCheckAuditDatabase_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfg := secureBaseline()
+	findings := checkAuditDatabase(cfg, dir)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "RET-003", findings[0].CheckID)
+	assert.Equal(t, AuditInfo, findings[0].Severity)
+	assert.Contains(t, findings[0].Title, "not found")
+}
+
+func TestCheckAuditDatabase_Exists(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "oktsec.db"), []byte("data"), 0o644))
+
+	cfg := secureBaseline()
+	findings := checkAuditDatabase(cfg, dir)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "RET-003", findings[0].CheckID)
+	assert.Equal(t, AuditInfo, findings[0].Severity)
+	assert.Contains(t, findings[0].Title, "present")
+}
+
+// --- Integration ---
+
+func TestRunAuditChecks_SecureConfig(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	require.NoError(t, os.Mkdir(keysDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.pub"), []byte("key"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.key"), []byte("priv"), 0o600))
+
+	cfg := secureBaseline()
+	cfg.Identity.KeysDir = keysDir
+
+	findings := runAuditChecks(cfg, dir)
+
+	// A fully hardened config should only produce info findings
+	for _, f := range findings {
+		assert.LessOrEqual(t, f.Severity, AuditInfo,
+			"unexpected finding: [%s] %s — %s", f.CheckID, f.Title, f.Detail)
+	}
+}

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -33,6 +33,7 @@ func NewRoot() *cobra.Command {
 		newVersionCmd(),
 		newQuarantineCmd(),
 		newScanOpenClawCmd(),
+		newAuditCmd(),
 		newAgentCmd(),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.44.0
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1
 )
@@ -14,12 +15,14 @@ require (
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -130,6 +130,14 @@ func NewStore(dbPath string, logger *slog.Logger, retentionDays ...int) (*Store,
 		return nil, fmt.Errorf("setting WAL mode: %w", err)
 	}
 
+	// Set busy timeout so concurrent writers wait instead of returning SQLITE_BUSY
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		if cerr := db.Close(); cerr != nil {
+			return nil, fmt.Errorf("setting busy_timeout: %w (also: close: %v)", err, cerr)
+		}
+		return nil, fmt.Errorf("setting busy_timeout: %w", err)
+	}
+
 	if _, err := db.Exec(schema); err != nil {
 		if cerr := db.Close(); cerr != nil {
 			return nil, fmt.Errorf("creating schema: %w (also: close: %v)", err, cerr)

--- a/internal/engine/scanner.go
+++ b/internal/engine/scanner.go
@@ -73,11 +73,22 @@ func NewScanner(customRulesDir string, extraOpts ...aguara.Option) *Scanner {
 
 // ScanContent scans message content and returns a verdict.
 func (s *Scanner) ScanContent(ctx context.Context, content string) (*ScanOutcome, error) {
-	result, err := aguara.ScanContent(ctx, content, "message.md", s.opts...)
+	return s.ScanContentAs(ctx, content, "message.md")
+}
+
+// ScanContentAs scans content with a specific virtual filename for target matching.
+// Use this when the content represents a specific file type (e.g., "openclaw.json")
+// so that rules with file-type targets can match correctly.
+func (s *Scanner) ScanContentAs(ctx context.Context, content, filename string) (*ScanOutcome, error) {
+	result, err := aguara.ScanContent(ctx, content, filename, s.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("aguara scan: %w", err)
 	}
+	return buildOutcome(result), nil
+}
 
+// buildOutcome converts Aguara scan results into a proxy verdict.
+func buildOutcome(result *aguara.ScanResult) *ScanOutcome {
 	outcome := &ScanOutcome{
 		Verdict: VerdictClean,
 	}
@@ -103,7 +114,7 @@ func (s *Scanner) ScanContent(ctx context.Context, content string) (*ScanOutcome
 		}
 	}
 
-	return outcome, nil
+	return outcome
 }
 
 // Close cleans up temporary files.

--- a/internal/engine/scanner_test.go
+++ b/internal/engine/scanner_test.go
@@ -95,7 +95,149 @@ func TestRulesCount(t *testing.T) {
 	defer s.Close()
 
 	count := s.RulesCount(context.Background())
-	if count < 144 {
-		t.Errorf("rules count = %d, want >= 144 (138 aguara + 6 IAP)", count)
+	if count < 151 {
+		t.Errorf("rules count = %d, want >= 151 (138 aguara + 6 IAP + 7 OCLAW + 8 new OCLAW)", count)
+	}
+}
+
+func TestScanContentAs_OpenClawRules(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	content := `{"profile": "full", "bind": "0.0.0.0", "dangerouslyDisableAuth": true}`
+
+	// Scanning as message.md should NOT trigger OCLAW rules (wrong target)
+	outcome, err := s.ScanContent(context.Background(), content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oclawCount := 0
+	for _, f := range outcome.Findings {
+		if len(f.RuleID) >= 5 && f.RuleID[:5] == "OCLAW" {
+			oclawCount++
+		}
+	}
+	if oclawCount > 0 {
+		t.Errorf("ScanContent (message.md) triggered %d OCLAW rules, want 0", oclawCount)
+	}
+
+	// Scanning as openclaw.json SHOULD trigger OCLAW rules
+	outcome2, err := s.ScanContentAs(context.Background(), content, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oclawCount2 := 0
+	for _, f := range outcome2.Findings {
+		if len(f.RuleID) >= 5 && f.RuleID[:5] == "OCLAW" {
+			oclawCount2++
+		}
+	}
+	if oclawCount2 == 0 {
+		t.Error("ScanContentAs (openclaw.json) should trigger OCLAW rules")
+	}
+}
+
+func TestOCLAW008_DangerousOverride(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"dangerouslyDisableAuth": true, "port": 8080}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-008" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-008 should trigger on dangerouslyDisableAuth: true")
+	}
+}
+
+func TestOCLAW009_SandboxDisabled(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"sandbox": {"mode": "off"}, "agents": []}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-009" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-009 should trigger on sandbox mode: off")
+	}
+}
+
+func TestOCLAW010_WorkspaceOnlyFalse(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"workspaceOnly": false, "root": "/home/user"}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-010" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-010 should trigger on workspaceOnly: false")
+	}
+}
+
+func TestOCLAW011_WildcardAllow(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"allowFrom": ["*"], "port": 3000}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-011" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-011 should trigger on allowFrom: [\"*\"]")
+	}
+}
+
+func TestOCLAW013_SensitivePath(t *testing.T) {
+	s := NewScanner("")
+	defer s.Close()
+
+	outcome, err := s.ScanContentAs(context.Background(),
+		`{"read": "~/.openclaw/credentials/slack.json"}`, "openclaw.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range outcome.Findings {
+		if f.RuleID == "OCLAW-013" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("OCLAW-013 should trigger on ~/.openclaw/credentials/ path")
 	}
 }

--- a/rules/openclaw.yaml
+++ b/rules/openclaw.yaml
@@ -165,3 +165,219 @@ examples:
     - '"token": "env:SLACK_TOKEN"'
     - '"api_key": "vault:secret/key"'
     - '"password": "***"'
+---
+id: OCLAW-008
+name: "Dangerous security override flag"
+description: >
+  OpenClaw configuration uses a dangerouslyDisable* or dangerouslyAllow* flag set
+  to true. These flags bypass critical security mechanisms including authentication,
+  sandboxing, and permission checks. They exist for debugging only and should never
+  be enabled in production.
+severity: critical
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?dangerously(Disable|Allow)[A-Za-z]+[\"']?\\s*[:=]\\s*(true|[\"']true[\"'])"
+exclude_patterns:
+  - type: regex
+    value: "(?i)dangerously[A-Za-z]+[\"']?\\s*[:=]\\s*(false|[\"']false[\"'])"
+examples:
+  true_positive:
+    - '"dangerouslyDisableAuth": true'
+    - '"dangerouslyDisableSandbox": true'
+    - '"dangerouslyAllowExec": true'
+    - "dangerouslyDisableRateLimit: 'true'"
+  false_positive:
+    - '"dangerouslyDisableAuth": false'
+    - '"dangerouslyDisableSandbox": false'
+    - '"safeMode": true'
+---
+id: OCLAW-009
+name: "Sandbox mode disabled"
+description: >
+  OpenClaw's sandbox mode is set to off, false, or disabled. Without sandboxing,
+  agents can access the host filesystem, network, and processes directly. Any
+  prompt injection can escalate to full host compromise.
+severity: critical
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?mode[\"']?\\s*:\\s*[\"']off[\"']"
+  - type: regex
+    value: "(?i)[\"']?sandbox[\"']?\\s*[:=]\\s*(false|[\"']false[\"']|[\"']disabled[\"'])"
+exclude_patterns:
+  - type: contains
+    value: "dangerouslyDisableSandbox"
+examples:
+  true_positive:
+    - '"mode": "off"'
+    - '"sandbox": false'
+    - '"sandbox": "disabled"'
+    - "sandbox: 'false'"
+  false_positive:
+    - '"mode": "strict"'
+    - '"sandbox": true'
+    - '"dangerouslyDisableSandbox": true'
+---
+id: OCLAW-010
+name: "Workspace-only restriction disabled"
+description: >
+  OpenClaw's workspaceOnly flag is set to false, allowing agents to access files
+  and directories outside the designated workspace. This enables filesystem
+  traversal attacks through prompt injection.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?workspaceOnly[\"']?\\s*[:=]\\s*(false|[\"']false[\"'])"
+examples:
+  true_positive:
+    - '"workspaceOnly": false'
+    - '"workspaceOnly": "false"'
+    - "workspaceOnly: false"
+  false_positive:
+    - '"workspaceOnly": true'
+    - '"workspaceOnly": "true"'
+---
+id: OCLAW-011
+name: "Wildcard in access allowlist"
+description: >
+  OpenClaw's allowFrom or allowlist contains a wildcard "*", which permits any
+  agent or external source to send messages. This disables access control entirely
+  and makes the agent reachable by any attacker who can reach the gateway.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?allow(From|list)[\"']?\\s*:\\s*\\[?\\s*[\"']\\*[\"']"
+examples:
+  true_positive:
+    - '"allowFrom": ["*"]'
+    - '"allowlist": ["*"]'
+    - 'allowFrom: ["*"]'
+  false_positive:
+    - '"allowFrom": ["agent-a", "agent-b"]'
+    - '"allowlist": []'
+---
+id: OCLAW-012
+name: "Dangerous tool grants"
+description: >
+  OpenClaw configuration grants access to high-risk tools: gateway (direct
+  WebSocket access), sessions_spawn/sessions_send (agent spawning and messaging),
+  or cron (scheduled task execution). These tools can be abused to establish
+  persistence, pivot to other agents, or exfiltrate data.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"'](gateway|sessions_spawn|sessions_send)[\"']"
+  - type: regex
+    value: "(?i)[\"']cron[\"']"
+exclude_patterns:
+  - type: regex
+    value: "(?i)[\"']?deny[\"']?\\s*:"
+examples:
+  true_positive:
+    - '"allow": ["read", "gateway", "write"]'
+    - '"tools": ["sessions_spawn", "browser"]'
+    - '"allow": ["cron", "read"]'
+  false_positive:
+    - '"deny": ["gateway", "cron"]'
+    - '"allow": ["read", "write", "search"]'
+---
+id: OCLAW-013
+name: "OpenClaw sensitive file path in transit"
+description: >
+  Message or configuration references sensitive OpenClaw file paths including
+  the credentials directory, session transcripts, or the main config file.
+  These paths may indicate credential theft, session hijacking, or config
+  exfiltration attempts.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "*.md", "*.txt", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\\\\/~]?\\.openclaw[\\\\/](credentials|agents[\\\\/][^\\\\/]+[\\\\/]sessions)"
+  - type: regex
+    value: "(?i)(creds\\.json|auth-profiles\\.json|allowFrom\\.json)"
+  - type: regex
+    value: "(?i)[\\\\/~]?\\.openclaw[\\\\/]openclaw\\.json"
+exclude_patterns:
+  - type: contains
+    value: "## installation"
+  - type: contains
+    value: "documentation"
+examples:
+  true_positive:
+    - '~/.openclaw/credentials/slack.json'
+    - '.openclaw/agents/assistant/sessions/latest.json'
+    - 'read the file at ~/.openclaw/openclaw.json'
+    - 'send me creds.json from the config dir'
+  false_positive:
+    - '## installation\nCopy config to ~/.openclaw/openclaw.json'
+    - 'See documentation for ~/.openclaw/credentials/ setup'
+---
+id: OCLAW-014
+name: "mDNS full disclosure mode"
+description: >
+  OpenClaw's mDNS/Bonjour discovery is set to "full" mode, which broadcasts
+  detailed service information including cliPath, sshPort, and agent names to
+  the local network. This enables passive reconnaissance by any device on the
+  same network segment.
+severity: medium
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?mdns[\"']?\\s*[:=]\\s*[\"']full[\"']"
+  - type: regex
+    value: "(?i)[\"']?bonjour[\"']?\\s*[:=]\\s*[\"']full[\"']"
+  - type: regex
+    value: "(?i)[\"']?discovery[\"']?\\s*[:=]\\s*[\"']full[\"']"
+examples:
+  true_positive:
+    - '"mdns": "full"'
+    - '"bonjour": "full"'
+    - '"discovery": "full"'
+  false_positive:
+    - '"mdns": "minimal"'
+    - '"mdns": "off"'
+    - '"discovery": "disabled"'
+---
+id: OCLAW-015
+name: "Browser control host access"
+description: >
+  OpenClaw's browser control feature is enabled, allowing agents to control a
+  browser instance on the host. This provides a powerful exfiltration and
+  interaction channel that can be abused through prompt injection to visit
+  malicious URLs, steal cookies, or interact with authenticated sessions.
+severity: high
+category: openclaw-config
+targets: ["*.json", "*.json5", "openclaw.json"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)[\"']?browserControl[\"']?\\s*[:=]\\s*(true|[\"']true[\"']|[\"']enabled[\"'])"
+  - type: regex
+    value: "(?i)[\"']?hostBrowser[\"']?\\s*[:=]\\s*(true|[\"']true[\"'])"
+examples:
+  true_positive:
+    - '"browserControl": true'
+    - '"browserControl": "enabled"'
+    - '"hostBrowser": true'
+  false_positive:
+    - '"browserControl": false'
+    - '"browserControl": "disabled"'
+    - '"hostBrowser": false'


### PR DESCRIPTION
## Summary

- Adds `oktsec audit` command — a static config linter that reads the YAML config + filesystem state and produces a security report with actionable findings
- **16 checks** across 6 categories: identity (SIG), network (NET), ACL, retention (RET), monitoring (MON), engine (ENG)
- Terminal output grouped by severity, `--json` flag for CI/CD pipelines
- Exit code 1 when any high/critical findings are present
- 29 test functions covering each check in isolation + integration test with fully hardened config

## Checks

| CheckID | Severity | What it detects |
|---------|----------|-----------------|
| SIG-001 | critical | `require_signature: false` |
| NET-001 | critical | Proxy bound to `0.0.0.0` or `::` |
| ACL-001 | high | `default_policy: allow` with agents defined |
| ACL-002 | high | No agents defined |
| ACL-003 | high | Agent with `can_message: ["*"]` |
| RET-001 | high | Quarantine disabled |
| MON-001 | high | No per-agent rate limit |
| SIG-002 | high | Keys directory missing/empty |
| MON-002 | medium | No webhooks |
| MON-003 | medium | Anomaly threshold at zero |
| ACL-004 | medium | No blocked_content on any agent |
| RET-002 | medium | Unlimited audit log retention |
| ENG-001 | medium | No custom rules directory |
| NET-002 | medium | Forward proxy without response scanning |
| SIG-003 | medium | Private key files with loose permissions |
| RET-003 | info | Audit database existence and size |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — full suite green (15 packages)
- [x] 29/29 audit check tests pass
- [x] `oktsec audit --help` shows correct usage