### PR TITLE
feat: policy as code — per-rule action enforcement

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type RuleAction struct {
 	Severity string   `yaml:"severity"`
 	Action   string   `yaml:"action"` // block, quarantine, allow-and-flag
 	Notify   []string `yaml:"notify"`
+	Template string   `yaml:"template,omitempty"` // webhook body template with {{RULE}}, {{ACTION}}, etc.
 }
 
 // RateLimitConfig controls per-agent message rate limiting.
@@ -181,7 +182,12 @@ func (c *Config) Validate() error {
 			}
 		}
 	}
+	seen := make(map[string]bool, len(c.Rules))
 	for _, ra := range c.Rules {
+		if seen[ra.ID] {
+			return fmt.Errorf("duplicate rule override for %q", ra.ID)
+		}
+		seen[ra.ID] = true
 		switch ra.Action {
 		case "block", "quarantine", "allow-and-flag", "ignore":
 			// valid

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,18 @@ func TestValidate_InvalidAction(t *testing.T) {
 	}
 }
 
+func TestValidate_DuplicateRuleID(t *testing.T) {
+	cfg := Defaults()
+	cfg.Rules = []RuleAction{
+		{ID: "PI-001", Action: "block"},
+		{ID: "PI-001", Action: "ignore"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("duplicate rule ID should be invalid")
+	}
+}
+
 func TestAgentMetadataRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "oktsec.yaml")

--- a/internal/proxy/webhook_test.go
+++ b/internal/proxy/webhook_test.go
@@ -1,0 +1,230 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+func TestRenderTemplate_PlainTextToSlackJSON(t *testing.T) {
+	event := WebhookEvent{
+		Event:     "rule_triggered",
+		MessageID: "msg-123",
+		From:      "agent-a",
+		To:        "agent-b",
+		Severity:  "critical",
+		Rule:      "CRED_001",
+		Timestamp: "2026-02-24T10:00:00Z",
+	}
+
+	tmpl := "Rule *{{RULE}}* triggered\n• Action: {{ACTION}}\n• Severity: {{SEVERITY}}\n• From: {{FROM}} → {{TO}}"
+	result := RenderTemplate(tmpl, event)
+
+	// Should be valid JSON
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("RenderTemplate output is not valid JSON: %v\nOutput: %s", err, result)
+	}
+
+	text, ok := payload["text"]
+	if !ok {
+		t.Fatal("JSON payload missing 'text' field")
+	}
+
+	// Verify tags were replaced
+	if want := "Rule *CRED_001* triggered"; !contains(text, want) {
+		t.Errorf("text missing rule: %s", text)
+	}
+	if want := "Action: rule_triggered"; !contains(text, want) {
+		t.Errorf("text missing action: %s", text)
+	}
+	if want := "Severity: critical"; !contains(text, want) {
+		t.Errorf("text missing severity: %s", text)
+	}
+	if want := "From: agent-a → agent-b"; !contains(text, want) {
+		t.Errorf("text missing from/to: %s", text)
+	}
+}
+
+func TestRenderTemplate_AllTags(t *testing.T) {
+	event := WebhookEvent{
+		Event:     "blocked",
+		MessageID: "msg-456",
+		From:      "sender",
+		To:        "receiver",
+		Severity:  "high",
+		Rule:      "PI-002",
+		Timestamp: "2026-02-24T12:00:00Z",
+	}
+
+	tmpl := "{{RULE}} {{ACTION}} {{SEVERITY}} {{FROM}} {{TO}} {{MESSAGE_ID}} {{TIMESTAMP}}"
+	result := RenderTemplate(tmpl, event)
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+
+	text := payload["text"]
+	expected := "PI-002 blocked high sender receiver msg-456 2026-02-24T12:00:00Z"
+	if text != expected {
+		t.Errorf("text = %q, want %q", text, expected)
+	}
+}
+
+func TestRenderTemplate_EmptyTemplate(t *testing.T) {
+	event := WebhookEvent{Rule: "X"}
+	result := RenderTemplate("", event)
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	if payload["text"] != "" {
+		t.Errorf("expected empty text, got %q", payload["text"])
+	}
+}
+
+func TestNotifyTemplated_SendsSlackJSON(t *testing.T) {
+	var receivedBody string
+	var receivedContentType string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = string(b)
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	notifier := NewWebhookNotifier(nil, logger)
+
+	event := WebhookEvent{
+		Event:    "rule_triggered",
+		Rule:     "TEST-001",
+		Severity: "high",
+		From:     "a",
+		To:       "b",
+	}
+
+	// Call synchronously for testing (bypass goroutine)
+	rendered := RenderTemplate("Alert: {{RULE}} fired ({{SEVERITY}})", event)
+	notifier.sendRaw(ts.URL, rendered)
+
+	if receivedContentType != "application/json" {
+		t.Errorf("content-type = %q, want application/json", receivedContentType)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(receivedBody), &payload); err != nil {
+		t.Fatalf("server received invalid JSON: %v\nBody: %s", err, receivedBody)
+	}
+	if want := "Alert: TEST-001 fired (high)"; payload["text"] != want {
+		t.Errorf("payload text = %q, want %q", payload["text"], want)
+	}
+}
+
+func TestNotifyTemplated_EmptyFallsBackToJSON(t *testing.T) {
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = string(b)
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	notifier := NewWebhookNotifier(nil, logger)
+
+	event := WebhookEvent{
+		Event: "rule_triggered",
+		Rule:  "X",
+		From:  "a",
+		To:    "b",
+	}
+
+	// Empty template — should send default JSON struct
+	notifier.send(ts.URL, event)
+
+	var payload WebhookEvent
+	if err := json.Unmarshal([]byte(receivedBody), &payload); err != nil {
+		t.Fatalf("server received invalid JSON: %v", err)
+	}
+	if payload.Rule != "X" {
+		t.Errorf("rule = %q, want X", payload.Rule)
+	}
+}
+
+func TestValidateWebhookURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"https://hooks.slack.com/services/T00/B00/xxx", false},
+		{"http://example.com/webhook", false},
+		{"ftp://example.com/file", true},
+		{"https://127.0.0.1/webhook", true},
+		{"https://10.0.0.1/webhook", true},
+		{"https://192.168.1.1/webhook", true},
+		{"not-a-url", true},
+	}
+
+	for _, tc := range tests {
+		err := validateWebhookURL(tc.url)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateWebhookURL(%q) err=%v, wantErr=%v", tc.url, err, tc.wantErr)
+		}
+	}
+}
+
+func TestNewWebhookNotifier_SkipsInvalidURLs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	webhooks := []config.Webhook{
+		{URL: "https://valid.example.com/hook", Events: []string{"blocked"}},
+		{URL: "https://127.0.0.1/bad", Events: []string{"blocked"}},
+		{URL: "https://also-valid.example.com/hook", Events: []string{"quarantined"}},
+	}
+
+	n := NewWebhookNotifier(webhooks, logger)
+	if len(n.webhooks) != 2 {
+		t.Errorf("expected 2 valid webhooks, got %d", len(n.webhooks))
+	}
+}
+
+func TestMatchesEvent(t *testing.T) {
+	tests := []struct {
+		configured []string
+		event      string
+		want       bool
+	}{
+		{nil, "message_blocked", true},          // no filter = all
+		{[]string{"blocked"}, "blocked", true},  // exact match
+		{[]string{"blocked"}, "message_blocked", true}, // prefix match
+		{[]string{"quarantined"}, "blocked", false},
+	}
+	for _, tc := range tests {
+		got := matchesEvent(tc.configured, tc.event)
+		if got != tc.want {
+			t.Errorf("matchesEvent(%v, %q) = %v, want %v", tc.configured, tc.event, got, tc.want)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Wire up `cfg.Rules[]` into the handler pipeline so per-rule actions (`block`, `quarantine`, `allow-and-flag`, `ignore`) are enforced at message processing time
- Engine stays pure (severity→verdict); overrides happen in the handler layer via `applyRuleOverrides()`
- Per-rule webhook notifications with plain-text message templates (auto-wrapped to Slack/Discord JSON on send)
- Dashboard **Enforcement** tab with searchable rule combobox, action selector, webhook URLs, and message template editor
- Override cards show rule name, description, category, default severity, expandable webhooks and template preview
- Config validation rejects duplicate rule IDs
- **15 new tests** across proxy, webhook, dashboard, and config packages

## Pipeline insertion

```
rate limit → identity → suspension → ACL → content scan → RULE OVERRIDES →
BlockedContent → split injection → concatenated scan → RULE OVERRIDES →
history escalation → verdict
```

Overrides run twice: after individual scan (step 4b) and after concatenated scan (step 6b), because `scanConcatenated` can fully replace findings.

## Files changed (9)

| File | Change |
|------|--------|
| `internal/proxy/handler.go` | `applyRuleOverrides()`, `defaultSeverityVerdict()`, `notifyByRuleOverrides()`, pipeline wiring |
| `internal/proxy/webhook.go` | `NotifyURL()`, `NotifyTemplated()`, `RenderTemplate()` (plain text → Slack JSON), `DefaultWebhookTemplate` |
| `internal/proxy/webhook_test.go` | 7 new tests: template rendering, Slack JSON wrapping, URL validation, event matching |
| `internal/proxy/handler_test.go` | 4 new tests: ignore, downgrade, escalate, no-override-keeps-default |
| `internal/config/config.go` | `Template` field on `RuleAction`, duplicate rule ID validation |
| `internal/config/config_test.go` | 1 new test: duplicate rule ID rejection |
| `internal/dashboard/handlers.go` | Enforcement tab data enrichment (description, category), save/update/delete handlers with template field |
| `internal/dashboard/templates.go` | Enforcement tab UI: combobox, form, override cards with description, expandable webhooks/template |
| `internal/dashboard/server_test.go` | 4 new tests: tab loads, save+display, update, delete |

## Test plan

- [x] `go test -race -count=1 ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] Manual: add override via dashboard, verify config persists to YAML
- [x] Manual: edit existing override, verify update (not duplicate)
- [x] Manual: delete override, verify removal
- [x] Manual: send message triggering overridden rule, verify action changes