### PR TITLE
feat: redesign login page, add 404 page and root splash

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -33,6 +33,11 @@ func (s *Server) renderJSON(w http.ResponseWriter, data any) {
 	}
 }
 
+func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	s.renderTemplate(w, notFoundTmpl, nil)
+}
+
 func (s *Server) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 	s.renderTemplate(w, loginTmpl, nil)
 }
@@ -621,7 +626,7 @@ func (s *Server) handleCategoryRules(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cat.Total == 0 {
-		http.NotFound(w, r)
+		s.handleNotFound(w, r)
 		return
 	}
 
@@ -639,7 +644,7 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	agent, ok := s.cfg.Agents[name]
 	if !ok {
-		http.NotFound(w, r)
+		s.handleNotFound(w, r)
 		return
 	}
 
@@ -796,7 +801,7 @@ func (s *Server) handleEventDetail(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	entry, err := s.audit.QueryByID(id)
 	if err != nil || entry == nil {
-		http.NotFound(w, r)
+		s.handleNotFound(w, r)
 		return
 	}
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -134,4 +134,7 @@ func (s *Server) routes() {
 	// Rule toggles (inline enable/disable)
 	s.mux.HandleFunc("POST /dashboard/api/rule/{id}/toggle", s.handleToggleRule)
 	s.mux.HandleFunc("POST /dashboard/api/category/{name}/toggle", s.handleToggleCategory)
+
+	// Catch-all for unmatched dashboard paths (must be registered last)
+	s.mux.HandleFunc("GET /dashboard/", s.handleNotFound)
 }

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -57,33 +57,39 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
   --mono:'JetBrains Mono','SF Mono','Fira Code',monospace;
   --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
 }
+@keyframes fadeIn{from{opacity:0;transform:translateY(12px)}to{opacity:1;transform:translateY(0)}}
 body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center}
-.login-card{background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:48px 40px;max-width:400px;width:100%;text-align:center;box-shadow:0 1px 2px rgba(0,0,0,0.3),0 4px 16px rgba(0,0,0,0.2)}
+.backdrop{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:600px;height:600px;background:radial-gradient(circle,rgba(99,102,241,0.06) 0%,transparent 70%);pointer-events:none;z-index:0}
+.login-card{position:relative;z-index:1;background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:48px 40px;max-width:400px;width:100%;text-align:center;box-shadow:0 1px 2px rgba(0,0,0,0.3),0 4px 16px rgba(0,0,0,0.2);animation:fadeIn 0.4s ease-out}
+.icon{margin-bottom:20px}
+.icon svg{width:48px;height:48px;color:var(--accent)}
 .logo{font-family:var(--mono);font-size:1.5rem;font-weight:700;letter-spacing:-0.3px;margin-bottom:8px}
 .subtitle{color:var(--text2);font-size:0.85rem;margin-bottom:32px}
-.lock-icon{font-size:2.5rem;margin-bottom:16px;opacity:0.6}
 .help{color:var(--text3);font-size:0.78rem;margin-bottom:24px;line-height:1.6}
 .help code{background:var(--surface2);padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.75rem;color:var(--accent-light)}
 input[type=text]{
   width:100%;padding:14px 16px;background:var(--bg);border:1px solid var(--border);
   border-radius:8px;color:var(--text);font-family:var(--mono);font-size:1.2rem;
-  text-align:center;letter-spacing:4px;outline:none;transition:border-color 0.2s;
+  text-align:center;letter-spacing:4px;outline:none;transition:border-color 0.2s,box-shadow 0.2s;
 }
-input[type=text]:focus{border-color:var(--accent)}
+input[type=text]:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(99,102,241,0.15)}
 input[type=text]::placeholder{letter-spacing:0;font-size:0.85rem;color:var(--text3)}
 button{
   width:100%;padding:12px;margin-top:16px;background:var(--accent);color:#fff;
   border:none;border-radius:8px;font-size:0.9rem;font-weight:600;cursor:pointer;
-  transition:background 0.2s;
+  transition:background 0.2s,transform 0.1s,box-shadow 0.2s;
 }
-button:hover{background:var(--accent-dim)}
-.error{color:var(--danger);font-size:0.82rem;margin-top:12px}
+button:hover{background:var(--accent-dim);box-shadow:0 4px 12px rgba(99,102,241,0.25)}
+button:active{transform:scale(0.98)}
+.error{display:flex;align-items:center;gap:8px;justify-content:center;margin-top:14px;padding:10px 14px;background:rgba(239,68,68,0.08);border:1px solid rgba(239,68,68,0.15);border-radius:8px;color:var(--danger);font-size:0.82rem}
+.error svg{flex-shrink:0;width:16px;height:16px}
 .footer{margin-top:32px;color:var(--text3);font-size:0.72rem}
 </style>
 </head>
 <body>
