### PR TITLE
fix: shard rate limiter, evict stale entries, fix SDK docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,24 +265,23 @@ pip install oktsec  # coming soon -- install from sdk/python/ for now
 ```
 
 ```python
-from oktsec import OktsecClient
+from oktsec import Client
 
-client = OktsecClient(base_url="http://127.0.0.1:8080")
+client = Client("http://127.0.0.1:8080", "coordinator")
 
 # Send a message
 result = client.send_message(
-    from_agent="coordinator",
-    to_agent="researcher",
+    to="researcher",
     content="Analyze the latest threat report",
 )
 
 # With Ed25519 signing
 from oktsec import load_keypair
 keypair = load_keypair("./keys", "coordinator")
-client = OktsecClient(base_url="http://127.0.0.1:8080", keypair=keypair)
+client = Client("http://127.0.0.1:8080", "coordinator", keypair=keypair)
 ```
 
-Async support via `AsyncOktsecClient` (httpx-based).
+Async support via `AsyncClient` (httpx-based).
 
 ## Agent CRUD API
 

--- a/documentation/guides/python-sdk.md
+++ b/documentation/guides/python-sdk.md
@@ -11,14 +11,13 @@ pip install oktsec
 ## Basic usage
 
 ```python
-from oktsec import OktsecClient
+from oktsec import Client
 
-client = OktsecClient(base_url="http://127.0.0.1:8080")
+client = Client("http://127.0.0.1:8080", "coordinator")
 
 # Send a message
 result = client.send_message(
-    from_agent="coordinator",
-    to_agent="researcher",
+    to="researcher",
     content="Analyze the latest threat report",
 )
 
@@ -31,15 +30,14 @@ print(result.verified_sender)  # False (unsigned)
 ## With Ed25519 signing
 
 ```python
-from oktsec import OktsecClient, load_keypair
+from oktsec import Client, load_keypair
 
 keypair = load_keypair("./keys", "coordinator")
-client = OktsecClient(base_url="http://127.0.0.1:8080", keypair=keypair)
+client = Client("http://127.0.0.1:8080", "coordinator", keypair=keypair)
 
 # Messages are automatically signed
 result = client.send_message(
-    from_agent="coordinator",
-    to_agent="researcher",
+    to="researcher",
     content="Analyze the latest threat report",
 )
 print(result.verified_sender)  # True
@@ -48,13 +46,12 @@ print(result.verified_sender)  # True
 ## Async support
 
 ```python
-from oktsec import AsyncOktsecClient
+from oktsec import AsyncClient
 
-client = AsyncOktsecClient(base_url="http://127.0.0.1:8080")
+client = AsyncClient("http://127.0.0.1:8080", "coordinator")
 
 result = await client.send_message(
-    from_agent="coordinator",
-    to_agent="researcher",
+    to="researcher",
     content="Analyze the latest threat report",
 )
 ```
@@ -72,15 +69,14 @@ print(result.findings)  # list of triggered rules
 ## Error handling
 
 ```python
-from oktsec import OktsecError
+from oktsec import PolicyError
 
 try:
     result = client.send_message(
-        from_agent="unknown",
-        to_agent="researcher",
+        to="researcher",
         content="hello",
     )
-except OktsecError as e:
-    print(e.status_code)      # 403
-    print(e.policy_decision)  # "acl_denied"
+except PolicyError as e:
+    print(e.status_code)                  # 403
+    print(e.response.policy_decision)     # "acl_denied"
 ```

--- a/documentation/use-cases/multi-agent-pipeline.md
+++ b/documentation/use-cases/multi-agent-pipeline.md
@@ -104,14 +104,13 @@ Each agent gets an Ed25519 keypair. The private key stays with the agent; the pu
 === "Python"
 
     ```python
-    from oktsec import OktsecClient, load_keypair
+    from oktsec import Client, load_keypair
 
     keypair = load_keypair("./keys", "planner")
-    client = OktsecClient(base_url="http://localhost:8080", keypair=keypair)
+    client = Client("http://localhost:8080", "planner", keypair=keypair)
 
     result = client.send_message(
-        from_agent="planner",
-        to_agent="researcher",
+        to="researcher",
         content="Find the top 5 papers on LLM security published in 2025",
     )
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -73,6 +73,12 @@ func NewHandler(cfg *config.Config, keys *identity.KeyStore, pol *policy.Evaluat
 	}
 }
 
