### PR TITLE
feat: centralized config, cascading resolution, doctor command

### DIFF
--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -61,7 +61,7 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				keysDir = cfg.Identity.KeysDir
 			}
 			if keysDir == "" {
-				keysDir = "./keys"
+				keysDir = config.DefaultKeysDir()
 			}
 
 			// Auto-register agent if not present

--- a/cmd/oktsec/commands/doctor.go
+++ b/cmd/oktsec/commands/doctor.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/spf13/cobra"
+
+	_ "modernc.org/sqlite"
+)
+
+type checkResult struct {
+	name   string
+	status string // "pass", "warn", "fail"
+	detail string
+}
+
+func newDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Run diagnostic checks on your oktsec setup",
+		Example: `  oktsec doctor
+  oktsec doctor --config /path/to/config.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctor()
+		},
+	}
+}
+
+func runDoctor() error {
+	fmt.Println()
+	fmt.Println("  oktsec doctor")
+	fmt.Println("  ────────────────────────────────────────")
+
+	var results []checkResult
+
+	// 1. Home directory
+	results = append(results, checkHomeDir())
+
+	// 2. Config
+	cfg, cfgResult := checkConfig()
+	results = append(results, cfgResult)
+
+	// 3. Secrets file
+	results = append(results, checkSecrets())
+
+	if cfg != nil {
+		// 4. DB accessible
+		results = append(results, checkDB(cfg))
+
+		// 5. Keypairs
+		results = append(results, checkKeypairs(cfg))
+
+		// 6. Port available
+		results = append(results, checkPort(cfg))
+
+		// 7. Rules compile
+		results = append(results, checkRules(cfg))
+	}
+
+	// Print results
+	var passed, warned, failed int
+	for _, r := range results {
+		icon := "✓"
+		switch r.status {
+		case "warn":
+			icon = "!"
+			warned++
+		case "fail":
+			icon = "✗"
+			failed++
+		default:
+			passed++
+		}
+		fmt.Printf("  [%s]  %s: %s\n", icon, r.name, r.detail)
+	}
+
+	fmt.Println("  ────────────────────────────────────────")
+	fmt.Printf("  %d passed", passed)
+	if warned > 0 {
+		fmt.Printf(", %d warnings", warned)
+	}
+	if failed > 0 {
+		fmt.Printf(", %d failed", failed)
+	}
+	fmt.Println()
+	fmt.Println()
+
+	if failed > 0 {
+		return fmt.Errorf("%d check(s) failed", failed)
+	}
+	return nil
+}
+
+func checkHomeDir() checkResult {
+	home := config.HomeDir()
+	info, err := os.Stat(home)
+	if err != nil {
+		return checkResult{"Home directory", "fail", fmt.Sprintf("%s does not exist", home)}
+	}
+	if !info.IsDir() {
+		return checkResult{"Home directory", "fail", fmt.Sprintf("%s is not a directory", home)}
+	}
+	return checkResult{"Home directory", "pass", home}
+}
+
+func checkConfig() (*config.Config, checkResult) {
+	path := cfgFile
+	cfg, err := config.Load(path)
+	if err != nil {
+		return nil, checkResult{"Config", "fail", fmt.Sprintf("cannot load %s: %v", path, err)}
+	}
+	if err := cfg.Validate(); err != nil {
+		return cfg, checkResult{"Config", "warn", fmt.Sprintf("loaded but invalid: %v", err)}
+	}
+	return cfg, checkResult{"Config", "pass", path}
+}
+
+func checkSecrets() checkResult {
+	envPath := config.DefaultEnvPath()
+	info, err := os.Stat(envPath)
+	if os.IsNotExist(err) {
+		return checkResult{"Secrets", "warn", fmt.Sprintf("%s not found (run 'oktsec run' to generate)", envPath)}
+	}
+	if err != nil {
+		return checkResult{"Secrets", "fail", fmt.Sprintf("cannot stat %s: %v", envPath, err)}
+	}
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return checkResult{"Secrets", "warn", fmt.Sprintf("%s has permissions %o (should be 600)", envPath, mode)}
+	}
+	return checkResult{"Secrets", "pass", fmt.Sprintf("%s (0%o)", envPath, mode)}
+}
+
+func checkDB(cfg *config.Config) checkResult {
+	dbPath := cfg.DBPath
+	if dbPath == "" {
+		dbPath = config.DefaultDBPath()
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return checkResult{"Audit DB", "fail", fmt.Sprintf("cannot open %s: %v", dbPath, err)}
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		return checkResult{"Audit DB", "fail", fmt.Sprintf("cannot access %s: %v", dbPath, err)}
+	}
+	return checkResult{"Audit DB", "pass", dbPath}
+}
+
+func checkKeypairs(cfg *config.Config) checkResult {
+	keysDir := cfg.Identity.KeysDir
+	if keysDir == "" {
+		keysDir = config.DefaultKeysDir()
+	}
+	if len(cfg.Agents) == 0 {
+		return checkResult{"Keypairs", "pass", "no agents configured"}
+	}
+	var missing []string
+	for name := range cfg.Agents {
+		keyFile := filepath.Join(keysDir, name+".key")
+		if _, err := os.Stat(keyFile); os.IsNotExist(err) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return checkResult{"Keypairs", "warn", fmt.Sprintf("%d missing: %v", len(missing), missing)}
+	}
+	return checkResult{"Keypairs", "pass", fmt.Sprintf("%d agent(s) in %s", len(cfg.Agents), keysDir)}
+}
+
+func checkPort(cfg *config.Config) checkResult {
+	bind := cfg.Server.Bind
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%d", bind, cfg.Server.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return checkResult{"Port", "warn", fmt.Sprintf("%s in use or unavailable", addr)}
+	}
+	_ = ln.Close()
+	return checkResult{"Port", "pass", fmt.Sprintf("%s available", addr)}
+}
+
+func checkRules(cfg *config.Config) checkResult {
+	scanner := engine.NewScanner(cfg.CustomRulesDir)
+	defer scanner.Close()
+	count := scanner.RulesCount(context.Background())
+	if count == 0 {
+		return checkResult{"Rules", "warn", "no rules loaded"}
+	}
+	return checkResult{"Rules", "pass", fmt.Sprintf("%d rules compiled", count)}
+}

--- a/cmd/oktsec/commands/keygen.go
+++ b/cmd/oktsec/commands/keygen.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,6 @@ func newKeygenCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringSliceVar(&agents, "agent", nil, "agent name(s) to generate keys for")
-	cmd.Flags().StringVar(&outDir, "out", "./keys", "output directory for keys")
+	cmd.Flags().StringVar(&outDir, "out", config.DefaultKeysDir(), "output directory for keys")
 	return cmd
 }

--- a/cmd/oktsec/commands/keys.go
+++ b/cmd/oktsec/commands/keys.go
@@ -207,7 +207,7 @@ func newKeysRevokeCmd() *cobra.Command {
 // persistRevocation records a key revocation in the audit database.
 func persistRevocation(fingerprint, agentName, reason string) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	store, err := audit.NewStore("oktsec.db", logger)
+	store, err := audit.NewStore(defaultDBPath(), logger)
 	if err != nil {
 		return
 	}

--- a/cmd/oktsec/commands/proxy.go
+++ b/cmd/oktsec/commands/proxy.go
@@ -5,8 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"runtime"
 	"syscall"
 
 	"github.com/oktsec/oktsec/internal/audit"
@@ -17,23 +15,8 @@ import (
 )
 
 // defaultDBPath returns a shared DB location so proxy and serve share the same audit trail.
-// Uses ~/.oktsec/oktsec.db on macOS/Linux, %LOCALAPPDATA%\oktsec\oktsec.db on Windows.
 func defaultDBPath() string {
-	var dir string
-	switch runtime.GOOS {
-	case "windows":
-		dir = os.Getenv("LOCALAPPDATA")
-		if dir == "" {
-			home, _ := os.UserHomeDir()
-			dir = filepath.Join(home, "AppData", "Local")
-		}
-		dir = filepath.Join(dir, "oktsec")
-	default:
-		home, _ := os.UserHomeDir()
-		dir = filepath.Join(home, ".oktsec")
-	}
-	_ = os.MkdirAll(dir, 0o700)
-	return filepath.Join(dir, "oktsec.db")
+	return config.DefaultDBPath()
 }
 
 func newProxyCmd() *cobra.Command {

--- a/cmd/oktsec/commands/quarantine.go
+++ b/cmd/oktsec/commands/quarantine.go
@@ -166,7 +166,7 @@ func newQuarantineRejectCmd() *cobra.Command {
 
 func openAuditStore() (*audit.Store, error) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	store, err := audit.NewStore("oktsec.db", logger)
+	store, err := audit.NewStore(defaultDBPath(), logger)
 	if err != nil {
 		return nil, fmt.Errorf("opening audit db: %w", err)
 	}

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,15 @@ func NewRoot() *cobra.Command {
 		},
 	}
 
-	root.PersistentFlags().StringVar(&cfgFile, "config", "oktsec.yaml", "config file path")
+	root.PersistentFlags().StringVar(&cfgFile, "config", "", "config file path (default: cascading resolution)")
+
+	// Resolve config path before any command runs
+	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		flagExplicit := cmd.Flags().Changed("config")
+		resolved, _ := config.ResolveConfigPath(cfgFile, flagExplicit)
+		cfgFile = resolved
+		return nil
+	}
 
 	// Flags for bare "oktsec" invocation (mirrors "oktsec run")
 	root.Flags().Int("port", 0, "override server port")
@@ -53,6 +62,7 @@ func NewRoot() *cobra.Command {
 	// User-facing commands
 	root.AddCommand(
 		newDiscoverCmd(),
+		newDoctorCmd(),
 		newWrapCmd(),
 		newUnwrapCmd(),
 		newRulesCmd(),

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -37,12 +37,15 @@ func newRunCmd() *cobra.Command {
 
 If no config file exists, runs first-time setup automatically:
   1. Scans for MCP clients and servers on this machine
-  2. Generates oktsec.yaml with observe-mode defaults
+  2. Generates config with observe-mode defaults
   3. Generates Ed25519 keypairs for each discovered agent
   4. Wraps discovered MCP servers through oktsec proxy
   5. Starts the proxy server with dashboard
 
-If a config already exists, starts the server directly.`,
+If a config already exists, starts the server directly.
+
+Config is resolved in order: --config flag, $OKTSEC_CONFIG env var,
+./oktsec.yaml (local), ~/.oktsec/config.yaml (home).`,
 		Example: `  oktsec run
   oktsec run --port 9000
   oktsec run --enforce
