### PR TITLE
fix: improve UX for 8 post-setup friction points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,20 @@ All notable changes to this project will be documented in this file.
 
 - **`oktsec init` output**: Now suggests `oktsec wrap --all` and `oktsec setup` as next steps instead of per-client `oktsec wrap <client>`.
 - **Generated config includes `db_path`**: Both `init` and `setup` set `db_path` to the shared location so proxy and serve align automatically.
+- **README quick-start**: Replaced 4-step manual flow with `oktsec setup` + `oktsec serve` two-liner. Added `setup` to CLI reference.
+- **Config validation errors**: Invalid rule action now lists valid values (`block`, `quarantine`, `allow-and-flag`, `ignore`).
 
 ### Fixed
 
 - **Proxy audit trail invisible in dashboard**: Proxy wrote to `/tmp/oktsec.db` while serve used CWD `oktsec.db`. Now both default to `~/.oktsec/oktsec.db`.
 - **Proxy ignored config features**: Wrapped proxy commands had no `--config` flag, so `allowed_tools` and other per-agent config was silently ignored.
+- **`serve` without config failed silently**: Now prints warning with the error, suggests running `oktsec setup`, then falls back to defaults. Banner shows "No agents configured" hint when agent count is 0.
+- **Dashboard empty state**: Overview page now shows welcome message when no agents are configured (links to `oktsec setup`) and "waiting for traffic" message when agents exist but no messages have been scanned yet.
+- **Login page access code UX**: Added note that the code changes on each server restart.
+- **`logs` empty state unhelpful**: Now explains that no messages have been scanned yet, shows the DB path, and suggests `oktsec logs --live`.
+- **`logs --live` silent when idle**: Shows periodic heartbeat message ("waiting for messages...") after 10 seconds of inactivity, then every 30 seconds.
+- **`wrap` "already wrapped" ambiguous**: Now suggests `oktsec logs --live` to verify traffic and hints at unwrap for mode changes.
+- **`logs` used hardcoded DB path**: Now uses shared `~/.oktsec/oktsec.db` default and respects config `db_path`, matching the proxy and serve behavior.
 
 ## [0.7.0] - 2026-03-03
 

