### PR TITLE
feat: verifiable intent — audit chain, intent validation, delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,115 @@ When the forward proxy is enabled, agents identify themselves via `X-Oktsec-Agen
 
 The `X-Oktsec-Agent` header is stripped before forwarding upstream (never leaked to destination).
 
+## Delegation Chains
+
+Agents can delegate messaging authority to other agents using cryptographically signed delegation tokens. Inspired by Verifiable Intent's 3-layer delegation model.
+
+```go
+// Create a delegation from parent to child, valid for 24h
+token := identity.CreateDelegation(parentPrivKey, "parent", "child", []string{"target-a", "target-b"}, 24*time.Hour)
+
+// Verify: checks signature, expiry, and scope
+result := identity.VerifyDelegation(parentPubKey, token, "target-a")
+// result.Valid == true
+```
+
+Canonical signing payload: `delegator\ndelegate\nscope_csv\nissuedAt\nexpiresAt`
+
+When a delegate sends a message, the handler can verify the chain: delegate's key signed the message, delegator's key signed the delegation, and ACL uses the delegator's permissions.
+
+## Scoped Constraints
+
+ACL entries can include constraints beyond simple allow/deny:
+
+```yaml
+agents:
+  researcher:
+    can_message:
+      - target: coder
+        constraints:
+          - type: rate
+            max_messages: 50
+            window_secs: 3600
+          - type: ttl
+            expires_at: "2026-04-01T00:00:00Z"
+      - target: coordinator   # no constraints = unrestricted
+```
+
+Constraint types:
+- `rate` — max N messages per window to a specific target
+- `ttl` — permission expires at a given timestamp
+
+Backward compatible: plain string entries in `can_message` still work as unrestricted permissions.
+
+## Intent Declaration
+
+Agents can declare what they intend to do via the `intent` field:
+
+```json
+{
+  "from": "researcher",
+  "to": "coder",
+  "content": "Please review PR #92",
+  "intent": "code_review",
+  "timestamp": "2026-03-06T12:00:00Z"
+}
+```
+
+The proxy validates intent against content using deterministic pattern matching (no LLM). Known categories: `code_review`, `deploy`, `debug`, `monitoring`, `testing`, `documentation`, `security`, `data`. A mismatch between declared intent and content triggers a flag.
+
+## Selective Disclosure (Audit Redaction)
+
+Audit log exports support three redaction levels:
+
+- `full` — all fields visible (admin only)
+- `analyst` — content hashes visible, matched content in findings redacted to `[REDACTED]`
+- `external` — only status, timestamp, agents, and policy decision
+
+```
+GET /v1/audit?redaction=analyst
+```
+
+## Verifiable Audit Trail
+
+Audit entries form a tamper-evident hash chain. Each entry includes:
+- `prev_hash` — SHA-256 of the previous entry's hash
+- `entry_hash` — SHA-256 of `prev_hash + id + timestamp + from + to + content_hash + status`
+- `proxy_signature` — Ed25519 signature of `entry_hash` by the proxy's key
+
+Verify chain integrity:
+```
+oktsec verify --audit
+GET /v1/audit/verify
+```
+
+## MCP Gateway Tool Constraints
+
+Per-agent tool constraints go beyond simple allowlists:
+
+```yaml
+agents:
+  researcher:
+    tool_constraints:
+      - tool: read_file
+        parameters:
+          path:
+            allowed_patterns: ["/data/*", "/public/*"]
+            blocked_patterns: ["/secrets/*", "*.env"]
+        max_response_bytes: 1048576
+      - tool: write_file
+        cooldown_secs: 10
+    tool_chain_rules:
+      - if: get_credentials
+        then: [send_email, http_request]
+        cooldown_secs: 300
+```
+
+Features:
+- **Parameter constraints**: allowed/blocked glob patterns, max length
+- **Tool cooldowns**: minimum interval between calls to the same tool
+- **Chain rules**: calling tool A blocks tools B and C for N seconds (prevents credential exfiltration)
+
 ## Rate Limiting
 
 When `rate_limit.per_agent > 0`, each agent is limited to N messages per window (sliding window). Exceeding the limit returns HTTP 429. Rate limiting runs before identity verification (cheapest check first).

--- a/internal/audit/chain.go
+++ b/internal/audit/chain.go
@@ -1,0 +1,98 @@
+package audit
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+// ComputeEntryHash computes a SHA-256 hash over the chain-relevant fields of an
+// audit entry. The hash covers the previous hash, entry ID, timestamp, agents,
+// content hash, and status to form a tamper-evident chain.
+func ComputeEntryHash(prevHash, id, ts, from, to, contentHash, status string) string {
+	payload := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%s", prevHash, id, ts, from, to, contentHash, status)
+	h := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(h[:])
+}
+
+// SignEntryHash signs an entry hash with the proxy's Ed25519 private key.
+func SignEntryHash(key ed25519.PrivateKey, entryHash string) string {
+	sig := ed25519.Sign(key, []byte(entryHash))
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+// VerifyEntrySignature verifies an entry hash signature against the proxy's public key.
+func VerifyEntrySignature(pub ed25519.PublicKey, entryHash, signature string) bool {
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(pub, []byte(entryHash), sig)
+}
+
+// ChainVerifyResult holds the result of verifying an audit chain.
+type ChainVerifyResult struct {
+	Valid      bool   `json:"valid"`
+	Entries    int    `json:"entries"`
+	BrokenAt   int    `json:"broken_at,omitempty"`  // index of first broken link (-1 if valid)
+	BrokenID   string `json:"broken_id,omitempty"`  // ID of the broken entry
+	Reason     string `json:"reason,omitempty"`
+}
+
+// VerifyChain validates the hash chain and signatures of a sequence of audit entries.
+// Entries must be ordered oldest-first (ascending timestamp).
+func VerifyChain(entries []ChainEntry, proxyPub ed25519.PublicKey) ChainVerifyResult {
+	if len(entries) == 0 {
+		return ChainVerifyResult{Valid: true, Entries: 0, BrokenAt: -1}
+	}
+
+	for i, e := range entries {
+		// Recompute hash
+		expectedHash := ComputeEntryHash(e.PrevHash, e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.ContentHash, e.Status)
+		if e.EntryHash != expectedHash {
+			return ChainVerifyResult{
+				Valid:    false,
+				Entries:  len(entries),
+				BrokenAt: i,
+				BrokenID: e.ID,
+				Reason:   "entry hash mismatch",
+			}
+		}
+
+		// Verify chain link (except first entry)
+		if i > 0 && e.PrevHash != entries[i-1].EntryHash {
+			return ChainVerifyResult{
+				Valid:    false,
+				Entries:  len(entries),
+				BrokenAt: i,
+				BrokenID: e.ID,
+				Reason:   "chain link broken — prev_hash does not match previous entry",
+			}
+		}
+
+		// Verify signature if proxy key provided
+		if proxyPub != nil && e.ProxySignature != "" {
+			if !VerifyEntrySignature(proxyPub, e.EntryHash, e.ProxySignature) {
+				return ChainVerifyResult{
+					Valid:    false,
+					Entries:  len(entries),
+					BrokenAt: i,
+					BrokenID: e.ID,
+					Reason:   "proxy signature invalid",
+				}
+			}
+		}
+	}
+
+	return ChainVerifyResult{Valid: true, Entries: len(entries), BrokenAt: -1}
+}
+
+// ChainEntry extends Entry with chain fields for verification purposes.
+type ChainEntry struct {
+	Entry
+	PrevHash       string `json:"prev_hash"`
+	EntryHash      string `json:"entry_hash"`
+	ProxySignature string `json:"proxy_signature"`
+}

--- a/internal/audit/chain_test.go
+++ b/internal/audit/chain_test.go
@@ -1,0 +1,161 @@
+package audit
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+func TestComputeEntryHash_Deterministic(t *testing.T) {
+	h1 := ComputeEntryHash("prev", "id1", "2026-01-01T00:00:00Z", "a", "b", "abc123", "delivered")
+	h2 := ComputeEntryHash("prev", "id1", "2026-01-01T00:00:00Z", "a", "b", "abc123", "delivered")
+	if h1 != h2 {
+		t.Fatalf("hash not deterministic: %s != %s", h1, h2)
+	}
+	if len(h1) != 64 { // SHA-256 hex
+		t.Fatalf("unexpected hash length: %d", len(h1))
+	}
+}
+
+func TestComputeEntryHash_DifferentInputs(t *testing.T) {
+	h1 := ComputeEntryHash("", "id1", "2026-01-01T00:00:00Z", "a", "b", "hash1", "delivered")
+	h2 := ComputeEntryHash("", "id1", "2026-01-01T00:00:00Z", "a", "b", "hash1", "blocked")
+	if h1 == h2 {
+		t.Fatal("different statuses should produce different hashes")
+	}
+}
+
+func TestSignAndVerifyEntryHash(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := ComputeEntryHash("", "id1", "2026-01-01T00:00:00Z", "a", "b", "abc", "delivered")
+	sig := SignEntryHash(priv, hash)
+
+	if !VerifyEntrySignature(pub, hash, sig) {
+		t.Fatal("valid signature rejected")
+	}
+
+	// Tampered hash
+	if VerifyEntrySignature(pub, hash+"x", sig) {
+		t.Fatal("tampered hash should fail verification")
+	}
+
+	// Invalid base64
+	if VerifyEntrySignature(pub, hash, "not-base64!!!") {
+		t.Fatal("invalid base64 should fail")
+	}
+}
+
+func TestVerifyChain_Empty(t *testing.T) {
+	result := VerifyChain(nil, nil)
+	if !result.Valid {
+		t.Fatal("empty chain should be valid")
+	}
+}
+
+func TestVerifyChain_ValidChain(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+
+	// Build a 3-entry chain
+	entries := make([]ChainEntry, 3)
+	prevHash := ""
+	for i := 0; i < 3; i++ {
+		e := ChainEntry{
+			Entry: Entry{
+				ID:          fmt.Sprintf("id-%d", i),
+				Timestamp:   "2026-01-01T00:00:00Z",
+				FromAgent:   "a",
+				ToAgent:     "b",
+				ContentHash: fmt.Sprintf("content-%d", i),
+				Status:      "delivered",
+			},
+			PrevHash: prevHash,
+		}
+		e.EntryHash = ComputeEntryHash(e.PrevHash, e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.ContentHash, e.Status)
+		e.ProxySignature = SignEntryHash(priv, e.EntryHash)
+		entries[i] = e
+		prevHash = e.EntryHash
+	}
+
+	result := VerifyChain(entries, pub)
+	if !result.Valid {
+		t.Fatalf("valid chain rejected: %s", result.Reason)
+	}
+	if result.Entries != 3 {
+		t.Fatalf("expected 3 entries, got %d", result.Entries)
+	}
+}
+
+func TestVerifyChain_TamperedEntry(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+
+	entries := make([]ChainEntry, 3)
+	prevHash := ""
+	for i := 0; i < 3; i++ {
+		e := ChainEntry{
+			Entry: Entry{
+				ID:          fmt.Sprintf("id-%d", i),
+				Timestamp:   "2026-01-01T00:00:00Z",
+				FromAgent:   "a",
+				ToAgent:     "b",
+				ContentHash: fmt.Sprintf("content-%d", i),
+				Status:      "delivered",
+			},
+			PrevHash: prevHash,
+		}
+		e.EntryHash = ComputeEntryHash(e.PrevHash, e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.ContentHash, e.Status)
+		e.ProxySignature = SignEntryHash(priv, e.EntryHash)
+		entries[i] = e
+		prevHash = e.EntryHash
+	}
+
+	// Tamper with middle entry's status
+	entries[1].Status = "blocked"
+
+	result := VerifyChain(entries, pub)
+	if result.Valid {
+		t.Fatal("tampered chain should be invalid")
+	}
+	if result.BrokenAt != 1 {
+		t.Fatalf("expected break at index 1, got %d", result.BrokenAt)
+	}
+}
+
+func TestVerifyChain_BrokenLink(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+
+	entries := make([]ChainEntry, 2)
+	// First entry
+	entries[0] = ChainEntry{
+		Entry: Entry{
+			ID: "id-0", Timestamp: "2026-01-01T00:00:00Z",
+			FromAgent: "a", ToAgent: "b", ContentHash: "c0", Status: "delivered",
+		},
+		PrevHash: "",
+	}
+	entries[0].EntryHash = ComputeEntryHash("", "id-0", "2026-01-01T00:00:00Z", "a", "b", "c0", "delivered")
+	entries[0].ProxySignature = SignEntryHash(priv, entries[0].EntryHash)
+
+	// Second entry with wrong prev_hash
+	entries[1] = ChainEntry{
+		Entry: Entry{
+			ID: "id-1", Timestamp: "2026-01-01T00:00:01Z",
+			FromAgent: "a", ToAgent: "b", ContentHash: "c1", Status: "delivered",
+		},
+		PrevHash: "wrong-prev-hash",
+	}
+	entries[1].EntryHash = ComputeEntryHash("wrong-prev-hash", "id-1", "2026-01-01T00:00:01Z", "a", "b", "c1", "delivered")
+	entries[1].ProxySignature = SignEntryHash(priv, entries[1].EntryHash)
+
+	result := VerifyChain(entries, nil) // skip sig verification
+	if result.Valid {
+		t.Fatal("broken chain link should be invalid")
+	}
+	if result.BrokenAt != 1 {
+		t.Fatalf("expected break at index 1, got %d", result.BrokenAt)
+	}
+}

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -15,6 +15,10 @@ type Entry struct {
 	RulesTriggered    string `json:"rules_triggered,omitempty"` // JSON array
 	PolicyDecision    string `json:"policy_decision"`
 	LatencyMs         int64  `json:"latency_ms"`
+	Intent            string `json:"intent,omitempty"`           // declared intent from sender
+	PrevHash          string `json:"prev_hash,omitempty"`        // hash chain: previous entry hash
+	EntryHash         string `json:"entry_hash,omitempty"`       // hash chain: this entry's hash
+	ProxySignature    string `json:"proxy_signature,omitempty"`  // Ed25519 signature by proxy
 }
 
 // RevokedKey represents a revoked agent public key.

--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -1,0 +1,125 @@
+package audit
+
+import (
+	"strings"
+)
+
+// RedactionLevel controls how much detail is visible in exported audit data.
+type RedactionLevel string
+
+const (
+	// RedactNone exposes all fields (admin-only).
+	RedactNone RedactionLevel = "full"
+	// RedactAnalyst hides PII from rule findings but keeps structure.
+	RedactAnalyst RedactionLevel = "analyst"
+	// RedactExternal shows only status, timestamp, agents, and policy decision.
+	RedactExternal RedactionLevel = "external"
+)
+
+// RedactedEntry is an audit entry with fields redacted per the chosen level.
+type RedactedEntry struct {
+	ID                string `json:"id"`
+	Timestamp         string `json:"timestamp"`
+	FromAgent         string `json:"from_agent"`
+	ToAgent           string `json:"to_agent"`
+	ContentHash       string `json:"content_hash,omitempty"`
+	SignatureVerified *int   `json:"signature_verified,omitempty"`
+	Status            string `json:"status"`
+	RulesTriggered    string `json:"rules_triggered,omitempty"`
+	PolicyDecision    string `json:"policy_decision"`
+	LatencyMs         *int64 `json:"latency_ms,omitempty"`
+}
+
+// Redact applies the given redaction level to an audit entry.
+func Redact(e Entry, level RedactionLevel) RedactedEntry {
+	switch level {
+	case RedactExternal:
+		return RedactedEntry{
+			ID:             e.ID,
+			Timestamp:      e.Timestamp,
+			FromAgent:      e.FromAgent,
+			ToAgent:        e.ToAgent,
+			Status:         e.Status,
+			PolicyDecision: e.PolicyDecision,
+		}
+	case RedactAnalyst:
+		rules := redactRuleFindings(e.RulesTriggered)
+		return RedactedEntry{
+			ID:                e.ID,
+			Timestamp:         e.Timestamp,
+			FromAgent:         e.FromAgent,
+			ToAgent:           e.ToAgent,
+			ContentHash:       e.ContentHash,
+			SignatureVerified: &e.SignatureVerified,
+			Status:            e.Status,
+			RulesTriggered:    rules,
+			PolicyDecision:    e.PolicyDecision,
+			LatencyMs:         &e.LatencyMs,
+		}
+	default: // RedactNone / "full"
+		return RedactedEntry{
+			ID:                e.ID,
+			Timestamp:         e.Timestamp,
+			FromAgent:         e.FromAgent,
+			ToAgent:           e.ToAgent,
+			ContentHash:       e.ContentHash,
+			SignatureVerified: &e.SignatureVerified,
+			Status:            e.Status,
+			RulesTriggered:    e.RulesTriggered,
+			PolicyDecision:    e.PolicyDecision,
+			LatencyMs:         &e.LatencyMs,
+		}
+	}
+}
+
+// RedactEntries applies redaction to a slice of entries.
+func RedactEntries(entries []Entry, level RedactionLevel) []RedactedEntry {
+	result := make([]RedactedEntry, len(entries))
+	for i, e := range entries {
+		result[i] = Redact(e, level)
+	}
+	return result
+}
+
+// redactRuleFindings strips matched content from rule findings JSON while
+// preserving rule IDs, names, and severities. This is a simple string-level
+// redaction that removes "matched" fields.
+func redactRuleFindings(rulesJSON string) string {
+	if rulesJSON == "" || rulesJSON == "[]" {
+		return rulesJSON
+	}
+
+	const needle = `"matched":"`
+	const placeholder = `"matched":"[REDACTED]"`
+	var b strings.Builder
+	b.Grow(len(rulesJSON))
+
+	remaining := rulesJSON
+	for {
+		idx := strings.Index(remaining, needle)
+		if idx == -1 {
+			b.WriteString(remaining)
+			break
+		}
+		// Write everything before the match key + the placeholder
+		b.WriteString(remaining[:idx])
+		b.WriteString(placeholder)
+
+		// Skip past the original value: find closing quote after the key
+		valStart := idx + len(needle)
+		end := valStart
+		for end < len(remaining) {
+			if remaining[end] == '\\' && end+1 < len(remaining) {
+				end += 2
+				continue
+			}
+			if remaining[end] == '"' {
+				end++ // consume closing quote
+				break
+			}
+			end++
+		}
+		remaining = remaining[end:]
+	}
+	return b.String()
+}

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -1,0 +1,114 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedact_FullLevel(t *testing.T) {
+	e := Entry{
+		ID: "1", Timestamp: "2026-01-01T00:00:00Z",
+		FromAgent: "a", ToAgent: "b", ContentHash: "abc",
+		SignatureVerified: 1, Status: "delivered",
+		RulesTriggered: `[{"rule_id":"IAP-001","matched":"secret stuff"}]`,
+		PolicyDecision: "allow", LatencyMs: 5,
+	}
+
+	r := Redact(e, RedactNone)
+	if r.ContentHash != "abc" {
+		t.Error("full level should include content hash")
+	}
+	if r.SignatureVerified == nil {
+		t.Error("full level should include signature_verified")
+	}
+	if !strings.Contains(r.RulesTriggered, "secret stuff") {
+		t.Error("full level should not redact rule findings")
+	}
+}
+
+func TestRedact_AnalystLevel(t *testing.T) {
+	e := Entry{
+		ID: "1", Timestamp: "2026-01-01T00:00:00Z",
+		FromAgent: "a", ToAgent: "b", ContentHash: "abc",
+		SignatureVerified: 1, Status: "blocked",
+		RulesTriggered: `[{"rule_id":"IAP-001","name":"Prompt Injection","matched":"ignore previous instructions"}]`,
+		PolicyDecision: "content_blocked", LatencyMs: 5,
+	}
+
+	r := Redact(e, RedactAnalyst)
+	if r.ContentHash != "abc" {
+		t.Error("analyst level should include content hash")
+	}
+	if strings.Contains(r.RulesTriggered, "ignore previous instructions") {
+		t.Error("analyst level should redact matched content")
+	}
+	if !strings.Contains(r.RulesTriggered, "[REDACTED]") {
+		t.Error("analyst level should contain [REDACTED] placeholder")
+	}
+	if !strings.Contains(r.RulesTriggered, "IAP-001") {
+		t.Error("analyst level should preserve rule IDs")
+	}
+}
+
+func TestRedact_ExternalLevel(t *testing.T) {
+	e := Entry{
+		ID: "1", Timestamp: "2026-01-01T00:00:00Z",
+		FromAgent: "a", ToAgent: "b", ContentHash: "abc",
+		SignatureVerified: 1, Status: "blocked",
+		RulesTriggered: `[{"rule_id":"IAP-001"}]`,
+		PolicyDecision: "content_blocked", LatencyMs: 5,
+	}
+
+	r := Redact(e, RedactExternal)
+	if r.ContentHash != "" {
+		t.Error("external level should not include content hash")
+	}
+	if r.SignatureVerified != nil {
+		t.Error("external level should not include signature_verified")
+	}
+	if r.RulesTriggered != "" {
+		t.Error("external level should not include rules triggered")
+	}
+	if r.LatencyMs != nil {
+		t.Error("external level should not include latency")
+	}
+	// Should still have the basics
+	if r.Status != "blocked" || r.PolicyDecision != "content_blocked" {
+		t.Error("external level should include status and policy decision")
+	}
+}
+
+func TestRedactEntries(t *testing.T) {
+	entries := []Entry{
+		{ID: "1", Status: "delivered", PolicyDecision: "allow"},
+		{ID: "2", Status: "blocked", PolicyDecision: "content_blocked"},
+	}
+
+	result := RedactEntries(entries, RedactExternal)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+	if result[0].ID != "1" || result[1].ID != "2" {
+		t.Error("entry IDs should be preserved")
+	}
+}
+
+func TestRedactRuleFindings_Empty(t *testing.T) {
+	if got := redactRuleFindings(""); got != "" {
+		t.Errorf("empty input should return empty, got %q", got)
+	}
+	if got := redactRuleFindings("[]"); got != "[]" {
+		t.Errorf("empty array should pass through, got %q", got)
+	}
+}
+
+func TestRedactRuleFindings_MultipleMatches(t *testing.T) {
+	input := `[{"rule_id":"A","matched":"secret1"},{"rule_id":"B","matched":"secret2"}]`
+	got := redactRuleFindings(input)
+	if strings.Contains(got, "secret1") || strings.Contains(got, "secret2") {
+		t.Errorf("should redact all matched values, got: %s", got)
+	}
+	if strings.Count(got, "[REDACTED]") != 2 {
+		t.Errorf("expected 2 redactions, got: %s", got)
+	}
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/safefile"
@@ -120,6 +121,7 @@ type Store struct {
 	proxyKey      ed25519.PrivateKey // proxy signing key for audit chain (nil = no signing)
 	lastHash      string             // last entry hash for chain continuity
 	lastHashMu    sync.Mutex
+	inflight      atomic.Int64 // entries being processed in writeLoop
 }
 
 // DB returns the underlying *sql.DB for direct access (benchmarking/migrations).
@@ -481,7 +483,7 @@ func EntryJSON(e Entry) []byte {
 
 // Flush blocks until all pending writes have been processed.
 func (s *Store) Flush() {
-	for len(s.writes) > 0 {
+	for len(s.writes) > 0 || s.inflight.Load() > 0 {
 		time.Sleep(5 * time.Millisecond)
 	}
 }
@@ -497,6 +499,7 @@ func (s *Store) Close() error {
 func (s *Store) writeLoop() {
 	defer close(s.done)
 	for entry := range s.writes {
+		s.inflight.Add(1)
 		// Compute hash chain
 		s.lastHashMu.Lock()
 		entry.PrevHash = s.lastHash
@@ -518,6 +521,7 @@ func (s *Store) writeLoop() {
 		} else {
 			s.Hub.broadcast(entry)
 		}
+		s.inflight.Add(-1)
 	}
 }
 

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"crypto/ed25519"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -28,7 +29,11 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	status TEXT NOT NULL,
 	rules_triggered TEXT,
 	policy_decision TEXT NOT NULL,
-	latency_ms INTEGER
+	latency_ms INTEGER,
+	intent TEXT DEFAULT '',
+	prev_hash TEXT DEFAULT '',
+	entry_hash TEXT DEFAULT '',
+	proxy_signature TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);
@@ -112,6 +117,9 @@ type Store struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	retentionDays int
+	proxyKey      ed25519.PrivateKey // proxy signing key for audit chain (nil = no signing)
+	lastHash      string             // last entry hash for chain continuity
+	lastHashMu    sync.Mutex
 }
 
 // DB returns the underlying *sql.DB for direct access (benchmarking/migrations).
@@ -187,9 +195,47 @@ func NewStore(dbPath string, logger *slog.Logger, retentionDays ...int) (*Store,
 		retentionDays: retention,
 	}
 
+	// Migrate schema: add columns if they don't exist (idempotent)
+	s.migrateSchema()
+
+	// Load last hash for chain continuity
+	s.loadLastHash()
+
 	go s.writeLoop()
 	go s.expiryLoop()
 	return s, nil
+}
+
+// SetProxyKey sets the Ed25519 private key used to sign audit chain entries.
+func (s *Store) SetProxyKey(key ed25519.PrivateKey) {
+	s.proxyKey = key
+}
+
+// migrateSchema adds columns that may not exist in older databases.
+func (s *Store) migrateSchema() {
+	migrations := []string{
+		"ALTER TABLE audit_log ADD COLUMN intent TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN prev_hash TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN entry_hash TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN proxy_signature TEXT DEFAULT ''",
+	}
+	for _, m := range migrations {
+		if _, err := s.db.Exec(m); err != nil {
+			// "duplicate column name" is expected on re-runs; ignore it
+			if !strings.Contains(err.Error(), "duplicate column") {
+				s.logger.Warn("migration skipped", "sql", m, "error", err)
+			}
+		}
+	}
+}
+
+// loadLastHash reads the most recent entry_hash for chain continuity on restart.
+func (s *Store) loadLastHash() {
+	var hash sql.NullString
+	err := s.db.QueryRow("SELECT entry_hash FROM audit_log WHERE entry_hash != '' ORDER BY timestamp DESC LIMIT 1").Scan(&hash)
+	if err == nil && hash.Valid {
+		s.lastHash = hash.String
+	}
 }
 
 // Log enqueues an audit entry for async writing.
@@ -203,7 +249,7 @@ func (s *Store) Log(entry Entry) {
 
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
-	query := "SELECT id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms FROM audit_log WHERE 1=1"
+	query := "SELECT id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(entry_hash,'') FROM audit_log WHERE 1=1"
 	var args []any
 
 	if opts.Status != "" {
@@ -258,7 +304,8 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		var e Entry
 		var fp, rules sql.NullString
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ContentHash,
-			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs); err != nil {
+			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
+			&e.Intent, &e.EntryHash); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		e.PubkeyFingerprint = fp.String
@@ -337,12 +384,13 @@ func (s *Store) QueryHourlyStats() (map[int]int, error) {
 // QueryByID fetches a single audit entry by ID.
 func (s *Store) QueryByID(id string) (*Entry, error) {
 	row := s.db.QueryRow(
-		"SELECT id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms FROM audit_log WHERE id = ?", id)
+		"SELECT id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(entry_hash,'') FROM audit_log WHERE id = ?", id)
 
 	var e Entry
 	var fp, rules sql.NullString
 	if err := row.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ContentHash,
-		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs); err != nil {
+		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
+		&e.Intent, &e.EntryHash); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -449,11 +497,21 @@ func (s *Store) Close() error {
 func (s *Store) writeLoop() {
 	defer close(s.done)
 	for entry := range s.writes {
+		// Compute hash chain
+		s.lastHashMu.Lock()
+		entry.PrevHash = s.lastHash
+		entry.EntryHash = ComputeEntryHash(entry.PrevHash, entry.ID, entry.Timestamp, entry.FromAgent, entry.ToAgent, entry.ContentHash, entry.Status)
+		if s.proxyKey != nil {
+			entry.ProxySignature = SignEntryHash(s.proxyKey, entry.EntryHash)
+		}
+		s.lastHash = entry.EntryHash
+		s.lastHashMu.Unlock()
+
 		_, err := s.db.Exec(
-			`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, prev_hash, entry_hash, proxy_signature) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			entry.ID, entry.Timestamp, entry.FromAgent, entry.ToAgent, entry.ContentHash,
 			entry.SignatureVerified, entry.PubkeyFingerprint, entry.Status, entry.RulesTriggered,
-			entry.PolicyDecision, entry.LatencyMs,
+			entry.PolicyDecision, entry.LatencyMs, entry.Intent, entry.PrevHash, entry.EntryHash, entry.ProxySignature,
 		)
 		if err != nil {
 			s.logger.Error("audit write failed", "id", entry.ID, "error", err)
@@ -1002,6 +1060,32 @@ func (s *Store) QueryAgentTopRules(agent string, limit int, since string) ([]Rul
 		result = result[:limit]
 	}
 	return result, rows.Err()
+}
+
+// QueryChainEntries returns entries with chain fields for verification, ordered oldest-first.
+func (s *Store) QueryChainEntries(limit int) ([]ChainEntry, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.Query(
+		`SELECT id, timestamp, from_agent, to_agent, content_hash, status,
+		 COALESCE(prev_hash,''), COALESCE(entry_hash,''), COALESCE(proxy_signature,'')
+		 FROM audit_log WHERE entry_hash != '' ORDER BY timestamp ASC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query chain entries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []ChainEntry
+	for rows.Next() {
+		var ce ChainEntry
+		if err := rows.Scan(&ce.ID, &ce.Timestamp, &ce.FromAgent, &ce.ToAgent,
+			&ce.ContentHash, &ce.Status, &ce.PrevHash, &ce.EntryHash, &ce.ProxySignature); err != nil {
+			return nil, fmt.Errorf("scanning chain entry: %w", err)
+		}
+		entries = append(entries, ce)
+	}
+	return entries, rows.Err()
 }
 
 // QueryAvgLatency returns the average message latency in milliseconds for the last 24 hours.

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -227,6 +227,10 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Verify audit chain integrity
+	chainEntries, _ := s.audit.QueryChainEntries(10000)
+	chainResult := audit.VerifyChain(chainEntries, nil) // skip sig verification for dashboard speed
+
 	data := map[string]any{
 		"Active":      "audit",
 		"RequireSig":  s.cfg.Identity.RequireSignature,
@@ -237,6 +241,8 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		"TopFixes":    topFixes,
 		"TotalChecks": len(findings),
 		"HasCritical": summary.Critical > 0,
+		"ChainValid":  chainResult.Valid,
+		"ChainCount":  chainResult.Entries,
 	}
 
 	s.renderTemplate(w, auditTmpl, data)

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -122,6 +122,14 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
   </div>
 </div>
 
+{{if .ChainCount}}
+<div style="display:flex;align-items:center;gap:10px;padding:12px 16px;border-left:3px solid {{if .ChainValid}}var(--success){{else}}var(--danger){{end}};background:{{if .ChainValid}}rgba(74,222,128,0.04){{else}}rgba(248,113,113,0.04){{end}};margin-bottom:24px;font-size:0.8125rem;color:var(--text2);border-radius:0 10px 10px 0">
+  {{if .ChainValid}}&#x2713;{{else}}&#x2717;{{end}}
+  <span>Audit chain: <strong style="color:{{if .ChainValid}}var(--success){{else}}var(--danger){{end}}">{{if .ChainValid}}verified{{else}}broken{{end}}</strong> &middot; {{.ChainCount}} entries</span>
+  <a href="/v1/audit/verify" target="_blank" style="margin-left:auto;color:var(--text3);font-size:0.75rem;text-decoration:none;white-space:nowrap">Verify API &rarr;</a>
+</div>
+{{end}}
+
 {{if .HasCritical}}
 <div class="a-alert">
   <strong>{{.Summary.Critical}} critical {{if eq .Summary.Critical 1}}finding{{else}}findings{{end}}</strong> require immediate action

--- a/internal/gateway/constraints.go
+++ b/internal/gateway/constraints.go
@@ -1,0 +1,213 @@
+package gateway
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ToolConstraint defines per-tool parameter and usage limits for an agent.
+type ToolConstraint struct {
+	Tool             string                     `yaml:"tool" json:"tool"`
+	Parameters       map[string]ParamConstraint `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	MaxResponseBytes int                        `yaml:"max_response_bytes,omitempty" json:"max_response_bytes,omitempty"`
+	CooldownSecs     int                        `yaml:"cooldown_secs,omitempty" json:"cooldown_secs,omitempty"`
+}
+
+// ParamConstraint defines validation rules for a single tool parameter.
+type ParamConstraint struct {
+	AllowedPatterns []string `yaml:"allowed_patterns,omitempty" json:"allowed_patterns,omitempty"` // glob patterns
+	BlockedPatterns []string `yaml:"blocked_patterns,omitempty" json:"blocked_patterns,omitempty"` // glob patterns
+	MaxLength       int      `yaml:"max_length,omitempty" json:"max_length,omitempty"`
+}
+
+// ToolChainRule blocks certain tools after a triggering tool is called.
+type ToolChainRule struct {
+	If           string   `yaml:"if" json:"if"`                       // tool that triggers
+	Then         []string `yaml:"then" json:"then"`                   // tools that become blocked
+	CooldownSecs int      `yaml:"cooldown_secs" json:"cooldown_secs"` // how long the block lasts
+}
+
+// ConstraintChecker validates tool calls against per-agent constraints.
+type ConstraintChecker struct {
+	constraints map[string][]ToolConstraint // agent → constraints
+	chainRules  map[string][]ToolChainRule  // agent → chain rules
+	cooldowns   *cooldownTracker
+}
+
+// NewConstraintChecker creates a constraint checker from agent configs.
+func NewConstraintChecker(agentConstraints map[string][]ToolConstraint, agentChainRules map[string][]ToolChainRule) *ConstraintChecker {
+	return &ConstraintChecker{
+		constraints: agentConstraints,
+		chainRules:  agentChainRules,
+		cooldowns:   newCooldownTracker(),
+	}
+}
+
+// ConstraintResult holds the outcome of a constraint check.
+type ConstraintResult struct {
+	Allowed bool
+	Reason  string
+}
+
+// CheckToolCall validates a tool call against the agent's constraints.
+func (cc *ConstraintChecker) CheckToolCall(agent, tool string, params map[string]string) ConstraintResult {
+	// Check chain rules first (tool blocked due to prior tool call)
+	if cc.cooldowns.isBlocked(agent, tool) {
+		return ConstraintResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("tool %q is blocked by chain rule for agent %q", tool, agent),
+		}
+	}
+
+	constraints, ok := cc.constraints[agent]
+	if !ok {
+		return ConstraintResult{Allowed: true, Reason: "no constraints configured"}
+	}
+
+	for _, tc := range constraints {
+		if tc.Tool != tool {
+			continue
+		}
+
+		// Check per-tool cooldown
+		if tc.CooldownSecs > 0 && cc.cooldowns.isOnCooldown(agent, tool, tc.CooldownSecs) {
+			return ConstraintResult{
+				Allowed: false,
+				Reason:  fmt.Sprintf("tool %q is on cooldown (%ds) for agent %q", tool, tc.CooldownSecs, agent),
+			}
+		}
+
+		// Check parameter constraints
+		for paramName, pc := range tc.Parameters {
+			val, exists := params[paramName]
+			if !exists {
+				continue
+			}
+
+			if r := checkParamConstraint(paramName, val, pc); !r.Allowed {
+				return r
+			}
+		}
+	}
+
+	return ConstraintResult{Allowed: true, Reason: "constraints satisfied"}
+}
+
+// RecordToolCall records a tool call for cooldown and chain rule tracking.
+func (cc *ConstraintChecker) RecordToolCall(agent, tool string) {
+	cc.cooldowns.record(agent, tool)
+
+	// Apply chain rules
+	rules, ok := cc.chainRules[agent]
+	if !ok {
+		return
+	}
+	for _, rule := range rules {
+		if rule.If == tool {
+			for _, blocked := range rule.Then {
+				cc.cooldowns.block(agent, blocked, rule.CooldownSecs)
+			}
+		}
+	}
+}
+
+func checkParamConstraint(name, value string, pc ParamConstraint) ConstraintResult {
+	// Max length
+	if pc.MaxLength > 0 && len(value) > pc.MaxLength {
+		return ConstraintResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("parameter %q exceeds max length %d", name, pc.MaxLength),
+		}
+	}
+
+	// Blocked patterns (checked first — deny takes precedence)
+	for _, pattern := range pc.BlockedPatterns {
+		if matched, _ := filepath.Match(pattern, value); matched {
+			return ConstraintResult{
+				Allowed: false,
+				Reason:  fmt.Sprintf("parameter %q matches blocked pattern %q", name, pattern),
+			}
+		}
+		// Also check if the value contains the pattern as a path segment
+		if strings.Contains(value, strings.TrimPrefix(strings.TrimSuffix(pattern, "**"), "**")) {
+			if matched, _ := filepath.Match(pattern, value); matched {
+				return ConstraintResult{
+					Allowed: false,
+					Reason:  fmt.Sprintf("parameter %q matches blocked pattern %q", name, pattern),
+				}
+			}
+		}
+	}
+
+	// Allowed patterns (if specified, value must match at least one)
+	if len(pc.AllowedPatterns) > 0 {
+		matched := false
+		for _, pattern := range pc.AllowedPatterns {
+			if m, _ := filepath.Match(pattern, value); m {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return ConstraintResult{
+				Allowed: false,
+				Reason:  fmt.Sprintf("parameter %q does not match any allowed pattern", name),
+			}
+		}
+	}
+
+	return ConstraintResult{Allowed: true}
+}
+
+// cooldownTracker manages per-agent tool call timing and chain blocks.
+type cooldownTracker struct {
+	mu        sync.Mutex
+	lastCalls map[string]time.Time // "agent:tool" → last call time
+	blocks    map[string]time.Time // "agent:tool" → blocked until
+}
+
+func newCooldownTracker() *cooldownTracker {
+	return &cooldownTracker{
+		lastCalls: make(map[string]time.Time),
+		blocks:    make(map[string]time.Time),
+	}
+}
+
+func (ct *cooldownTracker) record(agent, tool string) {
+	ct.mu.Lock()
+	ct.lastCalls[agent+":"+tool] = time.Now()
+	ct.mu.Unlock()
+}
+
+func (ct *cooldownTracker) isOnCooldown(agent, tool string, cooldownSecs int) bool {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	last, ok := ct.lastCalls[agent+":"+tool]
+	if !ok {
+		return false
+	}
+	return time.Since(last) < time.Duration(cooldownSecs)*time.Second
+}
+
+func (ct *cooldownTracker) block(agent, tool string, secs int) {
+	ct.mu.Lock()
+	ct.blocks[agent+":"+tool] = time.Now().Add(time.Duration(secs) * time.Second)
+	ct.mu.Unlock()
+}
+
+func (ct *cooldownTracker) isBlocked(agent, tool string) bool {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	until, ok := ct.blocks[agent+":"+tool]
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		delete(ct.blocks, agent+":"+tool)
+		return false
+	}
+	return true
+}

--- a/internal/gateway/constraints_test.go
+++ b/internal/gateway/constraints_test.go
@@ -1,0 +1,202 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConstraintChecker_NoConstraints(t *testing.T) {
+	cc := NewConstraintChecker(nil, nil)
+	r := cc.CheckToolCall("agent-a", "read_file", map[string]string{"path": "/data/file.txt"})
+	if !r.Allowed {
+		t.Fatalf("no constraints should allow: %s", r.Reason)
+	}
+}
+
+func TestConstraintChecker_AllowedPattern(t *testing.T) {
+	cc := NewConstraintChecker(
+		map[string][]ToolConstraint{
+			"agent-a": {{
+				Tool: "read_file",
+				Parameters: map[string]ParamConstraint{
+					"path": {AllowedPatterns: []string{"/data/*", "/public/*"}},
+				},
+			}},
+		}, nil,
+	)
+
+	// Allowed
+	r := cc.CheckToolCall("agent-a", "read_file", map[string]string{"path": "/data/report.csv"})
+	if !r.Allowed {
+		t.Fatalf("should match allowed pattern: %s", r.Reason)
+	}
+
+	// Blocked — not in allowed patterns
+	r = cc.CheckToolCall("agent-a", "read_file", map[string]string{"path": "/secrets/key.pem"})
+	if r.Allowed {
+		t.Fatal("should reject path not matching allowed patterns")
+	}
+}
+
+func TestConstraintChecker_BlockedPattern(t *testing.T) {
+	cc := NewConstraintChecker(
+		map[string][]ToolConstraint{
+			"agent-a": {{
+				Tool: "read_file",
+				Parameters: map[string]ParamConstraint{
+					"path": {BlockedPatterns: []string{"/secrets/*", "*.env"}},
+				},
+			}},
+		}, nil,
+	)
+
+	r := cc.CheckToolCall("agent-a", "read_file", map[string]string{"path": "/secrets/key.pem"})
+	if r.Allowed {
+		t.Fatal("should block /secrets/* pattern")
+	}
+
+	r = cc.CheckToolCall("agent-a", "read_file", map[string]string{"path": "/data/report.csv"})
+	if !r.Allowed {
+		t.Fatalf("should allow non-blocked path: %s", r.Reason)
+	}
+}
+
+func TestConstraintChecker_MaxLength(t *testing.T) {
+	cc := NewConstraintChecker(
+		map[string][]ToolConstraint{
+			"agent-a": {{
+				Tool: "write_file",
+				Parameters: map[string]ParamConstraint{
+					"content": {MaxLength: 100},
+				},
+			}},
+		}, nil,
+	)
+
+	r := cc.CheckToolCall("agent-a", "write_file", map[string]string{"content": "short"})
+	if !r.Allowed {
+		t.Fatalf("short content should be allowed: %s", r.Reason)
+	}
+
+	long := make([]byte, 150)
+	for i := range long {
+		long[i] = 'x'
+	}
+	r = cc.CheckToolCall("agent-a", "write_file", map[string]string{"content": string(long)})
+	if r.Allowed {
+		t.Fatal("content exceeding max_length should be blocked")
+	}
+}
+
+func TestConstraintChecker_Cooldown(t *testing.T) {
+	cc := NewConstraintChecker(
+		map[string][]ToolConstraint{
+			"agent-a": {{
+				Tool:         "write_file",
+				CooldownSecs: 2,
+			}},
+		}, nil,
+	)
+
+	// First call — allowed
+	r := cc.CheckToolCall("agent-a", "write_file", nil)
+	if !r.Allowed {
+		t.Fatalf("first call should be allowed: %s", r.Reason)
+	}
+	cc.RecordToolCall("agent-a", "write_file")
+
+	// Immediate second call — should be on cooldown
+	r = cc.CheckToolCall("agent-a", "write_file", nil)
+	if r.Allowed {
+		t.Fatal("immediate second call should be on cooldown")
+	}
+
+	// Different tool — not on cooldown
+	r = cc.CheckToolCall("agent-a", "read_file", nil)
+	if !r.Allowed {
+		t.Fatalf("different tool should not be on cooldown: %s", r.Reason)
+	}
+}
+
+func TestConstraintChecker_ChainRule(t *testing.T) {
+	cc := NewConstraintChecker(
+		nil,
+		map[string][]ToolChainRule{
+			"agent-a": {{
+				If:           "get_credentials",
+				Then:         []string{"send_email", "http_request"},
+				CooldownSecs: 2,
+			}},
+		},
+	)
+
+	// Call get_credentials
+	r := cc.CheckToolCall("agent-a", "get_credentials", nil)
+	if !r.Allowed {
+		t.Fatalf("get_credentials should be allowed: %s", r.Reason)
+	}
+	cc.RecordToolCall("agent-a", "get_credentials")
+
+	// send_email should now be blocked
+	r = cc.CheckToolCall("agent-a", "send_email", nil)
+	if r.Allowed {
+		t.Fatal("send_email should be blocked by chain rule")
+	}
+
+	// http_request should also be blocked
+	r = cc.CheckToolCall("agent-a", "http_request", nil)
+	if r.Allowed {
+		t.Fatal("http_request should be blocked by chain rule")
+	}
+
+	// Unrelated tool should be fine
+	r = cc.CheckToolCall("agent-a", "read_file", nil)
+	if !r.Allowed {
+		t.Fatalf("read_file should not be affected by chain rule: %s", r.Reason)
+	}
+
+	// Wait for cooldown to expire
+	time.Sleep(2100 * time.Millisecond)
+	r = cc.CheckToolCall("agent-a", "send_email", nil)
+	if !r.Allowed {
+		t.Fatalf("send_email should be allowed after cooldown: %s", r.Reason)
+	}
+}
+
+func TestConstraintChecker_DifferentAgents(t *testing.T) {
+	cc := NewConstraintChecker(
+		map[string][]ToolConstraint{
+			"agent-a": {{
+				Tool:         "write_file",
+				CooldownSecs: 60,
+			}},
+		}, nil,
+	)
+
+	cc.RecordToolCall("agent-a", "write_file")
+
+	// agent-b should not be affected
+	r := cc.CheckToolCall("agent-b", "write_file", nil)
+	if !r.Allowed {
+		t.Fatalf("agent-b should not share cooldown with agent-a: %s", r.Reason)
+	}
+}
+
+func TestCheckParamConstraint_AllowedAndBlocked(t *testing.T) {
+	pc := ParamConstraint{
+		AllowedPatterns: []string{"/data/*"},
+		BlockedPatterns: []string{"/data/secret*"},
+	}
+
+	// Allowed
+	r := checkParamConstraint("path", "/data/report.csv", pc)
+	if !r.Allowed {
+		t.Fatalf("should be allowed: %s", r.Reason)
+	}
+
+	// Blocked takes precedence
+	r = checkParamConstraint("path", "/data/secret.key", pc)
+	if r.Allowed {
+		t.Fatal("blocked pattern should take precedence over allowed")
+	}
+}

--- a/internal/identity/delegation.go
+++ b/internal/identity/delegation.go
@@ -1,0 +1,109 @@
+package identity
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DelegationToken represents a cryptographically signed authorization from one
+// agent (delegator) to another (delegate), granting scoped messaging permissions.
+// Inspired by Verifiable Intent's 3-layer delegation chain model.
+type DelegationToken struct {
+	Delegator string    `json:"delegator"`           // parent agent name
+	Delegate  string    `json:"delegate"`            // child agent name
+	Scope     []string  `json:"scope"`               // allowed recipients, or ["*"] for all
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	Signature string    `json:"signature,omitempty"` // base64(ed25519 sig by delegator)
+}
+
+// delegationPayload builds the canonical byte payload for signing/verification.
+// Format: delegator\ndelegate\nscope_csv\nissuedAt\nexpiresAt
+func delegationPayload(delegator, delegate string, scope []string, issuedAt, expiresAt time.Time) []byte {
+	scopeCSV := strings.Join(scope, ",")
+	s := fmt.Sprintf("%s\n%s\n%s\n%s\n%s",
+		delegator, delegate, scopeCSV,
+		issuedAt.UTC().Format(time.RFC3339),
+		expiresAt.UTC().Format(time.RFC3339),
+	)
+	return []byte(s)
+}
+
+// CreateDelegation creates a signed delegation token from delegator to delegate.
+// The delegator's private key signs the canonical payload.
+func CreateDelegation(delegatorKey ed25519.PrivateKey, delegator, delegate string, scope []string, ttl time.Duration) *DelegationToken {
+	now := time.Now().UTC()
+	token := &DelegationToken{
+		Delegator: delegator,
+		Delegate:  delegate,
+		Scope:     scope,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(ttl),
+	}
+
+	payload := delegationPayload(delegator, delegate, scope, token.IssuedAt, token.ExpiresAt)
+	sig := ed25519.Sign(delegatorKey, payload)
+	token.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	return token
+}
+
+// DelegationVerifyResult holds the outcome of delegation verification.
+type DelegationVerifyResult struct {
+	Valid  bool
+	Reason string
+}
+
+// VerifyDelegation checks that a delegation token is valid:
+// 1. Signature is valid against the delegator's public key
+// 2. Token is not expired
+// 3. The target recipient is within the delegation scope
+func VerifyDelegation(delegatorPub ed25519.PublicKey, token *DelegationToken, recipient string) DelegationVerifyResult {
+	if token == nil {
+		return DelegationVerifyResult{Valid: false, Reason: "nil delegation token"}
+	}
+
+	// Check expiry
+	if time.Now().UTC().After(token.ExpiresAt) {
+		return DelegationVerifyResult{Valid: false, Reason: "delegation expired"}
+	}
+
+	// Check not issued in the future (with 30s tolerance)
+	if token.IssuedAt.After(time.Now().UTC().Add(30 * time.Second)) {
+		return DelegationVerifyResult{Valid: false, Reason: "delegation issued in the future"}
+	}
+
+	// Verify signature
+	sig, err := base64.StdEncoding.DecodeString(token.Signature)
+	if err != nil {
+		return DelegationVerifyResult{Valid: false, Reason: "invalid signature encoding"}
+	}
+
+	payload := delegationPayload(token.Delegator, token.Delegate, token.Scope, token.IssuedAt, token.ExpiresAt)
+	if !ed25519.Verify(delegatorPub, payload, sig) {
+		return DelegationVerifyResult{Valid: false, Reason: "signature verification failed"}
+	}
+
+	// Check scope
+	if !scopeAllows(token.Scope, recipient) {
+		return DelegationVerifyResult{
+			Valid:  false,
+			Reason: fmt.Sprintf("recipient %q not in delegation scope", recipient),
+		}
+	}
+
+	return DelegationVerifyResult{Valid: true, Reason: "valid delegation"}
+}
+
+// scopeAllows checks if recipient is covered by the scope list.
+func scopeAllows(scope []string, recipient string) bool {
+	for _, s := range scope {
+		if s == "*" || s == recipient {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/identity/delegation_test.go
+++ b/internal/identity/delegation_test.go
@@ -1,0 +1,111 @@
+package identity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func TestCreateAndVerifyDelegation(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token := CreateDelegation(priv, "parent", "child", []string{"target-a", "target-b"}, time.Hour)
+
+	// Valid: recipient in scope
+	result := VerifyDelegation(pub, token, "target-a")
+	if !result.Valid {
+		t.Fatalf("expected valid delegation, got: %s", result.Reason)
+	}
+
+	// Valid: other recipient in scope
+	result = VerifyDelegation(pub, token, "target-b")
+	if !result.Valid {
+		t.Fatalf("expected valid for target-b: %s", result.Reason)
+	}
+
+	// Invalid: recipient not in scope
+	result = VerifyDelegation(pub, token, "target-c")
+	if result.Valid {
+		t.Fatal("expected rejection for target-c")
+	}
+	if result.Reason == "" {
+		t.Fatal("expected reason for rejection")
+	}
+}
+
+func TestDelegation_WildcardScope(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	token := CreateDelegation(priv, "parent", "child", []string{"*"}, time.Hour)
+
+	result := VerifyDelegation(pub, token, "anyone")
+	if !result.Valid {
+		t.Fatalf("wildcard scope should allow anyone: %s", result.Reason)
+	}
+}
+
+func TestDelegation_Expired(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	token := CreateDelegation(priv, "parent", "child", []string{"*"}, -time.Hour) // already expired
+
+	result := VerifyDelegation(pub, token, "target")
+	if result.Valid {
+		t.Fatal("expired delegation should be rejected")
+	}
+}
+
+func TestDelegation_WrongKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	token := CreateDelegation(priv, "parent", "child", []string{"*"}, time.Hour)
+
+	result := VerifyDelegation(otherPub, token, "target")
+	if result.Valid {
+		t.Fatal("wrong key should fail verification")
+	}
+}
+
+func TestDelegation_NilToken(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	result := VerifyDelegation(pub, nil, "target")
+	if result.Valid {
+		t.Fatal("nil token should be invalid")
+	}
+}
+
+func TestDelegation_TamperedSignature(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	token := CreateDelegation(priv, "parent", "child", []string{"target"}, time.Hour)
+
+	// Tamper with scope
+	token.Scope = []string{"*"}
+
+	result := VerifyDelegation(pub, token, "target")
+	if result.Valid {
+		t.Fatal("tampered token should fail signature verification")
+	}
+}
+
+func TestScopeAllows(t *testing.T) {
+	tests := []struct {
+		scope     []string
+		recipient string
+		want      bool
+	}{
+		{[]string{"a", "b"}, "a", true},
+		{[]string{"a", "b"}, "c", false},
+		{[]string{"*"}, "anything", true},
+		{nil, "a", false},
+		{[]string{}, "a", false},
+	}
+	for _, tt := range tests {
+		got := scopeAllows(tt.scope, tt.recipient)
+		if got != tt.want {
+			t.Errorf("scopeAllows(%v, %q) = %v, want %v", tt.scope, tt.recipient, got, tt.want)
+		}
+	}
+}

--- a/internal/policy/constraints.go
+++ b/internal/policy/constraints.go
@@ -1,0 +1,109 @@
+package policy
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Constraint defines a condition on an ACL entry beyond simple allow/deny.
+type Constraint struct {
+	Type        string   `yaml:"type" json:"type"`                             // "rate", "ttl"
+	MaxMessages int      `yaml:"max_messages,omitempty" json:"max_messages,omitempty"` // for type=rate
+	WindowSecs  int      `yaml:"window_secs,omitempty" json:"window_secs,omitempty"`   // for type=rate
+	ExpiresAt   string   `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`     // for type=ttl (RFC3339)
+	Categories  []string `yaml:"categories,omitempty" json:"categories,omitempty"`     // reserved for future use
+}
+
+// ACLEntry defines a permission from one agent to a target with optional constraints.
+type ACLEntry struct {
+	Target      string       `yaml:"target" json:"target"`
+	Constraints []Constraint `yaml:"constraints,omitempty" json:"constraints,omitempty"`
+}
+
+// constraintTracker tracks per-edge message counts for rate constraints.
+type constraintTracker struct {
+	mu      sync.Mutex
+	windows map[string]*slidingCount // key: "from->to"
+}
+
+type slidingCount struct {
+	timestamps []time.Time
+}
+
+func newConstraintTracker() *constraintTracker {
+	return &constraintTracker{
+		windows: make(map[string]*slidingCount),
+	}
+}
+
+// checkRate checks if a rate constraint is satisfied and records the message.
+// Returns true if the message is allowed.
+func (ct *constraintTracker) checkRate(from, to string, maxMessages, windowSecs int) bool {
+	if maxMessages <= 0 {
+		return true
+	}
+	window := time.Duration(windowSecs) * time.Second
+	if window <= 0 {
+		window = 60 * time.Second
+	}
+
+	key := from + "->" + to
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	sc, ok := ct.windows[key]
+	if !ok {
+		sc = &slidingCount{}
+		ct.windows[key] = sc
+	}
+
+	now := time.Now()
+	cutoff := now.Add(-window)
+
+	// Prune old entries
+	valid := sc.timestamps[:0]
+	for _, ts := range sc.timestamps {
+		if ts.After(cutoff) {
+			valid = append(valid, ts)
+		}
+	}
+	sc.timestamps = valid
+
+	if len(sc.timestamps) >= maxMessages {
+		return false
+	}
+
+	sc.timestamps = append(sc.timestamps, now)
+	return true
+}
+
+// EvaluateConstraints checks all constraints on an ACL entry.
+// Returns a Decision — allowed if all constraints pass.
+func EvaluateConstraints(from, to string, constraints []Constraint, tracker *constraintTracker) Decision {
+	for _, c := range constraints {
+		switch c.Type {
+		case "rate":
+			if !tracker.checkRate(from, to, c.MaxMessages, c.WindowSecs) {
+				return Decision{
+					Allowed: false,
+					Reason:  fmt.Sprintf("rate constraint exceeded: max %d messages per %ds for %s->%s", c.MaxMessages, c.WindowSecs, from, to),
+				}
+			}
+		case "ttl":
+			if c.ExpiresAt != "" {
+				exp, err := time.Parse(time.RFC3339, c.ExpiresAt)
+				if err != nil {
+					return Decision{Allowed: false, Reason: fmt.Sprintf("invalid ttl expires_at: %v", err)}
+				}
+				if time.Now().UTC().After(exp) {
+					return Decision{
+						Allowed: false,
+						Reason:  fmt.Sprintf("ttl constraint expired at %s for %s->%s", c.ExpiresAt, from, to),
+					}
+				}
+			}
+		}
+	}
+	return Decision{Allowed: true, Reason: "constraints satisfied"}
+}

--- a/internal/policy/constraints_test.go
+++ b/internal/policy/constraints_test.go
@@ -1,0 +1,116 @@
+package policy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateConstraints_RateAllow(t *testing.T) {
+	tracker := newConstraintTracker()
+	constraints := []Constraint{
+		{Type: "rate", MaxMessages: 5, WindowSecs: 60},
+	}
+
+	for i := 0; i < 5; i++ {
+		d := EvaluateConstraints("a", "b", constraints, tracker)
+		if !d.Allowed {
+			t.Fatalf("message %d should be allowed: %s", i+1, d.Reason)
+		}
+	}
+
+	// 6th should be denied
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if d.Allowed {
+		t.Fatal("6th message should be rate limited")
+	}
+}
+
+func TestEvaluateConstraints_RateDifferentEdges(t *testing.T) {
+	tracker := newConstraintTracker()
+	constraints := []Constraint{
+		{Type: "rate", MaxMessages: 1, WindowSecs: 60},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if !d.Allowed {
+		t.Fatalf("a->b should be allowed: %s", d.Reason)
+	}
+
+	// Different edge should have its own counter
+	d = EvaluateConstraints("a", "c", constraints, tracker)
+	if !d.Allowed {
+		t.Fatalf("a->c should be allowed (different edge): %s", d.Reason)
+	}
+}
+
+func TestEvaluateConstraints_TTLValid(t *testing.T) {
+	tracker := newConstraintTracker()
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	constraints := []Constraint{
+		{Type: "ttl", ExpiresAt: future},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if !d.Allowed {
+		t.Fatalf("future TTL should be allowed: %s", d.Reason)
+	}
+}
+
+func TestEvaluateConstraints_TTLExpired(t *testing.T) {
+	tracker := newConstraintTracker()
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	constraints := []Constraint{
+		{Type: "ttl", ExpiresAt: past},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if d.Allowed {
+		t.Fatal("expired TTL should be denied")
+	}
+}
+
+func TestEvaluateConstraints_TTLInvalid(t *testing.T) {
+	tracker := newConstraintTracker()
+	constraints := []Constraint{
+		{Type: "ttl", ExpiresAt: "not-a-date"},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if d.Allowed {
+		t.Fatal("invalid TTL should be denied")
+	}
+}
+
+func TestEvaluateConstraints_MultipleConstraints(t *testing.T) {
+	tracker := newConstraintTracker()
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	constraints := []Constraint{
+		{Type: "rate", MaxMessages: 10, WindowSecs: 60},
+		{Type: "ttl", ExpiresAt: future},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if !d.Allowed {
+		t.Fatalf("both constraints should pass: %s", d.Reason)
+	}
+}
+
+func TestEvaluateConstraints_Empty(t *testing.T) {
+	tracker := newConstraintTracker()
+	d := EvaluateConstraints("a", "b", nil, tracker)
+	if !d.Allowed {
+		t.Fatal("empty constraints should allow")
+	}
+}
+
+func TestEvaluateConstraints_UnknownType(t *testing.T) {
+	tracker := newConstraintTracker()
+	constraints := []Constraint{
+		{Type: "unknown_future_type"},
+	}
+
+	d := EvaluateConstraints("a", "b", constraints, tracker)
+	if !d.Allowed {
+		t.Fatal("unknown constraint types should be skipped (forward compat)")
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -26,6 +26,7 @@ type MessageRequest struct {
 	Content   string            `json:"content"`
 	Signature string            `json:"signature,omitempty"`
 	Timestamp string            `json:"timestamp"`
+	Intent    string            `json:"intent,omitempty"`
 	Metadata  map[string]string `json:"metadata,omitempty"`
 }
 
@@ -100,6 +101,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		FromAgent:   req.From,
 		ToAgent:     req.To,
 		ContentHash: sha256Hash(req.Content),
+		Intent:      req.Intent,
 	}
 
 	// Step 1: Identity verification
@@ -160,6 +162,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Step 5: Apply BlockedContent per-agent filter
 	h.applyBlockedContent(req.From, outcome)
+
+	// Step 5b: Intent validation (deterministic pattern matching, no LLM)
+	if req.Intent != "" {
+		intentResult := ValidateIntent(req.Intent, req.Content)
+		if intentResult.Status == "mismatch" {
+			h.logger.Warn("intent mismatch", "from", req.From, "intent", req.Intent, "reason", intentResult.Reason, "message_id", msgID)
+			// Escalate to at least Flag on mismatch
+			if verdictSeverity(outcome.Verdict) < verdictSeverity(engine.VerdictFlag) {
+				outcome.Verdict = engine.VerdictFlag
+			}
+		}
+	}
 
 	// Step 6: Split injection detection (multi-message window)
 	h.scanConcatenated(r.Context(), req.From, req.Content, outcome)

--- a/internal/proxy/intent.go
+++ b/internal/proxy/intent.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"strings"
+)
+
+// IntentResult describes the outcome of intent validation.
+type IntentResult struct {
+	Status string // "match", "mismatch", "missing"
+	Reason string
+}
+
+// intentKeywords maps common intent keywords to content patterns that should
+// appear when that intent is declared. This is a lightweight, deterministic
+// check — no LLM involved.
+var intentKeywords = map[string][]string{
+	"code_review":   {"review", "PR", "pull request", "diff", "approve", "merge", "lgtm"},
+	"deploy":        {"deploy", "release", "rollout", "ship", "production", "staging", "k8s"},
+	"debug":         {"debug", "error", "stack trace", "exception", "fix", "bug", "crash"},
+	"monitoring":    {"alert", "metric", "uptime", "latency", "cpu", "memory", "health"},
+	"testing":       {"test", "coverage", "assert", "spec", "passed", "failed", "flaky"},
+	"documentation": {"doc", "readme", "guide", "example", "api reference", "changelog"},
+	"security":      {"vulnerability", "cve", "patch", "audit", "credential", "token", "key"},
+	"data":          {"query", "database", "table", "export", "import", "csv", "sql", "schema"},
+}
+
+// ValidateIntent checks whether the declared intent aligns with message content.
+// Returns "match" if at least one keyword pattern appears in content,
+// "mismatch" if the intent is declared but no patterns match,
+// "missing" if no intent is provided.
+func ValidateIntent(intent, content string) IntentResult {
+	if intent == "" {
+		return IntentResult{Status: "missing", Reason: "no intent declared"}
+	}
+
+	intentLower := strings.ToLower(strings.TrimSpace(intent))
+	contentLower := strings.ToLower(content)
+
+	// Check each known intent category
+	for keyword, patterns := range intentKeywords {
+		if !strings.Contains(intentLower, keyword) {
+			continue
+		}
+		for _, p := range patterns {
+			if strings.Contains(contentLower, strings.ToLower(p)) {
+				return IntentResult{Status: "match", Reason: "intent aligns with content"}
+			}
+		}
+		// Matched intent keyword but no content patterns found
+		return IntentResult{
+			Status: "mismatch",
+			Reason: "declared intent '" + keyword + "' but content does not match expected patterns",
+		}
+	}
+
+	// Unknown intent category — cannot validate, treat as match to avoid false positives
+	return IntentResult{Status: "match", Reason: "unregistered intent category — skipped"}
+}

--- a/internal/proxy/intent_test.go
+++ b/internal/proxy/intent_test.go
@@ -1,0 +1,52 @@
+package proxy
+
+import "testing"
+
+func TestValidateIntent_Missing(t *testing.T) {
+	r := ValidateIntent("", "some content")
+	if r.Status != "missing" {
+		t.Fatalf("expected missing, got %s", r.Status)
+	}
+}
+
+func TestValidateIntent_Match(t *testing.T) {
+	tests := []struct {
+		intent  string
+		content string
+	}{
+		{"code_review", "Please review this PR and approve if it looks good"},
+		{"deploy", "Rolling out v2.1 to production k8s cluster"},
+		{"debug", "Got a stack trace from the worker — need to fix this bug"},
+		{"monitoring", "CPU alert: worker-3 at 95% for 10 minutes"},
+		{"testing", "All 347 tests passed, coverage at 72%"},
+		{"security", "Found a vulnerability in the auth token handling"},
+	}
+
+	for _, tt := range tests {
+		r := ValidateIntent(tt.intent, tt.content)
+		if r.Status != "match" {
+			t.Errorf("ValidateIntent(%q, %q) = %s (%s), want match", tt.intent, tt.content, r.Status, r.Reason)
+		}
+	}
+}
+
+func TestValidateIntent_Mismatch(t *testing.T) {
+	r := ValidateIntent("code_review", "Transfer $500 to account 12345 and send the receipt")
+	if r.Status != "mismatch" {
+		t.Fatalf("expected mismatch, got %s: %s", r.Status, r.Reason)
+	}
+}
+
+func TestValidateIntent_UnknownCategory(t *testing.T) {
+	r := ValidateIntent("casual_chat", "Hey how are you doing today?")
+	if r.Status != "match" {
+		t.Fatalf("unknown intent should default to match, got %s", r.Status)
+	}
+}
+
+func TestValidateIntent_CaseInsensitive(t *testing.T) {
+	r := ValidateIntent("CODE_REVIEW", "please review this DIFF")
+	if r.Status != "match" {
+		t.Fatalf("case insensitive match failed: %s", r.Status)
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -64,6 +65,25 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 		return nil, fmt.Errorf("opening audit store: %w — if another oktsec instance is running, stop it first", err)
 	}
 
+	// Proxy signing key for audit chain integrity
+	if cfg.Identity.KeysDir != "" {
+		proxyKP, err := identity.LoadKeypair(cfg.Identity.KeysDir, "_proxy")
+		if err != nil {
+			// First run: generate proxy keypair
+			proxyKP, err = identity.GenerateKeypair("_proxy")
+			if err != nil {
+				logger.Warn("could not generate proxy keypair", "error", err)
+			} else if saveErr := proxyKP.Save(cfg.Identity.KeysDir); saveErr != nil {
+				logger.Warn("could not save proxy keypair", "error", saveErr)
+			} else {
+				logger.Info("generated proxy signing key for audit chain")
+			}
+		}
+		if proxyKP != nil {
+			auditStore.SetProxyKey(proxyKP.PrivateKey)
+		}
+	}
+
 	// Webhook notifier
 	webhooks := NewWebhookNotifier(cfg.Webhooks, logger)
 
@@ -100,6 +120,38 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 		}
 		writeJSON(w, http.StatusOK, item)
 	})
+	// Audit chain verification endpoint
+	mux.HandleFunc("GET /v1/audit/verify", func(w http.ResponseWriter, r *http.Request) {
+		entries, qErr := auditStore.QueryChainEntries(10000)
+		if qErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to query chain"})
+			return
+		}
+		var proxyPub ed25519.PublicKey
+		if cfg.Identity.KeysDir != "" {
+			if pub, loadErr := identity.LoadPublicKey(cfg.Identity.KeysDir, "_proxy"); loadErr == nil {
+				proxyPub = pub
+			}
+		}
+		result := audit.VerifyChain(entries, proxyPub)
+		writeJSON(w, http.StatusOK, result)
+	})
+
+	// Audit export with redaction levels
+	mux.HandleFunc("GET /v1/audit/export", func(w http.ResponseWriter, r *http.Request) {
+		level := audit.RedactionLevel(r.URL.Query().Get("redaction"))
+		if level == "" {
+			level = audit.RedactNone
+		}
+		entries, err := auditStore.Query(audit.QueryOpts{Limit: 1000})
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query failed"})
+			return
+		}
+		redacted := audit.RedactEntries(entries, level)
+		writeJSON(w, http.StatusOK, redacted)
+	})
+
 	// Prometheus metrics endpoint
 	mux.Handle("GET /metrics", promhttp.Handler())
 


### PR DESCRIPTION
## Summary

- **Tamper-evident audit chain**: Each audit entry includes SHA-256 hash of previous entry + Ed25519 proxy signature, forming a cryptographic chain verified at `/v1/audit/verify`
- **Intent validation**: Agents declare intent (e.g. `code_review`, `deploy`), proxy validates alignment with content via deterministic pattern matching — mismatches escalate to `flag` verdict
- **Audit redaction**: 3-level export redaction (full/analyst/external) at `/v1/audit/export?redaction=analyst` — controls field visibility for compliance
- **Delegation tokens**: Ed25519-signed tokens for scoped, time-limited agent-to-agent authorization
- **Policy constraints**: Rate-limiting and TTL constraints per ACL edge
- **Gateway tool constraints**: Parameter-level glob patterns, cooldowns, and chain rules for MCP tool calls
- **Dashboard integration**: Audit page shows chain verification status with link to verify API

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` — 0 issues
- [x] All package tests pass with race detector (`audit`, `identity`, `proxy`, `policy`, `gateway`, `dashboard`)
- [x] Chain verification: deterministic hashing, sign/verify, tamper detection
- [x] Intent validation: 8 categories, case-insensitive matching, mismatch detection
- [x] Redaction: all 3 levels, rule finding sanitization
- [x] Delegation: create/verify, wildcard scope, expiry, tamper detection
- [x] Constraints: rate limits, TTL, parameter patterns, cooldowns, chain rules