### PR TITLE
feat: unified multi-product security auditor

### DIFF
--- a/cmd/oktsec/commands/audit_nanoclaw.go
+++ b/cmd/oktsec/commands/audit_nanoclaw.go
@@ -1,0 +1,143 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type nanoClawAllowlist struct {
+	AllowedRoots    []nanoClawRoot `json:"allowedRoots"`
+	BlockedPatterns []string       `json:"blockedPatterns"`
+	NonMainReadOnly bool           `json:"nonMainReadOnly"`
+}
+
+type nanoClawRoot struct {
+	Path           string `json:"path"`
+	AllowReadWrite bool   `json:"allowReadWrite"`
+	Description    string `json:"description,omitempty"`
+}
+
+func defaultNanoClawConfigDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "nanoclaw")
+}
+
+func defaultNanoClawAllowlistPath() string {
+	return filepath.Join(defaultNanoClawConfigDir(), "mount-allowlist.json")
+}
+
+func auditNanoClaw() []AuditFinding {
+	return auditNanoClawAt(defaultNanoClawAllowlistPath())
+}
+
+func auditNanoClawAt(allowlistPath string) []AuditFinding {
+	configDir := filepath.Dir(allowlistPath)
+
+	// Check if the config directory exists at all — if not, NanoClaw is not installed
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	var findings []AuditFinding
+	f := func(sev AuditSeverity, id, title, detail string) {
+		findings = append(findings, AuditFinding{
+			Severity: sev,
+			CheckID:  id,
+			Title:    title,
+			Detail:   detail,
+			Product:  "NanoClaw",
+		})
+	}
+
+	// NC-MNT-001: Mount allowlist file missing
+	data, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		f(AuditHigh, "NC-MNT-001", "Mount allowlist missing",
+			fmt.Sprintf("NanoClaw config directory exists but %s is missing — no mount security is configured.", allowlistPath))
+		return findings
+	}
+
+	var allowlist nanoClawAllowlist
+	if err := json.Unmarshal(data, &allowlist); err != nil {
+		f(AuditHigh, "NC-MNT-001", "Mount allowlist unparseable",
+			fmt.Sprintf("Cannot parse %s: %v", allowlistPath, err))
+		return findings
+	}
+
+	// NC-MNT-002: nonMainReadOnly is false
+	if !allowlist.NonMainReadOnly {
+		f(AuditHigh, "NC-MNT-002", "Non-main groups have write access",
+			"nonMainReadOnly is false — non-main groups can write to mounted paths. Set nonMainReadOnly: true.")
+	}
+
+	// NC-MNT-003: Dangerous root paths
+	home, _ := os.UserHomeDir()
+	for _, root := range allowlist.AllowedRoots {
+		p := root.Path
+		// Expand ~ and $HOME
+		expanded := p
+		if strings.HasPrefix(expanded, "~") {
+			expanded = filepath.Join(home, expanded[1:])
+		}
+		expanded = os.ExpandEnv(expanded)
+		expanded = filepath.Clean(expanded)
+
+		if expanded == "/" || expanded == home || p == "~" || p == "$HOME" {
+			f(AuditCritical, "NC-MNT-003", fmt.Sprintf("Dangerous mount root: %s", p),
+				fmt.Sprintf("Allowed root %q resolves to %q — agent can reach the entire directory tree. Restrict to specific subdirectories.", p, expanded))
+		}
+	}
+
+	// NC-MNT-004: No custom blocked patterns
+	if len(allowlist.BlockedPatterns) == 0 {
+		f(AuditMedium, "NC-MNT-004", "No blocked patterns configured",
+			"blockedPatterns is empty — no file patterns are blocked from agent access. Add patterns like \"*.env\", \".ssh/*\".")
+	}
+
+	// NC-SEC-001: Allowlist file permissions > 0600
+	if info, err := os.Stat(allowlistPath); err == nil {
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			f(AuditHigh, "NC-SEC-001", "Allowlist file has loose permissions",
+				fmt.Sprintf("%s has mode %04o — group/world accessible (tamper risk). Run: chmod 600 %s", allowlistPath, mode, allowlistPath))
+		}
+	}
+
+	// NC-MNT-005: allowReadWrite on sensitive paths
+	sensitivePaths := []string{home, "/etc", "/var"}
+	for _, root := range allowlist.AllowedRoots {
+		if !root.AllowReadWrite {
+			continue
+		}
+		expanded := root.Path
+		if strings.HasPrefix(expanded, "~") {
+			expanded = filepath.Join(home, expanded[1:])
+		}
+		expanded = os.ExpandEnv(expanded)
+		expanded = filepath.Clean(expanded)
+
+		for _, sp := range sensitivePaths {
+			if expanded == sp || strings.HasPrefix(expanded, sp+string(filepath.Separator)) {
+				f(AuditHigh, "NC-MNT-005", fmt.Sprintf("Read-write mount on sensitive path: %s", root.Path),
+					fmt.Sprintf("Allowed root %q has allowReadWrite: true and overlaps with %s. Use read-only access for sensitive paths.", root.Path, sp))
+				break
+			}
+		}
+	}
+
+	// NC-MNT-006: Allowlist stats (info)
+	rwCount := 0
+	for _, r := range allowlist.AllowedRoots {
+		if r.AllowReadWrite {
+			rwCount++
+		}
+	}
+	f(AuditInfo, "NC-MNT-006", "NanoClaw mount allowlist summary",
+		fmt.Sprintf("%d allowed roots (%d read-write), %d blocked patterns, nonMainReadOnly: %v",
+			len(allowlist.AllowedRoots), rwCount, len(allowlist.BlockedPatterns), allowlist.NonMainReadOnly))
+
+	return findings
+}

