### PR TITLE
feat: agent risk scoring and LLM rule auto-apply

### DIFF
--- a/internal/audit/llm.go
+++ b/internal/audit/llm.go
@@ -126,8 +126,8 @@ func (s *Store) QueryLLMStats() (*LLMStats, error) {
 		COALESCE(SUM(tokens_used), 0),
 		COALESCE(AVG(latency_ms), 0),
 		COALESCE(AVG(risk_score), 0),
-		COUNT(CASE WHEN threats_json != '[]' AND threats_json != '' AND threats_json != 'null' THEN 1 END),
-		COUNT(CASE WHEN rule_generated != '' THEN 1 END)
+		` + llmThreatCountExpr + `,
+		` + llmRuleGenCountExpr + `
 		FROM llm_analysis`).Scan(
 		&stats.TotalAnalyses, &stats.TotalTokens, &stats.AvgLatencyMs,
 		&stats.AvgRiskScore, &stats.TotalThreats, &stats.RulesGenerated,
@@ -177,6 +177,50 @@ func (s *Store) QueryLLMAgentHistory(agent string, excludeID string, limit int) 
 		results = append(results, a)
 	}
 	return results, nil
+}
+
+// AgentLLMRisk holds LLM-derived risk metrics for an agent.
+type AgentLLMRisk struct {
+	Agent          string  `json:"agent"`
+	AnalysisCount  int     `json:"analysis_count"`
+	AvgRiskScore   float64 `json:"avg_risk_score"`
+	MaxRiskScore   float64 `json:"max_risk_score"`
+	ThreatCount    int     `json:"threat_count"`
+	ConfirmedCount int     `json:"confirmed_count"`
+}
+
+// llmThreatCountExpr is the canonical SQL expression for counting analyses with threats.
+const llmThreatCountExpr = `COUNT(CASE WHEN threats_json != '[]' AND threats_json != '' AND threats_json != 'null' THEN 1 END)`
+
+// llmRuleGenCountExpr is the canonical SQL expression for counting analyses with generated rules.
+const llmRuleGenCountExpr = `COUNT(CASE WHEN COALESCE(rule_generated,'') != '' THEN 1 END)`
+
+// QueryAgentLLMRisk returns LLM-derived risk aggregates per agent.
+func (s *Store) QueryAgentLLMRisk() (map[string]*AgentLLMRisk, error) {
+	rows, err := s.db.Query(`SELECT
+		from_agent,
+		COUNT(*),
+		COALESCE(AVG(risk_score), 0),
+		COALESCE(MAX(risk_score), 0),
+		` + llmThreatCountExpr + `,
+		COUNT(CASE WHEN COALESCE(reviewed_status,'') = 'confirmed' THEN 1 END)
+		FROM llm_analysis
+		GROUP BY from_agent`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck // rows.Close error is non-actionable
+
+	result := make(map[string]*AgentLLMRisk)
+	for rows.Next() {
+		var r AgentLLMRisk
+		if err := rows.Scan(&r.Agent, &r.AnalysisCount, &r.AvgRiskScore,
+			&r.MaxRiskScore, &r.ThreatCount, &r.ConfirmedCount); err != nil {
+			continue
+		}
+		result[r.Agent] = &r
+	}
+	return result, rows.Err()
 }
 
 // UpdateLLMReviewStatus sets the review status for an LLM analysis entry.

--- a/internal/audit/llm_test.go
+++ b/internal/audit/llm_test.go
@@ -142,6 +142,150 @@ func TestQueryLLMAnalysisByMessage(t *testing.T) {
 	}
 }
 
+func TestQueryAgentLLMRisk(t *testing.T) {
+	store := newTestStore(t)
+
+	// Empty table returns empty map
+	empty, err := store.QueryAgentLLMRisk()
+	if err != nil {
+		t.Fatalf("empty table: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(empty))
+	}
+
+	// Insert analyses for two agents
+	records := []LLMAnalysis{
+		{
+			ID: "ar1", MessageID: "arm1", Timestamp: "2025-01-01T00:00:00Z",
+			FromAgent: "risky-bot", ToAgent: "target-a", Provider: "openai", Model: "gpt-4",
+			RiskScore: 80, RecommendedAction: "block", Confidence: 0.9,
+			ThreatsJSON: `["injection"]`, IntentJSON: `{}`, LatencyMs: 100, TokensUsed: 200,
+			RuleGenerated: "RULE-1",
+		},
+		{
+			ID: "ar2", MessageID: "arm2", Timestamp: "2025-01-01T00:01:00Z",
+			FromAgent: "risky-bot", ToAgent: "target-b", Provider: "openai", Model: "gpt-4",
+			RiskScore: 60, RecommendedAction: "investigate", Confidence: 0.8,
+			ThreatsJSON: `["exfil"]`, IntentJSON: `{}`, LatencyMs: 150, TokensUsed: 300,
+		},
+		{
+			ID: "ar3", MessageID: "arm3", Timestamp: "2025-01-01T00:02:00Z",
+			FromAgent: "safe-bot", ToAgent: "target-a", Provider: "openai", Model: "gpt-4",
+			RiskScore: 5, RecommendedAction: "none", Confidence: 0.95,
+			ThreatsJSON: `[]`, IntentJSON: `{}`, LatencyMs: 80, TokensUsed: 100,
+		},
+	}
+	for _, r := range records {
+		if err := store.LogLLMAnalysis(r); err != nil {
+			t.Fatalf("insert %s: %v", r.ID, err)
+		}
+	}
+
+	// Mark one as confirmed
+	if err := store.UpdateLLMReviewStatus("ar1", "confirmed"); err != nil {
+		t.Fatalf("update review status: %v", err)
+	}
+
+	risks, err := store.QueryAgentLLMRisk()
+	if err != nil {
+		t.Fatalf("QueryAgentLLMRisk: %v", err)
+	}
+
+	// risky-bot: 2 analyses, avg 70, max 80, 2 threats, 1 confirmed, 1 rule
+	rb, ok := risks["risky-bot"]
+	if !ok {
+		t.Fatal("expected risky-bot in results")
+	}
+	if rb.AnalysisCount != 2 {
+		t.Errorf("risky-bot AnalysisCount = %d, want 2", rb.AnalysisCount)
+	}
+	if rb.AvgRiskScore != 70 {
+		t.Errorf("risky-bot AvgRiskScore = %f, want 70", rb.AvgRiskScore)
+	}
+	if rb.MaxRiskScore != 80 {
+		t.Errorf("risky-bot MaxRiskScore = %f, want 80", rb.MaxRiskScore)
+	}
+	if rb.ThreatCount != 2 {
+		t.Errorf("risky-bot ThreatCount = %d, want 2", rb.ThreatCount)
+	}
+	if rb.ConfirmedCount != 1 {
+		t.Errorf("risky-bot ConfirmedCount = %d, want 1", rb.ConfirmedCount)
+	}
+
+	// safe-bot: 1 analysis, avg 5, max 5, 0 threats
+	sb, ok := risks["safe-bot"]
+	if !ok {
+		t.Fatal("expected safe-bot in results")
+	}
+	if sb.AnalysisCount != 1 {
+		t.Errorf("safe-bot AnalysisCount = %d, want 1", sb.AnalysisCount)
+	}
+	if sb.ThreatCount != 0 {
+		t.Errorf("safe-bot ThreatCount = %d, want 0", sb.ThreatCount)
+	}
+}
+
+func TestQueryAgentRiskBlendedScoring(t *testing.T) {
+	store := newTestStore(t)
+
+	// Create audit log entries — risky-bot has some blocks
+	ts := "2025-01-01T00:00:00Z"
+	for i := 0; i < 10; i++ {
+		status := "delivered"
+		if i < 3 {
+			status = "blocked"
+		}
+		store.Log(Entry{
+			ID: "blend-" + string(rune('a'+i)), Timestamp: ts,
+			FromAgent: "risky-bot", ToAgent: "target",
+			Status: status, PolicyDecision: "pipeline",
+		})
+	}
+	store.Flush()
+
+	// Insert LLM analysis for risky-bot
+	_ = store.LogLLMAnalysis(LLMAnalysis{
+		ID: "bl1", MessageID: "blm1", Timestamp: ts,
+		FromAgent: "risky-bot", ToAgent: "target", Provider: "openai", Model: "gpt-4",
+		RiskScore: 80, RecommendedAction: "block", Confidence: 0.9,
+		ThreatsJSON: `["injection"]`, IntentJSON: `{}`, LatencyMs: 100, TokensUsed: 200,
+	})
+
+	// Query agent risk — should blend audit + LLM
+	risks, err := store.QueryAgentRisk(ts)
+	if err != nil {
+		t.Fatalf("QueryAgentRisk: %v", err)
+	}
+	if len(risks) == 0 {
+		t.Fatal("expected at least one agent risk result")
+	}
+
+	var rb *AgentRisk
+	for i := range risks {
+		if risks[i].Agent == "risky-bot" {
+			rb = &risks[i]
+			break
+		}
+	}
+	if rb == nil {
+		t.Fatal("risky-bot not found in results")
+	}
+
+	// Audit-only score: (3*3 + 0*2) / 10 * 100 = 90 (clamped to 90, under 100)
+	// LLM avg risk: 80
+	// Blended: 90*0.6 + 80*0.4 = 54 + 32 = 86
+	if rb.RiskScore < 85 || rb.RiskScore > 87 {
+		t.Errorf("blended RiskScore = %f, want ~86", rb.RiskScore)
+	}
+	if rb.LLMAvgRisk != 80 {
+		t.Errorf("LLMAvgRisk = %f, want 80", rb.LLMAvgRisk)
+	}
+	if rb.LLMThreatCount != 1 {
+		t.Errorf("LLMThreatCount = %d, want 1", rb.LLMThreatCount)
+	}
+}
+
 func TestQueryLLMStats(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -74,11 +74,18 @@ type EdgeStat struct {
 	Total       int    `json:"total"`
 }
 
-// AgentRisk holds risk scoring for an agent based on audit history.
+// AgentRisk holds risk scoring for an agent based on audit history and LLM analysis.
 type AgentRisk struct {
 	Agent       string  `json:"agent"`
 	Total       int     `json:"total"`
 	Blocked     int     `json:"blocked"`
 	Quarantined int     `json:"quarantined"`
 	RiskScore   float64 `json:"risk_score"`
+
+	// LLM-enriched fields (populated when LLM data is available)
+	LLMAvgRisk      float64 `json:"llm_avg_risk,omitempty"`
+	LLMMaxRisk      float64 `json:"llm_max_risk,omitempty"`
+	LLMAnalysisCount int    `json:"llm_analysis_count,omitempty"`
+	LLMThreatCount  int     `json:"llm_threat_count,omitempty"`
+	LLMConfirmed    int     `json:"llm_confirmed,omitempty"`
 }

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +17,12 @@ import (
 
 	"github.com/oktsec/oktsec/internal/safefile"
 	_ "modernc.org/sqlite"
+)
+
+// Risk scoring weights for blending audit-based and LLM-based scores.
+const (
+	riskWeightAudit = 0.6
+	riskWeightLLM   = 0.4
 )
 
 const schema = `
@@ -241,7 +248,8 @@ func (s *Store) migrateSchema() {
 		rule_generated TEXT DEFAULT ''
 	);
 	CREATE INDEX IF NOT EXISTS idx_llm_message ON llm_analysis(message_id);
-	CREATE INDEX IF NOT EXISTS idx_llm_timestamp ON llm_analysis(timestamp);`
+	CREATE INDEX IF NOT EXISTS idx_llm_timestamp ON llm_analysis(timestamp);
+	CREATE INDEX IF NOT EXISTS idx_llm_from_agent ON llm_analysis(from_agent);`
 	if _, err := s.db.Exec(llmSchema); err != nil {
 		s.logger.Warn("llm_analysis table creation skipped", "error", err)
 	}
@@ -915,14 +923,28 @@ func (s *Store) QueryAgentRisk(since string) ([]AgentRisk, error) {
 		result = append(result, *ar)
 	}
 
-	// Sort by risk score descending
-	for i := 0; i < len(result); i++ {
-		for j := i + 1; j < len(result); j++ {
-			if result[j].RiskScore > result[i].RiskScore {
-				result[i], result[j] = result[j], result[i]
-			}
+	// Enrich with LLM risk data when available
+	llmRisks, _ := s.QueryAgentLLMRisk()
+	for i := range result {
+		// Clamp audit score to 0-100
+		if result[i].RiskScore > 100 {
+			result[i].RiskScore = 100
+		}
+		if lr, ok := llmRisks[result[i].Agent]; ok {
+			result[i].LLMAvgRisk = lr.AvgRiskScore
+			result[i].LLMMaxRisk = lr.MaxRiskScore
+			result[i].LLMAnalysisCount = lr.AnalysisCount
+			result[i].LLMThreatCount = lr.ThreatCount
+			result[i].LLMConfirmed = lr.ConfirmedCount
+			// Blend: 60% audit-based + 40% LLM-based
+			result[i].RiskScore = result[i].RiskScore*riskWeightAudit + lr.AvgRiskScore*riskWeightLLM
 		}
 	}
+
+	// Sort by risk score descending
+	sort.Slice(result, func(i, j int) bool {
+		return result[j].RiskScore < result[i].RiskScore
+	})
 
 	return result, rows.Err()
 }

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -237,9 +237,9 @@ func TestQueryAgentRisk(t *testing.T) {
 	if risks[0].Agent != "bad-agent" {
 		t.Errorf("highest risk agent = %q, want bad-agent", risks[0].Agent)
 	}
-	// RiskScore: (2*3 + 0*2) / 3 * 100 = 200
-	if risks[0].RiskScore != 200 {
-		t.Errorf("risk score = %f, want 200", risks[0].RiskScore)
+	// RiskScore: (2*3 + 0*2) / 3 * 100 = 200, clamped to 100
+	if risks[0].RiskScore != 100 {
+		t.Errorf("risk score = %f, want 100 (clamped)", risks[0].RiskScore)
 	}
 }
 

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -376,17 +376,18 @@ func (s *Server) getHourlyChart() []hourlyBar {
 }
 
 type agentRow struct {
-	Name        string
-	Description string
-	CanMessage  []string
-	Tags        []string
-	Suspended   bool
-	Total       int
-	Blocked     int
-	BlockedPct  int
-	RiskScore   float64
-	HasKey      bool
-	LastSeen    string
+	Name             string
+	Description      string
+	CanMessage       []string
+	Tags             []string
+	Suspended        bool
+	Total            int
+	Blocked          int
+	BlockedPct       int
+	RiskScore        float64
+	LLMThreatCount   int
+	HasKey           bool
+	LastSeen         string
 }
 
 func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
@@ -417,9 +418,10 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Risk score
+		// Risk score (blended audit + LLM)
 		if ar, ok := riskMap[name]; ok {
 			row.RiskScore = ar.RiskScore
+			row.LLMThreatCount = ar.LLMThreatCount
 		}
 
 		// Key status
@@ -487,12 +489,22 @@ func (s *Server) handleRules(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Load LLM-generated rules once (reused for counts and tab data)
+	var llmPending, llmActive []llm.GeneratedRule
+	if s.ruleGen != nil {
+		llmPending, _ = s.ruleGen.ListPending()
+		llmActive, _ = s.ruleGen.ListActive()
+	}
+
 	data := map[string]any{
 		"Active":           "rules",
 		"Tab":              tab,
 		"CustomRulesDir":   s.cfg.CustomRulesDir,
 		"CustomCount":      customCount,
 		"EnforcementCount": enforcementCount,
+		"LLMPendingCount":  len(llmPending),
+		"LLMActiveCount":   len(llmActive),
+		"LLMTotalCount":    len(llmPending) + len(llmActive),
 		"RequireSig":       s.cfg.Identity.RequireSignature,
 	}
 
@@ -600,6 +612,12 @@ func (s *Server) handleRules(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		data["CustomFiles"] = customFiles
+	}
+
+	// LLM-generated rules tab (data already loaded above)
+	if tab == "llm-rules" {
+		data["LLMPending"] = llmPending
+		data["LLMActive"] = llmActive
 	}
 
 	// Build enforcement data for enforcement tab
@@ -819,16 +837,22 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 	// Top triggered rules for this agent
 	topRules, _ := s.audit.QueryAgentTopRules(name, 5, "")
 
-	// Risk score for this agent
-	var riskScore float64
+	// Risk score for this agent (blended audit + LLM)
+	var agentRiskData *audit.AgentRisk
 	if agentRisks, err := s.audit.QueryAgentRisk(""); err == nil {
-		for _, ar := range agentRisks {
+		for i, ar := range agentRisks {
 			if ar.Agent == name {
-				riskScore = ar.RiskScore
+				agentRiskData = &agentRisks[i]
 				break
 			}
 		}
 	}
+	if agentRiskData == nil {
+		agentRiskData = &audit.AgentRisk{}
+	}
+
+	// LLM threat history for this agent
+	llmHistory, _ := s.audit.QueryLLMAgentHistory(name, "", 5)
 
 	// Communication partners — edges involving this agent
 	var commPartners []audit.EdgeStat
@@ -857,7 +881,10 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 		"KeyFP":        keyFP,
 		"RequireSig":   s.cfg.Identity.RequireSignature,
 		"TopRules":     topRules,
-		"RiskScore":    riskScore,
+		"RiskScore":    agentRiskData.RiskScore,
+		"AgentRisk":    agentRiskData,
+		"LLMHistory":   llmHistory,
+		"LLMEnabled":   s.cfg.LLM.Enabled,
 		"CommPartners": commPartners,
 	}
 
@@ -2111,6 +2138,48 @@ func (s *Server) handleLLMConfirm(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/html")
 	fmt.Fprintf(w, `<span class="ci-reviewed" style="background:rgba(239,68,68,0.1);color:#ef4444">&#10003; Confirmed as real threat</span>`)
+}
+
+func (s *Server) handleApproveLLMRule(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	if s.ruleGen == nil {
+		http.Error(w, "rule generator not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := s.ruleGen.ApproveRule(id); err != nil {
+		s.logger.Error("approve llm rule failed", "id", id, "error", err)
+		http.Error(w, "failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Reload detection rules if scanner supports it
+	if s.scanner != nil {
+		s.scanner.InvalidateCache()
+	}
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprintf(w, `<span style="color:var(--success);font-weight:600;font-size:0.82rem">&#10003; Approved &mdash; rule is now active</span>`)
+}
+
+func (s *Server) handleRejectLLMRule(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	if s.ruleGen == nil {
+		http.Error(w, "rule generator not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := s.ruleGen.RejectRule(id); err != nil {
+		s.logger.Error("reject llm rule failed", "id", id, "error", err)
+		http.Error(w, "failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprintf(w, `<span style="color:var(--text3);font-size:0.82rem">&#10003; Rejected</span>`)
 }
 
 // --- Settings section handlers ---

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	gwMu     sync.Mutex
 	gwCmd    *exec.Cmd
 	llmQueue *llm.Queue
+	ruleGen  *llm.RuleGenerator
 }
 
 // NewServer creates a dashboard server with access-code authentication.
@@ -69,6 +70,11 @@ func NewServer(cfg *config.Config, cfgPath string, auditStore *audit.Store, keys
 // SetLLMQueue attaches the LLM queue for budget status display.
 func (s *Server) SetLLMQueue(q *llm.Queue) {
 	s.llmQueue = q
+}
+
+// SetRuleGenerator attaches the LLM rule generator for the rules dashboard.
+func (s *Server) SetRuleGenerator(rg *llm.RuleGenerator) {
+	s.ruleGen = rg
 }
 
 // AccessCode returns the one-time access code displayed in the terminal.
@@ -213,6 +219,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/rules/custom", s.handleCustomRules)
 	s.mux.HandleFunc("POST /dashboard/rules/custom", s.handleCreateCustomRule)
 	s.mux.HandleFunc("DELETE /dashboard/rules/custom/{id}", s.handleDeleteCustomRule)
+
+	// LLM-generated rules
+	s.mux.HandleFunc("POST /dashboard/api/rules/llm/{id}/approve", s.handleApproveLLMRule)
+	s.mux.HandleFunc("POST /dashboard/api/rules/llm/{id}/reject", s.handleRejectLLMRule)
 
 	// Quarantine queue API
 	s.mux.HandleFunc("GET /dashboard/api/quarantine/{id}", s.handleQuarantineDetail)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -19,6 +19,19 @@ func snakeToTitle(s string) string {
 	return strings.Join(words, " ")
 }
 
+func toFloat64(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	default:
+		return 0
+	}
+}
+
 // tmplFuncs is the shared FuncMap for all event-rendering templates.
 var tmplFuncs = template.FuncMap{
 	"humanDecision": humanReadableDecision,
@@ -51,13 +64,14 @@ var tmplFuncs = template.FuncMap{
 	},
 	"lower": strings.ToLower,
 	"inc": func(i int) int { return i + 1 },
-	"divf": func(a, b int) float64 {
-		if b == 0 {
+	"divf": func(a, b any) float64 {
+		fb := toFloat64(b)
+		if fb == 0 {
 			return 0
 		}
-		return float64(a) / float64(b)
+		return toFloat64(a) / fb
 	},
-	"mulf":   func(a, b int) int { return a * b },
+	"mulf": func(a, b any) float64 { return toFloat64(a) * toFloat64(b) },
 	"divFloat": func(a, b float64) float64 {
 		if b == 0 {
 			return 0
@@ -1189,7 +1203,7 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
           <div class="risk-bar" style="flex:1">
             <div class="risk-bar-fill {{if gt .RiskScore 60.0}}risk-high{{else if gt .RiskScore 30.0}}risk-med{{else}}risk-low{{end}}" style="width:{{printf "%.0f" .RiskScore}}%"></div>
           </div>
-          <span style="font-family:var(--mono);font-size:0.72rem;color:var(--text3)">{{printf "%.0f" .RiskScore}}</span>
+          <span style="font-family:var(--mono);font-size:0.72rem;color:var(--text3)">{{printf "%.0f" .RiskScore}}</span>{{if gt .LLMThreatCount 0}}<span title="{{.LLMThreatCount}} LLM threats" style="font-size:0.6rem;color:var(--danger);margin-left:2px">&#x26A0;</span>{{end}}
         </div>
       </td>
       <td style="text-align:center">{{if .HasKey}}<span title="Key registered" style="color:var(--success)">&#x1f512;</span>{{else}}<span title="No key" style="color:var(--text3)">&#x1f513;</span>{{end}}</td>
@@ -1274,7 +1288,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
 
 <div class="grid-3" style="gap:16px;margin-bottom:20px">
   <div class="card" style="margin-bottom:0">
-    <div class="label" style="font-size:0.75rem;color:var(--text2);margin-bottom:6px">Risk Score</div>
+    <div class="label" style="font-size:0.75rem;color:var(--text2);margin-bottom:6px">Risk Score{{if and .LLMEnabled (gt .AgentRisk.LLMAnalysisCount 0)}} <span style="font-size:0.65rem;color:var(--accent-light)">(audit + LLM)</span>{{end}}</div>
     <div style="display:flex;align-items:center;gap:10px">
       <div style="font-size:1.6rem;font-weight:700" class="{{if gt .RiskScore 60.0}}danger{{else if gt .RiskScore 30.0}}warn{{else}}success{{end}}">{{printf "%.0f" .RiskScore}}</div>
       <div style="flex:1">
@@ -1282,6 +1296,13 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
       </div>
       <div style="font-size:0.72rem;color:var(--text3)">{{if gt .RiskScore 60.0}}High{{else if gt .RiskScore 30.0}}Medium{{else}}Low{{end}}</div>
     </div>
+    {{if and .LLMEnabled (gt .AgentRisk.LLMAnalysisCount 0)}}
+    <div style="margin-top:10px;padding-top:8px;border-top:1px solid var(--border);display:flex;gap:16px;font-size:0.72rem">
+      <div><span style="color:var(--text3)">LLM avg</span> <span style="font-family:var(--mono);font-weight:600;color:{{if gt .AgentRisk.LLMAvgRisk 60.0}}var(--danger){{else if gt .AgentRisk.LLMAvgRisk 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .AgentRisk.LLMAvgRisk}}</span></div>
+      <div><span style="color:var(--text3)">peak</span> <span style="font-family:var(--mono);font-weight:600">{{printf "%.0f" .AgentRisk.LLMMaxRisk}}</span></div>
+      <div><span style="color:var(--text3)">analyses</span> <span style="font-family:var(--mono)">{{.AgentRisk.LLMAnalysisCount}}</span></div>
+    </div>
+    {{end}}
   </div>
 
   {{if .TopRules}}
@@ -1326,6 +1347,47 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
     {{end}}
     </tbody>
   </table>
+</div>
+{{end}}
+
+{{if and .LLMEnabled .LLMHistory}}
+<div class="card">
+  <h2>LLM Threat Intelligence</h2>
+  {{if gt .AgentRisk.LLMThreatCount 0}}
+  <div style="display:flex;gap:16px;margin-bottom:16px;padding:12px;background:var(--surface2);border-radius:8px">
+    <div style="text-align:center">
+      <div style="font-size:1.4rem;font-weight:700;color:{{if gt .AgentRisk.LLMThreatCount 3}}var(--danger){{else if gt .AgentRisk.LLMThreatCount 1}}var(--warn){{else}}var(--text){{end}}">{{.AgentRisk.LLMThreatCount}}</div>
+      <div style="font-size:0.68rem;color:var(--text3)">Threats</div>
+    </div>
+    <div style="text-align:center">
+      <div style="font-size:1.4rem;font-weight:700;color:var(--danger)">{{.AgentRisk.LLMConfirmed}}</div>
+      <div style="font-size:0.68rem;color:var(--text3)">Confirmed</div>
+    </div>
+    <div style="text-align:center">
+      <div style="font-size:1.4rem;font-weight:700;color:{{if gt .AgentRisk.LLMAvgRisk 60.0}}var(--danger){{else if gt .AgentRisk.LLMAvgRisk 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .AgentRisk.LLMAvgRisk}}</div>
+      <div style="font-size:0.68rem;color:var(--text3)">Avg Risk</div>
+    </div>
+    <div style="text-align:center">
+      <div style="font-size:1.4rem;font-weight:700">{{printf "%.0f" .AgentRisk.LLMMaxRisk}}</div>
+      <div style="font-size:0.68rem;color:var(--text3)">Peak Risk</div>
+    </div>
+  </div>
+  {{end}}
+  <table>
+    <thead><tr><th>Time</th><th>To</th><th style="text-align:right">Risk</th><th>Action</th><th>Status</th></tr></thead>
+    <tbody>
+    {{range .LLMHistory}}
+    <tr class="clickable" onclick="window.location='/dashboard/llm/case/{{.ID}}'">
+      <td data-ts="{{.Timestamp}}" style="font-size:0.78rem">{{.Timestamp}}</td>
+      <td>{{agentCell .ToAgent}}</td>
+      <td style="text-align:right;font-family:var(--mono);font-weight:600;color:{{if gt .RiskScore 60.0}}var(--danger){{else if gt .RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .RiskScore}}</td>
+      <td>{{if eq .RecommendedAction "block"}}<span class="badge-blocked">block</span>{{else if eq .RecommendedAction "investigate"}}<span class="badge-quarantined">investigate</span>{{else}}<span class="badge-delivered">none</span>{{end}}</td>
+      <td>{{if eq .ReviewedStatus "confirmed"}}<span style="color:var(--danger);font-size:0.75rem;font-weight:600">confirmed</span>{{else if eq .ReviewedStatus "false_positive"}}<span style="color:var(--text3);font-size:0.75rem">dismissed</span>{{else}}<span style="color:var(--warn);font-size:0.75rem">pending</span>{{end}}</td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  <div style="margin-top:10px;text-align:right"><a href="/dashboard/llm" style="color:var(--accent);font-size:0.78rem">View all LLM analyses &rarr;</a></div>
 </div>
 {{end}}
 
@@ -1540,6 +1602,7 @@ var rulesTmpl = template.Must(template.New("rules").Funcs(tmplFuncs).Parse(layou
   <a href="/dashboard/rules?tab=detection" class="rules-tab {{if eq .Tab "detection"}}active{{end}}">Detection Rules{{if .RuleCount}} <span class="count">{{.RuleCount}}</span>{{end}}</a>
   <a href="/dashboard/rules?tab=enforcement" class="rules-tab {{if eq .Tab "enforcement"}}active{{end}}">Enforcement{{if .EnforcementCount}} <span class="count">{{.EnforcementCount}}</span>{{end}}</a>
   <a href="/dashboard/rules?tab=custom" class="rules-tab {{if eq .Tab "custom"}}active{{end}}">Custom Rules{{if .CustomCount}} <span class="count">{{.CustomCount}}</span>{{end}}</a>
+  {{if .LLMTotalCount}}<a href="/dashboard/rules?tab=llm-rules" class="rules-tab {{if eq .Tab "llm-rules"}}active{{end}}">LLM Rules{{if .LLMPendingCount}} <span class="count" style="background:rgba(251,146,60,0.15);color:#fb923c">{{.LLMPendingCount}} pending</span>{{else if .LLMTotalCount}} <span class="count">{{.LLMTotalCount}}</span>{{end}}</a>{{end}}
 </div>
 
 {{if eq .Tab "detection"}}
@@ -1574,6 +1637,88 @@ var rulesTmpl = template.Must(template.New("rules").Funcs(tmplFuncs).Parse(layou
 </div>
 {{else}}
 <div class="empty">No rules loaded.</div>
+{{end}}
+
+{{else if eq .Tab "llm-rules"}}
+<!-- LLM-Generated Rules Tab -->
+<style>
+.lr-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:16px 20px;margin-bottom:10px;transition:border-color 0.2s}
+.lr-card:hover{border-color:var(--accent)}
+.lr-card.pending{border-left:3px solid var(--warn)}
+.lr-card.active{border-left:3px solid var(--success)}
+.lr-card.rejected{border-left:3px solid var(--text3);opacity:0.6}
+.lr-top{display:flex;align-items:center;gap:12px;margin-bottom:8px}
+.lr-id{font-family:var(--mono);font-weight:600;font-size:0.85rem}
+.lr-name{color:var(--text2);font-size:0.82rem;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lr-desc{color:var(--text3);font-size:0.78rem;line-height:1.5;margin-bottom:10px}
+.lr-meta{display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:0.72rem}
+.lr-tag{padding:2px 8px;border-radius:4px;background:var(--surface2);font-family:var(--mono)}
+.lr-pattern{margin-top:10px;padding:8px 12px;background:var(--bg);border-radius:6px;font-family:var(--mono);font-size:0.72rem;color:var(--accent-light);word-break:break-all}
+.lr-actions{display:flex;gap:8px;margin-top:12px}
+</style>
+
+{{if .LLMPending}}
+<div style="margin-bottom:24px">
+  <h2 style="font-size:1rem;margin-bottom:12px;color:var(--warn)">Pending Review <span style="font-size:0.75rem;color:var(--text3)">({{len .LLMPending}} rules)</span></h2>
+  {{range .LLMPending}}
+  <div class="lr-card pending">
+    <div class="lr-top">
+      <span class="lr-id">{{.ID}}</span>
+      <span class="lr-name">{{.Name}}</span>
+      <span class="badge-quarantined" style="font-size:0.68rem">pending</span>
+      {{if eq .Severity "critical"}}<span class="badge-blocked" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else if eq .Severity "high"}}<span class="badge-blocked" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else if eq .Severity "medium"}}<span class="badge-quarantined" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else}}<span class="badge-delivered" style="font-size:0.65rem">{{.Severity}}</span>{{end}}
+    </div>
+    <div class="lr-desc">{{.Description}}</div>
+    <div class="lr-meta">
+      <span class="lr-tag" style="color:var(--text2)">{{.Category}}</span>
+      <span style="color:var(--text3)">confidence: <span style="font-family:var(--mono);color:var(--text)">{{printf "%.0f" (mulf .Confidence 100)}}%</span></span>
+      <span style="color:var(--text3)">by: <span style="font-family:var(--mono)">{{.GeneratedBy}}</span></span>
+      {{if .MessageID}}<span style="color:var(--text3)">from: <a href="/dashboard/llm/case/{{.MessageID}}" style="color:var(--accent);font-family:var(--mono);font-size:0.68rem">{{truncate .MessageID 8}}...</a></span>{{end}}
+    </div>
+    {{range .Patterns}}
+    <div class="lr-pattern">{{.Value}}</div>
+    {{end}}
+    <div class="lr-actions" id="lr-act-{{.ID}}">
+      <button class="btn btn-sm" style="background:var(--success)" hx-post="/dashboard/api/rules/llm/{{.ID}}/approve" hx-target="#lr-act-{{.ID}}" hx-swap="innerHTML">Approve &amp; Activate</button>
+      <button class="btn btn-sm" style="background:var(--surface2);color:var(--text3)" hx-post="/dashboard/api/rules/llm/{{.ID}}/reject" hx-target="#lr-act-{{.ID}}" hx-swap="innerHTML">Reject</button>
+    </div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+{{if .LLMActive}}
+<div>
+  <h2 style="font-size:1rem;margin-bottom:12px;color:var(--success)">Active <span style="font-size:0.75rem;color:var(--text3)">({{len .LLMActive}} rules)</span></h2>
+  {{range .LLMActive}}
+  <div class="lr-card active">
+    <div class="lr-top">
+      <span class="lr-id">{{.ID}}</span>
+      <span class="lr-name">{{.Name}}</span>
+      <span class="badge-delivered" style="font-size:0.68rem">active</span>
+      {{if eq .Severity "critical"}}<span class="badge-blocked" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else if eq .Severity "high"}}<span class="badge-blocked" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else if eq .Severity "medium"}}<span class="badge-quarantined" style="font-size:0.65rem">{{.Severity}}</span>
+      {{else}}<span class="badge-delivered" style="font-size:0.65rem">{{.Severity}}</span>{{end}}
+    </div>
+    <div class="lr-desc">{{.Description}}</div>
+    <div class="lr-meta">
+      <span class="lr-tag" style="color:var(--text2)">{{.Category}}</span>
+      <span style="color:var(--text3)">confidence: <span style="font-family:var(--mono);color:var(--text)">{{printf "%.0f" (mulf .Confidence 100)}}%</span></span>
+      {{range .Patterns}}
+      <span style="font-family:var(--mono);font-size:0.68rem;color:var(--accent-light);background:var(--bg);padding:2px 6px;border-radius:4px">{{.Value}}</span>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+{{if and (not .LLMPending) (not .LLMActive)}}
+<div class="empty">No LLM-generated rules found. Rules are generated when the LLM layer detects threats with high confidence.</div>
 {{end}}
 
 {{else if eq .Tab "enforcement"}}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -95,6 +95,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 
 	// LLM analysis queue (async, optional)
 	var llmQueue *llm.Queue
+	var ruleGen *llm.RuleGenerator
 	if cfg.LLM.Enabled {
 		llmCfg := llm.Config{
 			Enabled:          true,
@@ -147,7 +148,6 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 			}
 
 			// Wire callbacks: store results in audit and generate rules
-			var ruleGen *llm.RuleGenerator
 			if llmCfg.RuleGen.Enabled {
 				outputDir := llmCfg.RuleGen.OutputDir
 				if outputDir == "" {
@@ -221,6 +221,9 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	dash := dashboard.NewServer(cfg, cfgPath, auditStore, keys, scanner, logger)
 	if llmQueue != nil {
 		dash.SetLLMQueue(llmQueue)
+	}
+	if ruleGen != nil {
+		dash.SetRuleGenerator(ruleGen)
 	}
 
 	// Agent CRUD API


### PR DESCRIPTION
## Summary
- **Blended risk scoring**: 60% audit-based + 40% LLM-based risk scores with clamped audit component. Agents sorted by composite risk on the agents page with LLM threat indicators.
- **Agent detail LLM intelligence**: Shows LLM avg/peak risk, analysis count, threat summary, and recent LLM analyses table.
- **LLM rule review lifecycle**: Generated rules flow through pending → approve/reject → active. New "LLM Rules" tab on the Rules page with HTMX-powered approve/reject actions and scanner cache invalidation on approval.
- **Template hardening**: `mulf`/`divf` accept mixed numeric types (int/float64), MessageID truncation uses safe bounds check, deduplicated filesystem reads for rule counts, correct HTTP 500 status for server errors.

## Test plan
- [x] `TestQueryAgentLLMRisk` — empty table and multi-agent risk aggregation
- [x] `TestQueryAgentRiskBlendedScoring` — verifies 60/40 blend formula with clamped audit scores
- [x] Existing `TestQueryAgentRisk` updated for clamped score (100 max)
- [x] Full dashboard test suite passes (40s with race detector)
- [x] `make build && make lint` clean