### PR TITLE
feat: expand MCP client discovery to 17 clients

### DIFF
--- a/internal/discover/paths.go
+++ b/internal/discover/paths.go
@@ -1,5 +1,5 @@
 // Package discover auto-detects MCP client configurations and agent
-// framework installations (Claude Desktop, Cursor, VS Code, OpenClaw, NanoClaw).
+// framework installations.
 package discover
 
 import (
@@ -10,8 +10,9 @@ import (
 
 // Client represents a known MCP client application.
 type Client struct {
-	Name  string
-	Paths []string // Config file paths to check
+	Name      string
+	Paths     []string // Config file paths to check
+	ConfigKey string   // JSON key for server map ("" = "mcpServers")
 }
 
 // KnownClients returns all supported MCP client applications with their config paths.
@@ -27,20 +28,73 @@ func KnownClients() []Client {
 			Paths: []string{filepath.Join(home, ".cursor", "mcp.json")},
 		},
 		{
-			Name:  "vscode",
-			Paths: []string{filepath.Join(home, ".vscode", "mcp.json")},
+			Name:      "vscode",
+			Paths:     []string{filepath.Join(home, ".vscode", "mcp.json")},
+			ConfigKey: "servers", // VS Code native MCP uses "servers"; parser also tries "mcpServers" fallback
 		},
 		{
 			Name:  "cline",
 			Paths: []string{filepath.Join(home, ".cline", "mcp_settings.json")},
 		},
 		{
-			Name:  "windsurf",
-			Paths: []string{filepath.Join(home, ".windsurf", "mcp.json")},
+			Name: "windsurf",
+			Paths: []string{
+				filepath.Join(home, ".windsurf", "mcp.json"),
+				filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"),
+			},
 		},
 		{
 			Name:  "openclaw",
 			Paths: []string{filepath.Join(home, ".openclaw", "openclaw.json")},
+		},
+		// --- New clients ---
+		{
+			Name:      "opencode",
+			Paths:     []string{filepath.Join(home, ".config", "opencode", "opencode.json")},
+			ConfigKey: "opencode", // custom parser signal
+		},
+		{
+			Name:      "zed",
+			Paths:     []string{filepath.Join(home, ".config", "zed", "settings.json")},
+			ConfigKey: "context_servers",
+		},
+		{
+			Name:      "amp",
+			Paths:     []string{filepath.Join(home, ".config", "amp", "settings.json")},
+			ConfigKey: "mcpServers",
+		},
+		{
+			Name:  "gemini-cli",
+			Paths: []string{filepath.Join(home, ".gemini", "settings.json")},
+		},
+		{
+			Name:  "copilot-cli",
+			Paths: []string{filepath.Join(home, ".copilot", "mcp-config.json")},
+		},
+		{
+			Name:  "amazon-q",
+			Paths: []string{filepath.Join(home, ".aws", "amazonq", "mcp.json")},
+		},
+		{
+			Name:      "claude-code",
+			Paths:     []string{filepath.Join(home, ".claude.json")},
+			ConfigKey: "claude-code", // custom parser signal
+		},
+		{
+			Name:  "roo-code",
+			Paths: rooCodePaths(home),
+		},
+		{
+			Name:  "kilo-code",
+			Paths: kiloCodePaths(home),
+		},
+		{
+			Name:  "boltai",
+			Paths: boltAIPaths(home),
+		},
+		{
+			Name:  "jetbrains",
+			Paths: []string{filepath.Join(home, ".junie", "mcp", "mcp.json")},
 		},
 	}
 	return clients
@@ -67,4 +121,57 @@ func claudeDesktopPaths(home string) []string {
 	default:
 		return nil
 	}
+}
+
+func rooCodePaths(home string) []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(home, ".config", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		return []string{
+			filepath.Join(appdata, "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+func kiloCodePaths(home string) []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(home, ".config", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		return []string{
+			filepath.Join(appdata, "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+func boltAIPaths(home string) []string {
+	if runtime.GOOS == "darwin" {
+		return []string{filepath.Join(home, ".boltai", "mcp.json")}
+	}
+	return nil
 }

--- a/internal/discover/scanner_test.go
+++ b/internal/discover/scanner_test.go
@@ -74,6 +74,254 @@ func TestParseConfigFile_NoFile(t *testing.T) {
 	}
 }
 
+func TestParseConfigWithKey_ServersKey(t *testing.T) {
+	dir := t.TempDir()
+	// VS Code native MCP uses "servers" key
+	config := map[string]any{
+		"servers": map[string]mcpServerJSON{
+			"my-tool": {Command: "node", Args: []string{"server.js"}},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "mcp.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseConfigWithKey(path, "servers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "my-tool" {
+		t.Errorf("name = %q, want my-tool", servers[0].Name)
+	}
+	if servers[0].Command != "node" {
+		t.Errorf("command = %q, want node", servers[0].Command)
+	}
+}
+
+func TestParseConfigWithKey_ServersKeyFallbackToMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	// Config file with mcpServers but queried with "servers" key — should fallback
+	config := map[string]any{
+		"mcpServers": map[string]mcpServerJSON{
+			"fallback-tool": {Command: "python", Args: []string{"serve.py"}},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "mcp.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseConfigWithKey(path, "servers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "fallback-tool" {
+		t.Errorf("name = %q, want fallback-tool", servers[0].Name)
+	}
+}
+
+func TestParseConfigWithKey_EmptyKeyDefaultsToMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, "mcp.json", map[string]mcpServerJSON{
+		"test-srv": {Command: "test"},
+	})
+
+	servers, err := parseConfigWithKey(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "test-srv" {
+		t.Errorf("name = %q, want test-srv", servers[0].Name)
+	}
+}
+
+func TestParseOpenCodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcp": map[string]any{
+			"my-server": map[string]any{
+				"command":     []string{"npx", "-y", "@mcp/server"},
+				"environment": map[string]string{"API_KEY": "secret"},
+			},
+			"simple": map[string]any{
+				"command": []string{"mcp-tool"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "opencode.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseOpenCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("got %d servers, want 2", len(servers))
+	}
+
+	found := map[string]MCPServer{}
+	for _, s := range servers {
+		found[s.Name] = s
+	}
+
+	srv := found["my-server"]
+	if srv.Command != "npx" {
+		t.Errorf("my-server command = %q, want npx", srv.Command)
+	}
+	if len(srv.Args) != 2 || srv.Args[0] != "-y" || srv.Args[1] != "@mcp/server" {
+		t.Errorf("my-server args = %v, want [-y @mcp/server]", srv.Args)
+	}
+	if srv.Env["API_KEY"] != "secret" {
+		t.Errorf("my-server env = %v", srv.Env)
+	}
+
+	simple := found["simple"]
+	if simple.Command != "mcp-tool" {
+		t.Errorf("simple command = %q, want mcp-tool", simple.Command)
+	}
+	if len(simple.Args) != 0 {
+		t.Errorf("simple args = %v, want empty", simple.Args)
+	}
+}
+
+func TestParseOpenCodeConfig_NoMCPKey(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`{"theme": "dark"}`)
+	path := filepath.Join(dir, "opencode.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseOpenCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("got %d servers, want 0", len(servers))
+	}
+}
+
+func TestParseClaudeCodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"global-srv": map[string]any{
+				"command": "npx",
+				"args":    []string{"@mcp/global"},
+			},
+		},
+		"projects": map[string]any{
+			"/home/user/project-a": map[string]any{
+				"mcpServers": map[string]any{
+					"project-srv": map[string]any{
+						"command": "node",
+						"args":    []string{"local.js"},
+					},
+				},
+			},
+			"/home/user/project-b": map[string]any{
+				"mcpServers": map[string]any{
+					"global-srv": map[string]any{
+						"command": "npx",
+						"args":    []string{"@mcp/global"},
+					},
+					"another-srv": map[string]any{
+						"command": "python",
+						"args":    []string{"serve.py"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have 3 unique servers: global-srv, project-srv, another-srv
+	// global-srv appears in both top-level and project-b but should be deduped
+	if len(servers) != 3 {
+		t.Fatalf("got %d servers, want 3 (deduped)", len(servers))
+	}
+
+	found := map[string]bool{}
+	for _, s := range servers {
+		found[s.Name] = true
+	}
+	for _, name := range []string{"global-srv", "project-srv", "another-srv"} {
+		if !found[name] {
+			t.Errorf("missing server %q", name)
+		}
+	}
+}
+
+func TestParseClaudeCodeConfig_TopLevelOnly(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"only-srv": map[string]any{
+				"command": "echo",
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "only-srv" {
+		t.Errorf("name = %q, want only-srv", servers[0].Name)
+	}
+}
+
+func TestParseClaudeCodeConfig_NoServers(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`{"theme": "dark"}`)
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("got %d servers, want 0", len(servers))
+	}
+}
+
+func TestKnownClients_Count(t *testing.T) {
+	clients := KnownClients()
+	// 6 original + 11 new = 17
+	if len(clients) != 17 {
+		t.Errorf("got %d clients, want 17", len(clients))
+	}
+
+	names := map[string]bool{}
+	for _, c := range clients {
+		if names[c.Name] {
+			t.Errorf("duplicate client name: %s", c.Name)
+		}
+		names[c.Name] = true
+	}
+}
+
 func TestFormatTree(t *testing.T) {
 	result := &Result{
 		Clients: []ClientResult{
@@ -106,6 +354,12 @@ func TestFormatTree_Empty(t *testing.T) {
 	output := FormatTree(result)
 	if !strings.Contains(output, "No MCP configurations found") {
 		t.Error("empty result should show 'no configs found'")
+	}
+	// Verify new clients are listed
+	for _, name := range []string{"OpenCode", "Zed", "Amp", "Gemini CLI", "Claude Code", "BoltAI", "JetBrains"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("empty message should list %s", name)
+		}
 	}
 }
 
@@ -176,5 +430,32 @@ func TestWrapUnwrap(t *testing.T) {
 	fsSrv = restoredCfg.MCPServers["filesystem"]
 	if fsSrv.Command != "npx" {
 		t.Errorf("unwrapped command = %q, want npx", fsSrv.Command)
+	}
+}
+
+func TestClientDisplayName_AllClients(t *testing.T) {
+	expected := map[string]string{
+		"claude-desktop": "Claude Desktop",
+		"cursor":         "Cursor",
+		"vscode":         "VS Code",
+		"cline":          "Cline",
+		"windsurf":       "Windsurf",
+		"openclaw":       "OpenClaw",
+		"opencode":       "OpenCode",
+		"zed":            "Zed",
+		"amp":            "Amp",
+		"gemini-cli":     "Gemini CLI",
+		"copilot-cli":    "Copilot CLI",
+		"amazon-q":       "Amazon Q",
+		"claude-code":    "Claude Code",
+		"roo-code":       "Roo Code",
+		"kilo-code":      "Kilo Code",
+		"boltai":         "BoltAI",
+		"jetbrains":      "JetBrains",
+	}
+	for name, want := range expected {
+		if got := clientDisplayName(name); got != want {
+			t.Errorf("clientDisplayName(%q) = %q, want %q", name, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **11 new MCP clients** added to `oktsec discover`: OpenCode, Zed, Amp, Gemini CLI, Copilot CLI, Amazon Q, Claude Code, Roo Code, Kilo Code, BoltAI, and JetBrains/Junie
- **VS Code fix**: native MCP uses `"servers"` key — now tries `"servers"` first with `"mcpServers"` fallback
- **Windsurf**: added alternate config path `~/.codeium/windsurf/mcp_config.json`
- **Custom parsers** for non-standard formats:
  - **OpenCode**: `{"mcp": {"name": {"command": ["cmd", "arg"]}}}` — command as array
  - **Claude Code**: `~/.claude.json` with nested project scopes and server deduplication
- **Platform-specific paths** for Roo Code, Kilo Code (macOS/Linux/Windows), BoltAI (macOS only)
- `ConfigKey` field added to `Client` struct for configurable JSON key extraction

### Clients supported (6 → 17)

| Client | Config key | Parser |
|--------|-----------|--------|
| Claude Desktop | `mcpServers` | Standard |
| Cursor | `mcpServers` | Standard |
| VS Code | `servers` + `mcpServers` fallback | Standard |
| Cline | `mcpServers` | Standard |
| Windsurf | `mcpServers` | Standard (2 paths) |
| OpenClaw | custom | Custom |
| **OpenCode** | `mcp` | Custom (command=array) |
| **Zed** | `context_servers` | Configurable key |
| **Amp** | `mcpServers` | Standard |
| **Gemini CLI** | `mcpServers` | Standard |
| **Copilot CLI** | `mcpServers` | Standard |
| **Amazon Q** | `mcpServers` | Standard |
| **Claude Code** | `mcpServers` (nested) | Custom (scope dedup) |
| **Roo Code** | `mcpServers` | Standard (platform paths) |
| **Kilo Code** | `mcpServers` | Standard (platform paths) |
| **BoltAI** | `mcpServers` | Standard (macOS only) |
| **JetBrains** | `mcpServers` | Standard |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./internal/discover/` — all tests pass
- [x] New tests: `TestParseConfigWithKey_ServersKey`, `TestParseConfigWithKey_ServersKeyFallbackToMCPServers`, `TestParseOpenCodeConfig`, `TestParseClaudeCodeConfig` (dedup), `TestKnownClients_Count`, `TestClientDisplayName_AllClients`
- [x] Manual: `oktsec discover` on machine with various clients installed