--- a/cmd/oktsec/commands/audit_nanoclaw_test.go
+++ b/cmd/oktsec/commands/audit_nanoclaw_test.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditNanoClaw_NotInstalled(t *testing.T) {
+	findings := auditNanoClawAt("/nonexistent/nanoclaw/mount-allowlist.json")
+	assert.Nil(t, findings)
+}
+
+func TestAuditNanoClaw_MissingAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	// Config dir exists (dir), but allowlist file does not
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-001", AuditHigh)
+}
+
+func TestAuditNanoClaw_DangerousRoot_Slash(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [{"path": "/", "allowReadWrite": false}],
+		"blockedPatterns": ["*.env"],
+		"nonMainReadOnly": true
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-003", AuditCritical)
+}
+
+func TestAuditNanoClaw_DangerousRoot_Tilde(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [{"path": "~", "allowReadWrite": false}],
+		"blockedPatterns": ["*.env"],
+		"nonMainReadOnly": true
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-003", AuditCritical)
+}
+
+func TestAuditNanoClaw_NonMainReadOnlyFalse(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [{"path": "/tmp/safe", "allowReadWrite": false}],
+		"blockedPatterns": ["*.env"],
+		"nonMainReadOnly": false
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-002", AuditHigh)
+}
+
+func TestAuditNanoClaw_NoBlockedPatterns(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [{"path": "/tmp/safe", "allowReadWrite": false}],
+		"blockedPatterns": [],
+		"nonMainReadOnly": true
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-004", AuditMedium)
+}
+
+func TestAuditNanoClaw_ReadWriteSensitivePath(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [{"path": "/etc", "allowReadWrite": true}],
+		"blockedPatterns": ["*.env"],
+		"nonMainReadOnly": true
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-005", AuditHigh)
+}
+
+func TestAuditNanoClaw_SecureConfig(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	require.NoError(t, os.WriteFile(allowlistPath, []byte(`{
+		"allowedRoots": [
+			{"path": "/tmp/project", "allowReadWrite": true, "description": "project dir"}
+		],
+		"blockedPatterns": ["*.env", ".ssh/*", "*.key"],
+		"nonMainReadOnly": true
+	}`), 0o600))
+
+	findings := auditNanoClawAt(allowlistPath)
+	for _, f := range findings {
+		assert.LessOrEqual(t, f.Severity, AuditInfo,
+			"unexpected finding: [%s] %s — %s", f.CheckID, f.Title, f.Detail)
+	}
+}
+
+func TestAuditNanoClaw_Stats(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [
+			{"path": "/tmp/a", "allowReadWrite": true},
+			{"path": "/tmp/b", "allowReadWrite": false}
+		],
+		"blockedPatterns": ["*.env", ".ssh/*"],
+		"nonMainReadOnly": true
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	assertHasCheck(t, findings, "NC-MNT-006", AuditInfo)
+	// Verify stats content
+	for _, f := range findings {
+		if f.CheckID == "NC-MNT-006" {
+			assert.Contains(t, f.Detail, "2 allowed roots")
+			assert.Contains(t, f.Detail, "1 read-write")
+			assert.Contains(t, f.Detail, "2 blocked patterns")
+			break
+		}
+	}
+}
+
+func TestAuditNanoClaw_ProductField(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "mount-allowlist.json")
+	writeJSON(t, allowlistPath, `{
+		"allowedRoots": [],
+		"blockedPatterns": [],
+		"nonMainReadOnly": false
+	}`)
+
+	findings := auditNanoClawAt(allowlistPath)
+	require.NotEmpty(t, findings)
+	for _, f := range findings {
+		assert.Equal(t, "NanoClaw", f.Product)
+	}
+}