@@ -77,6 +80,11 @@ func executeRun(opts runOpts) error {
 }
 
 func autoSetup(configPath string, opts runOpts) error {
+	// Ensure parent directory exists (e.g. ~/.oktsec/)
+	if dir := filepath.Dir(configPath); dir != "." {
+		_ = os.MkdirAll(dir, 0o700)
+	}
+
 	// Step 1: Discover
 	fmt.Println("  Scanning for MCP servers...")
 	result, err := discover.Scan()
@@ -90,7 +98,10 @@ func autoSetup(configPath string, opts runOpts) error {
 		fmt.Println("  Starting with empty config (0 agents).")
 		fmt.Println("  Add agents via the dashboard after startup.")
 		fmt.Println()
-		return writeMinimalConfig(configPath)
+		if err := writeMinimalConfig(configPath); err != nil {
+			return err
+		}
+		return ensureSecrets(configPath)
 	}
 
 	fmt.Printf("  Found %d server(s) across %d client(s):\n\n", result.TotalServers(), result.TotalClients())
@@ -107,7 +118,7 @@ func autoSetup(configPath string, opts runOpts) error {
 	fmt.Println()
 
 	// Step 2: Generate config + keypairs
-	keysDir := "./keys"
+	keysDir := config.DefaultKeysDir()
 	if err := os.MkdirAll(keysDir, 0o700); err != nil {
 		return fmt.Errorf("creating keys directory: %w", err)
 	}
@@ -142,14 +153,14 @@ func autoSetup(configPath string, opts runOpts) error {
 		absConfig = configPath
 	}
 
-	dbPath := defaultDBPath()
+	dbPath := config.DefaultDBPath()
 
 	port := 8080
 	if opts.port != 0 {
 		port = opts.port
 	}
 
-	cfg := map[string]any{
+	cfgMap := map[string]any{
 		"version": "1",
 		"server": map[string]any{
 			"port":      port,
@@ -163,7 +174,7 @@ func autoSetup(configPath string, opts runOpts) error {
 		"agents":  agents,
 	}
 
-	data, err := yaml.Marshal(cfg)
+	data, err := yaml.Marshal(cfgMap)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
@@ -179,7 +190,12 @@ func autoSetup(configPath string, opts runOpts) error {
 	fmt.Printf("    Audit DB: %s\n", dbPath)
 	fmt.Println()
 
-	// Step 3: Wrap
+	// Step 3: Generate secrets (.env)
+	if err := ensureSecrets(configPath); err != nil {
+		return err
+	}
+
+	// Step 4: Wrap
 	if !opts.skipWrap {
 		fmt.Println("  Wrapping MCP servers...")
 
@@ -213,23 +229,33 @@ func autoSetup(configPath string, opts runOpts) error {
 	return nil
 }
 
+// ensureSecrets creates the .env file with auto-generated secrets if it doesn't exist.
+func ensureSecrets(configPath string) error {
+	envPath := filepath.Join(filepath.Dir(configPath), ".env")
+	if err := config.EnsureEnvFile(envPath); err != nil {
+		return fmt.Errorf("creating secrets file: %w", err)
+	}
+	return nil
+}
+
 func writeMinimalConfig(configPath string) error {
-	dbPath := defaultDBPath()
-	cfg := map[string]any{
+	dbPath := config.DefaultDBPath()
+	keysDir := config.DefaultKeysDir()
+	cfgMap := map[string]any{
 		"version": "1",
 		"server": map[string]any{
 			"port":      8080,
 			"log_level": "info",
 		},
 		"identity": map[string]any{
-			"keys_dir":          "./keys",
+			"keys_dir":          keysDir,
 			"require_signature": false,
 		},
 		"db_path": dbPath,
 		"agents":  map[string]any{},
 	}
 
-	data, err := yaml.Marshal(cfg)
+	data, err := yaml.Marshal(cfgMap)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
@@ -244,6 +270,12 @@ func startServer(configPath string, opts runOpts) error {
 		fmt.Fprintf(os.Stderr, "\n  Warning: could not load %s (%v)\n", configPath, err)
 		fmt.Fprintf(os.Stderr, "  Starting with default config.\n\n")
 		cfg = config.Defaults()
+	}
+
+	// Load secrets from .env (adjacent to config)
+	envPath := filepath.Join(filepath.Dir(configPath), ".env")
+	if env, _ := config.LoadEnv(envPath); env != nil {
+		config.ApplyEnv(cfg, env)
 	}
 
 	if opts.port != 0 {

--- a/cmd/oktsec/commands/status.go
+++ b/cmd/oktsec/commands/status.go
@@ -61,7 +61,7 @@ func newStatusCmd() *cobra.Command {
 
 			// Audit stats
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-			store, err := audit.NewStore("oktsec.db", logger)
+			store, err := audit.NewStore(defaultDBPath(), logger)
 			if err == nil {
 				defer func() { _ = store.Close() }()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -358,7 +358,7 @@ func Defaults() *Config {
 			LogLevel: "info",
 		},
 		Identity: IdentityConfig{
-			KeysDir:          "./keys",
+			KeysDir:          DefaultKeysDir(),
 			RequireSignature: true,
 		},
 		Agents: make(map[string]Agent),
@@ -370,7 +370,13 @@ func Defaults() *Config {
 }
 
 // Save writes the config to a YAML file at the given path.
+// Creates a .bak backup of the existing file before overwriting.
 func (c *Config) Save(path string) error {
+	// Backup existing file (best-effort)
+	if existing, err := os.ReadFile(path); err == nil {
+		_ = os.WriteFile(path+".bak", existing, 0o600)
+	}
+
 	data, err := yaml.Marshal(c)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LoadEnv reads a .env file and returns key-value pairs.
+// Supports KEY=VALUE lines; ignores comments (#) and blank lines.
+// Returns nil if the file does not exist.
+func LoadEnv(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	env := make(map[string]string)
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		env[strings.TrimSpace(k)] = stripQuotes(strings.TrimSpace(v))
+	}
+	return env, sc.Err()
+}
+
+// stripQuotes removes surrounding single or double quotes from a value.
+func stripQuotes(s string) string {
+	if len(s) >= 2 && ((s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'')) {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// ApplyEnv merges .env secrets into a Config.
+// Only sets fields that are empty in the config (explicit config wins).
+func ApplyEnv(cfg *Config, env map[string]string) {
+	if cfg == nil || env == nil {
+		return
+	}
+	if cfg.Server.APIKey == "" {
+		if v, ok := env["OKTSEC_API_KEY"]; ok {
+			cfg.Server.APIKey = v
+		}
+	}
+}
+
+// EnsureEnvFile creates a .env file with a random API key if it doesn't exist.
+// Uses O_CREATE|O_EXCL for atomic create-if-not-exists. Sets permissions to 0o600.
+func EnsureEnvFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil // already exists
+		}
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		_ = os.Remove(path) // clean up empty file
+		return fmt.Errorf("generating API key: %w", err)
+	}
+
+	_, err = fmt.Fprintf(f, "# oktsec secrets — auto-generated, do not commit\nOKTSEC_API_KEY=%s\n", hex.EncodeToString(key))
+	return err
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+var (
+	homeDirOnce  sync.Once
+	homeDirValue string
+)
+
+// HomeDir returns the oktsec home directory.
+// Uses ~/.oktsec/ on macOS/Linux, %LOCALAPPDATA%\oktsec\ on Windows.
+// Creates the directory with 0o700 permissions on first call.
+func HomeDir() string {
+	homeDirOnce.Do(func() {
+		switch runtime.GOOS {
+		case "windows":
+			dir := os.Getenv("LOCALAPPDATA")
+			if dir == "" {
+				home, _ := os.UserHomeDir()
+				dir = filepath.Join(home, "AppData", "Local")
+			}
+			homeDirValue = filepath.Join(dir, "oktsec")
+		default:
+			home, _ := os.UserHomeDir()
+			homeDirValue = filepath.Join(home, ".oktsec")
+		}
+		_ = os.MkdirAll(homeDirValue, 0o700)
+	})
+	return homeDirValue
+}
+
+// DefaultConfigPath returns ~/.oktsec/config.yaml.
+func DefaultConfigPath() string {
+	return filepath.Join(HomeDir(), "config.yaml")
+}
+
+// DefaultKeysDir returns ~/.oktsec/keys/.
+func DefaultKeysDir() string {
+	return filepath.Join(HomeDir(), "keys")
+}
+
+// DefaultDBPath returns ~/.oktsec/oktsec.db.
+func DefaultDBPath() string {
+	return filepath.Join(HomeDir(), "oktsec.db")
+}
+
+// DefaultEnvPath returns ~/.oktsec/.env.
+func DefaultEnvPath() string {
+	return filepath.Join(HomeDir(), ".env")
+}
+
+// ResolveConfigPath finds the config file using cascading resolution:
+//  1. flagValue if flagExplicit is true (user passed --config)
+//  2. $OKTSEC_CONFIG env var
+//  3. ./oktsec.yaml in current directory (backward compat)
+//  4. ~/.oktsec/config.yaml (home default)
+//
+// Returns the resolved path and whether the file exists on disk.
+func ResolveConfigPath(flagValue string, flagExplicit bool) (path string, found bool) {
+	// 1. Explicit CLI flag
+	if flagExplicit && flagValue != "" {
+		_, err := os.Stat(flagValue)
+		return flagValue, err == nil
+	}
+
+	// 2. Environment variable
+	if envPath := os.Getenv("OKTSEC_CONFIG"); envPath != "" {
+		_, err := os.Stat(envPath)
+		return envPath, err == nil
+	}
+
+	// 3. Local oktsec.yaml (backward compat)
+	local := "oktsec.yaml"
+	if _, err := os.Stat(local); err == nil {
+		abs, _ := filepath.Abs(local)
+		if abs != "" {
+			return abs, true
+		}
+		return local, true
+	}
+
+	// 4. Home default
+	home := DefaultConfigPath()
+	_, err := os.Stat(home)
+	return home, err == nil
+}


### PR DESCRIPTION
## Summary
- Centralizes all oktsec state under `~/.oktsec/` (config, keys, DB, secrets)
- Config resolution cascades: `--config` flag > `$OKTSEC_CONFIG` > `./oktsec.yaml` > `~/.oktsec/config.yaml`
- New `oktsec doctor` command with 7 health checks (home dir, config, secrets, DB, keypairs, port, rules)
- Separates secrets to `.env` file with atomic `O_EXCL` creation and `0o600` permissions
- `Config.Save()` creates `.bak` backup before overwriting
- `HomeDir()` cached with `sync.Once` to avoid redundant syscalls
- Fixes hardcoded `"oktsec.db"` paths in quarantine, keys, and status commands
- Updates `./keys` references to use `config.DefaultKeysDir()` across connect, keygen, run

## Test plan
- [x] `go build`, `go vet`, `golangci-lint` pass (0 issues)
- [x] Full test suite passes (16/17, 1 pre-existing env-dependent)
- [x] `oktsec doctor` runs correctly, reports 7 checks
- [x] Backward compat: local `oktsec.yaml` still detected in cascade step 3
- [x] `/simplify` review completed (TOCTOU fix, lightweight DB check, quote stripping, sync.Once)