+<div class="backdrop"></div>
 <div class="login-card">
-  <div class="lock-icon">&#x1f512;</div>
+  <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><rect x="9" y="11" width="6" height="5" rx="1"/><path d="M12 11V9a2 2 0 0 0-4 0"/></svg></div>
   <div class="logo">oktsec</div>
   <div class="subtitle">Dashboard Access</div>
   <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec serve</code> to get a code.</p>
@@ -91,8 +97,108 @@ button:hover{background:var(--accent-dim)}
     <input type="text" name="code" placeholder="00000000" maxlength="8" pattern="\d{8}" inputmode="numeric" autofocus required>
     <button type="submit">Authenticate</button>
   </form>
-  {{if .Error}}<p class="error">{{.Error}}</p>{{end}}
-  <p class="footer">Local access only &middot; 127.0.0.1</p>
+  {{if .Error}}<div class="error"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>{{.Error}}</div>{{end}}
+  <p class="footer">Local access only <span style="opacity:0.4;margin:0 6px">&middot;</span> 127.0.0.1</p>
+</div>
+</body>
+</html>`))
+
+// SplashTmpl is the root landing page template, exported for use by the proxy server.
+var SplashTmpl = template.Must(template.New("splash").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>oktsec</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#050507;--surface:#0c0c10;--border:#1c1c24;
+  --text:#f0f0f3;--text2:#a0a0b0;--text3:#606070;
+  --accent:#6366f1;--accent-light:#818cf8;--accent-dim:#4f46e5;
+  --mono:'JetBrains Mono','SF Mono','Fira Code',monospace;
+  --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+}
+@keyframes fadeIn{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:translateY(0)}}
+@keyframes pulse{0%,100%{opacity:0.15}50%{opacity:0.25}}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center;overflow:hidden}
+.backdrop{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:800px;height:800px;background:radial-gradient(circle,rgba(99,102,241,0.08) 0%,transparent 65%);pointer-events:none;animation:pulse 6s ease-in-out infinite}
+.container{position:relative;z-index:1;text-align:center;animation:fadeIn 0.6s ease-out}
+.logo{font-family:var(--mono);font-size:4.5rem;font-weight:700;letter-spacing:-2px;margin-bottom:12px;background:linear-gradient(135deg,var(--text) 0%,var(--accent-light) 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.tagline{color:var(--text3);font-size:1rem;letter-spacing:0.5px;margin-bottom:40px}
+.links{display:flex;gap:16px;justify-content:center;flex-wrap:wrap}
+.links a{display:inline-flex;align-items:center;gap:8px;padding:10px 22px;border-radius:8px;font-size:0.88rem;font-weight:500;text-decoration:none;transition:background 0.2s,transform 0.1s,box-shadow 0.2s}
+.links a:active{transform:scale(0.98)}
+.primary{background:var(--accent);color:#fff}
+.primary:hover{background:var(--accent-dim);box-shadow:0 4px 12px rgba(99,102,241,0.25)}
+.secondary{background:var(--surface);color:var(--text2);border:1px solid var(--border)}
+.secondary:hover{border-color:var(--accent);color:var(--text)}
+.version{margin-top:48px;color:var(--text3);font-family:var(--mono);font-size:0.72rem;opacity:0.6}
+</style>
+</head>
+<body>
+<div class="backdrop"></div>
+<div class="container">
+  <div class="logo">OKTSEC</div>
+  <p class="tagline">Security proxy for inter-agent communication</p>
+  <div class="links">
+    <a class="primary" href="/dashboard">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+      Dashboard
+    </a>
+    <a class="secondary" href="/health">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+      Health
+    </a>
+  </div>
+  <p class="version">v0.1.0</p>
+</div>
+</body>
+</html>`))
+
+var notFoundTmpl = template.Must(template.New("notfound").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>oktsec — 404</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#050507;--surface:#0c0c10;--surface2:#0f0f14;--border:#1c1c24;
+  --text:#f0f0f3;--text2:#a0a0b0;--text3:#606070;
+  --accent:#6366f1;--accent-light:#818cf8;--accent-dim:#4f46e5;
+  --mono:'JetBrains Mono','SF Mono','Fira Code',monospace;
+  --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+}
+@keyframes fadeIn{from{opacity:0;transform:translateY(12px)}to{opacity:1;transform:translateY(0)}}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center}
+.backdrop{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:600px;height:600px;background:radial-gradient(circle,rgba(99,102,241,0.06) 0%,transparent 70%);pointer-events:none;z-index:0}
+.card{position:relative;z-index:1;background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:48px 40px;max-width:420px;width:100%;text-align:center;box-shadow:0 1px 2px rgba(0,0,0,0.3),0 4px 16px rgba(0,0,0,0.2);animation:fadeIn 0.4s ease-out}
+.icon{margin-bottom:20px}
+.icon svg{width:48px;height:48px;color:var(--accent);opacity:0.8}
+.code{font-family:var(--mono);font-size:4rem;font-weight:700;letter-spacing:-2px;color:var(--accent);line-height:1;margin-bottom:8px}
+.title{font-size:1.25rem;font-weight:600;margin-bottom:12px}
+.desc{color:var(--text3);font-size:0.85rem;line-height:1.6;margin-bottom:32px}
+.back{display:inline-block;padding:10px 24px;background:var(--accent);color:#fff;border:none;border-radius:8px;font-size:0.9rem;font-weight:600;text-decoration:none;cursor:pointer;transition:background 0.2s,transform 0.1s,box-shadow 0.2s}
+.back:hover{background:var(--accent-dim);box-shadow:0 4px 12px rgba(99,102,241,0.25)}
+.back:active{transform:scale(0.98)}
+.footer{margin-top:32px;color:var(--text3);font-size:0.72rem}
+</style>
+</head>
+<body>
+<div class="backdrop"></div>
+<div class="card">
+  <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/></svg></div>
+  <div class="code">404</div>
+  <div class="title">Page not found</div>
+  <p class="desc">The page you're looking for doesn't exist or has been moved.</p>
+  <a class="back" href="/dashboard">Back to Dashboard</a>
+  <p class="footer">oktsec</p>
 </div>
 </body>
 </html>`))

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -93,6 +93,12 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 		}
 		writeJSON(w, http.StatusOK, item)
 	})
+	// Root splash page
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = dashboard.SplashTmpl.Execute(w, nil)
+	})
+
 	// Mount dashboard (auth middleware applied internally)
 	mux.Handle("/dashboard/", dash.Handler())
 	mux.Handle("/dashboard", dash.Handler())

--- a/internal/proxy/webhook.go
+++ b/internal/proxy/webhook.go
@@ -2,8 +2,10 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -13,6 +15,88 @@ import (
 
 	"github.com/oktsec/oktsec/internal/config"
 )
+
+// blockedCIDRs is a comprehensive list of RFC special-use IP ranges that
+// must never be used as webhook destinations (SSRF prevention).
+// Covers: private, loopback, link-local, documentation, benchmarking,
+// multicast, reserved, and IPv6 transition mechanism prefixes.
+var blockedCIDRs = func() []*net.IPNet {
+	cidrs := []string{
+		"0.0.0.0/8",        // "This" network (RFC 1122)
+		"10.0.0.0/8",       // Private-Use (RFC 1918)
+		"100.64.0.0/10",    // Shared Address / CGN (RFC 6598)
+		"127.0.0.0/8",      // Loopback (RFC 1122)
+		"169.254.0.0/16",   // Link-Local (RFC 3927)
+		"172.16.0.0/12",    // Private-Use (RFC 1918)
+		"192.0.0.0/24",     // IETF Protocol Assignments (RFC 6890)
+		"192.0.2.0/24",     // TEST-NET-1 (RFC 5737)
+		"192.168.0.0/16",   // Private-Use (RFC 1918)
+		"198.18.0.0/15",    // Benchmarking (RFC 2544)
+		"198.51.100.0/24",  // TEST-NET-2 (RFC 5737)
+		"203.0.113.0/24",   // TEST-NET-3 (RFC 5737)
+		"224.0.0.0/4",      // Multicast (RFC 5771)
+		"240.0.0.0/4",      // Reserved (RFC 1112)
+		"::1/128",          // IPv6 Loopback
+		"fc00::/7",         // IPv6 Unique Local (RFC 4193)
+		"fe80::/10",        // IPv6 Link-Local (RFC 4291)
+		"2001:db8::/32",    // IPv6 Documentation (RFC 3849)
+		"2001::/32",        // Teredo (RFC 4380) — embeds IPv4
+		"2002::/16",        // 6to4 (RFC 3056) — embeds IPv4
+		"64:ff9b::/96",     // NAT64 (RFC 6052) — embeds IPv4
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err == nil {
+			nets = append(nets, ipnet)
+		}
+	}
+	return nets
+}()
+
+// isBlockedIP checks if an IP falls within any RFC special-use range.
+func isBlockedIP(ip net.IP) bool {
+	// Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) to IPv4 so
+	// that IPv4 CIDRs match correctly.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	for _, cidr := range blockedCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// safeDialContext resolves DNS and validates the resolved IP before connecting.
+// This prevents DNS rebinding and TOCTOU attacks where a hostname resolves to
+// a public IP during URL validation but to a private IP at connection time.
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses for %q", host)
+	}
+
+	// Reject if ANY resolved IP is in a blocked range
+	for _, ip := range ips {
+		if isBlockedIP(ip.IP) {
+			return nil, fmt.Errorf("blocked: %s resolves to %s (private/reserved range)", host, ip.IP)
+		}
+	}
+
+	// Connect directly to validated IP (prevents re-resolution TOCTOU)
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}
 
 // WebhookEvent is the payload sent to webhook endpoints.
 type WebhookEvent struct {
@@ -47,9 +131,17 @@ func NewWebhookNotifier(webhooks []config.Webhook, logger *slog.Logger) *Webhook
 		webhooks: valid,
 		client: &http.Client{
 			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				DialContext: safeDialContext,
+			},
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				if len(via) >= 2 {
 					return errors.New("too many redirects")
+				}
+				// Validate redirect destination URL (defense-in-depth;
+				// safeDialContext also validates at connection time)
+				if err := validateWebhookURL(req.URL.String()); err != nil {
+					return fmt.Errorf("redirect to blocked URL: %w", err)
 				}
 				return nil
 			},
@@ -58,7 +150,9 @@ func NewWebhookNotifier(webhooks []config.Webhook, logger *slog.Logger) *Webhook
 	}
 }
 
-// validateWebhookURL rejects private/loopback IPs to prevent SSRF.
+// validateWebhookURL performs pre-DNS validation on webhook URLs.
+// It rejects non-HTTP schemes, alternative IP encodings, and known
+// blocked IP ranges. Post-DNS validation happens in safeDialContext.
 func validateWebhookURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -68,13 +162,60 @@ func validateWebhookURL(rawURL string) error {
 		return errors.New("webhook URL must use http or https")
 	}
 	host := u.Hostname()
+
+	// Reject alternative numeric IP encodings (hex, octal, packed decimal)
+	// that bypass standard net.ParseIP but some HTTP stacks interpret.
+	if looksLikeAlternativeIP(host) {
+		return errors.New("webhook URL contains alternative IP encoding")
+	}
+
+	// Check parsed IP against comprehensive CIDR blocklist
 	ip := net.ParseIP(host)
 	if ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-			return errors.New("webhook URL must not point to private/loopback addresses")
+		if isBlockedIP(ip) {
+			return errors.New("webhook URL points to a blocked IP range")
 		}
 	}
 	return nil
+}
+
+// looksLikeAlternativeIP detects hex (0xA9FEA9FE), dot-separated hex
+// (0x7f.0x00.0x00.0x01), octal (0177.0.0.1), and packed decimal
+// (2130706433) hostnames used to bypass SSRF IP blocklists.
+func looksLikeAlternativeIP(host string) bool {
+	// Hex prefix: 0xA9FEA9FE
+	if len(host) > 2 && (host[:2] == "0x" || host[:2] == "0X") {
+		return true
+	}
+	// Dot-separated with hex octets or leading-zero octal octets
+	parts := strings.Split(host, ".")
+	if len(parts) == 4 {
+		for _, p := range parts {
+			if len(p) > 2 && (p[:2] == "0x" || p[:2] == "0X") {
+				return true // hex octet
+			}
+			if len(p) > 1 && p[0] == '0' && isAllDigits(p) {
+				return true // leading-zero octal
+			}
+		}
+	}
+	// Packed decimal: pure numeric hostname (e.g. 2130706433 = 127.0.0.1)
+	if isAllDigits(host) {
+		return true
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // Notify sends the event to all matching webhooks (fire-and-forget).


### PR DESCRIPTION
## Summary

- **Login page**: replaced emoji lock with SVG shield-lock icon, added radial gradient backdrop, card fade-in animation, accent glow ring on input focus, button hover scale + active press effect, and styled error state with red-tinted background strip and alert icon
- **404 page**: new standalone page (compass SVG, large `404` mono heading, "Back to Dashboard" button) — replaces Go's plain-text `404 page not found` for all unmatched `/dashboard/` paths plus agent/event/category not-found cases
- **Root splash**: landing page at `/` with large `OKTSEC` gradient text, pulsing backdrop, and links to Dashboard and Health endpoints

## Test plan

- [x] Visit `/` — splash page with OKTSEC branding
- [x] Visit `/dashboard/login` — redesigned login with SVG icon, animations
- [x] Submit wrong code — styled error strip with alert icon
- [x] Visit `/dashboard/nonexistent` — custom 404 page
- [x] Visit `/dashboard/agents/fake-agent` — custom 404 page
- [x] Login flow still works with valid access code