### PR TITLE
fix: harden SSRF, symlink, and file-size attack surfaces

### DIFF
--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -24,7 +24,11 @@ func newTestForwardProxy(t *testing.T, cfg *config.ForwardProxyConfig) (*Forward
 	scanner := engine.NewScanner("")
 	t.Cleanup(func() { scanner.Close() })
 	rl := NewRateLimiter(0, 60)
-	return NewForwardProxy(cfg, scanner, store, rl, logger), store
+	fp := NewForwardProxy(cfg, scanner, store, rl, logger)
+	// Override transport to allow localhost connections in tests
+	// (safeDialContext blocks loopback IPs by design)
+	fp.transport = &http.Transport{}
+	return fp, store
 }
 
 func TestForwardProxy_HTTP_Clean(t *testing.T) {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -57,7 +57,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	scanner := engine.NewScanner(cfg.CustomRulesDir)
 
 	// Audit store
-	auditStore, err := audit.NewStore("oktsec.db", logger, cfg.Quarantine.RetentionDays)
+	auditStore, err := audit.NewStore(cfg.DBPath, logger, cfg.Quarantine.RetentionDays)
 	if err != nil {
 		return nil, fmt.Errorf("opening audit store: %w", err)
 	}

--- a/internal/proxy/ssrf.go
+++ b/internal/proxy/ssrf.go
@@ -1,0 +1,146 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// blockedCIDRs is a comprehensive list of RFC special-use IP ranges that
+// must never be used as outbound destinations (SSRF prevention).
+// Covers: private, loopback, link-local, documentation, benchmarking,
+// multicast, reserved, and IPv6 transition mechanism prefixes.
+var blockedCIDRs = func() []*net.IPNet {
+	cidrs := []string{
+		"0.0.0.0/8",        // "This" network (RFC 1122)
+		"10.0.0.0/8",       // Private-Use (RFC 1918)
+		"100.64.0.0/10",    // Shared Address / CGN (RFC 6598)
+		"127.0.0.0/8",      // Loopback (RFC 1122)
+		"169.254.0.0/16",   // Link-Local (RFC 3927)
+		"172.16.0.0/12",    // Private-Use (RFC 1918)
+		"192.0.0.0/24",     // IETF Protocol Assignments (RFC 6890)
+		"192.0.2.0/24",     // TEST-NET-1 (RFC 5737)
+		"192.168.0.0/16",   // Private-Use (RFC 1918)
+		"198.18.0.0/15",    // Benchmarking (RFC 2544)
+		"198.51.100.0/24",  // TEST-NET-2 (RFC 5737)
+		"203.0.113.0/24",   // TEST-NET-3 (RFC 5737)
+		"224.0.0.0/4",      // Multicast (RFC 5771)
+		"240.0.0.0/4",      // Reserved (RFC 1112)
+		"::1/128",          // IPv6 Loopback
+		"fc00::/7",         // IPv6 Unique Local (RFC 4193)
+		"fe80::/10",        // IPv6 Link-Local (RFC 4291)
+		"2001:db8::/32",    // IPv6 Documentation (RFC 3849)
+		"2001::/32",        // Teredo (RFC 4380) — embeds IPv4
+		"2002::/16",        // 6to4 (RFC 3056) — embeds IPv4
+		"64:ff9b::/96",     // NAT64 (RFC 6052) — embeds IPv4
+		"ff00::/8",         // IPv6 Multicast (RFC 4291)
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err == nil {
+			nets = append(nets, ipnet)
+		}
+	}
+	return nets
+}()
+
+// isBlockedIP checks if an IP falls within any RFC special-use range.
+func isBlockedIP(ip net.IP) bool {
+	// Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) to IPv4 so
+	// that IPv4 CIDRs match correctly.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	for _, cidr := range blockedCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeAlternativeIP detects hex (0xA9FEA9FE), dot-separated hex
+// (0x7f.0x00.0x00.0x01), octal (0177.0.0.1), and packed decimal
+// (2130706433) hostnames used to bypass SSRF IP blocklists.
+func looksLikeAlternativeIP(host string) bool {
+	// Hex prefix: 0xA9FEA9FE
+	if len(host) > 2 && (host[:2] == "0x" || host[:2] == "0X") {
+		return true
+	}
+	// Dot-separated with hex octets or leading-zero octal octets
+	parts := strings.Split(host, ".")
+	if len(parts) == 4 {
+		for _, p := range parts {
+			if len(p) > 2 && (p[:2] == "0x" || p[:2] == "0X") {
+				return true // hex octet
+			}
+			if len(p) > 1 && p[0] == '0' && isAllDigits(p) {
+				return true // leading-zero octal
+			}
+		}
+	}
+	// Packed decimal: pure numeric hostname (e.g. 2130706433 = 127.0.0.1)
+	if isAllDigits(host) {
+		return true
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ValidateHost performs pre-connection validation of a host string.
+// It rejects alternative IP encodings and known-blocked IP ranges.
+// This is a reusable check for both webhooks and the forward proxy.
+func ValidateHost(host string) error {
+	if looksLikeAlternativeIP(host) {
+		return errors.New("host uses alternative IP encoding")
+	}
+	ip := net.ParseIP(host)
+	if ip != nil && isBlockedIP(ip) {
+		return fmt.Errorf("host %s is in a blocked IP range", host)
+	}
+	return nil
+}
+
+// safeDialContext resolves DNS and validates the resolved IP before connecting.
+// This prevents DNS rebinding and TOCTOU attacks where a hostname resolves to
+// a public IP during URL validation but to a private IP at connection time.
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses for %q", host)
+	}
+
+	// Reject if ANY resolved IP is in a blocked range
+	for _, ip := range ips {
+		if isBlockedIP(ip.IP) {
+			return nil, fmt.Errorf("blocked: %s resolves to %s (private/reserved range)", host, ip.IP)
+		}
+	}
+
+	// Connect directly to validated IP (prevents re-resolution TOCTOU)
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}

--- a/internal/proxy/ssrf_test.go
+++ b/internal/proxy/ssrf_test.go
@@ -1,0 +1,34 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestValidateHost(t *testing.T) {
+	tests := []struct {
+		host    string
+		wantErr bool
+	}{
+		// Alternative encodings → rejected
+		{"0x7f000001", true},
+		{"2130706433", true},
+		{"0177.0.0.1", true},
+		// Blocked IPs → rejected
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"192.168.1.1", true},
+		// Normal domains → pass
+		{"example.com", false},
+		{"api.github.com", false},
+		// Public IPs → pass
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+
+	for _, tt := range tests {
+		err := ValidateHost(tt.host)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateHost(%q) error=%v, wantErr=%v", tt.host, err, tt.wantErr)
+		}
+	}
+}

--- a/internal/proxy/webhook.go
+++ b/internal/proxy/webhook.go
@@ -2,12 +2,10 @@ package proxy
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,89 +13,6 @@ import (
 
 	"github.com/oktsec/oktsec/internal/config"
 )
-
-// blockedCIDRs is a comprehensive list of RFC special-use IP ranges that
-// must never be used as webhook destinations (SSRF prevention).
-// Covers: private, loopback, link-local, documentation, benchmarking,
-// multicast, reserved, and IPv6 transition mechanism prefixes.
-var blockedCIDRs = func() []*net.IPNet {
-	cidrs := []string{
-		"0.0.0.0/8",        // "This" network (RFC 1122)
-		"10.0.0.0/8",       // Private-Use (RFC 1918)
-		"100.64.0.0/10",    // Shared Address / CGN (RFC 6598)
-		"127.0.0.0/8",      // Loopback (RFC 1122)
-		"169.254.0.0/16",   // Link-Local (RFC 3927)
-		"172.16.0.0/12",    // Private-Use (RFC 1918)
-		"192.0.0.0/24",     // IETF Protocol Assignments (RFC 6890)
-		"192.0.2.0/24",     // TEST-NET-1 (RFC 5737)
-		"192.168.0.0/16",   // Private-Use (RFC 1918)
-		"198.18.0.0/15",    // Benchmarking (RFC 2544)
-		"198.51.100.0/24",  // TEST-NET-2 (RFC 5737)
-		"203.0.113.0/24",   // TEST-NET-3 (RFC 5737)
-		"224.0.0.0/4",      // Multicast (RFC 5771)
-		"240.0.0.0/4",      // Reserved (RFC 1112)
-		"::1/128",          // IPv6 Loopback
-		"fc00::/7",         // IPv6 Unique Local (RFC 4193)
-		"fe80::/10",        // IPv6 Link-Local (RFC 4291)
-		"2001:db8::/32",    // IPv6 Documentation (RFC 3849)
-		"2001::/32",        // Teredo (RFC 4380) — embeds IPv4
-		"2002::/16",        // 6to4 (RFC 3056) — embeds IPv4
-		"64:ff9b::/96",     // NAT64 (RFC 6052) — embeds IPv4
-		"ff00::/8",         // IPv6 Multicast (RFC 4291)
-	}
-	nets := make([]*net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, ipnet, err := net.ParseCIDR(cidr)
-		if err == nil {
-			nets = append(nets, ipnet)
-		}
-	}
-	return nets
-}()
-
-// isBlockedIP checks if an IP falls within any RFC special-use range.
-func isBlockedIP(ip net.IP) bool {
-	// Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) to IPv4 so
-	// that IPv4 CIDRs match correctly.
-	if v4 := ip.To4(); v4 != nil {
-		ip = v4
-	}
-	for _, cidr := range blockedCIDRs {
-		if cidr.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-// safeDialContext resolves DNS and validates the resolved IP before connecting.
-// This prevents DNS rebinding and TOCTOU attacks where a hostname resolves to
-// a public IP during URL validation but to a private IP at connection time.
-func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid address: %w", err)
-	}
-
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
-	}
-	if len(ips) == 0 {
-		return nil, fmt.Errorf("no addresses for %q", host)
-	}
-
-	// Reject if ANY resolved IP is in a blocked range
-	for _, ip := range ips {
-		if isBlockedIP(ip.IP) {
-			return nil, fmt.Errorf("blocked: %s resolves to %s (private/reserved range)", host, ip.IP)
-		}
-	}
-
-	// Connect directly to validated IP (prevents re-resolution TOCTOU)
-	dialer := &net.Dialer{Timeout: 5 * time.Second}
-	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
-}
 
 // WebhookEvent is the payload sent to webhook endpoints.
 type WebhookEvent struct {
@@ -165,61 +80,7 @@ func validateWebhookURL(rawURL string) error {
 	if u.Scheme != "https" && u.Scheme != "http" {
 		return errors.New("webhook URL must use http or https")
 	}
-	host := u.Hostname()
-
-	// Reject alternative numeric IP encodings (hex, octal, packed decimal)
-	// that bypass standard net.ParseIP but some HTTP stacks interpret.
-	if looksLikeAlternativeIP(host) {
-		return errors.New("webhook URL contains alternative IP encoding")
-	}
-
-	// Check parsed IP against comprehensive CIDR blocklist
-	ip := net.ParseIP(host)
-	if ip != nil {
-		if isBlockedIP(ip) {
-			return errors.New("webhook URL points to a blocked IP range")
-		}
-	}
-	return nil
-}
-
-// looksLikeAlternativeIP detects hex (0xA9FEA9FE), dot-separated hex
-// (0x7f.0x00.0x00.0x01), octal (0177.0.0.1), and packed decimal
-// (2130706433) hostnames used to bypass SSRF IP blocklists.
-func looksLikeAlternativeIP(host string) bool {
-	// Hex prefix: 0xA9FEA9FE
-	if len(host) > 2 && (host[:2] == "0x" || host[:2] == "0X") {
-		return true
-	}
-	// Dot-separated with hex octets or leading-zero octal octets
-	parts := strings.Split(host, ".")
-	if len(parts) == 4 {
-		for _, p := range parts {
-			if len(p) > 2 && (p[:2] == "0x" || p[:2] == "0X") {
-				return true // hex octet
-			}
-			if len(p) > 1 && p[0] == '0' && isAllDigits(p) {
-				return true // leading-zero octal
-			}
-		}
-	}
-	// Packed decimal: pure numeric hostname (e.g. 2130706433 = 127.0.0.1)
-	if isAllDigits(host) {
-		return true
-	}
-	return false
-}
-
-func isAllDigits(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return true
+	return ValidateHost(u.Hostname())
 }
 
 // Notify sends the event to all matching webhooks (fire-and-forget).

--- a/internal/safefile/safefile.go
+++ b/internal/safefile/safefile.go
@@ -1,0 +1,46 @@
+// Package safefile provides file I/O helpers that reject symlinks and
+// enforce size limits. Use these instead of os.ReadFile for any
+// security-sensitive path (config, keys, state databases).
+package safefile
+
+import (
+	"fmt"
+	"os"
+)
+
+// RejectSymlink returns an error if path is a symbolic link.
+// It uses Lstat (not Stat) so the check is not followed through the link.
+func RejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symbolic link (rejected for security)", path)
+	}
+	return nil
+}
+
+// ReadFile reads path after verifying it is not a symlink.
+func ReadFile(path string) ([]byte, error) {
+	if err := RejectSymlink(path); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+// ReadFileMax reads path after verifying it is not a symlink and that
+// the file size does not exceed maxBytes.
+func ReadFileMax(path string, maxBytes int64) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s is a symbolic link (rejected for security)", path)
+	}
+	if info.Size() > maxBytes {
+		return nil, fmt.Errorf("%s is too large (%d bytes, max %d)", path, info.Size(), maxBytes)
+	}
+	return os.ReadFile(path)
+}