--- a/cmd/oktsec/commands/audit_openclaw.go
+++ b/cmd/oktsec/commands/audit_openclaw.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oktsec/oktsec/internal/discover"
+)
+
+// OpenClaw config structs (local subset of fields we need for auditing).
+type ocAuditConfig struct {
+	Gateway  ocAuditGateway          `json:"gateway"`
+	Agents   map[string]ocAuditAgent `json:"agents"`
+	Tools    ocAuditTools            `json:"tools"`
+	DMPolicy string                  `json:"dmPolicy"`
+	Include  []string                `json:"$include"`
+}
+
+type ocAuditGateway struct {
+	Bind string `json:"bind"`
+}
+
+type ocAuditAgent struct {
+	Sandbox bool `json:"sandbox"`
+}
+
+type ocAuditTools struct {
+	Profile string   `json:"profile"`
+	Allow   []string `json:"allow"`
+	Deny    []string `json:"deny"`
+}
+
+func defaultOpenClawConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".openclaw", "openclaw.json")
+}
+
+func auditOpenClaw() []AuditFinding {
+	return auditOpenClawAt(defaultOpenClawConfigPath())
+}
+
+func auditOpenClawAt(configPath string) []AuditFinding {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		// Not installed — not an error, just skip
+		return nil
+	}
+
+	clean := discover.StripJSON5Comments(data)
+
+	var cfg ocAuditConfig
+	if err := json.Unmarshal(clean, &cfg); err != nil {
+		return nil
+	}
+
+	var findings []AuditFinding
+	f := func(sev AuditSeverity, id, title, detail string) {
+		findings = append(findings, AuditFinding{
+			Severity: sev,
+			CheckID:  id,
+			Title:    title,
+			Detail:   detail,
+			Product:  "OpenClaw",
+		})
+	}
+
+	// OC-001: Gateway exposed to network
+	bind := strings.ToLower(cfg.Gateway.Bind)
+	if bind == "0.0.0.0" || bind == "::" || bind == "lan" {
+		f(AuditCritical, "OC-001", "Gateway exposed to network",
+			fmt.Sprintf("gateway.bind is %q — the WebSocket gateway accepts connections from any host. Set gateway.bind: \"127.0.0.1\".", cfg.Gateway.Bind))
+	}
+
+	// OC-002: Full tool profile without deny list
+	if cfg.Tools.Profile == "full" && len(cfg.Tools.Deny) == 0 {
+		f(AuditCritical, "OC-002", "Full tool profile without deny list",
+			"tools.profile is \"full\" with no deny list — agents have unrestricted tool access. Add a tools.deny list or use a restrictive profile.")
+	}
+
+	// OC-003: Exec/shell tools without sandboxed agents
+	hasDangerous := false
+	for _, t := range cfg.Tools.Allow {
+		tl := strings.ToLower(t)
+		if tl == "exec" || tl == "shell" || tl == "terminal" || tl == "bash" {
+			hasDangerous = true
+			break
+		}
+	}
+	if hasDangerous {
+		anySandbox := false
+		for _, a := range cfg.Agents {
+			if a.Sandbox {
+				anySandbox = true
+				break
+			}
+		}
+		if !anySandbox {
+			f(AuditCritical, "OC-003", "Exec/shell tools without sandboxed agents",
+				"Exec or shell tools are allowed but no agents have sandbox enabled — arbitrary code execution risk.")
+		}
+	}
+
+	// OC-004: Open DM policy
+	if strings.ToLower(cfg.DMPolicy) == "open" {
+		f(AuditHigh, "OC-004", "Open DM policy",
+			"dmPolicy is \"open\" — any external message can reach agents. This is a prompt injection vector. Set dmPolicy: \"restricted\".")
+	}
+
+	// OC-005: $include with path traversal
+	for _, inc := range cfg.Include {
+		if strings.Contains(inc, "..") {
+			f(AuditCritical, "OC-005", "Path traversal in $include",
+				fmt.Sprintf("$include contains %q with path traversal — could load config from outside the expected directory.", inc))
+			break
+		}
+	}
+
+	// OC-006: No agents have sandbox enabled
+	if len(cfg.Agents) > 0 {
+		allUnsandboxed := true
+		for _, a := range cfg.Agents {
+			if a.Sandbox {
+				allUnsandboxed = false
+				break
+			}
+		}
+		if allUnsandboxed {
+			f(AuditHigh, "OC-006", "No agents have sandbox enabled",
+				"All agents run with full host access. Enable sandbox on at least one agent.")
+		}
+	}
+
+	// OC-007: Directory permissions > 0700
+	dir := filepath.Dir(configPath)
+	if info, err := os.Stat(dir); err == nil {
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			f(AuditHigh, "OC-007", "OpenClaw directory has loose permissions",
+				fmt.Sprintf("%s has mode %04o — group/world accessible. Run: chmod 700 %s", dir, mode, dir))
+		}
+	}
+
+	// OC-008: Config file permissions > 0600
+	if info, err := os.Stat(configPath); err == nil {
+		mode := info.Mode().Perm()
+		if mode&0o077 != 0 {
+			f(AuditMedium, "OC-008", "OpenClaw config has loose permissions",
+				fmt.Sprintf("%s has mode %04o — group/world readable. Run: chmod 600 %s", configPath, mode, configPath))
+		}
+	}
+
+	return findings
+}

