### PR TITLE
feat: verifiable intent dashboard — tool policies, overview redesign, audit chain

### DIFF
--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -43,7 +43,7 @@ func Redact(e Entry, level RedactionLevel) RedactedEntry {
 			PolicyDecision: e.PolicyDecision,
 		}
 	case RedactAnalyst:
-		rules := redactRuleFindings(e.RulesTriggered)
+		rules := RedactRuleFindings(e.RulesTriggered)
 		return RedactedEntry{
 			ID:                e.ID,
 			Timestamp:         e.Timestamp,
@@ -81,10 +81,10 @@ func RedactEntries(entries []Entry, level RedactionLevel) []RedactedEntry {
 	return result
 }
 
-// redactRuleFindings strips matched content from rule findings JSON while
+// RedactRuleFindings strips matched content from rule findings JSON while
 // preserving rule IDs, names, and severities. This is a simple string-level
 // redaction that removes "matched" fields.
-func redactRuleFindings(rulesJSON string) string {
+func RedactRuleFindings(rulesJSON string) string {
 	if rulesJSON == "" || rulesJSON == "[]" {
 		return rulesJSON
 	}

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -94,17 +94,17 @@ func TestRedactEntries(t *testing.T) {
 }
 
 func TestRedactRuleFindings_Empty(t *testing.T) {
-	if got := redactRuleFindings(""); got != "" {
+	if got := RedactRuleFindings(""); got != "" {
 		t.Errorf("empty input should return empty, got %q", got)
 	}
-	if got := redactRuleFindings("[]"); got != "[]" {
+	if got := RedactRuleFindings("[]"); got != "[]" {
 		t.Errorf("empty array should pass through, got %q", got)
 	}
 }
 
 func TestRedactRuleFindings_MultipleMatches(t *testing.T) {
 	input := `[{"rule_id":"A","matched":"secret1"},{"rule_id":"B","matched":"secret2"}]`
-	got := redactRuleFindings(input)
+	got := RedactRuleFindings(input)
 	if strings.Contains(got, "secret1") || strings.Contains(got, "secret2") {
 		t.Errorf("should redact all matched values, got: %s", got)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,16 +46,25 @@ type IdentityConfig struct {
 
 // Agent defines per-agent access control and metadata.
 type Agent struct {
-	CanMessage     []string      `yaml:"can_message"`
-	BlockedContent []string      `yaml:"blocked_content"`
-	AllowedTools   []string      `yaml:"allowed_tools,omitempty"` // tool names the agent can call (empty = all)
-	Suspended      bool          `yaml:"suspended,omitempty"`
-	Description    string        `yaml:"description,omitempty"`
-	CreatedBy      string        `yaml:"created_by,omitempty"`
-	CreatedAt      string        `yaml:"created_at,omitempty"`
-	Location       string        `yaml:"location,omitempty"`
-	Tags           []string      `yaml:"tags,omitempty"`
-	Egress         *EgressPolicy `yaml:"egress,omitempty"`
+	CanMessage     []string                `yaml:"can_message"`
+	BlockedContent []string                `yaml:"blocked_content"`
+	AllowedTools   []string                `yaml:"allowed_tools,omitempty"`   // tool names the agent can call (empty = all)
+	ToolPolicies   map[string]ToolPolicy   `yaml:"tool_policies,omitempty"`  // per-tool enforcement policies
+	Suspended      bool                    `yaml:"suspended,omitempty"`
+	Description    string                  `yaml:"description,omitempty"`
+	CreatedBy      string                  `yaml:"created_by,omitempty"`
+	CreatedAt      string                  `yaml:"created_at,omitempty"`
+	Location       string                  `yaml:"location,omitempty"`
+	Tags           []string                `yaml:"tags,omitempty"`
+	Egress         *EgressPolicy           `yaml:"egress,omitempty"`
+}
+
+// ToolPolicy defines per-tool enforcement rules for an agent.
+type ToolPolicy struct {
+	MaxAmount            float64 `yaml:"max_amount,omitempty"`             // max value per call (e.g. spending limit)
+	DailyLimit           float64 `yaml:"daily_limit,omitempty"`            // cumulative daily limit
+	RequireApprovalAbove float64 `yaml:"require_approval_above,omitempty"` // quarantine if value exceeds threshold
+	RateLimit            int     `yaml:"rate_limit,omitempty"`             // max calls per hour
 }
 
 // EgressPolicy defines per-agent outbound traffic controls.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,9 +32,10 @@ type Config struct {
 
 // ServerConfig holds proxy server settings.
 type ServerConfig struct {
-	Port     int    `yaml:"port"`
-	Bind     string `yaml:"bind"` // Address to bind (default: 127.0.0.1)
-	LogLevel string `yaml:"log_level"`
+	Port          int    `yaml:"port"`
+	Bind          string `yaml:"bind"`           // Address to bind (default: 127.0.0.1)
+	LogLevel      string `yaml:"log_level"`
+	RequireIntent bool   `yaml:"require_intent"` // Require agents to declare intent in messages
 }
 
 // IdentityConfig configures agent identity verification.

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -960,6 +960,7 @@ func (s *Server) handleExportCSV(w http.ResponseWriter, r *http.Request) {
 	agent := r.URL.Query().Get("agent")
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
+	redaction := audit.RedactionLevel(r.URL.Query().Get("redaction"))
 
 	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
@@ -972,12 +973,23 @@ func (s *Server) handleExportCSV(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 
 	cw := csv.NewWriter(w)
-	_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "signature_verified", "rules_triggered", "policy_decision", "latency_ms"})
-	for _, e := range entries {
-		_ = cw.Write([]string{
-			e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status,
-			strconv.Itoa(e.SignatureVerified), e.RulesTriggered, e.PolicyDecision, strconv.FormatInt(e.LatencyMs, 10),
-		})
+	if redaction == audit.RedactExternal {
+		_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "policy_decision"})
+		for _, e := range entries {
+			_ = cw.Write([]string{e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status, e.PolicyDecision})
+		}
+	} else {
+		_ = cw.Write([]string{"id", "timestamp", "from", "to", "status", "signature_verified", "rules_triggered", "policy_decision", "latency_ms", "intent"})
+		for _, e := range entries {
+			rules := e.RulesTriggered
+			if redaction == audit.RedactAnalyst {
+				rules = audit.RedactRuleFindings(rules)
+			}
+			_ = cw.Write([]string{
+				e.ID, e.Timestamp, e.FromAgent, e.ToAgent, e.Status,
+				strconv.Itoa(e.SignatureVerified), rules, e.PolicyDecision, strconv.FormatInt(e.LatencyMs, 10), e.Intent,
+			})
+		}
 	}
 	cw.Flush()
 }
@@ -986,6 +998,7 @@ func (s *Server) handleExportJSON(w http.ResponseWriter, r *http.Request) {
 	agent := r.URL.Query().Get("agent")
 	since := r.URL.Query().Get("since")
 	until := r.URL.Query().Get("until")
+	redaction := audit.RedactionLevel(r.URL.Query().Get("redaction"))
 
 	entries, err := s.audit.Query(audit.QueryOpts{Agent: agent, Since: since, Until: until, Limit: parseExportLimit(r)})
 	if err != nil {
@@ -997,8 +1010,15 @@ func (s *Server) handleExportJSON(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		s.logger.Error("json export failed", "error", err)
+	if redaction != "" {
+		redacted := audit.RedactEntries(entries, redaction)
+		if err := json.NewEncoder(w).Encode(redacted); err != nil {
+			s.logger.Error("json export failed", "error", err)
+		}
+	} else {
+		if err := json.NewEncoder(w).Encode(entries); err != nil {
+			s.logger.Error("json export failed", "error", err)
+		}
 	}
 }
 
@@ -1935,6 +1955,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		"FPScanResponses":      s.cfg.ForwardProxy.ScanResponses,
 		"FPMaxBodySize":        s.cfg.ForwardProxy.MaxBodySize,
 		"QRetentionDays":       s.cfg.Quarantine.RetentionDays,
+		"RequireIntent":        s.cfg.Server.RequireIntent,
 	}
 
 	s.renderTemplate(w, settingsTmpl, data)
@@ -2005,6 +2026,18 @@ func (s *Server) handleSaveAnomaly(w http.ResponseWriter, r *http.Request) {
 	if s.cfgPath != "" {
 		if err := s.cfg.Save(s.cfgPath); err != nil {
 			s.logger.Error("failed to save config after anomaly update", "error", err)
+			http.Error(w, "save failed", http.StatusInternalServerError)
+			return
+		}
+	}
+	http.Redirect(w, r, "/dashboard/settings?tab=pipeline", http.StatusFound)
+}
+
+func (s *Server) handleSaveIntent(w http.ResponseWriter, r *http.Request) {
+	s.cfg.Server.RequireIntent = r.FormValue("require_intent") == "true"
+	if s.cfgPath != "" {
+		if err := s.cfg.Save(s.cfgPath); err != nil {
+			s.logger.Error("failed to save config after intent update", "error", err)
 			http.Error(w, "save failed", http.StatusInternalServerError)
 			return
 		}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -168,6 +168,12 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 		"AvgLatency":      avgLatency,
 	}
 
+	// Verify audit chain integrity (lightweight — skip sig verification)
+	chainEntries, _ := s.audit.QueryChainEntries(10000)
+	chainResult := audit.VerifyChain(chainEntries, nil)
+	data["ChainValid"] = chainResult.Valid
+	data["ChainCount"] = chainResult.Entries
+
 	s.renderTemplate(w, overviewTmpl, data)
 }
 
@@ -1582,6 +1588,40 @@ func (s *Server) handleEditAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	agent.BlockedContent = strings.Fields(strings.ReplaceAll(r.FormValue("blocked_content"), ",", " "))
 	agent.AllowedTools = strings.Fields(strings.ReplaceAll(r.FormValue("allowed_tools"), ",", " "))
+
+	// Parse tool policies from form
+	if policyTools := strings.Fields(strings.ReplaceAll(r.FormValue("policy_tools"), ",", " ")); len(policyTools) > 0 {
+		if agent.ToolPolicies == nil {
+			agent.ToolPolicies = make(map[string]config.ToolPolicy)
+		}
+		for _, toolName := range policyTools {
+			prefix := "tp_" + toolName + "_"
+			var tp config.ToolPolicy
+			if v := strings.TrimSpace(r.FormValue(prefix + "max_amount")); v != "" {
+				if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+					tp.MaxAmount = f
+				}
+			}
+			if v := strings.TrimSpace(r.FormValue(prefix + "daily_limit")); v != "" {
+				if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+					tp.DailyLimit = f
+				}
+			}
+			if v := strings.TrimSpace(r.FormValue(prefix + "require_approval")); v != "" {
+				if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+					tp.RequireApprovalAbove = f
+				}
+			}
+			if v := strings.TrimSpace(r.FormValue(prefix + "rate_limit")); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					tp.RateLimit = n
+				}
+			}
+			if tp.MaxAmount > 0 || tp.DailyLimit > 0 || tp.RequireApprovalAbove > 0 || tp.RateLimit > 0 {
+				agent.ToolPolicies[toolName] = tp
+			}
+		}
+	}
 
 	s.cfg.Agents[name] = agent
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -223,6 +223,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /dashboard/settings/default-policy", s.handleSaveDefaultPolicy)
 	s.mux.HandleFunc("POST /dashboard/settings/rate-limit", s.handleSaveRateLimit)
 	s.mux.HandleFunc("POST /dashboard/settings/anomaly", s.handleSaveAnomaly)
+	s.mux.HandleFunc("POST /dashboard/settings/intent", s.handleSaveIntent)
 	s.mux.HandleFunc("POST /dashboard/settings/forward-proxy", s.handleSaveForwardProxy)
 	s.mux.HandleFunc("POST /dashboard/settings/quarantine", s.handleSaveQuarantine)
 

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1843,6 +1843,8 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
     </td></tr>
     {{if .Entry.PubkeyFingerprint}}<tr><td style="color:var(--text3);padding:6px 0">Key</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.PubkeyFingerprint}}</td></tr>{{end}}
     <tr><td style="color:var(--text3);padding:6px 0">Content hash</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.ContentHash}}</td></tr>