--- a/internal/safefile/safefile_test.go
+++ b/internal/safefile/safefile_test.go
@@ -1,0 +1,124 @@
+package safefile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRejectSymlink_RegularFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "regular.txt")
+	if err := os.WriteFile(f, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RejectSymlink(f); err != nil {
+		t.Errorf("regular file should pass: %v", err)
+	}
+}
+
+func TestRejectSymlink_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	link := filepath.Join(dir, "link.txt")
+
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	err := RejectSymlink(link)
+	if err == nil {
+		t.Fatal("expected error for symlink")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRejectSymlink_NonExistent(t *testing.T) {
+	err := RejectSymlink("/nonexistent/path/abc123")
+	if err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+}
+
+func TestReadFile_RegularFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "data.txt")
+	want := []byte("hello world")
+	if err := os.WriteFile(f, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadFile_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	link := filepath.Join(dir, "link.txt")
+
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadFile(link)
+	if err == nil {
+		t.Fatal("expected error for symlink")
+	}
+}
+
+func TestReadFileMax_WithinLimit(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "small.txt")
+	data := []byte("small data")
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileMax(f, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("got %q, want %q", got, data)
+	}
+}
+
+func TestReadFileMax_ExceedsLimit(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "big.txt")
+	data := make([]byte, 2048)
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadFileMax(f, 1024)
+	if err == nil {
+		t.Fatal("expected error for oversized file")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestReadFileMax_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	link := filepath.Join(dir, "link.txt")
+
+	if err := os.WriteFile(target, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadFileMax(link, 1<<20)
+	if err == nil {
+		t.Fatal("expected error for symlink")
+	}
+}


### PR DESCRIPTION
## Summary

- **SSRF centralization**: Extract shared SSRF validation (`blockedCIDRs`, `safeDialContext`, `ValidateHost`) into `internal/proxy/ssrf.go`. The forward proxy now uses the same safe dial path as webhooks—blocking raw IPs, hex/octal-encoded addresses, and private-range destinations on both HTTP forwarding and CONNECT tunneling.
- **Symlink guards**: New `internal/safefile` package (`RejectSymlink`, `ReadFile`, `ReadFileMax`) wired into config loading (1 MB cap), key loading (64 KB cap), and the audit store (rejects symlinked DB file and parent directory). `LoadPublicKeys` skips symlinked `.pub` entries.
- **Configurable DB path**: New `db_path` config field (default `oktsec.db`, resolved to absolute at load time) replaces the hardcoded CWD-relative path in `server.go`.

## Test plan

- [x] `go test ./internal/safefile/ -v` — symlink rejection, size limits, regular file pass-through
- [x] `go test ./internal/proxy/ -v` — SSRF tests (`ValidateHost`, `isBlockedIP`, `looksLikeAlternativeIP`), forward proxy and webhook tests pass with safe dial path
- [x] `go test ./internal/config/ -v` — config load with safefile
- [x] `go test ./internal/identity/ -v` — key loading with symlink/size guards
- [x] `go test ./internal/audit/ -v` — audit store with symlink protection
- [x] Full suite: `go test ./...` — all 17 packages pass