+// Close stops background goroutines (rate limiter eviction, message window eviction).
+func (h *Handler) Close() {
+	h.rateLimiter.Stop()
+	h.window.Stop()
+}
+
 // SetLLMQueue attaches the async LLM analysis queue to the handler.
 func (h *Handler) SetLLMQueue(q *llm.Queue) {
 	h.llmQueue = q

--- a/internal/proxy/ratelimit.go
+++ b/internal/proxy/ratelimit.go
@@ -3,16 +3,26 @@
 package proxy
 
 import (
+	"hash/fnv"
 	"sync"
 	"time"
 )
 
-// RateLimiter implements a sliding-window rate limit per agent.
-type RateLimiter struct {
+const rlShardCount = 64
+
+// rlShard is one partition of the rate limiter's state.
+type rlShard struct {
 	mu       sync.Mutex
-	limit    int
-	window   time.Duration
 	counters map[string][]time.Time
+}
+
+// RateLimiter implements a sliding-window rate limit per agent.
+// Internally it uses sharded locks to reduce contention at high request rates.
+type RateLimiter struct {
+	limit  int
+	window time.Duration
+	shards [rlShardCount]rlShard
+	done   chan struct{}
 }
 
 // NewRateLimiter creates a rate limiter. If limit <= 0, Allow always returns true.
@@ -20,11 +30,22 @@ func NewRateLimiter(limit int, windowSeconds int) *RateLimiter {
 	if windowSeconds <= 0 {
 		windowSeconds = 60
 	}
-	return &RateLimiter{
-		limit:    limit,
-		window:   time.Duration(windowSeconds) * time.Second,
-		counters: make(map[string][]time.Time),
+	rl := &RateLimiter{
+		limit:  limit,
+		window: time.Duration(windowSeconds) * time.Second,
+		done:   make(chan struct{}),
 	}
+	for i := range rl.shards {
+		rl.shards[i].counters = make(map[string][]time.Time)
+	}
+	// Evict stale entries periodically. The interval is 2x the window
+	// duration (minimum 30s) so we don't spin for very small windows.
+	evictInterval := rl.window * 2
+	if evictInterval < 30*time.Second {
+		evictInterval = 30 * time.Second
+	}
+	go rl.evictLoop(evictInterval)
+	return rl
 }
 
 // Allow checks whether the agent is within rate limit. Returns false if exceeded.
@@ -33,14 +54,15 @@ func (rl *RateLimiter) Allow(agent string) bool {
 		return true
 	}
 
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
+	s := &rl.shards[rl.shardIndex(agent)]
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	now := time.Now()
 	cutoff := now.Add(-rl.window)
 
 	// Prune old timestamps
-	timestamps := rl.counters[agent]
+	timestamps := s.counters[agent]
 	pruned := timestamps[:0]
 	for _, ts := range timestamps {
 		if ts.After(cutoff) {
@@ -49,10 +71,57 @@ func (rl *RateLimiter) Allow(agent string) bool {
 	}
 
 	if len(pruned) >= rl.limit {
-		rl.counters[agent] = pruned
+		s.counters[agent] = pruned
 		return false
 	}
 
-	rl.counters[agent] = append(pruned, now)
+	s.counters[agent] = append(pruned, now)
 	return true
+}
+
+// Stop terminates the background eviction goroutine. Safe to call multiple times.
+func (rl *RateLimiter) Stop() {
+	select {
+	case <-rl.done:
+	default:
+		close(rl.done)
+	}
+}
+
+// shardIndex returns the shard index for the given key.
+func (rl *RateLimiter) shardIndex(key string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return h.Sum32() % rlShardCount
+}
+
+// evictLoop periodically removes map entries whose newest timestamp
+// is older than 2x the window duration.
+func (rl *RateLimiter) evictLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-rl.done:
+			return
+		case <-ticker.C:
+			rl.evict()
+		}
+	}
+}
+
+// evict removes stale entries from all shards. An entry is stale when all
+// of its timestamps are older than 2x the window duration.
+func (rl *RateLimiter) evict() {
+	cutoff := time.Now().Add(-2 * rl.window)
+	for i := range rl.shards {
+		s := &rl.shards[i]
+		s.mu.Lock()
+		for agent, timestamps := range s.counters {
+			if len(timestamps) == 0 || timestamps[len(timestamps)-1].Before(cutoff) {
+				delete(s.counters, agent)
+			}
+		}
+		s.mu.Unlock()
+	}
 }

--- a/internal/proxy/ratelimit_test.go
+++ b/internal/proxy/ratelimit_test.go
@@ -1,11 +1,14 @@
 package proxy
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 )
 
 func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
 	rl := NewRateLimiter(5, 60)
