### PR TITLE
feat: dashboard visibility for verifiable intent features

### DIFF
--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -43,7 +43,7 @@ func Redact(e Entry, level RedactionLevel) RedactedEntry {
 			PolicyDecision: e.PolicyDecision,
 		}
 	case RedactAnalyst:
-		rules := redactRuleFindings(e.RulesTriggered)
+		rules := RedactRuleFindings(e.RulesTriggered)
 		return RedactedEntry{
 			ID:                e.ID,
 			Timestamp:         e.Timestamp,
@@ -81,10 +81,10 @@ func RedactEntries(entries []Entry, level RedactionLevel) []RedactedEntry {
 	return result
 }
 
-// redactRuleFindings strips matched content from rule findings JSON while
+// RedactRuleFindings strips matched content from rule findings JSON while
 // preserving rule IDs, names, and severities. This is a simple string-level
 // redaction that removes "matched" fields.
-func redactRuleFindings(rulesJSON string) string {
+func RedactRuleFindings(rulesJSON string) string {
 	if rulesJSON == "" || rulesJSON == "[]" {
 		return rulesJSON
 	}

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -94,17 +94,17 @@ func TestRedactEntries(t *testing.T) {
 }
 
 func TestRedactRuleFindings_Empty(t *testing.T) {
-	if got := redactRuleFindings(""); got != "" {
+	if got := RedactRuleFindings(""); got != "" {
 		t.Errorf("empty input should return empty, got %q", got)
 	}
-	if got := redactRuleFindings("[]"); got != "[]" {
+	if got := RedactRuleFindings("[]"); got != "[]" {
 		t.Errorf("empty array should pass through, got %q", got)
 	}
 }
 
 func TestRedactRuleFindings_MultipleMatches(t *testing.T) {
 	input := `[{"rule_id":"A","matched":"secret1"},{"rule_id":"B","matched":"secret2"}]`
-	got := redactRuleFindings(input)
+	got := RedactRuleFindings(input)
 	if strings.Contains(got, "secret1") || strings.Contains(got, "secret2") {
 		t.Errorf("should redact all matched values, got: %s", got)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,9 +32,10 @@ type Config struct {
 
 // ServerConfig holds proxy server settings.
 type ServerConfig struct {
-	Port     int    `yaml:"port"`
-	Bind     string `yaml:"bind"` // Address to bind (default: 127.0.0.1)
-	LogLevel string `yaml:"log_level"`
+	Port          int    `yaml:"port"`
+	Bind          string `yaml:"bind"`           // Address to bind (default: 127.0.0.1)
+	LogLevel      string `yaml:"log_level"`
+	RequireIntent bool   `yaml:"require_intent"` // Require agents to declare intent in messages
 }
 
 // IdentityConfig configures agent identity verification.

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -960,6 +960,7 @@ func (s *Server) handleExportCSV(w http.ResponseWriter, r *http.Request) {
 	agent := r.URL.Query().Get("agent")
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
+	redaction := audit.RedactionLevel(r.URL.Query().Get("redaction"))
 
 	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
@@ -972,12 +973,23 @@ func (s *Server) handleExportCSV(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 
 	cw := csv.NewWriter(w)
-	_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "signature_verified", "rules_triggered", "policy_decision", "latency_ms"})
-	for _, e := range entries {
-		_ = cw.Write([]string{
-			e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status,
-			strconv.Itoa(e.SignatureVerified), e.RulesTriggered, e.PolicyDecision, strconv.FormatInt(e.LatencyMs, 10),
-		})
+	if redaction == audit.RedactExternal {
+		_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "policy_decision"})
+		for _, e := range entries {
+			_ = cw.Write([]string{e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status, e.PolicyDecision})
+		}
+	} else {
+		_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "signature_verified", "rules_triggered", "policy_decision", "latency_ms", "intent"})
+		for _, e := range entries {
+			rules := e.RulesTriggered
+			if redaction == audit.RedactAnalyst {
+				rules = audit.RedactRuleFindings(rules)
+			}
+			_ = cw.Write([]string{
+				e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status,
+				strconv.Itoa(e.SignatureVerified), rules, e.PolicyDecision, strconv.FormatInt(e.LatencyMs, 10), e.Intent,
+			})
+		}
 	}
 	cw.Flush()
 }
@@ -986,6 +998,7 @@ func (s *Server) handleExportJSON(w http.ResponseWriter, r *http.Request) {
 	agent := r.URL.Query().Get("agent")
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
+	redaction := audit.RedactionLevel(r.URL.Query().Get("redaction"))
 
 	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
@@ -997,8 +1010,15 @@ func (s *Server) handleExportJSON(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		s.logger.Error("json export failed", "error", err)
+	if redaction != "" {
+		redacted := audit.RedactEntries(entries, redaction)
+		if err := json.NewEncoder(w).Encode(redacted); err != nil {
+			s.logger.Error("json export failed", "error", err)
+		}
+	} else {
+		if err := json.NewEncoder(w).Encode(entries); err != nil {
+			s.logger.Error("json export failed", "error", err)
+		}
 	}
 }
 
@@ -1935,6 +1955,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		"FPScanResponses":      s.cfg.ForwardProxy.ScanResponses,
 		"FPMaxBodySize":        s.cfg.ForwardProxy.MaxBodySize,
 		"QRetentionDays":       s.cfg.Quarantine.RetentionDays,
+		"RequireIntent":        s.cfg.Server.RequireIntent,
 	}
 
 	s.renderTemplate(w, settingsTmpl, data)
@@ -2005,6 +2026,18 @@ func (s *Server) handleSaveAnomaly(w http.ResponseWriter, r *http.Request) {
 	if s.cfgPath != "" {
 		if err := s.cfg.Save(s.cfgPath); err != nil {
 			s.logger.Error("failed to save config after anomaly update", "error", err)
+			http.Error(w, "save failed", http.StatusInternalServerError)
+			return
+		}
+	}
+	http.Redirect(w, r, "/dashboard/settings?tab=pipeline", http.StatusFound)
+}
+
+func (s *Server) handleSaveIntent(w http.ResponseWriter, r *http.Request) {
+	s.cfg.Server.RequireIntent = r.FormValue("require_intent") == "true"
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after intent update", "error", err)
 			http.Error(w, "save failed", http.StatusInternalServerError)
 			return
 		}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -223,6 +223,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /dashboard/settings/default-policy", s.handleSaveDefaultPolicy)
 	s.mux.HandleFunc("POST /dashboard/settings/rate-limit", s.handleSaveRateLimit)
 	s.mux.HandleFunc("POST /dashboard/settings/anomaly", s.handleSaveAnomaly)
+	s.mux.HandleFunc("POST /dashboard/settings/intent", s.handleSaveIntent)
 	s.mux.HandleFunc("POST /dashboard/settings/forward-proxy", s.handleSaveForwardProxy)
 	s.mux.HandleFunc("POST /dashboard/settings/quarantine", s.handleSaveQuarantine)
 

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1843,6 +1843,8 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
     </td></tr>
     {{if .Entry.PubkeyFingerprint}}<tr><td style="color:var(--text3);padding:6px 0">Key</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.PubkeyFingerprint}}</td></tr>{{end}}
     <tr><td style="color:var(--text3);padding:6px 0">Content hash</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.ContentHash}}</td></tr>
