### PR TITLE
feat: add MCP gateway management to dashboard

### DIFF
--- a/cmd/oktsec/commands/gateway.go
+++ b/cmd/oktsec/commands/gateway.go
@@ -41,6 +41,9 @@ func newGatewayCmd() *cobra.Command {
 			if err := cfg.Validate(); err != nil {
 				return err
 			}
+			if len(cfg.MCPServers) == 0 {
+				return fmt.Errorf("gateway requires at least one entry in mcp_servers")
+			}
 
 			level := slog.LevelInfo
 			switch cfg.Server.LogLevel {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,11 +252,10 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("rule %q has invalid action %q", ra.ID, ra.Action)
 		}
 	}
-	// Gateway validation
-	if c.Gateway.Enabled {
-		if len(c.MCPServers) == 0 {
-			return fmt.Errorf("gateway is enabled but no mcp_servers configured")
-		}
+	// Gateway validation (transport checks only; backend count and port
+	// binding are validated at gateway startup so `serve` can manage it
+	// via the dashboard).
+	if c.Gateway.Enabled && len(c.MCPServers) > 0 {
 		if c.Gateway.Port < 1 || c.Gateway.Port > 65535 {
 			return fmt.Errorf("invalid gateway port: %d", c.Gateway.Port)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -300,10 +300,12 @@ mcp_servers:
 }
 
 func TestGatewayValidate_NoServers(t *testing.T) {
+	// Gateway enabled without mcp_servers is allowed at config level;
+	// the gateway command validates backend count at startup.
 	cfg := Defaults()
 	cfg.Gateway.Enabled = true
-	if err := cfg.Validate(); err == nil {
-		t.Error("gateway enabled without mcp_servers should be invalid")
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("gateway enabled without mcp_servers should be valid at config level: %v", err)
 	}
 }
 

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1384,13 +1385,18 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	canMessage := strings.Fields(strings.ReplaceAll(r.FormValue("can_message"), ",", " "))
 	tags := strings.Fields(strings.ReplaceAll(r.FormValue("tags"), ",", " "))
 
+	blockedContent := strings.Fields(strings.ReplaceAll(r.FormValue("blocked_content"), ",", " "))
+	allowedTools := strings.Fields(strings.ReplaceAll(r.FormValue("allowed_tools"), ",", " "))
+
 	s.cfg.Agents[name] = config.Agent{
-		CanMessage:  canMessage,
-		Description: strings.TrimSpace(r.FormValue("description")),
-		CreatedBy:   "dashboard",
-		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-		Location:    strings.TrimSpace(r.FormValue("location")),
-		Tags:        tags,
+		CanMessage:     canMessage,
+		Description:    strings.TrimSpace(r.FormValue("description")),
+		CreatedBy:      "dashboard",
+		CreatedAt:      time.Now().UTC().Format(time.RFC3339),
+		Location:       strings.TrimSpace(r.FormValue("location")),
+		Tags:           tags,
+		BlockedContent: blockedContent,
+		AllowedTools:   allowedTools,
 	}
 
 	if s.cfgPath != "" {
@@ -1417,6 +1423,8 @@ func (s *Server) handleEditAgent(w http.ResponseWriter, r *http.Request) {
 	if len(canMessage) > 0 {
 		agent.CanMessage = canMessage
 	}
+	agent.BlockedContent = strings.Fields(strings.ReplaceAll(r.FormValue("blocked_content"), ",", " "))
+	agent.AllowedTools = strings.Fields(strings.ReplaceAll(r.FormValue("allowed_tools"), ",", " "))
 
 	s.cfg.Agents[name] = agent
 
@@ -1928,4 +1936,228 @@ func (s *Server) handleEdgeDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.renderTemplate(w, edgeDetailTmpl, data)
+}
+
+// --- Gateway handlers ---
+
+type mcpServerRow struct {
+	Name      string
+	Transport string
+	Command   string
+	URL       string
+}
+
+func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
+	var servers []mcpServerRow
+	for name, srv := range s.cfg.MCPServers {
+		servers = append(servers, mcpServerRow{
+			Name:      name,
+			Transport: srv.Transport,
+			Command:   srv.Command,
+			URL:       srv.URL,
+		})
+	}
+	sort.Slice(servers, func(i, j int) bool { return servers[i].Name < servers[j].Name })
+
+	gw := s.cfg.Gateway
+	data := map[string]any{
+		"Active":  "gateway",
+		"Gateway": gw,
+		"Servers": servers,
+	}
+	s.renderTemplate(w, gatewayTmpl, data)
+}
+
+func (s *Server) handleSaveGatewaySettings(w http.ResponseWriter, r *http.Request) {
+	wasEnabled := s.cfg.Gateway.Enabled
+	nowEnabled := r.FormValue("enabled") == "true"
+
+	s.cfg.Gateway.Enabled = nowEnabled
+	s.cfg.Gateway.ScanResponses = r.FormValue("scan_responses") == "true"
+
+	if p := strings.TrimSpace(r.FormValue("port")); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 && port <= 65535 {
+			s.cfg.Gateway.Port = port
+		}
+	}
+	if b := strings.TrimSpace(r.FormValue("bind")); b != "" {
+		s.cfg.Gateway.Bind = b
+	}
+	if ep := strings.TrimSpace(r.FormValue("endpoint_path")); ep != "" {
+		s.cfg.Gateway.EndpointPath = ep
+	}
+
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after gateway settings update", "error", err)
+		}
+	}
+
+	// Manage gateway lifecycle based on enabled toggle
+	s.gwMu.Lock()
+	hasBackends := len(s.cfg.MCPServers) > 0
+	if nowEnabled && !wasEnabled && hasBackends {
+		s.startGateway()
+	} else if !nowEnabled && wasEnabled {
+		s.stopGateway()
+	} else if nowEnabled && wasEnabled && hasBackends {
+		// Settings changed while running — restart
+		s.stopGateway()
+		s.startGateway()
+	}
+	s.gwMu.Unlock()
+
+	http.Redirect(w, r, "/dashboard/gateway", http.StatusFound)
+}
+
+var mcpServerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" || !mcpServerNameRe.MatchString(name) {
+		http.Error(w, "invalid server name (alphanumeric, hyphens, underscores)", http.StatusBadRequest)
+		return
+	}
+	if _, exists := s.cfg.MCPServers[name]; exists {
+		http.Error(w, "server already exists", http.StatusConflict)
+		return
+	}
+
+	if s.cfg.MCPServers == nil {
+		s.cfg.MCPServers = make(map[string]config.MCPServerConfig)
+	}
+
+	transport := r.FormValue("transport")
+	srv := config.MCPServerConfig{Transport: transport}
+	if transport == "stdio" {
+		srv.Command = strings.TrimSpace(r.FormValue("command"))
+		if args := strings.TrimSpace(r.FormValue("args")); args != "" {
+			srv.Args = strings.Fields(args)
+		}
+	} else {
+		srv.URL = strings.TrimSpace(r.FormValue("url"))
+	}
+
+	s.cfg.MCPServers[name] = srv
+
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after MCP server create", "error", err)
+		}
+	}
+
+	http.Redirect(w, r, "/dashboard/gateway/servers/"+name, http.StatusFound)
+}
+
+type relatedAgent struct {
+	Name         string
+	AllowedTools []string
+}
+
+func (s *Server) handleMCPServerDetail(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	srv, ok := s.cfg.MCPServers[name]
+	if !ok {
+		s.handleNotFound(w, r)
+		return
+	}
+
+	var related []relatedAgent
+	for aName, agent := range s.cfg.Agents {
+		if len(agent.AllowedTools) > 0 {
+			related = append(related, relatedAgent{Name: aName, AllowedTools: agent.AllowedTools})
+		}
+	}
+	sort.Slice(related, func(i, j int) bool { return related[i].Name < related[j].Name })
+
+	data := map[string]any{
+		"Active":        "gateway",
+		"Name":          name,
+		"Server":        srv,
+		"RelatedAgents": related,
+	}
+	s.renderTemplate(w, mcpServerDetailTmpl, data)
+}
+
+func (s *Server) handleEditMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if _, ok := s.cfg.MCPServers[name]; !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	transport := r.FormValue("transport")
+	srv := config.MCPServerConfig{Transport: transport}
+	if transport == "stdio" {
+		srv.Command = strings.TrimSpace(r.FormValue("command"))
+		if args := strings.TrimSpace(r.FormValue("args")); args != "" {
+			srv.Args = strings.Fields(args)
+		}
+	} else {
+		srv.URL = strings.TrimSpace(r.FormValue("url"))
+	}
+
+	// Parse env vars from textarea (KEY=VALUE per line)
+	if envText := strings.TrimSpace(r.FormValue("env")); envText != "" {
+		srv.Env = make(map[string]string)
+		for _, line := range strings.Split(envText, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if k, v, ok := strings.Cut(line, "="); ok {
+				srv.Env[strings.TrimSpace(k)] = strings.TrimSpace(v)
+			}
+		}
+	}
+
+	s.cfg.MCPServers[name] = srv
+
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after MCP server edit", "error", err)
+		}
+	}
+
+	http.Redirect(w, r, "/dashboard/gateway/servers/"+name, http.StatusFound)
+}
+
+func (s *Server) handleDeleteMCPServer(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	delete(s.cfg.MCPServers, name)
+
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after MCP server delete", "error", err)
+			http.Error(w, "save failed", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleGatewayHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	pill := func(bg, color, text string) string {
+		return fmt.Sprintf(`<span style="display:inline-block;padding:4px 12px;border-radius:12px;font-size:0.75rem;background:%s;color:%s">%s</span>`, bg, color, text)
+	}
+
+	if !s.cfg.Gateway.Enabled {
+		fmt.Fprint(w, pill("var(--surface2)", "var(--text3)", "disabled"))
+		return
+	}
+
+	if len(s.cfg.MCPServers) == 0 {
+		fmt.Fprint(w, pill("var(--warn)", "#000", "no backends"))
+		return
+	}
+
+	if s.GatewayRunning() {
+		fmt.Fprint(w, pill("var(--success)", "#fff", "online"))
+		return
+	}
+
+	fmt.Fprint(w, pill("var(--danger)", "#fff", "offline"))
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -3,6 +3,9 @@ package dashboard
 import (
 	"log/slog"
 	"net/http"
+	"os"
+	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/audit"
@@ -21,6 +24,9 @@ type Server struct {
 	scanner *engine.Scanner
 	logger  *slog.Logger
 	mux     *http.ServeMux
+
+	gwMu  sync.Mutex
+	gwCmd *exec.Cmd
 }
 
 // NewServer creates a dashboard server with access-code authentication.
@@ -36,6 +42,13 @@ func NewServer(cfg *config.Config, cfgPath string, auditStore *audit.Store, keys
 		mux:     http.NewServeMux(),
 	}
 	s.routes()
+
+	// Auto-start gateway if enabled in config and backends exist
+	if cfg.Gateway.Enabled && len(cfg.MCPServers) > 0 {
+		s.gwMu.Lock()
+		s.startGateway()
+		s.gwMu.Unlock()
+	}
 
 	// Periodic cleanup of expired sessions and stale rate-limit entries
 	go func() {
@@ -57,6 +70,63 @@ func (s *Server) AccessCode() string {
 // Handler returns the dashboard HTTP handler with auth middleware applied.
 func (s *Server) Handler() http.Handler {
 	return s.auth.Middleware(s.mux)
+}
+
+// startGateway spawns `oktsec gateway` as a child process. Caller must hold gwMu.
+func (s *Server) startGateway() {
+	if s.gwCmd != nil && s.gwCmd.Process != nil {
+		return // already running
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		s.logger.Error("failed to find executable for gateway", "error", err)
+		return
+	}
+	args := []string{"gateway"}
+	if s.cfgPath != "" {
+		args = append(args, "--config", s.cfgPath)
+	}
+	cmd := exec.Command(exe, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		s.logger.Error("failed to start gateway process", "error", err)
+		return
+	}
+	s.gwCmd = cmd
+	s.logger.Info("gateway process started", "pid", cmd.Process.Pid)
+
+	// Reap the process in the background so we detect when it exits
+	go func() {
+		_ = cmd.Wait()
+		s.gwMu.Lock()
+		if s.gwCmd == cmd {
+			s.gwCmd = nil
+		}
+		s.gwMu.Unlock()
+		s.logger.Info("gateway process exited")
+	}()
+}
+
+// stopGateway stops the gateway child process. Caller must hold gwMu.
+func (s *Server) stopGateway() {
+	if s.gwCmd == nil || s.gwCmd.Process == nil {
+		s.gwCmd = nil
+		return
+	}
+	if err := s.gwCmd.Process.Signal(os.Interrupt); err != nil {
+		s.logger.Warn("failed to send interrupt to gateway, killing", "error", err)
+		_ = s.gwCmd.Process.Kill()
+	}
+	s.gwCmd = nil
+	s.logger.Info("gateway process stopped")
+}
+
+// GatewayRunning returns true if the gateway child process is alive.
+func (s *Server) GatewayRunning() bool {
+	s.gwMu.Lock()
+	defer s.gwMu.Unlock()
+	return s.gwCmd != nil && s.gwCmd.Process != nil
 }
 
 func (s *Server) routes() {
@@ -138,6 +208,15 @@ func (s *Server) routes() {
 	// Webhook channels
 	s.mux.HandleFunc("POST /dashboard/settings/webhooks", s.handleSaveWebhookChannel)
 	s.mux.HandleFunc("DELETE /dashboard/settings/webhooks/{name}", s.handleDeleteWebhookChannel)
+
+	// Gateway management
+	s.mux.HandleFunc("GET /dashboard/gateway", s.handleGateway)
+	s.mux.HandleFunc("POST /dashboard/gateway/settings", s.handleSaveGatewaySettings)
+	s.mux.HandleFunc("POST /dashboard/gateway/servers", s.handleCreateMCPServer)
+	s.mux.HandleFunc("GET /dashboard/gateway/servers/{name}", s.handleMCPServerDetail)
+	s.mux.HandleFunc("POST /dashboard/gateway/servers/{name}/edit", s.handleEditMCPServer)
+	s.mux.HandleFunc("DELETE /dashboard/gateway/servers/{name}", s.handleDeleteMCPServer)
+	s.mux.HandleFunc("GET /dashboard/api/gateway/health", s.handleGatewayHealthCheck)
 
 	// Catch-all for unmatched dashboard paths (must be registered last)
 	s.mux.HandleFunc("GET /dashboard/", s.handleNotFound)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -529,6 +529,10 @@ input:checked + .toggle-slider::before{transform:translateX(16px);background:var
   </div>
   <div class="sidebar-section">
     <div class="sidebar-section-label">Management</div>
+    <a href="/dashboard/gateway" class="sidebar-item {{if eq .Active "gateway"}}active{{end}}">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+      Gateway
+    </a>
     <a href="/dashboard/settings" class="sidebar-item {{if eq .Active "settings"}}active{{end}}">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
       Settings
@@ -1077,6 +1081,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
   <table>
     <tr><td style="color:var(--text3)">Can message</td><td>{{range $i, $t := .Agent.CanMessage}}{{if $i}} {{end}}<span class="acl-target">{{$t}}</span>{{end}}{{if not .Agent.CanMessage}}<span style="color:var(--text3)">none</span>{{end}}</td></tr>
     {{if .Agent.BlockedContent}}<tr><td style="color:var(--text3)">Blocked content</td><td>{{range $i, $c := .Agent.BlockedContent}}{{if $i}}, {{end}}{{$c}}{{end}}</td></tr>{{end}}
+    {{if .Agent.AllowedTools}}<tr><td style="color:var(--text3)">Allowed tools</td><td>{{range $i, $t := .Agent.AllowedTools}}{{if $i}} {{end}}<code style="background:var(--bg3);padding:2px 6px;border-radius:4px;font-size:0.75rem">{{$t}}</code>{{end}}</td></tr>{{end}}
     {{if .Agent.Location}}<tr><td style="color:var(--text3)">Location</td><td>{{.Agent.Location}}</td></tr>{{end}}
     {{if .Agent.Tags}}<tr><td style="color:var(--text3)">Tags</td><td>{{range $i, $tag := .Agent.Tags}}{{if $i}} {{end}}<span class="agent-tag">{{$tag}}</span>{{end}}</td></tr>{{end}}
     {{if .Agent.CreatedBy}}<tr><td style="color:var(--text3)">Created by</td><td>{{.Agent.CreatedBy}}</td></tr>{{end}}
@@ -1111,6 +1116,16 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
       <div class="form-group">
         <label>Tags (space-separated)</label>
         <input type="text" name="tags" value="{{range $i, $t := .Agent.Tags}}{{if $i}} {{end}}{{$t}}{{end}}">
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Blocked Content (space-separated categories)</label>
+        <input type="text" name="blocked_content" value="{{range $i, $c := .Agent.BlockedContent}}{{if $i}} {{end}}{{$c}}{{end}}">
+      </div>
+      <div class="form-group">
+        <label>Allowed Tools (space-separated, empty = all)</label>
+        <input type="text" name="allowed_tools" value="{{range $i, $t := .Agent.AllowedTools}}{{if $i}} {{end}}{{$t}}{{end}}">
       </div>
     </div>
     <button type="submit" class="btn btn-sm">Save</button>
@@ -2791,4 +2806,203 @@ var edgeDetailTmpl = template.Must(template.New("edge-detail").Funcs(tmplFuncs).
   {{end}}
 </div>
 `))
+
+var gatewayTmpl = template.Must(template.New("gateway").Funcs(tmplFuncs).Parse(layoutHead + `
+<h1>MCP <span>Gateway</span></h1>
+<p class="page-desc">The MCP gateway fronts backend MCP servers, applying security scanning and per-agent tool allowlists to every tool call.</p>
+
+<div class="card">
+  <h2>Gateway Status</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    The gateway runs as a separate process (<code style="background:var(--bg);padding:2px 8px;border-radius:4px;font-family:var(--mono);font-size:0.75rem;color:var(--accent-light)">oktsec gateway</code>). This dashboard manages its configuration.
+  </p>
+  <div style="display:flex;gap:24px;margin-bottom:12px">
+    <div>
+      <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Health</span>
+      <div style="margin-top:6px" id="gateway-health" hx-get="/dashboard/api/gateway/health" hx-trigger="load" hx-swap="innerHTML">
+        <span style="color:var(--text3);font-size:0.85rem">checking...</span>
+      </div>
+    </div>
+    <div>
+      <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Listen</span>
+      <div style="font-size:1rem;font-weight:600;margin-top:4px;font-family:var(--mono)">{{if .Gateway.Bind}}{{.Gateway.Bind}}{{else}}127.0.0.1{{end}}:{{if .Gateway.Port}}{{.Gateway.Port}}{{else}}9090{{end}}</div>
+    </div>
+    <div>
+      <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Endpoint</span>
+      <div style="font-size:1rem;font-weight:600;margin-top:4px;font-family:var(--mono)">{{if .Gateway.EndpointPath}}{{.Gateway.EndpointPath}}{{else}}/mcp{{end}}</div>
+    </div>
+    <div>
+      <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Backends</span>
+      <div style="font-size:1rem;font-weight:600;margin-top:4px">{{len .Servers}}</div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <h2>Configuration</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Controls whether the gateway is active and how it processes MCP traffic. Changes are saved to <code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-size:0.72rem;font-family:var(--mono);color:var(--accent-light)">oktsec.yaml</code> and take effect on next gateway start.
+  </p>
+  <form method="POST" action="/dashboard/gateway/settings">
+    <div style="display:flex;gap:32px;margin-bottom:20px">
+      <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="enabled" value="true" {{if .Gateway.Enabled}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Gateway enabled</span>
+      </label>
+      <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="scan_responses" value="true" {{if .Gateway.ScanResponses}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Scan backend responses</span>
+      </label>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Port</label>
+        <input type="number" name="port" value="{{.Gateway.Port}}" min="1" max="65535">
+      </div>
+      <div class="form-group">
+        <label>Bind Address</label>
+        <input type="text" name="bind" value="{{.Gateway.Bind}}" placeholder="127.0.0.1">
+      </div>
+      <div class="form-group">
+        <label>Endpoint Path</label>
+        <input type="text" name="endpoint_path" value="{{.Gateway.EndpointPath}}" placeholder="/mcp">
+      </div>
+    </div>
+    <button type="submit" class="btn btn-sm">Save Configuration</button>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Backend MCP Servers</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Each backend server exposes MCP tools that agents can call through the gateway. The gateway auto-discovers tools from each server and applies security policies.
+  </p>
+  {{if .Servers}}
+  <table>
+    <thead><tr><th>Name</th><th>Transport</th><th>Target</th><th></th></tr></thead>
+    <tbody>
+    {{range .Servers}}
+    <tr id="server-row-{{.Name}}" class="clickable" onclick="window.location='/dashboard/gateway/servers/{{.Name}}'">
+      <td style="font-weight:600"><a href="/dashboard/gateway/servers/{{.Name}}" style="color:var(--accent-light);text-decoration:none">{{.Name}}</a></td>
+      <td><span class="badge-{{if eq .Transport "stdio"}}delivered{{else}}quarantined{{end}}" style="font-size:0.7rem">{{.Transport}}</span></td>
+      <td style="color:var(--text3);font-family:var(--mono);font-size:0.8rem">{{if eq .Transport "stdio"}}{{.Command}}{{else}}{{.URL}}{{end}}</td>
+      <td style="text-align:right" onclick="event.stopPropagation()"><button class="btn btn-sm btn-danger" hx-delete="/dashboard/gateway/servers/{{.Name}}" hx-confirm="Delete server {{.Name}}?" hx-target="#server-row-{{.Name}}" hx-swap="outerHTML swap:200ms">delete</button></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{else}}
+  <div class="empty">No MCP servers configured. Add one below to get started.</div>
+  {{end}}
+
+  <form method="POST" action="/dashboard/gateway/servers" class="inline-add">
+    <div class="form-group" style="min-width:150px">
+      <label>Name</label>
+      <input type="text" name="name" required pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*" placeholder="e.g. my-server">
+    </div>
+    <div class="form-group" style="min-width:100px;flex:0.5">
+      <label>Transport</label>
+      <select name="transport" onchange="var s=this.value;document.getElementById('stdio-fields').style.display=s==='stdio'?'':'none';document.getElementById('http-fields').style.display=s==='http'?'':'none'">
+        <option value="stdio">stdio</option>
+        <option value="http">http</option>
+      </select>
+    </div>
+    <div class="form-group" style="flex:2" id="stdio-fields">
+      <label>Command</label>
+      <input type="text" name="command" placeholder="e.g. npx -y @example/server">
+    </div>
+    <div class="form-group" style="flex:2;display:none" id="http-fields">
+      <label>URL</label>
+      <input type="text" name="url" placeholder="e.g. http://localhost:8080/mcp">
+    </div>
+    <button type="submit" class="btn">Add</button>
+  </form>
+  <p style="color:var(--text3);font-size:0.72rem;margin-top:8px">Configure args, env vars, and headers from the server detail page.</p>
+</div>
+` + layoutFoot))
+
+var mcpServerDetailTmpl = template.Must(template.New("mcpServerDetail").Funcs(tmplFuncs).Parse(layoutHead + `
+<p style="margin-bottom:16px"><a href="/dashboard/gateway" style="color:var(--accent)">&larr; Back to Gateway</a></p>
+<h1>MCP Server: <span>{{.Name}}</span></h1>
+
+<div class="card">
+  <h2>Server Configuration</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Current settings for this backend MCP server. The gateway connects to this server to discover and proxy tool calls.
+  </p>
+  <table>
+    <tbody>
+    <tr><td style="color:var(--text3);font-weight:600;width:140px">Transport</td><td><span class="badge-{{if eq .Server.Transport "stdio"}}delivered{{else}}quarantined{{end}}" style="font-size:0.7rem">{{.Server.Transport}}</span></td></tr>
+    {{if eq .Server.Transport "stdio"}}
+    <tr><td style="color:var(--text3);font-weight:600">Command</td><td><code style="background:var(--bg);padding:2px 8px;border-radius:4px;font-family:var(--mono);font-size:0.82rem;color:var(--accent-light)">{{.Server.Command}}</code></td></tr>
+    {{if .Server.Args}}<tr><td style="color:var(--text3);font-weight:600">Args</td><td>{{range $i, $a := .Server.Args}}{{if $i}} {{end}}<code style="background:var(--bg);padding:2px 8px;border-radius:4px;font-family:var(--mono);font-size:0.82rem">{{$a}}</code>{{end}}</td></tr>{{end}}
+    {{else}}
+    <tr><td style="color:var(--text3);font-weight:600">URL</td><td><code style="background:var(--bg);padding:2px 8px;border-radius:4px;font-family:var(--mono);font-size:0.82rem;color:var(--accent-light)">{{.Server.URL}}</code></td></tr>
+    {{if .Server.Headers}}<tr><td style="color:var(--text3);font-weight:600">Headers</td><td>{{range $k, $v := .Server.Headers}}<code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.78rem">{{$k}}: {{$v}}</code><br>{{end}}</td></tr>{{end}}
+    {{end}}
+    {{if .Server.Env}}<tr><td style="color:var(--text3);font-weight:600">Env vars</td><td>{{range $k, $v := .Server.Env}}<code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.78rem">{{$k}}={{$v}}</code><br>{{end}}</td></tr>{{end}}
+    </tbody>
+  </table>
+</div>
+
+<div class="card">
+  <h2>Edit Server</h2>
+  <form method="POST" action="/dashboard/gateway/servers/{{.Name}}/edit">
+    <div class="form-row">
+      <div class="form-group" style="flex:0.5;min-width:120px">
+        <label>Transport</label>
+        <select name="transport" onchange="var s=this.value;document.getElementById('edit-stdio').style.display=s==='stdio'?'flex':'none';document.getElementById('edit-http').style.display=s==='http'?'flex':'none'">
+          <option value="stdio" {{if eq .Server.Transport "stdio"}}selected{{end}}>stdio</option>
+          <option value="http" {{if eq .Server.Transport "http"}}selected{{end}}>http</option>
+        </select>
+      </div>
+    </div>
+    <div class="form-row" id="edit-stdio" style="display:{{if eq .Server.Transport "stdio"}}flex{{else}}none{{end}}">
+      <div class="form-group" style="flex:2">
+        <label>Command</label>
+        <input type="text" name="command" value="{{.Server.Command}}">
+      </div>
+      <div class="form-group" style="flex:1">
+        <label>Args (space-separated)</label>
+        <input type="text" name="args" value="{{range $i, $a := .Server.Args}}{{if $i}} {{end}}{{$a}}{{end}}">
+      </div>
+    </div>
+    <div class="form-row" id="edit-http" style="display:{{if eq .Server.Transport "http"}}flex{{else}}none{{end}}">
+      <div class="form-group">
+        <label>URL</label>
+        <input type="text" name="url" value="{{.Server.URL}}">
+      </div>
+    </div>
+    <div class="form-group" style="margin-bottom:12px">
+      <label>Env Vars (KEY=VALUE per line)</label>
+      <textarea name="env" rows="3" style="font-family:var(--mono);font-size:0.82rem">{{range $k, $v := .Server.Env}}{{$k}}={{$v}}
+{{end}}</textarea>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center">
+      <button type="submit" class="btn btn-sm">Save Changes</button>
+      <button type="button" class="btn btn-sm btn-danger" hx-delete="/dashboard/gateway/servers/{{.Name}}" hx-confirm="Delete server {{.Name}}? This cannot be undone." hx-swap="none" onclick="setTimeout(function(){window.location='/dashboard/gateway'},300)">Delete Server</button>
+    </div>
+  </form>
+</div>
+
+{{if .RelatedAgents}}
+<div class="card">
+  <h2>Related Agents</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Agents that have tool allowlists configured. These restrictions apply when agents call tools through the gateway.
+  </p>
+  <table>
+    <thead><tr><th>Agent</th><th>Allowed Tools</th></tr></thead>
+    <tbody>
+    {{range .RelatedAgents}}
+    <tr class="clickable" onclick="window.location='/dashboard/agents/{{.Name}}'">
+      <td style="font-weight:600"><a href="/dashboard/agents/{{.Name}}" style="color:var(--accent-light);text-decoration:none">{{.Name}}</a></td>
+      <td>{{range $i, $t := .AllowedTools}}{{if $i}} {{end}}<span class="acl-target">{{$t}}</span>{{end}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+</div>
+{{end}}
+` + layoutFoot))
 


### PR DESCRIPTION
## Summary

- Adds a dedicated **Gateway** page to the dashboard for managing MCP gateway configuration, backend servers, and per-agent tool allowlists directly from the UI
- The dashboard now **starts and stops the gateway process** automatically when the enabled toggle is changed — no need to run `oktsec gateway` manually
- Enhances the agent detail page with **AllowedTools** and **BlockedContent** form fields

## Changes

### New: Gateway dashboard page (`/dashboard/gateway`)
- **Status card** — live HTMX health indicator showing online/offline/disabled/no backends
- **Configuration form** — toggle switches for `enabled` and `scan_responses`, inputs for port, bind address, and endpoint path
- **Backend MCP Servers** — sortable table with clickable rows, inline add form with stdio/http transport selector
- **Server detail page** (`/dashboard/gateway/servers/{name}`) — read-only config view, edit form with env vars textarea, delete button, related agents section

### New: Gateway lifecycle management
- `startGateway()` spawns `oktsec gateway` as a child process using `os/exec`
- `stopGateway()` sends `SIGINT` for graceful shutdown
- Auto-starts on dashboard init if gateway is enabled with backends configured
- Toggling enabled on/off from the UI starts/stops the process in real time
- Settings changes while running trigger automatic restart

### Enhanced: Agent detail page
- Displays `AllowedTools` as `<code>` badges in the configuration section
- New form fields for `BlockedContent` (space-separated categories) and `AllowedTools` (space-separated, empty = all)
- `handleCreateAgent` and `handleEditAgent` now persist both fields to config

### Changed: Config validation
- Moved the "gateway enabled without mcp_servers" check from `config.Validate()` to the `gateway` command
- This allows `oktsec serve` to start with gateway enabled but no backends (the dashboard manages the lifecycle)

## Files changed

| File | Lines | Description |
|------|-------|-------------|
| `internal/dashboard/templates.go` | +214 | Sidebar nav item, `gatewayTmpl`, `mcpServerDetailTmpl`, agent detail enhancements |
| `internal/dashboard/handlers.go` | +244 | 7 gateway handlers, agent handler changes, health check |
| `internal/dashboard/server.go` | +79 | Gateway lifecycle (start/stop/auto-start), `gwCmd` field |
| `internal/config/config.go` | +4/-5 | Relaxed gateway validation |
| `internal/config/config_test.go` | +4/-2 | Updated test expectation |
| `cmd/oktsec/commands/gateway.go` | +3 | Backend count check at command level |

## Test plan

- [x] `make build && make test && make lint && make vet` — all pass, 0 lint issues
- [x] Start `oktsec serve`, navigate to Gateway page
- [x] Add an MCP server (stdio type), verify it appears in table
- [x] Click server row, verify detail page renders correctly
- [x] Edit server config, verify changes persist in YAML
- [x] Delete server, verify HTMX row removal
- [x] Enable gateway toggle with a backend configured, verify health shows "online"
- [x] Disable gateway toggle, verify health shows "disabled" and process stops
- [x] Enable gateway with 0 backends, verify health shows "no backends" (yellow)
- [x] Navigate to agent detail, verify AllowedTools/BlockedContent fields
- [x] Edit agent with tool restrictions, verify YAML updated