+	defer rl.Stop()
 	for i := 0; i < 5; i++ {
 		if !rl.Allow("agent-a") {
 			t.Errorf("request %d should be allowed", i)
@@ -15,6 +18,7 @@ func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
 
 func TestRateLimiter_BlocksOverLimit(t *testing.T) {
 	rl := NewRateLimiter(3, 60)
+	defer rl.Stop()
 	for i := 0; i < 3; i++ {
 		rl.Allow("agent-a")
 	}
@@ -25,6 +29,7 @@ func TestRateLimiter_BlocksOverLimit(t *testing.T) {
 
 func TestRateLimiter_DisabledWhenZero(t *testing.T) {
 	rl := NewRateLimiter(0, 60)
+	defer rl.Stop()
 	for i := 0; i < 100; i++ {
 		if !rl.Allow("agent-a") {
 			t.Error("disabled limiter should always allow")
@@ -34,6 +39,7 @@ func TestRateLimiter_DisabledWhenZero(t *testing.T) {
 
 func TestRateLimiter_DisabledWhenNegative(t *testing.T) {
 	rl := NewRateLimiter(-1, 60)
+	defer rl.Stop()
 	if !rl.Allow("agent-a") {
 		t.Error("negative limit should always allow")
 	}
@@ -41,6 +47,7 @@ func TestRateLimiter_DisabledWhenNegative(t *testing.T) {
 
 func TestRateLimiter_IsolatesAgents(t *testing.T) {
 	rl := NewRateLimiter(2, 60)
+	defer rl.Stop()
 	rl.Allow("agent-a")
 	rl.Allow("agent-a")
 
@@ -55,6 +62,7 @@ func TestRateLimiter_IsolatesAgents(t *testing.T) {
 
 func TestRateLimiter_DefaultWindow(t *testing.T) {
 	rl := NewRateLimiter(5, 0)
+	defer rl.Stop()
 	if rl.window.Seconds() != 60 {
 		t.Errorf("default window = %v, want 60s", rl.window)
 	}
@@ -62,7 +70,53 @@ func TestRateLimiter_DefaultWindow(t *testing.T) {
 
 func TestRateLimiter_NegativeWindow(t *testing.T) {
 	rl := NewRateLimiter(5, -10)
+	defer rl.Stop()
 	if rl.window.Seconds() != 60 {
 		t.Errorf("negative window should default to 60s, got %v", rl.window)
+	}
+}
+
+func TestRateLimiter_ConcurrentAccess(t *testing.T) {
+	rl := NewRateLimiter(1000, 60)
+	defer rl.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			agent := fmt.Sprintf("agent-%d", id%5)
+			for j := 0; j < 100; j++ {
+				rl.Allow(agent)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRateLimiter_Evict(t *testing.T) {
+	rl := NewRateLimiter(10, 1)
+	defer rl.Stop()
+
+	rl.Allow("agent-stale")
+	// Verify the entry exists in a shard
+	idx := rl.shardIndex("agent-stale")
+	s := &rl.shards[idx]
+	s.mu.Lock()
+	if _, ok := s.counters["agent-stale"]; !ok {
+		t.Fatal("expected agent-stale entry before eviction")
+	}
+	// Manually clear timestamps to simulate staleness
+	s.counters["agent-stale"] = nil
+	s.mu.Unlock()
+
+	// Run eviction directly
+	rl.evict()
+
+	s.mu.Lock()
+	_, ok := s.counters["agent-stale"]
+	s.mu.Unlock()
+	if ok {
+		t.Error("expected agent-stale to be evicted")
 	}
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	webhooks      *WebhookNotifier
 	dashboard     *dashboard.Server
 	llmQueue      *llm.Queue // nil if LLM disabled
+	handler       *Handler
 	logger        *slog.Logger
 	anomalyCancel context.CancelFunc
 	fwdSrv        *http.Server   // forward proxy (nil if disabled)
@@ -312,6 +313,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 		scanner:   scanner,
 		audit:     auditStore,
 		webhooks:  webhooks,
+		handler:   handler,
 		dashboard: dash,
 		llmQueue:  llmQueue,
 		logger:    logger,
@@ -508,6 +510,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		_ = s.fwdSrv.Shutdown(ctx)
 	}
 	err := s.srv.Shutdown(ctx)
+	s.handler.Close()
 	s.scanner.Close()
 	if cerr := s.audit.Close(); cerr != nil && err == nil {
 		err = cerr

--- a/internal/proxy/window.go
+++ b/internal/proxy/window.go
@@ -1,10 +1,13 @@
 package proxy
 
 import (
+	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
 )
+
+const mwShardCount = 64
 
 // windowEntry is a single buffered message.
 type windowEntry struct {
@@ -12,33 +15,52 @@ type windowEntry struct {
 	added   time.Time
 }
 
+// mwShard is one partition of the MessageWindow's state.
+type mwShard struct {
+	mu      sync.Mutex
+	entries map[string][]windowEntry
+}
+
 // MessageWindow is a per-sender sliding window buffer for detecting
 // split injection attacks across multiple messages.
+// Internally it uses sharded locks to reduce contention.
 type MessageWindow struct {
-	mu      sync.Mutex
 	maxSize int
 	maxAge  time.Duration
-	entries map[string][]windowEntry
+	shards  [mwShardCount]mwShard
+	done    chan struct{}
 }
 
 // NewMessageWindow creates a window buffer.
 // maxSize is the maximum number of messages to keep per sender.
 // maxAge is the maximum age of a message before it is evicted.
 func NewMessageWindow(maxSize int, maxAge time.Duration) *MessageWindow {
-	return &MessageWindow{
+	w := &MessageWindow{
 		maxSize: maxSize,
 		maxAge:  maxAge,
-		entries: make(map[string][]windowEntry),
+		done:    make(chan struct{}),
 	}
+	for i := range w.shards {
+		w.shards[i].entries = make(map[string][]windowEntry)
+	}
+	// Evict stale sender entries periodically. The interval is 2x the
+	// maxAge (minimum 30s) so we don't spin for very small windows.
+	evictInterval := maxAge * 2
+	if evictInterval < 30*time.Second {
+		evictInterval = 30 * time.Second
+	}
+	go w.evictLoop(evictInterval)
+	return w
 }
 
 // Add appends a message from the given agent and evicts old entries.
 func (w *MessageWindow) Add(agent, content string) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	s := &w.shards[w.shardIndex(agent)]
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	now := time.Now()
-	entries := w.entries[agent]
+	entries := s.entries[agent]
 
 	// Evict by age
 	cutoff := now.Add(-w.maxAge)
@@ -54,16 +76,17 @@ func (w *MessageWindow) Add(agent, content string) {
 		fresh = fresh[len(fresh)-w.maxSize+1:]
 	}
 
-	w.entries[agent] = append(fresh, windowEntry{content: content, added: now})
+	s.entries[agent] = append(fresh, windowEntry{content: content, added: now})
 }
 
 // Concatenated returns all buffered messages for the agent joined with a separator.
 // Returns "" if there are fewer than 2 messages (no cross-message context to check).
 func (w *MessageWindow) Concatenated(agent string) string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	s := &w.shards[w.shardIndex(agent)]
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	entries := w.entries[agent]
+	entries := s.entries[agent]
 	if len(entries) < 2 {
 		return ""
 	}
@@ -73,4 +96,50 @@ func (w *MessageWindow) Concatenated(agent string) string {
 		parts[i] = e.content
 	}
 	return strings.Join(parts, "\n---\n")
+}
+
+// Stop terminates the background eviction goroutine. Safe to call multiple times.
+func (w *MessageWindow) Stop() {
+	select {
+	case <-w.done:
+	default:
+		close(w.done)
+	}
+}
+
+// shardIndex returns the shard index for the given key.
+func (w *MessageWindow) shardIndex(key string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return h.Sum32() % mwShardCount
+}
+
+// evictLoop periodically removes sender entries where all messages are stale.
+func (w *MessageWindow) evictLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+			w.evict()
+		}
+	}
+}
+
+// evict removes entries from all shards where every message is older than
+// 2x the maxAge duration.
+func (w *MessageWindow) evict() {
+	cutoff := time.Now().Add(-2 * w.maxAge)
+	for i := range w.shards {
+		s := &w.shards[i]
+		s.mu.Lock()
+		for agent, entries := range s.entries {
+			if len(entries) == 0 || entries[len(entries)-1].added.Before(cutoff) {
+				delete(s.entries, agent)
+			}
+		}
+		s.mu.Unlock()
+	}
 }

--- a/internal/proxy/window_test.go
+++ b/internal/proxy/window_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestMessageWindow_AddAndConcatenate(t *testing.T) {
 	w := NewMessageWindow(10, time.Hour)
+	defer w.Stop()
 
 	w.Add("agent-a", "first message")
 	w.Add("agent-a", "second message")
@@ -22,6 +23,7 @@ func TestMessageWindow_AddAndConcatenate(t *testing.T) {
 
 func TestMessageWindow_SingleMessageReturnsEmpty(t *testing.T) {
 	w := NewMessageWindow(10, time.Hour)
+	defer w.Stop()
 
 	w.Add("agent-a", "only one")
 
@@ -33,6 +35,7 @@ func TestMessageWindow_SingleMessageReturnsEmpty(t *testing.T) {
 
 func TestMessageWindow_MaxSizeEviction(t *testing.T) {
 	w := NewMessageWindow(3, time.Hour)
+	defer w.Stop()
 
 	w.Add("agent-a", "msg-1")
 	w.Add("agent-a", "msg-2")
@@ -48,12 +51,13 @@ func TestMessageWindow_MaxSizeEviction(t *testing.T) {
 
 func TestMessageWindow_MaxAgeEviction(t *testing.T) {
 	w := NewMessageWindow(10, 50*time.Millisecond)
+	defer w.Stop()
 
 	w.Add("agent-a", "old message")
 	time.Sleep(100 * time.Millisecond)
 	w.Add("agent-a", "new message")
 
-	// "old message" should be evicted by age; only one entry remains → empty
+	// "old message" should be evicted by age; only one entry remains -> empty
 	got := w.Concatenated("agent-a")
 	if got != "" {
 		t.Errorf("expired messages should be evicted, got: %q", got)
@@ -62,6 +66,7 @@ func TestMessageWindow_MaxAgeEviction(t *testing.T) {
 
 func TestMessageWindow_IsolatesSenders(t *testing.T) {
 	w := NewMessageWindow(10, time.Hour)
+	defer w.Stop()
 
 	w.Add("agent-a", "a-msg-1")
 	w.Add("agent-a", "a-msg-2")
@@ -80,6 +85,7 @@ func TestMessageWindow_IsolatesSenders(t *testing.T) {
 
 func TestMessageWindow_ConcurrentAccess(t *testing.T) {
 	w := NewMessageWindow(100, time.Hour)
+	defer w.Stop()
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -94,4 +100,31 @@ func TestMessageWindow_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestMessageWindow_Evict(t *testing.T) {
+	w := NewMessageWindow(10, 50*time.Millisecond)
+	defer w.Stop()
+
+	w.Add("agent-stale", "msg")
+	// Verify entry exists
+	idx := w.shardIndex("agent-stale")
+	s := &w.shards[idx]
+	s.mu.Lock()
+	if _, ok := s.entries["agent-stale"]; !ok {
+		t.Fatal("expected agent-stale entry before eviction")
+	}
+	// Overwrite with old timestamp to simulate staleness
+	old := time.Now().Add(-1 * time.Hour)
+	s.entries["agent-stale"] = []windowEntry{{content: "old", added: old}}
+	s.mu.Unlock()
+
+	w.evict()
+
+	s.mu.Lock()
+	_, ok := s.entries["agent-stale"]
+	s.mu.Unlock()
+	if ok {
+		t.Error("expected agent-stale to be evicted")
+	}
 }


### PR DESCRIPTION
## Summary

Second round of audit fixes:

**Performance — RateLimiter & MessageWindow sharding**
- Replace single global `sync.Mutex` with 64 FNV-1a sharded locks — eliminates serialization bottleneck at >5K req/sec
- Background eviction goroutines remove stale map entries (2x window interval) — fixes unbounded memory growth
- `Handler.Close()` stops eviction goroutines on server shutdown
- New tests: concurrent access (20 goroutines x 5 agents) + eviction verification

**Documentation — Python SDK naming**
- `OktsecClient` → `Client`, `AsyncOktsecClient` → `AsyncClient` across AGENTS.md and docs site
- `OktsecError` → `PolicyError` (actual exception class)
- Constructor params and `send_message` API corrected to match actual SDK exports

## Test plan
- [x] `make build` — clean
- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] `go test -race ./internal/proxy/` — all pass (10.8s)
- [x] New concurrent access + eviction tests pass