### PR TITLE
feat: dashboard redesign, SSRF hardening, webhook enrichment

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,8 +92,19 @@ type ForwardProxyConfig struct {
 
 // Webhook defines an outgoing notification endpoint.
 type Webhook struct {
+	Name   string   `yaml:"name,omitempty"` // friendly name for dashboard selection
 	URL    string   `yaml:"url"`
 	Events []string `yaml:"events"` // blocked, quarantined, rejected
+}
+
+// WebhookByName returns the first webhook with the given name, or nil.
+func (c *Config) WebhookByName(name string) *Webhook {
+	for i := range c.Webhooks {
+		if c.Webhooks[i].Name == name {
+			return &c.Webhooks[i]
+		}
+	}
+	return nil
 }
 
 // Load reads and parses an oktsec config file.

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -135,6 +135,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /dashboard/api/rule/{id}/toggle", s.handleToggleRule)
 	s.mux.HandleFunc("POST /dashboard/api/category/{name}/toggle", s.handleToggleCategory)
 
+	// Webhook channels
+	s.mux.HandleFunc("POST /dashboard/settings/webhooks", s.handleSaveWebhookChannel)
+	s.mux.HandleFunc("DELETE /dashboard/settings/webhooks/{name}", s.handleDeleteWebhookChannel)
+
 	// Catch-all for unmatched dashboard paths (must be registered last)
 	s.mux.HandleFunc("GET /dashboard/", s.handleNotFound)
 }

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -828,11 +828,11 @@ func TestServer_EnforcementSaveAndDisplay(t *testing.T) {
 
 	// Save an override with template
 	form := url.Values{
-		"rule_id":  {"CRED_001"},
-		"action":   {"block"},
-		"severity": {"critical"},
-		"notify":   {"https://hooks.slack.com/test"},
-		"template": {"Alert: {{RULE}} fired with {{SEVERITY}}"},
+		"rule_id":     {"CRED_001"},
+		"action":      {"block"},
+		"severity":    {"critical"},
+		"notify_urls": {"https://hooks.slack.com/test"},
+		"template":    {"Alert: {{RULE}} fired with {{SEVERITY}}"},
 	}
 	req := httptest.NewRequest("POST", "/dashboard/rules/enforcement", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/proxy/webhook.go
+++ b/internal/proxy/webhook.go
@@ -106,6 +106,9 @@ type WebhookEvent struct {
 	To        string `json:"to"`
 	Severity  string `json:"severity,omitempty"`
 	Rule      string `json:"rule,omitempty"`
+	RuleName  string `json:"rule_name,omitempty"`
+	Category  string `json:"category,omitempty"`
+	Match     string `json:"match,omitempty"`
 	Timestamp string `json:"timestamp"`
 }
 
@@ -258,6 +261,9 @@ func (n *WebhookNotifier) NotifyTemplated(rawURL, tmpl string, event WebhookEven
 func RenderTemplate(tmpl string, event WebhookEvent) string {
 	r := strings.NewReplacer(
 		"{{RULE}}", event.Rule,
+		"{{RULE_NAME}}", event.RuleName,
+		"{{CATEGORY}}", event.Category,
+		"{{MATCH}}", event.Match,
 		"{{ACTION}}", event.Event,
 		"{{SEVERITY}}", event.Severity,
 		"{{FROM}}", event.From,
@@ -272,7 +278,7 @@ func RenderTemplate(tmpl string, event WebhookEvent) string {
 
 // DefaultWebhookTemplate is the plain-text default shown in the UI.
 // RenderTemplate wraps it in Slack JSON automatically.
-const DefaultWebhookTemplate = "Rule *{{RULE}}* triggered\n• Action: {{ACTION}}\n• Severity: {{SEVERITY}}\n• From: {{FROM}} → {{TO}}\n• Message: {{MESSAGE_ID}}"
+const DefaultWebhookTemplate = "\U0001f6a8 *{{RULE}}* \u2014 {{RULE_NAME}}\n\u2022 *Severity:* {{SEVERITY}} | *Category:* {{CATEGORY}}\n\u2022 *Agents:* {{FROM}} \u2192 {{TO}}\n\u2022 *Match:* `{{MATCH}}`\n\u2022 *Message:* {{MESSAGE_ID}}\n\u2022 *Time:* {{TIMESTAMP}}"
 
 func (n *WebhookNotifier) sendRaw(url, body string) {
 	resp, err := n.client.Post(url, "application/json", strings.NewReader(body))

--- a/internal/proxy/webhook_test.go
+++ b/internal/proxy/webhook_test.go
@@ -61,10 +61,13 @@ func TestRenderTemplate_AllTags(t *testing.T) {
 		To:        "receiver",
 		Severity:  "high",
 		Rule:      "PI-002",
+		RuleName:  "Prompt Injection",
+		Category:  "injection",
+		Match:     "ignore previous instructions",
 		Timestamp: "2026-02-24T12:00:00Z",
 	}
 
-	tmpl := "{{RULE}} {{ACTION}} {{SEVERITY}} {{FROM}} {{TO}} {{MESSAGE_ID}} {{TIMESTAMP}}"
+	tmpl := "{{RULE}} {{RULE_NAME}} {{CATEGORY}} {{MATCH}} {{ACTION}} {{SEVERITY}} {{FROM}} {{TO}} {{MESSAGE_ID}} {{TIMESTAMP}}"
 	result := RenderTemplate(tmpl, event)
 
 	var payload map[string]string
@@ -73,7 +76,7 @@ func TestRenderTemplate_AllTags(t *testing.T) {
 	}
 
 	text := payload["text"]
-	expected := "PI-002 blocked high sender receiver msg-456 2026-02-24T12:00:00Z"
+	expected := "PI-002 Prompt Injection injection ignore previous instructions blocked high sender receiver msg-456 2026-02-24T12:00:00Z"
 	if text != expected {
 		t.Errorf("text = %q, want %q", text, expected)
 	}


### PR DESCRIPTION
## Summary

- **Login & splash pages**: Redesigned login page, new 404 page, and root splash screen
- **SSRF hardening**: Comprehensive webhook URL validation against RFC special-use IP ranges, DNS rebinding protection, and credential redaction in logs
- **Webhook notification enrichment**: Events now include `rule_name`, `category`, and `match` fields from FindingSummary — operators get actionable context in Slack/Discord alerts instead of bare rule IDs
- **Named webhook channels**: Define webhook destinations once by name in settings, reference them in enforcement overrides instead of pasting raw URLs. Dashboard gets channel management UI and chip-based selection in the enforcement form

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all packages)
- [x] Manual test: sent malicious message triggering CMDEXEC_003 → Slack received enriched notification with rule name, category, and match content
- [x] Verify dashboard enforcement form shows new template variables and channel chips
- [x] Verify webhook channel CRUD in settings page persists to config