### PR TITLE
fix: close 5 minor friction items for better UX

### DIFF
--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -655,6 +655,38 @@ func (s *Store) QueryUnsignedRate() (unsigned, total int, err error) {
 	return unsigned, total, nil
 }
 
+// UnsignedByAgent holds per-agent unsigned message counts.
+type UnsignedByAgent struct {
+	Agent    string
+	Unsigned int
+	Total    int
+}
+
+// QueryUnsignedByAgent returns unsigned/total message counts per agent in the last 24h.
+func (s *Store) QueryUnsignedByAgent() ([]UnsignedByAgent, error) {
+	cutoff := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	rows, err := s.db.Query(
+		`SELECT from_agent, COUNT(*),
+			COALESCE(SUM(CASE WHEN signature_verified != 1 THEN 1 ELSE 0 END), 0)
+		FROM audit_log WHERE timestamp >= ?
+		GROUP BY from_agent ORDER BY COUNT(*) DESC`,
+		cutoff,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query unsigned by agent: %w", err)
+	}
+	defer rows.Close()
+	var result []UnsignedByAgent
+	for rows.Next() {
+		var u UnsignedByAgent
+		if err := rows.Scan(&u.Agent, &u.Total, &u.Unsigned); err != nil {
+			return nil, err
+		}
+		result = append(result, u)
+	}
+	return result, rows.Err()
+}
+
 // QueryTrafficAgents returns distinct agent names seen in traffic in the last 24h.
 func (s *Store) QueryTrafficAgents() ([]string, error) {
 	cutoff := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -675,7 +675,7 @@ func (s *Store) QueryUnsignedByAgent() ([]UnsignedByAgent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("query unsigned by agent: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []UnsignedByAgent
 	for rows.Next() {
 		var u UnsignedByAgent

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -373,3 +373,55 @@ func TestStoreLogAndQuery(t *testing.T) {
 		t.Errorf("got %d entries for agent-a, want 1", len(agentEntries))
 	}
 }
+
+func TestQueryUnsignedByAgent(t *testing.T) {
+	store := newTestStore(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	entries := []Entry{
+		{ID: "u1", Timestamp: now, FromAgent: "alice", ToAgent: "bob", ContentHash: "h", Status: "delivered", PolicyDecision: "allow", SignatureVerified: 1},
+		{ID: "u2", Timestamp: now, FromAgent: "alice", ToAgent: "bob", ContentHash: "h", Status: "delivered", PolicyDecision: "allow", SignatureVerified: 0},
+		{ID: "u3", Timestamp: now, FromAgent: "bob", ToAgent: "alice", ContentHash: "h", Status: "delivered", PolicyDecision: "allow", SignatureVerified: 0},
+		{ID: "u4", Timestamp: now, FromAgent: "bob", ToAgent: "alice", ContentHash: "h", Status: "delivered", PolicyDecision: "allow", SignatureVerified: 0},
+	}
+	for _, e := range entries {
+		store.Log(e)
+	}
+	store.Flush()
+
+	results, err := store.QueryUnsignedByAgent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d agents, want 2", len(results))
+	}
+
+	// bob has 2 total (both unsigned), alice has 2 total (1 unsigned)
+	agentMap := make(map[string]UnsignedByAgent)
+	for _, r := range results {
+		agentMap[r.Agent] = r
+	}
+
+	if a, ok := agentMap["alice"]; !ok {
+		t.Error("missing alice")
+	} else {
+		if a.Total != 2 {
+			t.Errorf("alice total = %d, want 2", a.Total)
+		}
+		if a.Unsigned != 1 {
+			t.Errorf("alice unsigned = %d, want 1", a.Unsigned)
+		}
+	}
+
+	if b, ok := agentMap["bob"]; !ok {
+		t.Error("missing bob")
+	} else {
+		if b.Total != 2 {
+			t.Errorf("bob total = %d, want 2", b.Total)
+		}
+		if b.Unsigned != 2 {
+			t.Errorf("bob unsigned = %d, want 2", b.Unsigned)
+		}
+	}
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -136,6 +136,7 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	topRules, _ := s.audit.QueryTopRules(5, "")
 	agentRisks, _ := s.audit.QueryAgentRisk("")
 	unsigned, totalRecent, _ := s.audit.QueryUnsignedRate()
+	unsignedByAgent, _ := s.audit.QueryUnsignedByAgent()
 
 	detectionRate := 0
 	if stats.TotalMessages > 0 {
@@ -161,9 +162,10 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 		"TopRules":      topRules,
 		"AgentRisks":    agentRisks,
 		"DetectionRate": detectionRate,
-		"UnsignedCount": unsigned,
-		"UnsignedPct":   unsignedPct,
-		"AvgLatency":    avgLatency,
+		"UnsignedCount":   unsigned,
+		"UnsignedPct":     unsignedPct,
+		"UnsignedByAgent": unsignedByAgent,
+		"AvgLatency":      avgLatency,
 	}
 
 	s.renderTemplate(w, overviewTmpl, data)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -334,6 +334,14 @@ tr:hover td{background:rgba(99,102,241,0.04)}
 .toggle-btn{display:inline-block;padding:6px 14px;background:var(--surface2);color:var(--text2);border:1px solid var(--border);border-radius:8px;font-size:0.78rem;cursor:pointer;text-decoration:none;transition:all 0.2s}
 .toggle-btn:hover{background:var(--accent-dim);color:#fff;border-color:var(--accent)}
 
+/* HTMX loading indicator */
+.htmx-indicator{display:none}
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator{display:inline-block}
+.loading-spinner{width:14px;height:14px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:spin 0.6s linear infinite;display:inline-block;vertical-align:middle;margin-left:6px}
+@keyframes spin{to{transform:rotate(360deg)}}
+.htmx-request td,.htmx-request .stat{opacity:0.5;transition:opacity 0.2s}
+
 /* Key table */
 .fp{color:var(--text3);font-size:0.72rem}
 
@@ -603,6 +611,7 @@ const layoutFoot = `</main>
 <!-- Slide-in panel -->
 <div class="panel-overlay" id="panel-overlay" onclick="closePanel()"></div>
 <div class="panel" id="detail-panel">
+  <div id="panel-loading" class="htmx-indicator" style="text-align:center;padding:40px"><span class="loading-spinner" style="width:24px;height:24px"></span></div>
   <div id="panel-content"></div>
 </div>
 
@@ -625,9 +634,19 @@ document.addEventListener('keydown', function(e) {
   if (e.key === 'Escape') closePanel();
 });
 
+// HTMX: show loading spinner when panel requests start
+document.body.addEventListener('htmx:beforeRequest', function(e) {
+  if (e.detail.target && e.detail.target.id === 'panel-content') {
+    document.getElementById('panel-loading').style.display='block';
+    document.getElementById('panel-content').innerHTML='';
+    document.getElementById('detail-panel').classList.add('open');
+    document.getElementById('panel-overlay').classList.add('open');
+  }
+});
 // HTMX: when a panel response arrives, open the panel
 document.body.addEventListener('htmx:afterSwap', function(e) {
   if (e.detail.target.id === 'panel-content') {
+    document.getElementById('panel-loading').style.display='none';
     document.getElementById('detail-panel').classList.add('open');
     document.getElementById('panel-overlay').classList.add('open');
   }
@@ -746,7 +765,7 @@ var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse
   <div class="stat">
     <div class="label">Unsigned Messages (24h)</div>
     <div class="value {{if gt .UnsignedPct 50}}danger{{else if gt .UnsignedPct 20}}warn{{else}}success{{end}}">{{.UnsignedCount}}</div>
-    <div class="sub">{{.UnsignedPct}}% of recent traffic</div>
+    <div class="sub">{{.UnsignedPct}}% of recent traffic{{if .UnsignedByAgent}} — {{range $i, $a := .UnsignedByAgent}}{{if $i}}, {{end}}{{$a.Agent}}: {{$a.Unsigned}}/{{$a.Total}}{{end}}{{end}}</div>
   </div>
   <div class="stat">
     <div class="label">Avg Latency (24h)</div>
@@ -827,7 +846,8 @@ var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse
   <h2><span class="dot"></span> Recent Events</h2>
   <div class="search-bar">
     <span class="search-icon">&#x1f50d;</span>
-    <input type="text" placeholder="Search events..." hx-get="/dashboard/api/search" hx-trigger="input changed delay:300ms" hx-target="#search-results" name="q">
+    <input type="text" placeholder="Search events..." hx-get="/dashboard/api/search" hx-trigger="input changed delay:300ms" hx-target="#search-results" hx-indicator="#search-loading" name="q">
+    <span id="search-loading" class="htmx-indicator"><span class="loading-spinner"></span></span>
   </div>
   <div id="search-results" style="display:none"></div>
   <div id="recent-events">
@@ -2426,7 +2446,8 @@ updateExportLinks();
   <div class="search-bar">
     <span class="search-icon">&#x1F50D;</span>
     <input type="text" placeholder="Search events by agent, rule, or content hash..."
-           hx-get="/dashboard/api/search" hx-trigger="keyup changed delay:300ms" hx-target="#search-results" name="q">
+           hx-get="/dashboard/api/search" hx-trigger="keyup changed delay:300ms" hx-target="#search-results" hx-indicator="#events-search-loading" name="q">
+    <span id="events-search-loading" class="htmx-indicator"><span class="loading-spinner"></span></span>
   </div>
 
   <div id="search-results">

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -37,6 +37,7 @@ type MessageResponse struct {
 	RulesTriggered []engine.FindingSummary `json:"rules_triggered"`
 	VerifiedSender bool                    `json:"verified_sender"`
 	QuarantineID   string                  `json:"quarantine_id,omitempty"`
+	ExpiresAt      string                  `json:"expires_at,omitempty"`
 }
 
 // Handler processes /v1/message requests through the full pipeline.
@@ -85,7 +86,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Rate limit check (before any expensive operations)
 	if !h.rateLimiter.Allow(req.From) {
 		writeJSON(w, http.StatusTooManyRequests, map[string]string{
-			"error": fmt.Sprintf("rate limit exceeded for agent %q", req.From),
+			"error": "rate limit exceeded",
 		})
 		return
 	}
@@ -139,7 +140,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		entry.PolicyDecision = "scan_error"
 		entry.LatencyMs = time.Since(start).Milliseconds()
 		h.audit.Log(entry)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "scan failed"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "content scan failed — retry or check server logs"})
 		return
 	}
 
@@ -168,7 +169,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	entry.LatencyMs = time.Since(start).Milliseconds()
 	h.audit.Log(entry)
 
-	quarantineID := h.enqueueIfQuarantined(outcome.Verdict, msgID, req, rulesJSON)
+	qr := h.enqueueIfQuarantined(outcome.Verdict, msgID, req, rulesJSON)
 	h.notifyIfSevere(outcome.Verdict, status, msgID, req, outcome.Findings)
 	h.notifyByRuleOverrides(msgID, req, outcome.Findings)
 
@@ -178,7 +179,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		PolicyDecision: policyDecision,
 		RulesTriggered: outcome.Findings,
 		VerifiedSender: verified,
-		QuarantineID:   quarantineID,
+		QuarantineID:   qr.ID,
+		ExpiresAt:      qr.ExpiresAt,
 	})
 }
 
@@ -422,14 +424,20 @@ func encodeFindings(findings []engine.FindingSummary) string {
 	return "[]"
 }
 
-func (h *Handler) enqueueIfQuarantined(verdict engine.ScanVerdict, msgID string, req *MessageRequest, rulesJSON string) string {
+type quarantineResult struct {
+	ID        string
+	ExpiresAt string
+}
+
+func (h *Handler) enqueueIfQuarantined(verdict engine.ScanVerdict, msgID string, req *MessageRequest, rulesJSON string) quarantineResult {
 	if verdict != engine.VerdictQuarantine {
-		return ""
+		return quarantineResult{}
 	}
 	expiryHours := h.cfg.Quarantine.ExpiryHours
 	if expiryHours <= 0 {
 		expiryHours = 24
 	}
+	expiresAt := time.Now().Add(time.Duration(expiryHours) * time.Hour).UTC().Format(time.RFC3339)
 	qItem := audit.QuarantineItem{
 		ID:             msgID,
 		AuditEntryID:   msgID,
@@ -437,7 +445,7 @@ func (h *Handler) enqueueIfQuarantined(verdict engine.ScanVerdict, msgID string,
 		FromAgent:      req.From,
 		ToAgent:        req.To,
 		Status:         "pending",
-		ExpiresAt:      time.Now().Add(time.Duration(expiryHours) * time.Hour).UTC().Format(time.RFC3339),
+		ExpiresAt:      expiresAt,
 		CreatedAt:      time.Now().UTC().Format(time.RFC3339),
 		RulesTriggered: rulesJSON,
 		Signature:      req.Signature,
@@ -445,9 +453,9 @@ func (h *Handler) enqueueIfQuarantined(verdict engine.ScanVerdict, msgID string,
 	}
 	if err := h.audit.Enqueue(qItem); err != nil {
 		h.logger.Error("quarantine enqueue failed", "error", err, "id", msgID)
-		return ""
+		return quarantineResult{}
 	}
-	return msgID
+	return quarantineResult{ID: msgID, ExpiresAt: expiresAt}
 }
 
 func (h *Handler) notifyIfSevere(verdict engine.ScanVerdict, status, msgID string, req *MessageRequest, findings []engine.FindingSummary) {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -59,7 +59,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	// Audit store
 	auditStore, err := audit.NewStore(cfg.DBPath, logger, cfg.Quarantine.RetentionDays)
 	if err != nil {
-		return nil, fmt.Errorf("opening audit store: %w", err)
+		return nil, fmt.Errorf("opening audit store: %w — if another oktsec instance is running, stop it first", err)
 	}
 
 	// Webhook notifier
@@ -189,7 +189,7 @@ func listenAutoPort(bind string, port int, logger *slog.Logger) (net.Listener, i
 			return ln, tryPort, nil
 		}
 	}
-	return nil, 0, fmt.Errorf("port %d and next 10 ports are all in use", port)
+	return nil, 0, fmt.Errorf("port %d and next 10 ports are all in use — try 'oktsec serve --port <port>' or stop existing instances", port)
 }
 
 func isAddrInUse(err error) bool {


### PR DESCRIPTION
## Summary

- **Rate limit info disclosure**: removed agent name from 429 error response to prevent enumeration
- **Specific error messages**: port exhaustion now suggests `--port`, DB lock suggests checking running instances, scan errors suggest checking logs
- **Quarantine expiry in API**: `MessageResponse` now includes `expires_at` for quarantined messages
- **Per-agent unsigned breakdown**: new `QueryUnsignedByAgent()` query + display in dashboard overview stats
- **Dashboard loading states**: htmx loading spinners for panel requests and search inputs, CSS indicator classes

## Test plan

- [x] All existing tests pass (21 packages, race detector enabled)
- [x] New `TestQueryUnsignedByAgent` validates per-agent unsigned counts
- [x] `go vet` clean
- [ ] Manually verify dashboard loading spinner appears when clicking event rows
- [ ] Verify 429 response no longer contains agent name
- [ ] Verify quarantine response includes `expires_at` field