### PR TITLE
fix: dashboard security hardening

### DIFF
--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	sessionCookieName = "oktsec_session"
-	sessionDuration   = 24 * time.Hour
+	sessionDuration   = 8 * time.Hour
 	maxSessions       = 50 // max concurrent sessions before cleanup
 
 	// Rate limiting thresholds
@@ -223,6 +223,9 @@ func (a *Auth) cleanStaleAttemptsLocked() {
 }
 
 // Middleware protects dashboard routes, redirecting unauthenticated requests to login.
+// CSRF note: the session cookie uses SameSite=Strict, which prevents cross-origin
+// cookie sends. Combined with localhost-only binding, CSRF risk is effectively
+// mitigated without dedicated tokens.
 func (a *Auth) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Allow login page without auth

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -712,6 +712,23 @@ func TestAuditStore_QueryAgentStats(t *testing.T) {
 	}
 }
 
+func TestServer_SearchLengthLimit(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Build a query longer than maxSearchLen (200)
+	longQuery := strings.Repeat("a", 300)
+	req := httptest.NewRequest("GET", "/dashboard/api/search?q="+longQuery, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("search with long query: status = %d, want 200", w.Code)
+	}
+}
+
 func TestAuditStore_QueryStatuses(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -15,7 +15,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 .a-stat-val.v-high{color:#f97316}
 .a-stat-val.v-med{color:var(--text2)}
 .a-stat-val.v-dim{color:var(--text3)}
-.a-grade{font-size:0.82rem;font-weight:600;margin-left:8px;color:var(--text3);font-family:var(--mono);vertical-align:baseline}
+.a-grade{display:block;font-size:0.68rem;font-weight:500;color:var(--text3);font-family:var(--mono);margin-top:2px;letter-spacing:0.5px}
 
 /* Alert strip */
 .a-alert{display:flex;align-items:center;gap:10px;padding:11px 16px;border-left:3px solid #ef4444;background:rgba(239,68,68,0.04);margin-bottom:24px;font-size:0.8rem;color:var(--text2)}
@@ -97,7 +97,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 <div class="a-stats">
   <div class="a-stat">
     <div class="a-stat-label">Posture Score</div>
-    <div class="a-stat-val{{if lt .Score 40}} v-crit{{else if lt .Score 75}} v-high{{end}}">{{.Score}}<span class="a-grade">{{.Grade}}</span></div>
+    <div class="a-stat-val{{if lt .Score 40}} v-crit{{else if lt .Score 75}} v-high{{end}}">{{.Score}}<span class="a-grade">Grade {{.Grade}}</span></div>
   </div>
   <div class="a-stat">
     <div class="a-stat-label">Critical</div>

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,9 +19,18 @@ func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Permissions-Policy", "interest-cohort=()")
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'")
+			"default-src 'self'; "+
+				"script-src 'self' 'unsafe-inline' https://unpkg.com; "+
+				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
+				"font-src 'self' https://fonts.gstatic.com; "+
+				"img-src 'self' data:; "+
+				"connect-src 'self'")
+		if strings.HasPrefix(r.URL.Path, "/dashboard") {
+			w.Header().Set("Cache-Control", "no-store")
+		}
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Summary

- **CSP fix**: Add `font-src` and `style-src` directives for Google Fonts (Inter + JetBrains Mono were broken), add `Permissions-Policy` header, and `Cache-Control: no-store` for dashboard pages containing sensitive audit data
- **Template error logging**: Replace 26 silent `_ =` error discards with `renderTemplate`/`renderJSON` helpers that log failures via slog — blank pages are now diagnosable
- **Search input validation**: Cap search query at 200 chars to bound SQLite input
- **Session hardening**: Reduce session duration from 24h to 8h (covers a workday; re-auth is quick via terminal access code)
- **CSRF documentation**: Document the `SameSite=Strict` + localhost-only CSRF mitigation decision

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all packages green
- [x] Manual: `oktsec serve` → DevTools → verify `Content-Security-Policy` includes `font-src`, `Cache-Control: no-store` on dashboard pages
- [x] Manual: verify Google Fonts load correctly (Inter + JetBrains Mono)