--- a/cmd/oktsec/commands/audit_openclaw_test.go
+++ b/cmd/oktsec/commands/audit_openclaw_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditOpenClaw_NotInstalled(t *testing.T) {
+	findings := auditOpenClawAt("/nonexistent/path/openclaw.json")
+	assert.Nil(t, findings)
+}
+
+func TestAuditOpenClaw_ExposedGateway(t *testing.T) {
+	for _, bind := range []string{"0.0.0.0", "::", "lan"} {
+		t.Run(bind, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "openclaw.json")
+			writeJSON(t, configPath, `{"gateway": {"bind": "`+bind+`"}}`)
+
+			findings := auditOpenClawAt(configPath)
+			assertHasCheck(t, findings, "OC-001", AuditCritical)
+		})
+	}
+}
+
+func TestAuditOpenClaw_FullProfileNoDeny(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{"tools": {"profile": "full"}}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertHasCheck(t, findings, "OC-002", AuditCritical)
+}
+
+func TestAuditOpenClaw_FullProfileWithDeny(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{"tools": {"profile": "full", "deny": ["exec"]}}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertNoCheck(t, findings, "OC-002")
+}
+
+func TestAuditOpenClaw_ExecWithoutSandbox(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{
+		"tools": {"allow": ["exec"]},
+		"agents": {"worker": {"sandbox": false}}
+	}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertHasCheck(t, findings, "OC-003", AuditCritical)
+}
+
+func TestAuditOpenClaw_ExecWithSandbox(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{
+		"tools": {"allow": ["exec"]},
+		"agents": {"worker": {"sandbox": true}}
+	}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertNoCheck(t, findings, "OC-003")
+}
+
+func TestAuditOpenClaw_OpenDM(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{"dmPolicy": "open"}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertHasCheck(t, findings, "OC-004", AuditHigh)
+}
+
+func TestAuditOpenClaw_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{"$include": ["../../etc/secrets.json"]}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertHasCheck(t, findings, "OC-005", AuditCritical)
+}
+
+func TestAuditOpenClaw_NoSandboxedAgents(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{
+		"agents": {
+			"a": {"sandbox": false},
+			"b": {"sandbox": false}
+		}
+	}`)
+
+	findings := auditOpenClawAt(configPath)
+	assertHasCheck(t, findings, "OC-006", AuditHigh)
+}
+
+func TestAuditOpenClaw_SecureConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	require.NoError(t, os.Chmod(dir, 0o700))
+	writeJSON(t, configPath, `{
+		"gateway": {"bind": "127.0.0.1"},
+		"tools": {"profile": "minimal"},
+		"dmPolicy": "restricted",
+		"agents": {"worker": {"sandbox": true}}
+	}`)
+	require.NoError(t, os.Chmod(configPath, 0o600))
+
+	findings := auditOpenClawAt(configPath)
+	for _, f := range findings {
+		assert.LessOrEqual(t, f.Severity, AuditInfo,
+			"unexpected finding: [%s] %s", f.CheckID, f.Title)
+	}
+}
+
+func TestAuditOpenClaw_ProductField(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "openclaw.json")
+	writeJSON(t, configPath, `{"dmPolicy": "open"}`)
+
+	findings := auditOpenClawAt(configPath)
+	require.NotEmpty(t, findings)
+	for _, f := range findings {
+		assert.Equal(t, "OpenClaw", f.Product)
+	}
+}
+
+// --- helpers ---
+
+func writeJSON(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func assertHasCheck(t *testing.T, findings []AuditFinding, checkID string, severity AuditSeverity) {
+	t.Helper()
+	for _, f := range findings {
+		if f.CheckID == checkID {
+			assert.Equal(t, severity, f.Severity, "check %s has wrong severity", checkID)
+			return
+		}
+	}
+	t.Errorf("expected finding %s not found in %d findings", checkID, len(findings))
+}
+
+func assertNoCheck(t *testing.T, findings []AuditFinding, checkID string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.CheckID == checkID {
+			t.Errorf("unexpected finding %s: %s", checkID, f.Title)
+			return
+		}
+	}
+}

--- a/internal/discover/openclaw.go
+++ b/internal/discover/openclaw.go
@@ -46,7 +46,7 @@ func scanOpenClawConfig(path string) (*ClientResult, error) {
 		return nil, err
 	}
 
-	clean := stripJSON5Comments(data)
+	clean := StripJSON5Comments(data)
 
 	var cfg openClawConfig
 	if err := json.Unmarshal(clean, &cfg); err != nil {
@@ -91,9 +91,9 @@ func scanOpenClawConfig(path string) (*ClientResult, error) {
 	}, nil
 }
 
-// stripJSON5Comments removes // and /* */ comments from JSON5 data,
+// StripJSON5Comments removes // and /* */ comments from JSON5 data,
 // being careful not to strip inside string literals.
-func stripJSON5Comments(data []byte) []byte {
+func StripJSON5Comments(data []byte) []byte {
 	var out []byte
 	i := 0
 	n := len(data)
@@ -155,7 +155,7 @@ func AssessOpenClawRisk(path string) (*OpenClawRisk, error) {
 		return nil, err
 	}
 
-	clean := stripJSON5Comments(data)
+	clean := StripJSON5Comments(data)
 
 	var cfg openClawConfig
 	if err := json.Unmarshal(clean, &cfg); err != nil {

--- a/internal/discover/openclaw_test.go
+++ b/internal/discover/openclaw_test.go
@@ -144,7 +144,7 @@ func TestStripJSON5Comments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := string(stripJSON5Comments([]byte(tt.input)))
+			got := string(StripJSON5Comments([]byte(tt.input)))
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

- `oktsec audit` now **auto-detects** installed agent frameworks (OpenClaw, NanoClaw) and audits them in a single pass alongside existing oktsec config checks
- Adds `productAuditor` abstraction — each product auditor is a self-contained function that handles detection + checks; returns nil if not installed
- **8 OpenClaw checks** (OC-001..OC-008): gateway exposure, full tool profile, exec/shell without sandbox, open DM policy, $include path traversal, no sandbox agents, directory perms, config file perms
- **7 NanoClaw checks** (NC-MNT-001..NC-MNT-006, NC-SEC-001): missing mount allowlist, non-main write access, dangerous root paths (/, ~), no blocked patterns, file perms, RW on sensitive paths, stats summary
- Terminal output groups findings by product; JSON includes `product` and `detected` fields
- Exports `StripJSON5Comments` from `discover` package for reuse

Builds on #7 (`oktsec audit` — 16 self-checks).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 14 packages pass
- [x] 11 OpenClaw audit tests (all OC- checks + product field + secure config)
- [x] 11 NanoClaw audit tests (all NC- checks + product field + stats + secure config)
- [x] Existing 16 oktsec audit tests still pass
- [x] Product auditor registration test
- [x] Manual: `go run ./cmd/oktsec audit` — shows detected products (or none)
- [x] Manual: `go run ./cmd/oktsec audit --json` — JSON includes `detected` and `product` fields