### PR TITLE
feat: SARIF output for audit + health score in status

### DIFF
--- a/cmd/oktsec/commands/audit.go
+++ b/cmd/oktsec/commands/audit.go
@@ -82,6 +82,7 @@ var productAuditors = []productAuditor{
 
 func newAuditCmd() *cobra.Command {
 	var jsonOutput bool
+	var sarifOutput bool
 
 	cmd := &cobra.Command{
 		Use:   "audit",
@@ -89,6 +90,7 @@ func newAuditCmd() *cobra.Command {
 		Long:  "Analyzes the oktsec configuration file and filesystem state, producing a security report with actionable findings.",
 		Example: `  oktsec audit
   oktsec audit --json
+  oktsec audit --sarif
   oktsec audit --config /path/to/oktsec.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(cfgFile)
@@ -140,6 +142,9 @@ func newAuditCmd() *cobra.Command {
 				}
 			}
 
+			if sarifOutput {
+				return printAuditSARIF(report)
+			}
 			if jsonOutput {
 				return printAuditJSON(report)
 			}
@@ -153,6 +158,7 @@ func newAuditCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	cmd.Flags().BoolVar(&sarifOutput, "sarif", false, "output as SARIF v2.1.0")
 	return cmd
 }
 

--- a/cmd/oktsec/commands/audit_sarif.go
+++ b/cmd/oktsec/commands/audit_sarif.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// SARIF v2.1.0 types — minimal subset for audit output.
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Version        string      `json:"version"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string            `json:"id"`
+	ShortDescription sarifMessage      `json:"shortDescription"`
+	DefaultConfig    sarifDefaultConfig `json:"defaultConfiguration"`
+	Properties       sarifProperties   `json:"properties,omitempty"`
+}
+
+type sarifDefaultConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifProperties struct {
+	Product string `json:"product,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID  string       `json:"ruleId"`
+	Level   string       `json:"level"`
+	Message sarifMessage `json:"message"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+func auditSeverityToSARIFLevel(s AuditSeverity) string {
+	switch s {
+	case AuditCritical, AuditHigh:
+		return "error"
+	case AuditMedium:
+		return "warning"
+	case AuditLow, AuditInfo:
+		return "note"
+	default:
+		return "none"
+	}
+}
+
+func printAuditSARIF(report auditReport) error {
+	// Build rule index — deduplicate by CheckID
+	ruleIndex := map[string]int{}
+	var rules []sarifRule
+	for _, f := range report.Findings {
+		if _, exists := ruleIndex[f.CheckID]; exists {
+			continue
+		}
+		ruleIndex[f.CheckID] = len(rules)
+		rule := sarifRule{
+			ID:               f.CheckID,
+			ShortDescription: sarifMessage{Text: f.Title},
+			DefaultConfig:    sarifDefaultConfig{Level: auditSeverityToSARIFLevel(f.Severity)},
+		}
+		if f.Product != "" {
+			rule.Properties = sarifProperties{Product: f.Product}
+		}
+		rules = append(rules, rule)
+	}
+
+	var results []sarifResult
+	for _, f := range report.Findings {
+		results = append(results, sarifResult{
+			RuleID:  f.CheckID,
+			Level:   auditSeverityToSARIFLevel(f.Severity),
+			Message: sarifMessage{Text: fmt.Sprintf("%s — %s", f.Title, f.Detail)},
+		})
+	}
+
+	log := sarifLog{
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{{
+			Tool: sarifTool{
+				Driver: sarifDriver{
+					Name:           "oktsec",
+					InformationURI: "https://github.com/oktsec/oktsec",
+					Version:        version,
+					Rules:          rules,
+				},
+			},
+			Results: results,
+		}},
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(log)
+}

--- a/cmd/oktsec/commands/audit_sarif_test.go
+++ b/cmd/oktsec/commands/audit_sarif_test.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintAuditSARIF_Structure(t *testing.T) {
+	report := auditReport{
+		ConfigPath: "oktsec.yaml",
+		Findings: []AuditFinding{
+			{Severity: AuditCritical, CheckID: "SIG-001", Title: "Signatures not required", Detail: "detail1"},
+			{Severity: AuditHigh, CheckID: "ACL-001", Title: "Default allow", Detail: "detail2"},
+			{Severity: AuditMedium, CheckID: "MON-002", Title: "No webhooks", Detail: "detail3"},
+			{Severity: AuditInfo, CheckID: "RET-003", Title: "DB present", Detail: "detail4"},
+			{Severity: AuditHigh, CheckID: "OC-004", Title: "Open DM", Detail: "detail5", Product: "OpenClaw"},
+		},
+		Detected: []string{"OpenClaw"},
+		Summary:  auditSummary{Critical: 1, High: 2, Medium: 1, Info: 1},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printAuditSARIF(report)
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+
+	// Verify top-level SARIF structure
+	assert.Equal(t, "2.1.0", log.Version)
+	assert.Contains(t, log.Schema, "sarif-schema-2.1.0")
+	require.Len(t, log.Runs, 1)
+
+	run := log.Runs[0]
+
+	// Tool metadata
+	assert.Equal(t, "oktsec", run.Tool.Driver.Name)
+	assert.Contains(t, run.Tool.Driver.InformationURI, "oktsec")
+
+	// Rules — one per unique CheckID
+	assert.Len(t, run.Tool.Driver.Rules, 5)
+	ruleIDs := map[string]bool{}
+	for _, r := range run.Tool.Driver.Rules {
+		ruleIDs[r.ID] = true
+	}
+	assert.True(t, ruleIDs["SIG-001"])
+	assert.True(t, ruleIDs["OC-004"])
+
+	// Results — one per finding
+	assert.Len(t, run.Results, 5)
+}
+
+func TestAuditSeverityToSARIFLevel(t *testing.T) {
+	tests := []struct {
+		sev  AuditSeverity
+		want string
+	}{
+		{AuditCritical, "error"},
+		{AuditHigh, "error"},
+		{AuditMedium, "warning"},
+		{AuditLow, "note"},
+		{AuditInfo, "note"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, auditSeverityToSARIFLevel(tt.sev), "severity=%s", tt.sev)
+	}
+}
+
+func TestSARIF_ProductInRuleProperties(t *testing.T) {
+	report := auditReport{
+		Findings: []AuditFinding{
+			{Severity: AuditHigh, CheckID: "OC-001", Title: "Gateway exposed", Detail: "d", Product: "OpenClaw"},
+			{Severity: AuditHigh, CheckID: "SIG-001", Title: "No sigs", Detail: "d"},
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	_ = printAuditSARIF(report)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+
+	rules := log.Runs[0].Tool.Driver.Rules
+	require.Len(t, rules, 2)
+
+	// OC-001 should have product property
+	assert.Equal(t, "OpenClaw", rules[0].Properties.Product)
+	// SIG-001 should not
+	assert.Empty(t, rules[1].Properties.Product)
+}
+
+func TestSARIF_EmptyFindings(t *testing.T) {
+	report := auditReport{Findings: nil}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printAuditSARIF(report)
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+
+	assert.Empty(t, log.Runs[0].Results)
+	assert.Empty(t, log.Runs[0].Tool.Driver.Rules)
+}

--- a/cmd/oktsec/commands/status_test.go
+++ b/cmd/oktsec/commands/status_test.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeHealthScore_Perfect(t *testing.T) {
+	findings := []AuditFinding{
+		{Severity: AuditInfo, CheckID: "RET-003"},
+	}
+	score, grade := computeHealthScore(findings)
+	assert.Equal(t, 100, score)
+	assert.Equal(t, "A", grade)
+}
+
+func TestComputeHealthScore_NoFindings(t *testing.T) {
+	score, grade := computeHealthScore(nil)
+	assert.Equal(t, 100, score)
+	assert.Equal(t, "A", grade)
+}
+
+func TestComputeHealthScore_OneCritical(t *testing.T) {
+	findings := []AuditFinding{
+		{Severity: AuditCritical, CheckID: "SIG-001"},
+	}
+	score, grade := computeHealthScore(findings)
+	assert.Equal(t, 75, score)
+	assert.Equal(t, "B", grade)
+}
+
+func TestComputeHealthScore_ManyIssues(t *testing.T) {
+	findings := []AuditFinding{
+		{Severity: AuditCritical, CheckID: "SIG-001"}, // -25
+		{Severity: AuditCritical, CheckID: "NET-001"}, // -25
+		{Severity: AuditHigh, CheckID: "ACL-001"},     // -15
+		{Severity: AuditHigh, CheckID: "ACL-002"},     // -15
+		{Severity: AuditMedium, CheckID: "MON-002"},   // -5
+	}
+	score, grade := computeHealthScore(findings)
+	assert.Equal(t, 15, score) // 100 - 25 - 25 - 15 - 15 - 5
+	assert.Equal(t, "F", grade)
+}
+
+func TestComputeHealthScore_FloorAtZero(t *testing.T) {
+	findings := []AuditFinding{
+		{Severity: AuditCritical},
+		{Severity: AuditCritical},
+		{Severity: AuditCritical},
+		{Severity: AuditCritical},
+		{Severity: AuditCritical}, // 5 * -25 = -125
+	}
+	score, grade := computeHealthScore(findings)
+	assert.Equal(t, 0, score)
+	assert.Equal(t, "F", grade)
+}
+
+func TestComputeHealthScore_GradeBoundaries(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []AuditFinding
+		score    int
+		grade    string
+	}{
+		{"perfect", nil, 100, "A"},
+		{"one medium", []AuditFinding{{Severity: AuditMedium}}, 95, "A"},            // 100-5=95
+		{"two medium", []AuditFinding{{Severity: AuditMedium}, {Severity: AuditMedium}}, 90, "A"}, // 100-10=90
+		{"one high", []AuditFinding{{Severity: AuditHigh}}, 85, "B"},                 // 100-15=85
+		{"crit+high", []AuditFinding{{Severity: AuditCritical}, {Severity: AuditHigh}}, 60, "C"}, // 100-25-15=60
+		{"two crit", []AuditFinding{{Severity: AuditCritical}, {Severity: AuditCritical}}, 50, "D"}, // 100-50=50
+		{"three crit", []AuditFinding{{Severity: AuditCritical}, {Severity: AuditCritical}, {Severity: AuditCritical}}, 25, "F"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, grade := computeHealthScore(tt.findings)
+			assert.Equal(t, tt.score, score)
+			assert.Equal(t, tt.grade, grade)
+		})
+	}
+}
+
+func TestComputeHealthScore_MediumOnly(t *testing.T) {
+	findings := []AuditFinding{
+		{Severity: AuditMedium}, // -5
+		{Severity: AuditMedium}, // -5
+		{Severity: AuditMedium}, // -5
+	}
+	score, grade := computeHealthScore(findings)
+	assert.Equal(t, 85, score)
+	assert.Equal(t, "B", grade)
+}


### PR DESCRIPTION
## Summary

- **`oktsec audit --sarif`** — SARIF v2.1.0 output for GitHub Code Scanning / CI integration. Each audit finding maps to a SARIF result with `ruleId`, severity `level` (error/warning/note), and `product` property for multi-product findings
- **`oktsec status` health score** — Runs audit checks inline and displays a 0-100 score with A-F letter grade. Shows detected products (OpenClaw, NanoClaw) and top 3 critical/high issues when score < 100

Builds on #8 (multi-product auditor).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 14 packages pass
- [x] SARIF structure test: valid JSON, correct schema/version, rules deduplicated, results count matches findings
- [x] SARIF severity mapping: critical/high→error, medium→warning, low/info→note
- [x] SARIF product properties: OpenClaw/NanoClaw findings carry product in rule properties
- [x] SARIF empty findings: produces valid empty SARIF
- [x] Health score: perfect=100/A, one critical=75/B, floor at 0/F
- [x] Health score grade boundaries: A(>=90), B(>=75), C(>=60), D(>=40), F(<40)
- [ ] Manual: `go run ./cmd/oktsec audit --sarif | jq .` — valid SARIF output
- [ ] Manual: `go run ./cmd/oktsec status` — shows Health line with score/grade