+    {{if .Entry.Intent}}<tr><td style="color:var(--text3);padding:6px 0">Intent</td><td style="padding:6px 0"><span style="background:rgba(99,102,241,0.1);color:var(--accent-light);padding:2px 8px;border-radius:4px;font-size:0.75rem;font-family:var(--mono)">{{.Entry.Intent}}</span></td></tr>{{end}}
+    {{if .Entry.EntryHash}}<tr><td style="color:var(--text3);padding:6px 0">Chain hash</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.EntryHash}}</td></tr>{{end}}
   </table>
 </div>`))
 
@@ -2276,6 +2278,29 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
   </form>
 </div>
 
+<div class="card">
+  <h2>Intent Validation</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Agents can declare their intent (e.g. <code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-size:0.72rem;font-family:var(--mono);color:var(--accent-light)">code_review</code>, <code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-size:0.72rem;font-family:var(--mono);color:var(--accent-light)">deploy</code>). The proxy validates that the message content is consistent with the declared intent. Mismatches escalate the verdict to <strong style="color:var(--warn)">flag</strong>.
+  </p>
+  <form method="POST" action="/dashboard/settings/intent">
+    <div style="margin-bottom:20px">
+      <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="require_intent" value="true" {{if .RequireIntent}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Require intent declaration</span>
+      </label>
+      <p style="color:var(--text3);font-size:0.75rem;margin-top:8px;line-height:1.5">
+        When enabled, messages without an <code style="font-size:0.72rem;font-family:var(--mono)">intent</code> field are flagged. When disabled, intent is validated only if provided.
+      </p>
+    </div>
+    <div style="color:var(--text3);font-size:0.78rem;margin-bottom:12px">
+      <strong>Supported categories:</strong>
+      <span style="font-family:var(--mono);font-size:0.72rem;color:var(--text2)">code_review, deploy, data_query, monitoring, security, communication, file_ops, config</span>
+    </div>
+    <button type="submit" class="btn btn-sm">Save</button>
+  </form>
+</div>
+
 </div>
 
 <!-- Infrastructure -->
@@ -2395,6 +2420,11 @@ var eventsTmpl = template.Must(template.New("events").Funcs(tmplFuncs).Parse(lay
   <input type="date" id="filter-until" value="{{.FilterUntil}}" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--surface);color:var(--text);font-size:0.82rem" title="Until date">
   <button class="btn btn-sm" onclick="clearEventFilters()" style="font-size:0.78rem">Clear</button>
   <span style="flex:1"></span>
+  <select id="export-redaction" style="padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--surface);color:var(--text);font-size:0.78rem" title="Redaction level" onchange="updateExportLinks()">
+    <option value="">Full (admin)</option>
+    <option value="analyst">Analyst (redacted matches)</option>
+    <option value="external">External (metadata only)</option>
+  </select>
   <a id="export-csv" class="btn btn-sm" style="font-size:0.78rem;text-decoration:none" download>CSV</a>
   <a id="export-json" class="btn btn-sm" style="font-size:0.78rem;text-decoration:none" download>JSON</a>
 </div>
@@ -2403,10 +2433,12 @@ function buildExportURL(format) {
   var agent = document.getElementById('filter-agent').value;
   var since = document.getElementById('filter-since').value;
   var until = document.getElementById('filter-until').value;
+  var redaction = document.getElementById('export-redaction').value;
   var url = '/dashboard/api/export/' + format + '?_=1';
   if (agent) url += '&agent=' + encodeURIComponent(agent);
   if (since) url += '&since=' + encodeURIComponent(since + 'T00:00:00Z');
   if (until) url += '&until=' + encodeURIComponent(until + 'T23:59:59Z');
+  if (redaction) url += '&redaction=' + encodeURIComponent(redaction);
   return url;
 }
 function updateExportLinks() {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -168,10 +168,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		intentResult := ValidateIntent(req.Intent, req.Content)
 		if intentResult.Status == "mismatch" {
 			h.logger.Warn("intent mismatch", "from", req.From, "intent", req.Intent, "reason", intentResult.Reason, "message_id", msgID)
-			// Escalate to at least Flag on mismatch
 			if verdictSeverity(outcome.Verdict) < verdictSeverity(engine.VerdictFlag) {
 				outcome.Verdict = engine.VerdictFlag
 			}
+		}
+	} else if h.cfg.Server.RequireIntent {
+		h.logger.Warn("missing required intent", "from", req.From, "message_id", msgID)
+		if verdictSeverity(outcome.Verdict) < verdictSeverity(engine.VerdictFlag) {
+			outcome.Verdict = engine.VerdictFlag
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Event detail**: shows Intent badge and Chain hash for each audit entry
- **Export redaction**: dropdown selector (Full/Analyst/External) in Events export - CSV and JSON both respect the selected level
- **Settings > Pipeline**: new Intent Validation card with require_intent toggle and supported categories list
- **RequireIntent config**: `server.require_intent` in oktsec.yaml - when enabled, messages without intent are flagged

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` - 0 issues
- [x] All tests pass with race detector (audit, proxy, dashboard, config)