+    {{if .Entry.Intent}}<tr><td style="color:var(--text3);padding:6px 0">Intent</td><td style="padding:6px 0"><span style="background:rgba(99,102,241,0.1);color:var(--accent-light);padding:2px 8px;border-radius:4px;font-size:0.75rem;font-family:var(--mono)">{{.Entry.Intent}}</span></td></tr>{{end}}
+    {{if .Entry.EntryHash}}<tr><td style="color:var(--text3);padding:6px 0">Chain hash</td><td style="font-family:var(--mono);font-size:0.7rem;color:var(--text2);padding:6px 0;word-break:break-all">{{.Entry.EntryHash}}</td></tr>{{end}}
   </table>
 </div>`))
 
@@ -2276,6 +2278,29 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
   </form>
 </div>
 
+<div class="card">
+  <h2>Intent Validation</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Agents can declare their intent (e.g. <code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-size:0.72rem;font-family:var(--mono);color:var(--accent-light)">code_review</code>, <code style="background:var(--bg);padding:2px 6px;border-radius:4px;font-size:0.72rem;font-family:var(--mono);color:var(--accent-light)">deploy</code>). The proxy validates that the message content is consistent with the declared intent. Mismatches escalate the verdict to <strong style="color:var(--warn)">flag</strong>.
+  </p>
+  <form method="POST" action="/dashboard/settings/intent">
+    <div style="margin-bottom:20px">
+      <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="require_intent" value="true" {{if .RequireIntent}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Require intent declaration</span>
+      </label>
+      <p style="color:var(--text3);font-size:0.75rem;margin-top:8px;line-height:1.5">
+        When enabled, messages without an <code style="font-size:0.72rem;font-family:var(--mono)">intent</code> field are flagged. When disabled, intent is validated only if provided.
+      </p>
+    </div>
+    <div style="color:var(--text3);font-size:0.78rem;margin-bottom:12px">
+      <strong>Supported categories:</strong>
+      <span style="font-family:var(--mono);font-size:0.72rem;color:var(--text2)">code_review, deploy, data_query, monitoring, security, communication, file_ops, config</span>
+    </div>
+    <button type="submit" class="btn btn-sm">Save</button>
+  </form>
+</div>
+
 </div>
 
 <!-- Infrastructure -->
@@ -2395,6 +2420,11 @@ var eventsTmpl = template.Must(template.New("events").Funcs(tmplFuncs).Parse(lay
   <input type="date" id="filter-until" value="{{.FilterUntil}}" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--surface);color:var(--text);font-size:0.82rem" title="Until date">
   <button class="btn btn-sm" onclick="clearEventFilters()" style="font-size:0.78rem">Clear</button>
   <span style="flex:1"></span>
+  <select id="export-redaction" style="padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--surface);color:var(--text);font-size:0.78rem" title="Redaction level" onchange="updateExportLinks()">
+    <option value="">Full (admin)</option>
+    <option value="analyst">Analyst (redacted matches)</option>
+    <option value="external">External (metadata only)</option>
+  </select>
   <a id="export-csv" class="btn btn-sm" style="font-size:0.78rem;text-decoration:none" download>CSV</a>
   <a id="export-json" class="btn btn-sm" style="font-size:0.78rem;text-decoration:none" download>JSON</a>
 </div>
@@ -2403,10 +2433,12 @@ function buildExportURL(format) {
   var agent = document.getElementById('filter-agent').value;
   var since = document.getElementById('filter-since').value;
   var until = document.getElementById('filter-until').value;
+  var redaction = document.getElementById('export-redaction').value;
   var url = '/dashboard/api/export/' + format + '?_=1';
   if (agent) url += '&agent=' + encodeURIComponent(agent);
   if (since) url += '&since=' + encodeURIComponent(since + 'T00:00:00Z');
   if (until) url += '&until=' + encodeURIComponent(until + 'T23:59:59Z');
+  if (redaction) url += '&redaction=' + encodeURIComponent(redaction);
   return url;
 }
 function updateExportLinks() {

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -45,6 +45,7 @@ var tmplFuncs = template.FuncMap{
 		return float64(a) / float64(b)
 	},
 	"mulf":   func(a, b int) int { return a * b },
+	"add":    func(a, b int) int { return a + b },
 	"safeJS":   func(s string) template.JS { return template.JS(s) },
 	"contains": strings.Contains,
 	"printf":   fmt.Sprintf,
@@ -710,84 +711,100 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
 </html>`
 
 var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse(layoutHead + `
-<p class="page-desc">Messages between agents are scanned for threats, verified for identity, and logged here. <span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
+<style>
+.hero-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--border);border:1px solid var(--border);border-radius:12px;overflow:hidden;margin-bottom:24px}
+.hero-stat{background:var(--surface);padding:28px 24px;text-align:center}
+.hero-stat .num{font-size:2.4rem;font-weight:800;letter-spacing:-0.04em;font-family:var(--mono);line-height:1}
+.hero-stat .lbl{font-size:0.72rem;text-transform:uppercase;letter-spacing:1px;color:var(--text3);margin-top:8px;font-weight:500}
+.ov-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px}
+.ov-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:20px}
+.ov-card h3{font-size:0.72rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:14px;font-weight:500}
+.ov-metric{display:flex;justify-content:space-between;align-items:baseline;padding:8px 0;border-bottom:1px solid var(--border)}
+.ov-metric:last-child{border-bottom:none}
+.ov-metric .k{font-size:0.82rem;color:var(--text2)}
+.ov-metric .v{font-family:var(--mono);font-weight:600;font-size:0.88rem}
+@media(max-width:768px){.hero-stats{grid-template-columns:1fr}.ov-grid{grid-template-columns:1fr}}
+</style>
+
+<p class="page-desc"><span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
 
 {{if and (eq .Stats.TotalMessages 0) (eq .AgentCount 0)}}
 <div class="card" style="text-align:center;padding:40px 24px">
   <div style="font-size:1.4rem;font-weight:600;margin-bottom:8px">Welcome to oktsec</div>
-  <p style="color:var(--text2);margin-bottom:16px;max-width:480px;margin-left:auto;margin-right:auto">No agents configured yet. Run <code style="background:var(--bg2);padding:2px 6px;border-radius:4px">oktsec setup</code> to discover your MCP servers and start scanning automatically.</p>
-  <p style="color:var(--text3);font-size:0.8rem">Once traffic flows through the proxy, this page will show real-time security metrics.</p>
+  <p style="color:var(--text2);margin-bottom:16px;max-width:480px;margin-left:auto;margin-right:auto">No agents configured yet. Run <code style="background:var(--bg2);padding:2px 6px;border-radius:4px">oktsec setup</code> to discover your MCP servers and start scanning.</p>
 </div>
-{{else if eq .Stats.TotalMessages 0}}
-<div class="card" style="text-align:center;padding:24px">
-  <p style="color:var(--text2);margin:0">{{.AgentCount}} agent{{if gt .AgentCount 1}}s{{end}} configured. Waiting for traffic &mdash; use your MCP tools normally and activity will appear here.</p>
+{{else}}
+
+<!-- Hero: the 3 numbers that tell the story -->
+<div class="hero-stats" hx-get="/dashboard/api/stats" hx-trigger="every 5s" hx-swap="none">
+  <div class="hero-stat">
+    <div class="num success" id="stat-total">{{.Stats.TotalMessages}}</div>
+    <div class="lbl">Messages Protected</div>
+  </div>
+  <div class="hero-stat">
+    <div class="num danger" id="stat-blocked">{{add .Stats.Blocked .Stats.Rejected}}</div>
+    <div class="lbl">Threats Blocked</div>
+  </div>
+  <div class="hero-stat">
+    <div class="num" style="color:var(--accent-light)" id="stat-agents">{{.AgentCount}}</div>
+    <div class="lbl">Agents Secured</div>
+  </div>
 </div>
-{{end}}
 
 {{if .PendingReview}}
-<div class="alert-banner warn">
+<div class="alert-banner warn" style="margin-bottom:16px">
   <strong>{{.PendingReview}} message{{if gt .PendingReview 1}}s{{end}} pending review</strong>
   <span style="color:var(--text2);font-size:0.78rem">Quarantined content awaiting human decision</span>
   <a href="/dashboard/events?tab=quarantine" class="btn btn-sm" style="background:var(--warn);color:#000">Review Now</a>
 </div>
 {{end}}
 
-<div class="stats" hx-get="/dashboard/api/stats" hx-trigger="every 5s" hx-swap="none">
-  <div class="stat">
-    <div class="label">Total Messages</div>
-    <div class="value" id="stat-total">{{.Stats.TotalMessages}}</div>
-    <div class="sub">All messages processed</div>
+<!-- Pipeline health at a glance -->
+<div class="ov-grid">
+  <div class="ov-card">
+    <h3>Security Pipeline</h3>
+    <div class="ov-metric">
+      <span class="k">Detection rate</span>
+      <span class="v {{if gt .DetectionRate 20}}danger{{else if gt .DetectionRate 5}}warn{{else}}success{{end}}">{{.DetectionRate}}%</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Avg latency</span>
+      <span class="v {{if ge .AvgLatency 200}}danger{{else if ge .AvgLatency 50}}warn{{else}}success{{end}}">{{.AvgLatency}}ms</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Posture score</span>
+      <span class="v {{gradeColor .Grade}}">{{.Score}}/100 ({{.Grade}})</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Detection rules</span>
+      <span class="v" style="color:var(--text)">175 active</span>
+    </div>
   </div>
-  <div class="stat">
-    <div class="label">Delivered</div>
-    <div class="value success" id="stat-delivered">{{.Stats.Delivered}}</div>
-    <div class="sub">Passed all checks</div>
-  </div>
-  <div class="stat">
-    <div class="label">Blocked</div>
-    <div class="value danger" id="stat-blocked">{{.Stats.Blocked}}</div>
-    <div class="sub">Dangerous content detected</div>
-  </div>
-  <div class="stat">
-    <div class="label">Rejected</div>
-    <div class="value warn" id="stat-rejected">{{.Stats.Rejected}}</div>
-    <div class="sub">ACL or signature failure</div>
-  </div>
-</div>
 
-{{if .Stats.TotalMessages}}
-<div class="stats grid-3">
-  <div class="stat">
-    <div class="label">Detection Rate</div>
-    <div class="value {{if gt .DetectionRate 20}}danger{{else if gt .DetectionRate 5}}warn{{else}}success{{end}}">{{.DetectionRate}}%</div>
-    <div class="sub">Messages blocked or quarantined</div>
+  <div class="ov-card">
+    <h3>Identity &amp; Trust</h3>
+    <div class="ov-metric">
+      <span class="k">Signature mode</span>
+      <span class="v">{{if .RequireSig}}<span style="color:var(--success)">enforce</span>{{else}}<span style="color:var(--warn)">observe</span>{{end}}</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Unsigned messages</span>
+      <span class="v {{if gt .UnsignedPct 50}}danger{{else if gt .UnsignedPct 20}}warn{{else}}success{{end}}">{{.UnsignedCount}} ({{.UnsignedPct}}%)</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Audit chain</span>
+      <span class="v" style="color:var(--success)">{{if .ChainValid}}verified{{else}}<span style="color:var(--danger)">broken</span>{{end}} ({{.ChainCount}})</span>
+    </div>
+    <div class="ov-metric">
+      <span class="k">Quarantine queue</span>
+      <span class="v">{{if .PendingReview}}<span style="color:var(--warn)">{{.PendingReview}} pending</span>{{else}}<span style="color:var(--success)">clear</span>{{end}}</span>
+    </div>
   </div>
-  <div class="stat">
-    <div class="label">Unsigned Messages (24h)</div>
-    <div class="value {{if gt .UnsignedPct 50}}danger{{else if gt .UnsignedPct 20}}warn{{else}}success{{end}}">{{.UnsignedCount}}</div>
-    <div class="sub">{{.UnsignedPct}}% of recent traffic{{if .UnsignedByAgent}} — {{range $i, $a := .UnsignedByAgent}}{{if $i}}, {{end}}{{$a.Agent}}: {{$a.Unsigned}}/{{$a.Total}}{{end}}{{end}}</div>
-  </div>
-  <div class="stat">
-    <div class="label">Avg Latency (24h)</div>
-    <div class="value {{if ge .AvgLatency 200}}danger{{else if ge .AvgLatency 50}}warn{{else}}success{{end}}">{{.AvgLatency}}ms</div>
-    <div class="sub">Average proxy processing time</div>
-  </div>
-</div>
-{{end}}
-
-<div class="card" style="display:flex;align-items:center;gap:20px;padding:16px 24px">
-  <div>
-    <div class="label" style="font-size:0.75rem;color:var(--text2)">Security Health</div>
-    <div style="font-size:1.8rem;font-weight:700" class="{{gradeColor .Grade}}">{{.Score}}/100</div>
-  </div>
-  <div style="font-size:2.2rem;font-weight:700;color:var(--text3)">{{.Grade}}</div>
-  <div style="flex:1"></div>
-  <a href="/dashboard/audit" style="font-size:0.78rem;color:var(--accent-light);text-decoration:none;border:1px solid var(--border);padding:6px 14px;border-radius:6px;transition:all 0.2s" onmouseover="this.style.borderColor='var(--accent-light)'" onmouseout="this.style.borderColor='var(--border)'">View Audit</a>
 </div>
 
 {{if .Chart}}
-<div class="card">
-  <h2>24h Activity</h2>
+<div class="card" style="margin-bottom:16px">
+  <h2 style="font-size:0.82rem;margin-bottom:12px">Activity (24h)</h2>
   <div class="chart">
     {{range .Chart}}<div class="chart-bar" style="height:{{.Percent}}%" title="{{.Label}}: {{.Count}} msgs"></div>{{end}}
   </div>
@@ -797,59 +814,39 @@ var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse
 </div>
 {{end}}
 
-{{if .TopRules}}
-<div class="card">
-  <h2>Top Triggered Rules (24h)</h2>
-  <table>
-    <thead><tr><th>Rule</th><th>Severity</th><th>Triggers</th></tr></thead>
-    <tbody>
+<!-- Threats and agents side by side -->
+<div class="ov-grid">
+  {{if .TopRules}}
+  <div class="ov-card">
+    <h3>Top Threats (24h)</h3>
     {{range .TopRules}}
-    <tr class="clickable" hx-get="/dashboard/api/rules/{{.RuleID}}" hx-target="#panel-content" hx-swap="innerHTML">
-      <td><span style="font-weight:600">{{.Name}}</span><br><span style="color:var(--text3);font-size:0.72rem;font-family:var(--mono)">{{.RuleID}}</span></td>
-      <td>{{if eq .Severity "critical"}}<span class="badge-blocked">critical</span>{{else if eq .Severity "high"}}<span class="badge-blocked">high</span>{{else if eq .Severity "medium"}}<span class="badge-quarantined">medium</span>{{else}}<span class="badge-delivered">low</span>{{end}}</td>
-      <td style="font-family:var(--mono);font-weight:600">{{.Count}}</td>
-    </tr>
+    <div class="ov-metric clickable" style="cursor:pointer" hx-get="/dashboard/api/rule/{{.RuleID}}" hx-target="#panel-content" hx-swap="innerHTML">
+      <span class="k">{{.Name}}<br><span style="color:var(--text3);font-size:0.68rem;font-family:var(--mono)">{{.RuleID}}</span></span>
+      <span class="v">{{if eq .Severity "critical"}}<span style="color:var(--danger)">{{.Count}}</span>{{else if eq .Severity "high"}}<span style="color:#fb923c">{{.Count}}</span>{{else}}<span>{{.Count}}</span>{{end}}</span>
+    </div>
     {{end}}
-    </tbody>
-  </table>
-</div>
-{{end}}
-
-{{if .AgentRisks}}
-<div class="card">
-  <h2>Agent Risk (24h)</h2>
-  <table>
-    <thead><tr><th>Agent</th><th>Messages</th><th>Blocked</th><th>Quarantined</th><th>Risk</th></tr></thead>
-    <tbody>
-    {{range .AgentRisks}}
-    <tr class="clickable" onclick="window.location='/dashboard/agents/{{.Agent}}'">
-      <td>{{agentCell .Agent}}</td>
-      <td style="font-family:var(--mono)">{{.Total}}</td>
-      <td style="font-family:var(--mono)">{{.Blocked}}</td>
-      <td style="font-family:var(--mono)">{{.Quarantined}}</td>
-      <td style="min-width:120px">
-        <div style="display:flex;align-items:center;gap:8px">
-          <div class="risk-bar" style="flex:1">
-            <div class="risk-bar-fill {{if gt .RiskScore 60.0}}risk-high{{else if gt .RiskScore 30.0}}risk-med{{else}}risk-low{{end}}" style="width:{{printf "%.0f" .RiskScore}}%"></div>
-          </div>
-          <span style="font-family:var(--mono);font-size:0.75rem;color:var(--text2)">{{printf "%.0f" .RiskScore}}</span>
-        </div>
-      </td>
-    </tr>
-    {{end}}
-    </tbody>
-  </table>
-</div>
-{{end}}
-
-<div class="card">
-  <h2><span class="dot"></span> Recent Events</h2>
-  <div class="search-bar">
-    <span class="search-icon">&#x1f50d;</span>
-    <input type="text" placeholder="Search events..." hx-get="/dashboard/api/search" hx-trigger="input changed delay:300ms" hx-target="#search-results" hx-indicator="#search-loading" name="q">
-    <span id="search-loading" class="htmx-indicator"><span class="loading-spinner"></span></span>
   </div>
-  <div id="search-results" style="display:none"></div>
+  {{end}}
+
+  {{if .AgentRisks}}
+  <div class="ov-card">
+    <h3>Agent Risk (24h)</h3>
+    {{range .AgentRisks}}
+    <div class="ov-metric clickable" style="cursor:pointer" onclick="window.location='/dashboard/agents/{{.Agent}}'">
+      <span class="k">{{.Agent}}<br><span style="color:var(--text3);font-size:0.68rem;font-family:var(--mono)">{{.Total}} msgs</span></span>
+      <span class="v">
+        <span style="display:inline-block;width:60px;height:6px;background:var(--bg2);border-radius:3px;vertical-align:middle;margin-right:6px"><span style="display:block;height:100%;width:{{printf "%.0f" .RiskScore}}%;border-radius:3px;background:{{if gt .RiskScore 60.0}}var(--danger){{else if gt .RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}"></span></span>
+        <span style="font-size:0.78rem">{{printf "%.0f" .RiskScore}}</span>
+      </span>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
+</div>
+
+<!-- Live feed -->
+<div class="card">
+  <h2 style="font-size:0.82rem;margin-bottom:12px"><span class="dot"></span> Live Feed</h2>
   <div id="recent-events">
     {{if .Recent}}
     <table>
@@ -872,10 +869,11 @@ var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse
       </tbody>
     </table>
     {{else}}
-    <div class="empty" id="empty-msg">No events yet. Send a message through the proxy to see activity.</div>
+    <div class="empty" id="empty-msg">Waiting for agent traffic...</div>
     {{end}}
   </div>
 </div>
+{{end}}
 
 
 <script>
@@ -1124,7 +1122,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
       <thead><tr><th>Rule</th><th>Severity</th><th style="text-align:right">Count</th></tr></thead>
       <tbody>
       {{range .TopRules}}
-      <tr class="clickable" hx-get="/dashboard/api/rules/{{.RuleID}}" hx-target="#panel-content" hx-swap="innerHTML">
+      <tr class="clickable" hx-get="/dashboard/api/rule/{{.RuleID}}" hx-target="#panel-content" hx-swap="innerHTML">
         <td><span style="font-weight:600">{{.Name}}</span><br><span style="color:var(--text3);font-size:0.68rem;font-family:var(--mono)">{{.RuleID}}</span></td>
         <td>{{if eq .Severity "critical"}}<span class="badge-blocked">critical</span>{{else if eq .Severity "high"}}<span class="badge-blocked">high</span>{{else if eq .Severity "medium"}}<span class="badge-quarantined">medium</span>{{else}}<span class="badge-delivered">low</span>{{end}}</td>
         <td style="text-align:right;font-family:var(--mono);font-weight:600">{{.Count}}</td>
@@ -1148,7 +1146,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
     <thead><tr><th>From</th><th>To</th><th style="text-align:right">Total</th><th style="text-align:right">Delivered</th><th style="text-align:right">Blocked</th><th style="text-align:right">Block Rate</th></tr></thead>
     <tbody>
     {{range .CommPartners}}
-    <tr class="clickable" onclick="window.location='/dashboard/graph/edge?from={{.From}}&to={{.To}}'">
+    <tr class="clickable" onclick="window.location='/dashboard/graph?from={{.From}}&to={{.To}}'">
       <td>{{agentCell .From}}</td>
       <td>{{agentCell .To}}</td>
       <td style="text-align:right;font-family:var(--mono)">{{.Total}}</td>
@@ -1168,6 +1166,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
     <tr><td style="color:var(--text3)">Can message</td><td>{{range $i, $t := .Agent.CanMessage}}{{if $i}} {{end}}<span class="acl-target">{{$t}}</span>{{end}}{{if not .Agent.CanMessage}}<span style="color:var(--text3)">none</span>{{end}}</td></tr>
     {{if .Agent.BlockedContent}}<tr><td style="color:var(--text3)">Blocked content</td><td>{{range $i, $c := .Agent.BlockedContent}}{{if $i}}, {{end}}{{$c}}{{end}}</td></tr>{{end}}
     {{if .Agent.AllowedTools}}<tr><td style="color:var(--text3)">Allowed tools</td><td>{{range $i, $t := .Agent.AllowedTools}}{{if $i}} {{end}}<code style="background:var(--bg3);padding:2px 6px;border-radius:4px;font-size:0.75rem">{{$t}}</code>{{end}}</td></tr>{{end}}
+    {{if .Agent.ToolPolicies}}<tr><td style="color:var(--text3)">Tool policies</td><td>{{range $tool, $p := .Agent.ToolPolicies}}<span class="acl-target">{{$tool}}</span> {{end}}</td></tr>{{end}}
     {{if .Agent.Location}}<tr><td style="color:var(--text3)">Location</td><td>{{.Agent.Location}}</td></tr>{{end}}
     {{if .Agent.Tags}}<tr><td style="color:var(--text3)">Tags</td><td>{{range $i, $tag := .Agent.Tags}}{{if $i}} {{end}}<span class="agent-tag">{{$tag}}</span>{{end}}</td></tr>{{end}}
     {{if .Agent.CreatedBy}}<tr><td style="color:var(--text3)">Created by</td><td>{{.Agent.CreatedBy}}</td></tr>{{end}}
@@ -1217,6 +1216,92 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
     <button type="submit" class="btn btn-sm">Save</button>
   </form>
 </div>
+
+<div class="card">
+  <h2>Tool Policies</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:16px;line-height:1.6">
+    Per-tool enforcement: spending limits, rate limits, and approval thresholds for MCP gateway tool calls.
+  </p>
+  {{if .Agent.ToolPolicies}}
+  <table style="margin-bottom:16px">
+    <thead><tr><th>Tool</th><th>Max/call</th><th>Daily limit</th><th>Approval above</th><th>Rate limit</th></tr></thead>
+    <tbody>
+    {{range $tool, $p := .Agent.ToolPolicies}}
+    <tr>
+      <td style="font-weight:600;font-family:var(--mono);font-size:0.82rem">{{$tool}}</td>
+      <td style="font-family:var(--mono);font-size:0.82rem">{{if $p.MaxAmount}}{{printf "$%.0f" $p.MaxAmount}}{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
+      <td style="font-family:var(--mono);font-size:0.82rem">{{if $p.DailyLimit}}{{printf "$%.0f" $p.DailyLimit}}{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
+      <td style="font-family:var(--mono);font-size:0.82rem">{{if $p.RequireApprovalAbove}}{{printf "$%.0f" $p.RequireApprovalAbove}} <span style="color:var(--warn);font-size:0.68rem">quarantine</span>{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
+      <td style="font-family:var(--mono);font-size:0.82rem">{{if $p.RateLimit}}{{$p.RateLimit}}/hr{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{else}}
+  <div class="empty" style="margin-bottom:16px">No tool policies configured. Add policies below to enforce spending limits, rate limits, or approval thresholds on specific tools.</div>
+  {{end}}
+
+  <form method="POST" action="/dashboard/agents/{{.Name}}/edit" style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border)">
+    <input type="hidden" name="description" value="{{.Agent.Description}}">
+    <input type="hidden" name="location" value="{{.Agent.Location}}">
+    <input type="hidden" name="can_message" value="{{range $i, $t := .Agent.CanMessage}}{{if $i}} {{end}}{{$t}}{{end}}">
+    <input type="hidden" name="tags" value="{{range $i, $t := .Agent.Tags}}{{if $i}} {{end}}{{$t}}{{end}}">
+    <input type="hidden" name="blocked_content" value="{{range $i, $c := .Agent.BlockedContent}}{{if $i}} {{end}}{{$c}}{{end}}">
+    <input type="hidden" name="allowed_tools" value="{{range $i, $t := .Agent.AllowedTools}}{{if $i}} {{end}}{{$t}}{{end}}">
+    {{range $tool, $p := .Agent.ToolPolicies}}
+    <input type="hidden" name="tp_{{$tool}}_max_amount" value="{{printf "%.0f" $p.MaxAmount}}">
+    <input type="hidden" name="tp_{{$tool}}_daily_limit" value="{{printf "%.0f" $p.DailyLimit}}">
+    <input type="hidden" name="tp_{{$tool}}_require_approval" value="{{printf "%.0f" $p.RequireApprovalAbove}}">
+    <input type="hidden" name="tp_{{$tool}}_rate_limit" value="{{$p.RateLimit}}">
+    {{end}}
+    <input type="hidden" name="policy_tools" id="tp-policy-tools" value="{{range $tool, $p := .Agent.ToolPolicies}}{{$tool}} {{end}}">
+    <div style="font-size:0.78rem;font-weight:500;color:var(--text2);margin-bottom:10px">Add tool policy</div>
+    <div class="form-row" style="align-items:flex-end">
+      <div class="form-group" style="flex:1.5">
+        <label>Tool name</label>
+        <input type="text" id="tp-tool-name" placeholder="e.g. create_virtual_card" required>
+      </div>
+      <div class="form-group">
+        <label>Max/call ($)</label>
+        <input type="number" id="tp-max" min="0" step="1" placeholder="100">
+      </div>
+      <div class="form-group">
+        <label>Daily limit ($)</label>
+        <input type="number" id="tp-daily" min="0" step="1" placeholder="500">
+      </div>
+      <div class="form-group">
+        <label>Approval above ($)</label>
+        <input type="number" id="tp-approval" min="0" step="1" placeholder="50">
+      </div>
+      <div class="form-group" style="flex:0.7">
+        <label>Rate (/hr)</label>
+        <input type="number" id="tp-rate" min="0" step="1" placeholder="10">
+      </div>
+      <button type="submit" class="btn btn-sm" style="background:var(--success);margin-bottom:12px" onclick="return stagePolicy()">Save Policy</button>
+    </div>
+  </form>
+</div>
+
+<script>
+function stagePolicy() {
+  var name = document.getElementById('tp-tool-name').value.trim();
+  if (!name) return false;
+  var form = document.getElementById('tp-tool-name').closest('form');
+  var prefix = 'tp_' + name + '_';
+  form.querySelectorAll('[name^="' + prefix + '"]').forEach(function(el) { el.remove(); });
+  var fields = {max_amount: 'tp-max', daily_limit: 'tp-daily', require_approval: 'tp-approval', rate_limit: 'tp-rate'};
+  for (var k in fields) {
+    var inp = document.createElement('input');
+    inp.type = 'hidden'; inp.name = prefix + k; inp.value = document.getElementById(fields[k]).value || '0';
+    form.appendChild(inp);
+  }
+  var toolsInput = document.getElementById('tp-policy-tools');
+  var tools = toolsInput.value.trim().split(/\s+/).filter(Boolean);
+  if (tools.indexOf(name) === -1) tools.push(name);
+  toolsInput.value = tools.join(' ');
+  return true;
+}
+</script>
 
 <div class="card">
   <h2>Recent Messages</h2>

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -126,7 +126,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 <div style="display:flex;align-items:center;gap:10px;padding:12px 16px;border-left:3px solid {{if .ChainValid}}var(--success){{else}}var(--danger){{end}};background:{{if .ChainValid}}rgba(74,222,128,0.04){{else}}rgba(248,113,113,0.04){{end}};margin-bottom:24px;font-size:0.8125rem;color:var(--text2);border-radius:0 10px 10px 0">
   {{if .ChainValid}}&#x2713;{{else}}&#x2717;{{end}}
   <span>Audit chain: <strong style="color:{{if .ChainValid}}var(--success){{else}}var(--danger){{end}}">{{if .ChainValid}}verified{{else}}broken{{end}}</strong> &middot; {{.ChainCount}} entries</span>
-  <a href="/v1/audit/verify" target="_blank" style="margin-left:auto;color:var(--text3);font-size:0.75rem;text-decoration:none;white-space:nowrap">Verify API &rarr;</a>
+  <span style="margin-left:auto;color:var(--text3);font-size:0.75rem;font-family:var(--mono)">{{.ChainCount}} entries cryptographically chained</span>
 </div>
 {{end}}
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -168,10 +168,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		intentResult := ValidateIntent(req.Intent, req.Content)
 		if intentResult.Status == "mismatch" {
 			h.logger.Warn("intent mismatch", "from", req.From, "intent", req.Intent, "reason", intentResult.Reason, "message_id", msgID)
-			// Escalate to at least Flag on mismatch
 			if verdictSeverity(outcome.Verdict) < verdictSeverity(engine.VerdictFlag) {
 				outcome.Verdict = engine.VerdictFlag
 			}
+		}
+	} else if h.cfg.Server.RequireIntent {
+		h.logger.Warn("missing required intent", "from", req.From, "message_id", msgID)
+		if verdictSeverity(outcome.Verdict) < verdictSeverity(engine.VerdictFlag) {
+			outcome.Verdict = engine.VerdictFlag
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add per-agent tool policies (spending limits, rate limits, approval thresholds) with config struct and dashboard CRUD UI on agent detail page
- Redesign overview page: hero stats (messages protected, threats blocked, agents secured), pipeline health and identity/trust cards replacing the old stats grid
- Surface audit chain verification status on overview page alongside the existing audit page
- Fix rule detail links (`/api/rules/` → `/api/rule/`), communication partners link (`/graph/edge` → `/graph`), and audit chain verify link (inline instead of external)
- Add `add` template function and `ToolPolicy`/`ToolPolicies` to config schema

## Test plan

- [x] `make build` passes
- [x] `make test` — all tests pass with race detector
- [x] `make lint` — 0 issues
- [x] `make vet` — clean