### PR TITLE
fix: close 3 known dashboard issues

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -745,9 +745,11 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	agent, ok := s.cfg.Agents[name]
 	if !ok {
-		// Could be a gateway-namespaced agent (e.g. "gateway/create_card")
-		// visible in traffic but not in config. Show a read-only view.
-		agent = config.Agent{Description: "Discovered from gateway traffic"}
+		desc := "Discovered from traffic"
+		if strings.HasPrefix(name, "gateway/") {
+			desc = "MCP gateway tool: " + strings.TrimPrefix(name, "gateway/")
+		}
+		agent = config.Agent{Description: desc}
 	}
 
 	// Get recent messages for this agent
@@ -921,12 +923,25 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 // --- Export handlers ---
 
+func parseExportLimit(r *http.Request) int {
+	limit := 10000
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 50000 {
+		limit = 50000
+	}
+	return limit
+}
+
 func (s *Server) handleExportCSV(w http.ResponseWriter, r *http.Request) {
 	agent := r.URL.Query().Get("agent")
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
 
-	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: 10000})
+	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
 		http.Error(w, "query failed", http.StatusInternalServerError)
 		return
@@ -952,7 +967,7 @@ func (s *Server) handleExportJSON(w http.ResponseWriter, r *http.Request) {
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
 
-	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: 10000})
+	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
 		http.Error(w, "query failed", http.StatusInternalServerError)
 		return
@@ -982,9 +997,9 @@ func (s *Server) handleBulkToggleRules(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if action == "disable-all" {
-		disabledSet := s.disabledRuleSet()
+		existingIDs := s.existingRuleIDSet()
 		for _, ri := range s.scanner.ListRules() {
-			if !disabledSet[ri.ID] {
+			if !existingIDs[ri.ID] {
 				s.cfg.Rules = append(s.cfg.Rules, config.RuleAction{ID: ri.ID, Action: "ignore"})
 			}
 		}
@@ -1651,11 +1666,12 @@ func (s *Server) handleToggleCategory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	disabledSet := s.disabledRuleSet()
+	existingIDs := s.existingRuleIDSet()
 	disabledCount := countInSet(ruleIDs, disabledSet)
 
 	// If most are enabled → disable all; if most disabled → enable all
 	if disabledCount < len(ruleIDs)/2+1 {
-		s.disableCategoryRules(ruleIDs, disabledSet)
+		s.disableCategoryRules(ruleIDs, existingIDs)
 	} else {
 		s.enableCategoryRules(ruleIDs)
 	}
@@ -1695,6 +1711,14 @@ func (s *Server) disabledRuleSet() map[string]bool {
 	return set
 }
 
+func (s *Server) existingRuleIDSet() map[string]bool {
+	set := make(map[string]bool, len(s.cfg.Rules))
+	for _, ra := range s.cfg.Rules {
+		set[ra.ID] = true
+	}
+	return set
+}
+
 func countInSet(ids []string, set map[string]bool) int {
 	n := 0
 	for _, id := range ids {
@@ -1705,9 +1729,9 @@ func countInSet(ids []string, set map[string]bool) int {
 	return n
 }
 
-func (s *Server) disableCategoryRules(ruleIDs []string, alreadyDisabled map[string]bool) {
+func (s *Server) disableCategoryRules(ruleIDs []string, existingIDs map[string]bool) {
 	for _, id := range ruleIDs {
-		if !alreadyDisabled[id] {
+		if !existingIDs[id] {
 			s.cfg.Rules = append(s.cfg.Rules, config.RuleAction{ID: id, Action: "ignore"})
 		}
 	}

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1447,6 +1447,114 @@ func TestParseDomainList(t *testing.T) {
 	}
 }
 
+func TestServer_BulkToggleIdempotent(t *testing.T) {
+	srv := newTestServer(t)
+	dir := t.TempDir()
+	srv.cfgPath = filepath.Join(dir, "oktsec.yaml")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Disable-all twice
+	for i := 0; i < 2; i++ {
+		form := url.Values{"action": {"disable-all"}}
+		req := httptest.NewRequest("POST", "/dashboard/api/rules/bulk-toggle", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusFound {
+			t.Fatalf("bulk toggle %d: status = %d, want 302", i+1, w.Code)
+		}
+	}
+
+	// Verify no duplicate rule IDs
+	seen := make(map[string]bool)
+	for _, ra := range srv.cfg.Rules {
+		if seen[ra.ID] {
+			t.Errorf("duplicate rule ID in cfg.Rules: %s", ra.ID)
+		}
+		seen[ra.ID] = true
+	}
+}
+
+func TestServer_BulkToggleWithExistingOverride(t *testing.T) {
+	srv := newTestServer(t)
+	dir := t.TempDir()
+	srv.cfgPath = filepath.Join(dir, "oktsec.yaml")
+
+	// Pre-set a rule with a "block" override
+	rules := srv.scanner.ListRules()
+	if len(rules) == 0 {
+		t.Skip("no rules loaded")
+	}
+	srv.cfg.Rules = []config.RuleAction{
+		{ID: rules[0].ID, Action: "block"},
+	}
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Disable-all should not create a duplicate for the "block" rule
+	form := url.Values{"action": {"disable-all"}}
+	req := httptest.NewRequest("POST", "/dashboard/api/rules/bulk-toggle", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("bulk toggle: status = %d, want 302", w.Code)
+	}
+
+	seen := make(map[string]bool)
+	for _, ra := range srv.cfg.Rules {
+		if seen[ra.ID] {
+			t.Errorf("duplicate rule ID in cfg.Rules: %s", ra.ID)
+		}
+		seen[ra.ID] = true
+	}
+
+	// The original "block" override must still be there (not replaced)
+	found := false
+	for _, ra := range srv.cfg.Rules {
+		if ra.ID == rules[0].ID && ra.Action == "block" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("original 'block' override was lost after disable-all")
+	}
+}
+
+func TestServer_ExportLimitParam(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	tests := []struct {
+		name     string
+		query    string
+		wantCode int
+	}{
+		{"default", "/dashboard/api/export/csv", http.StatusOK},
+		{"custom limit", "/dashboard/api/export/csv?limit=5", http.StatusOK},
+		{"cap at 50k", "/dashboard/api/export/json?limit=100000", http.StatusOK},
+		{"invalid ignored", "/dashboard/api/export/json?limit=abc", http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.query, nil)
+			req.AddCookie(cookie)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
 func TestServer_ModeToggleRedirectsToSecurityTab(t *testing.T) {
 	srv := newTestServer(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- **Bulk toggle idempotency**: `handleBulkToggleRules` and `disableCategoryRules` now check all existing rule overrides (not just "ignore" entries), preventing duplicate rule IDs when a rule already has a non-ignore override like "block"
- **Export configurable limit**: CSV/JSON export endpoints accept optional `limit` query param (default 10K, capped at 50K) via shared `parseExportLimit` helper
- **Gateway agent description**: Agent detail page derives description from `gateway/` prefix instead of showing a generic fallback

## Test plan
- [x] `TestServer_BulkToggleIdempotent` — disable-all twice, verify no duplicate rule IDs
- [x] `TestServer_BulkToggleWithExistingOverride` — rule has "block" override, disable-all must not duplicate
- [x] `TestServer_ExportLimitParam` — custom limit, 50K cap, invalid input fallback
- [x] `make build && make test && make lint && make vet` — all green, 0 lint issues