### PR TITLE
chore: quality audit fixes — CI, test coverage, package docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Integration Test
+        run: make integration-test
+
       - name: Vet
         run: make vet

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -1,3 +1,5 @@
+// Package audit provides the SQLite-backed audit trail for message events,
+// key revocation tracking, and quarantine queue management.
 package audit
 
 // Entry represents a single audit log record.

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -66,6 +66,246 @@ func TestQueryEdgeStats(t *testing.T) {
 	}
 }
 
+func TestRevokeAndListKeys(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.RevokeKey("fp-abc", "agent-a", "compromised"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RevokeKey("fp-def", "agent-b", "rotated"); err != nil {
+		t.Fatal(err)
+	}
+
+	// IsRevoked
+	revoked, err := store.IsRevoked("fp-abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !revoked {
+		t.Error("fp-abc should be revoked")
+	}
+	revoked, err = store.IsRevoked("fp-unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revoked {
+		t.Error("fp-unknown should not be revoked")
+	}
+
+	// ListRevokedKeys
+	keys, err := store.ListRevokedKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("got %d revoked keys, want 2", len(keys))
+	}
+	// Verify both agents present
+	agents := map[string]bool{}
+	for _, k := range keys {
+		agents[k.AgentName] = true
+	}
+	if !agents["agent-a"] || !agents["agent-b"] {
+		t.Errorf("missing agents in revoked keys: %+v", keys)
+	}
+
+	// RevokeKey with same fingerprint overwrites (INSERT OR REPLACE)
+	if err := store.RevokeKey("fp-abc", "agent-a", "new reason"); err != nil {
+		t.Fatal(err)
+	}
+	keys, _ = store.ListRevokedKeys()
+	if len(keys) != 2 {
+		t.Errorf("got %d keys after re-revoke, want 2", len(keys))
+	}
+}
+
+func TestQueryStatsAndAgentStats(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	entries := []Entry{
+		{ID: "s1", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"},
+		{ID: "s2", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "blocked", PolicyDecision: "content_blocked"},
+		{ID: "s3", Timestamp: now, FromAgent: "b", ToAgent: "a", ContentHash: "h", Status: "quarantined", PolicyDecision: "content_quarantined"},
+		{ID: "s4", Timestamp: now, FromAgent: "c", ToAgent: "a", ContentHash: "h", Status: "rejected", PolicyDecision: "identity_rejected"},
+	}
+	for _, e := range entries {
+		store.Log(e)
+	}
+	store.Flush()
+
+	// QueryStats (global)
+	sc, err := store.QueryStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.Total != 4 || sc.Delivered != 1 || sc.Blocked != 1 || sc.Quarantined != 1 || sc.Rejected != 1 {
+		t.Errorf("stats = %+v", sc)
+	}
+
+	// QueryAgentStats
+	as, err := store.QueryAgentStats("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// agent "a" appears in s1(from), s2(from), s3(to), s4(to) = 4 entries
+	if as.Total != 4 {
+		t.Errorf("agent-a total = %d, want 4", as.Total)
+	}
+}
+
+func TestQueryHourlyStats(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	store.Log(Entry{ID: "h1", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Log(Entry{ID: "h2", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Flush()
+
+	stats, err := store.QueryHourlyStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should have at least one hour bucket
+	total := 0
+	for _, c := range stats {
+		total += c
+	}
+	if total != 2 {
+		t.Errorf("hourly total = %d, want 2", total)
+	}
+}
+
+func TestQueryTopRulesAndEdgeRules(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	rules := `[{"rule_id":"PI-001","name":"Prompt Injection","severity":"critical"},{"rule_id":"CRED-001","name":"Credential Leak","severity":"high"}]`
+
+	store.Log(Entry{ID: "r1", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "blocked", PolicyDecision: "content_blocked", RulesTriggered: rules})
+	store.Log(Entry{ID: "r2", Timestamp: now, FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "blocked", PolicyDecision: "content_blocked", RulesTriggered: `[{"rule_id":"PI-001","name":"Prompt Injection","severity":"critical"}]`})
+	store.Flush()
+
+	// QueryTopRules
+	top, err := store.QueryTopRules(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(top) != 2 {
+		t.Fatalf("got %d rules, want 2", len(top))
+	}
+	if top[0].RuleID != "PI-001" || top[0].Count != 2 {
+		t.Errorf("top rule = %+v, want PI-001 count=2", top[0])
+	}
+
+	// QueryEdgeRules
+	er, err := store.QueryEdgeRules("a", "b", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(er) != 2 {
+		t.Fatalf("got %d edge rules, want 2", len(er))
+	}
+
+	// Non-existent edge returns empty
+	er, err = store.QueryEdgeRules("x", "y", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(er) != 0 {
+		t.Errorf("got %d edge rules for x→y, want 0", len(er))
+	}
+}
+
+func TestQueryAgentRisk(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	store.Log(Entry{ID: "ar1", Timestamp: now, FromAgent: "bad-agent", ToAgent: "b", ContentHash: "h", Status: "blocked", PolicyDecision: "content_blocked"})
+	store.Log(Entry{ID: "ar2", Timestamp: now, FromAgent: "bad-agent", ToAgent: "b", ContentHash: "h", Status: "blocked", PolicyDecision: "content_blocked"})
+	store.Log(Entry{ID: "ar3", Timestamp: now, FromAgent: "bad-agent", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Log(Entry{ID: "ar4", Timestamp: now, FromAgent: "good-agent", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Flush()
+
+	risks, err := store.QueryAgentRisk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(risks) < 2 {
+		t.Fatalf("got %d agents, want >= 2", len(risks))
+	}
+	// bad-agent should be first (highest risk)
+	if risks[0].Agent != "bad-agent" {
+		t.Errorf("highest risk agent = %q, want bad-agent", risks[0].Agent)
+	}
+	// RiskScore: (2*3 + 0*2) / 3 * 100 = 200
+	if risks[0].RiskScore != 200 {
+		t.Errorf("risk score = %f, want 200", risks[0].RiskScore)
+	}
+}
+
+func TestQueryByID(t *testing.T) {
+	store := newTestStore(t)
+
+	store.Log(Entry{ID: "byid-1", Timestamp: "2026-02-24T10:00:00Z", FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Flush()
+	time.Sleep(20 * time.Millisecond) // ensure write loop completes
+
+	e, err := store.QueryByID("byid-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e == nil || e.FromAgent != "a" {
+		t.Errorf("QueryByID = %+v", e)
+	}
+
+	// Miss returns nil, nil
+	e, err = store.QueryByID("nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e != nil {
+		t.Error("expected nil for nonexistent")
+	}
+}
+
+func TestEntryJSON(t *testing.T) {
+	e := Entry{ID: "j1", Status: "delivered"}
+	b := EntryJSON(e)
+	if len(b) == 0 {
+		t.Fatal("empty JSON")
+	}
+	if !containsStr(string(b), `"id":"j1"`) {
+		t.Errorf("JSON missing id: %s", b)
+	}
+}
+
+func TestHubBroadcast(t *testing.T) {
+	store := newTestStore(t)
+	ch := store.Hub.Subscribe()
+	defer store.Hub.Unsubscribe(ch)
+
+	store.Log(Entry{ID: "hub1", Timestamp: time.Now().UTC().Format(time.RFC3339), FromAgent: "a", ToAgent: "b", ContentHash: "h", Status: "delivered", PolicyDecision: "allow"})
+	store.Flush()
+
+	select {
+	case e := <-ch:
+		if e.ID != "hub1" {
+			t.Errorf("broadcast entry ID = %q, want hub1", e.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no broadcast received")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
 func TestStoreLogAndQuery(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config loads and validates the oktsec YAML configuration file.
 package config
 
 import (

--- a/internal/dashboard/avatar.go
+++ b/internal/dashboard/avatar.go
@@ -1,3 +1,5 @@
+// Package dashboard serves the real-time web UI for monitoring events,
+// managing agents, reviewing quarantine items, and configuring policies.
 package dashboard
 
 import (

--- a/internal/discover/paths.go
+++ b/internal/discover/paths.go
@@ -1,3 +1,5 @@
+// Package discover auto-detects MCP client configurations and agent
+// framework installations (Claude Desktop, Cursor, VS Code, OpenClaw, NanoClaw).
 package discover
 
 import (

--- a/internal/engine/rules.go
+++ b/internal/engine/rules.go
@@ -1,3 +1,5 @@
+// Package engine wraps the Aguara detection library to scan message content
+// and map findings to security verdicts (block, quarantine, flag, clean).
 package engine
 
 import (

--- a/internal/identity/keypair.go
+++ b/internal/identity/keypair.go
@@ -1,3 +1,5 @@
+// Package identity provides Ed25519 key generation, message signing,
+// and signature verification for agent-to-agent authentication.
 package identity
 
 import (

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,3 +1,5 @@
+// Package mcp implements an MCP tool server that exposes security operations
+// (scan, audit query, agent verification, quarantine review) to AI agents.
 package mcp
 
 import (

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -1,3 +1,5 @@
+// Package policy evaluates per-agent ACL rules to determine whether a
+// message between two agents should be allowed or denied.
 package policy
 
 import (

--- a/internal/proxy/ratelimit.go
+++ b/internal/proxy/ratelimit.go
@@ -1,3 +1,5 @@
+// Package proxy implements the HTTP message proxy, stdio proxy, forward proxy,
+// and the security pipeline (rate limiting, identity, ACL, scanning, verdicts).
 package proxy
 
 import (


### PR DESCRIPTION
## Summary

Addresses three gaps identified in an internal quality audit:

- **CI pipeline**: Added `make integration-test` step to the GitHub Actions workflow, ensuring integration tests run on every PR alongside unit tests, lint, and vet
- **Audit store test coverage**: Added 9 new test functions covering 12 previously untested public methods (`RevokeKey`, `IsRevoked`, `ListRevokedKeys`, `QueryStats`, `QueryAgentStats`, `QueryHourlyStats`, `QueryTopRules`, `QueryEdgeRules`, `QueryAgentRisk`, `QueryByID`, `EntryJSON`, `Hub.Subscribe`/`broadcast`)
- **Package documentation**: Added `godoc`-compliant package-level doc comments to all 9 internal packages (`audit`, `config`, `dashboard`, `discover`, `engine`, `identity`, `mcp`, `policy`, `proxy`)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `make integration-test` step |
| `internal/audit/store_test.go` | +240 lines — 9 new test functions |
| `internal/audit/models.go` | Package doc comment |
| `internal/config/config.go` | Package doc comment |
| `internal/dashboard/avatar.go` | Package doc comment |
| `internal/discover/paths.go` | Package doc comment |
| `internal/engine/rules.go` | Package doc comment |
| `internal/identity/keypair.go` | Package doc comment |
| `internal/mcp/server.go` | Package doc comment |
| `internal/policy/evaluator.go` | Package doc comment |
| `internal/proxy/ratelimit.go` | Package doc comment |

## New test functions

| Test | Methods covered |
|------|----------------|
| `TestRevokeAndListKeys` | `RevokeKey`, `IsRevoked`, `ListRevokedKeys` |
| `TestQueryStatsAndAgentStats` | `QueryStats`, `QueryAgentStats` |
| `TestQueryHourlyStats` | `QueryHourlyStats` |
| `TestQueryTopRulesAndEdgeRules` | `QueryTopRules`, `QueryEdgeRules` |
| `TestQueryAgentRisk` | `QueryAgentRisk` (incl. risk score calculation) |
| `TestQueryByID` | `QueryByID` (hit + miss) |
| `TestEntryJSON` | `EntryJSON` |
| `TestHubBroadcast` | `Hub.Subscribe`, `Hub.Unsubscribe`, `broadcast` |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all packages green
- [x] `go test -race -count=3 ./internal/audit/` — no flakes