--- a/README.md
+++ b/README.md
@@ -111,32 +111,32 @@ For using Oktsec alongside **Docker Sandboxes** (isolated micro VMs for AI agent
 
 ## Quick start
 
-### Automatic setup (recommended)
-
-Oktsec discovers your existing MCP servers and OpenClaw installations, generates a config, and wraps MCP clients with security monitoring:
+### One-command setup (recommended)
 
 ```bash
-# 1. Discover all agent platforms on this machine
-oktsec discover
-
-# 2. Auto-generate config + keypairs
-oktsec init
-
-# 3. Wrap your MCP client so traffic routes through oktsec
-oktsec wrap cursor          # or: claude-desktop, vscode, cline, windsurf
-
-# 4. Start the proxy with dashboard
+oktsec setup
 oktsec serve
 ```
 
-Oktsec starts in **observe mode** — it logs everything but blocks nothing. Review activity in the dashboard at `http://127.0.0.1:8080/dashboard` using the access code shown in your terminal.
+That's it. `oktsec setup` discovers all MCP clients on your machine, generates a config with sensible defaults, creates Ed25519 keypairs, and wraps every MCP server through the security proxy — all in one step.
+
+Oktsec starts in **observe mode** — it logs everything but blocks nothing. Review activity in the dashboard at `http://127.0.0.1:8080/dashboard` using the access code shown in your terminal. Restart your MCP clients (Claude Desktop, Cursor, etc.) to activate.
 
 To enable **enforcement mode** (block malicious requests with JSON-RPC errors):
 
 ```bash
-oktsec wrap --enforce cursor
+oktsec wrap --all --enforce
 # or for a single server:
 oktsec proxy --enforce --agent filesystem -- npx @mcp/server-filesystem /data
+```
+
+### Step-by-step setup (if you prefer control)
+
+```bash
+oktsec discover                    # See what's installed
+oktsec init                        # Generate config + keypairs
+oktsec wrap claude-desktop         # Wrap one client at a time
+oktsec serve                       # Start proxy + dashboard
 ```
 
 ### Manual setup
@@ -718,9 +718,10 @@ Analytics queries use a 24-hour time window with covering indexes. All dashboard
 ## CLI reference
 
 ```
+oktsec setup [--enforce] [--skip-wrap]                   # One-command onboarding: discover + init + wrap all
 oktsec discover                                          # Scan for MCP servers, OpenClaw, NanoClaw
 oktsec init [--keys ./keys] [--config oktsec.yaml]       # Auto-generate config + keypairs
-oktsec wrap [--enforce] <client>                         # Route MCP client through oktsec proxy
+oktsec wrap [--enforce] [--all | <client>]               # Route MCP client(s) through oktsec proxy
 oktsec unwrap <client>                                   # Restore original client config
 oktsec scan-openclaw [--path ~/.openclaw/openclaw.json]  # Analyze OpenClaw installation
 oktsec proxy [--enforce] --agent <name> -- <cmd> [args]  # Stdio proxy for single MCP server

--- a/cmd/oktsec/commands/logs.go
+++ b/cmd/oktsec/commands/logs.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,15 @@ func newLogsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-			store, err := audit.NewStore("oktsec.db", logger)
+			dbPath := defaultDBPath()
+			configPath, _ := cmd.Flags().GetString("config")
+			if configPath != "" {
+				if cfg, err := config.Load(configPath); err == nil && cfg.DBPath != "" {
+					dbPath = cfg.DBPath
+				}
+			}
+
+			store, err := audit.NewStore(dbPath, logger)
 			if err != nil {
 				return fmt.Errorf("opening audit db: %w", err)
 			}
@@ -61,6 +70,13 @@ func newLogsCmd() *cobra.Command {
 
 			if len(entries) == 0 {
 				fmt.Println("No audit entries found.")
+				fmt.Println()
+				fmt.Println("  If you just set up oktsec, this is expected — no messages")
+				fmt.Println("  have been scanned yet. Use your MCP tools normally and")
+				fmt.Println("  entries will appear here.")
+				fmt.Println()
+				fmt.Printf("  Audit DB: %s\n", dbPath)
+				fmt.Println("  Try: oktsec logs --live")
 				return nil
 			}
 
@@ -110,6 +126,7 @@ func streamLive(store *audit.Store, status, agent string, unverified bool) error
 
 	// Seed with recent entries
 	sinceTime := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	idleTicks := 0
 
 	for {
 		select {
@@ -128,6 +145,7 @@ func streamLive(store *audit.Store, status, agent string, unverified bool) error
 				continue
 			}
 
+			newCount := 0
 			// Entries come DESC; reverse for chronological printing
 			for i := len(entries) - 1; i >= 0; i-- {
 				e := entries[i]
@@ -135,6 +153,8 @@ func streamLive(store *audit.Store, status, agent string, unverified bool) error
 					continue
 				}
 				seen[e.ID] = struct{}{}
+				newCount++
+				idleTicks = 0
 
 				verified := "unsigned"
 				switch e.SignatureVerified {
@@ -148,6 +168,14 @@ func streamLive(store *audit.Store, status, agent string, unverified bool) error
 				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%dms\n", //nolint:errcheck
 					e.Timestamp, e.FromAgent, e.ToAgent, e.Status, e.PolicyDecision, verified, e.LatencyMs)
 				_ = tw.Flush()
+			}
+
+			if newCount == 0 {
+				idleTicks++
+				// Show heartbeat at 10s, then every 30s
+				if idleTicks == 10 || (idleTicks > 10 && idleTicks%30 == 0) {
+					fmt.Fprintf(os.Stderr, "  ... waiting for messages (use your MCP tools to generate traffic)\n")
+				}
 			}
 
 			// Move window forward

--- a/cmd/oktsec/commands/serve.go
+++ b/cmd/oktsec/commands/serve.go
@@ -24,7 +24,11 @@ func newServeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(cfgFile)
 			if err != nil {
-				// Fall back to defaults if no config file
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintf(os.Stderr, "  Warning: could not load %s (%v)\n", cfgFile, err)
+				fmt.Fprintf(os.Stderr, "  Starting with default config (0 agents, observe mode).\n")
+				fmt.Fprintf(os.Stderr, "  Run 'oktsec setup' to generate a config from your MCP servers.\n")
+				fmt.Fprintln(os.Stderr)
 				cfg = config.Defaults()
 			}
 
@@ -105,8 +109,13 @@ func printBanner(cfg *config.Config, dashCode string) {
 	fmt.Printf("  Access code:  %s\n", dashCode)
 	fmt.Println("  ────────────────────────────────────────")
 	fmt.Printf("  Mode: %s  |  Agents: %d\n", mode, len(cfg.Agents))
+	if len(cfg.Agents) == 0 {
+		fmt.Println("  ────────────────────────────────────────")
+		fmt.Println("  No agents configured. Run 'oktsec setup' to get started.")
+	}
 	fmt.Println()
 	fmt.Println("  Enter this code in the browser to access the dashboard.")
+	fmt.Println("  Code is valid for this session only (regenerated on restart).")
 	fmt.Println("  Press Ctrl+C to stop.")
 	fmt.Println()
 }

--- a/cmd/oktsec/commands/wrap.go
+++ b/cmd/oktsec/commands/wrap.go
@@ -56,6 +56,10 @@ func newWrapCmd() *cobra.Command {
 
 			if wrapped == 0 {
 				fmt.Println("  All servers already wrapped.")
+				if enforce {
+					fmt.Println("  To change mode, unwrap first: oktsec unwrap " + client)
+				}
+				fmt.Println("  Run 'oktsec logs --live' to verify traffic is flowing.")
 			} else {
 				fmt.Printf("  %d server(s) wrapped.\n", wrapped)
 				if enforce {
@@ -110,6 +114,7 @@ func wrapAll(opts discover.WrapOpts) error {
 		fmt.Println("  Run 'oktsec logs --live' to watch in real time.")
 	} else {
 		fmt.Println("  All servers already wrapped.")
+		fmt.Println("  Run 'oktsec logs --live' to verify traffic is flowing.")
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,7 +256,7 @@ func (c *Config) Validate() error {
 		case "block", "quarantine", "allow-and-flag", "ignore":
 			// valid
 		default:
-			return fmt.Errorf("rule %q has invalid action %q", ra.ID, ra.Action)
+			return fmt.Errorf("rule %q has invalid action %q (valid: block, quarantine, allow-and-flag, ignore)", ra.ID, ra.Action)
 		}
 	}
 	// Gateway validation (transport checks only; backend count and port

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -102,7 +102,7 @@ button:active{transform:scale(0.98)}
   <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><rect x="9" y="11" width="6" height="5" rx="1"/><path d="M12 11V9a2 2 0 0 0-4 0"/></svg></div>
   <div class="logo">oktsec</div>
   <div class="subtitle">Dashboard Access</div>
-  <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec serve</code> to get a code.</p>
+  <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec serve</code> to get a code.<br><small style="opacity:0.5">Code changes each time the server restarts.</small></p>
   <form method="POST" action="/dashboard/login" autocomplete="off">
     <input type="text" name="code" placeholder="00000000" maxlength="8" pattern="\d{8}" inputmode="numeric" autofocus required>
     <button type="submit">Authenticate</button>
@@ -692,6 +692,18 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
 
 var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse(layoutHead + `
 <p class="page-desc">Messages between agents are scanned for threats, verified for identity, and logged here. <span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
+
+{{if and (eq .Stats.TotalMessages 0) (eq .AgentCount 0)}}
+<div class="card" style="text-align:center;padding:40px 24px">
+  <div style="font-size:1.4rem;font-weight:600;margin-bottom:8px">Welcome to oktsec</div>
+  <p style="color:var(--text2);margin-bottom:16px;max-width:480px;margin-left:auto;margin-right:auto">No agents configured yet. Run <code style="background:var(--bg2);padding:2px 6px;border-radius:4px">oktsec setup</code> to discover your MCP servers and start scanning automatically.</p>
+  <p style="color:var(--text3);font-size:0.8rem">Once traffic flows through the proxy, this page will show real-time security metrics.</p>
+</div>
+{{else if eq .Stats.TotalMessages 0}}
+<div class="card" style="text-align:center;padding:24px">
+  <p style="color:var(--text2);margin:0">{{.AgentCount}} agent{{if gt .AgentCount 1}}s{{end}} configured. Waiting for traffic &mdash; use your MCP tools normally and activity will appear here.</p>
+</div>
+{{end}}
 
 {{if .PendingReview}}
 <div class="alert-banner warn">


### PR DESCRIPTION
## Summary

Fix the most impactful UX issues that confuse or block users after running `oktsec setup`.

Based on a 26-point friction audit of the post-setup experience, this PR resolves the **top 8 issues** that either block users or cause confusion during first use.

### Fixes

| # | Problem | Fix |
|---|---------|-----|
| 1 | `serve` without config silently falls back to 0 agents | Warning message + suggestion to run `oktsec setup` |
| 2 | Banner shows "Agents: 0" with no guidance | "No agents configured" hint when count is 0 |
| 3 | Dashboard overview blank on first use | Welcome message (no agents) + "waiting for traffic" (agents exist, no messages) |
| 4 | Login page doesn't explain access code lifecycle | Added "code changes on restart" note |
| 5 | `oktsec logs` with no data says only "No audit entries" | Explains it's expected, shows DB path, suggests `--live` |
| 6 | `oktsec logs --live` is silent when idle | Heartbeat at 10s, then every 30s: "waiting for messages..." |
| 7 | `wrap` "already wrapped" gives no next step | Suggests `logs --live` to verify traffic |
| 8 | `logs` used hardcoded `oktsec.db` instead of shared path | Now uses `~/.oktsec/oktsec.db` default, respects config |

### Also

- README quick-start now leads with `oktsec setup` + `oktsec serve` (2 commands instead of 4)
- Config validation errors list valid values for rule actions
- CLI reference updated with `setup` and `wrap --all`

## Test plan

- [x] `make build && make test && make lint` — all pass (415 tests, 0 issues)
- [x] `oktsec serve --config /nonexistent.yaml` — shows warning + setup suggestion
- [x] Dashboard overview template includes empty-state blocks
- [x] Login template includes access code explanation
- [ ] Manual: verify dashboard shows welcome message on fresh install
- [ ] Manual: verify `logs --live` heartbeat after 10s idle