### PR TITLE
fix: harden proxy against replay, SSRF, and identity spoofing

### DIFF
--- a/internal/proxy/webhook.go
+++ b/internal/proxy/webhook.go
@@ -43,6 +43,7 @@ var blockedCIDRs = func() []*net.IPNet {
 		"2001::/32",        // Teredo (RFC 4380) — embeds IPv4
 		"2002::/16",        // 6to4 (RFC 3056) — embeds IPv4
 		"64:ff9b::/96",     // NAT64 (RFC 6052) — embeds IPv4
+		"ff00::/8",         // IPv6 Multicast (RFC 4291)
 	}
 	nets := make([]*net.IPNet, 0, len(cidrs))
 	for _, cidr := range cidrs {

--- a/internal/proxy/webhook_test.go
+++ b/internal/proxy/webhook_test.go
@@ -243,6 +243,8 @@ func TestIsBlockedIP(t *testing.T) {
 		{"fc00::1", true},              // IPv6 ULA
 		{"2001:db8::1", true},          // IPv6 documentation
 		{"2607:f8b0:4004:800::200e", false}, // Google IPv6
+		{"ff02::1", true},                   // IPv6 multicast all-nodes
+		{"ff05::1", true},                   // IPv6 multicast site-local
 	}
 	for _, tc := range tests {
 		ip := net.ParseIP(tc.ip)


### PR DESCRIPTION
## Summary

Security hardening for the proxy message handler and webhook subsystem:

- **IPv6 multicast SSRF block**: Added `ff00::/8` to webhook CIDR blocklist, preventing SSRF via multicast addresses (RFC 4291)
- **Timestamp freshness validation**: Messages older than 5 minutes or with future timestamps are now rejected, mitigating replay attacks
- **Unverified sender warning**: Log a warning when `require_signature: false` and a message arrives without identity verification

## Test plan

- [x] `make test` passes (16 packages)
- [x] IPv6 multicast addresses (`ff02::1`, `ff05::1`) correctly blocked in webhook tests
- [x] Stale timestamp (>5min) returns 400
- [x] Future timestamp (>30s ahead) returns 400
- [x] Existing tests updated to use `time.Now()` instead of hardcoded timestamps