### PR TITLE
release: v1.0 prep — docs, test fix, config cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,29 +114,33 @@ For using Oktsec alongside **Docker Sandboxes** (isolated micro VMs for AI agent
 ### One-command setup (recommended)
 
 ```bash
-oktsec setup
-oktsec serve
+oktsec run
 ```
 
-That's it. `oktsec setup` discovers all MCP clients on your machine, generates a config with sensible defaults, creates Ed25519 keypairs, and wraps every MCP server through the security proxy — all in one step.
+That's it. If no config exists, `oktsec run` auto-discovers all MCP clients on your machine, generates a config with sensible defaults, creates Ed25519 keypairs, wraps every MCP server through the security proxy, and starts the proxy + dashboard. If a config already exists, it just starts serving. All state lives in `~/.oktsec/` (config, keys, database, secrets).
 
 Oktsec starts in **observe mode** — it logs everything but blocks nothing. Review activity in the dashboard at `http://127.0.0.1:8080/dashboard` using the access code shown in your terminal. Restart your MCP clients (Claude Desktop, Cursor, etc.) to activate.
 
 To enable **enforcement mode** (block malicious requests with JSON-RPC errors):
 
 ```bash
-oktsec wrap --all --enforce
+oktsec run --enforce
 # or for a single server:
 oktsec proxy --enforce --agent filesystem -- npx @mcp/server-filesystem /data
+```
+
+Check deployment health at any time:
+
+```bash
+oktsec doctor
 ```
 
 ### Step-by-step setup (if you prefer control)
 
 ```bash
 oktsec discover                    # See what's installed
-oktsec init                        # Generate config + keypairs
 oktsec wrap claude-desktop         # Wrap one client at a time
-oktsec serve                       # Start proxy + dashboard
+oktsec run                         # Auto-setup (if needed) + start proxy + dashboard
 ```
 
 ### Manual setup
@@ -316,18 +320,18 @@ Found 2 MCP configuration(s):
 
 Total: 6 MCP servers across 3 clients
 
-Run 'oktsec init' to generate configuration and start observing.
+Run 'oktsec run' to generate configuration and start observing.
 ```
 
 Supported clients: Claude Desktop, Cursor, VS Code, Cline, Windsurf, OpenClaw, NanoClaw.
 
 ### Init
 
-Auto-generates an `oktsec.yaml` config and Ed25519 keypairs for each discovered server:
+`oktsec run` auto-generates config and Ed25519 keypairs for each discovered server on first launch. For manual control:
 
 ```bash
-oktsec init
-oktsec init --keys ./keys --config ./oktsec.yaml
+oktsec run                         # Auto-generates config at ~/.oktsec/config.yaml if missing
+oktsec run --config ./oktsec.yaml  # Use a specific config path
 ```
 
 Each server is auto-classified by risk level based on its capabilities:
@@ -501,7 +505,7 @@ Available tools (6):
 Real-time web UI for monitoring agent activity. Protected by a GitHub-style local access code.
 
 ```bash
-oktsec serve
+oktsec run
 ```
 
 ```
@@ -573,6 +577,13 @@ oktsec keys revoke --agent my-agent             # Revoke without replacement
 Set `require_signature: false` to deploy Oktsec as a content scanner first. Messages without signatures are accepted but logged as `verified_sender: false`. Enable signatures when ready.
 
 ## Configuration
+
+Config resolution (first match wins):
+
+1. `--config` flag (explicit path)
+2. `$OKTSEC_CONFIG` environment variable
+3. `./oktsec.yaml` (backward compatibility)
+4. `~/.oktsec/config.yaml` (default)
 
 ```yaml
 version: "1"
@@ -718,14 +729,14 @@ Analytics queries use a 24-hour time window with covering indexes. All dashboard
 ## CLI reference
 
 ```
-oktsec setup [--enforce] [--skip-wrap]                   # One-command onboarding: discover + init + wrap all
+oktsec run [--port N] [--bind ADDR] [--enforce] [--skip-wrap]  # Auto-setup + serve (recommended)
+oktsec doctor                                            # Check deployment health (config, secrets, DB, keys, port, rules)
 oktsec discover                                          # Scan for MCP servers, OpenClaw, NanoClaw
-oktsec init [--keys ./keys] [--config oktsec.yaml]       # Auto-generate config + keypairs
 oktsec wrap [--enforce] [--all | <client>]               # Route MCP client(s) through oktsec proxy
 oktsec unwrap <client>                                   # Restore original client config
 oktsec scan-openclaw [--path ~/.openclaw/openclaw.json]  # Analyze OpenClaw installation
 oktsec proxy [--enforce] --agent <name> -- <cmd> [args]  # Stdio proxy for single MCP server
-oktsec serve [--config oktsec.yaml] [--port 8080] [--bind 127.0.0.1]
+oktsec serve [--config oktsec.yaml] [--port 8080] [--bind 127.0.0.1]  # Start proxy + dashboard
 oktsec mcp [--config oktsec.yaml]                        # Run as MCP tool server
 oktsec keygen --agent <name> [--agent <name>...] --out <dir>
 oktsec keys list|rotate|revoke [--agent <name>]
@@ -739,6 +750,8 @@ oktsec agent unsuspend <name>                            # Unsuspend an agent
 oktsec audit [--json] [--sarif]                          # Deployment security audit (41 checks)
 oktsec status                                            # Health score, detected products, top issues
 oktsec enforce [on|off]                                  # Toggle enforce/observe mode
+oktsec setup [--enforce] [--skip-wrap]                   # Deprecated: use 'oktsec run' instead
+oktsec init [--keys ./keys] [--config oktsec.yaml]       # Deprecated: use 'oktsec run' instead
 oktsec version
 ```
 

--- a/documentation/getting-started/onboarding.md
+++ b/documentation/getting-started/onboarding.md
@@ -1,5 +1,23 @@
 # Onboarding Flow
 
+## Quick path
+
+The fastest way to get started is `oktsec run`, which handles discovery, config generation, wrapping, and server startup in one command:
+
+```bash
+oktsec run
+```
+
+If no config exists, `run` performs the full onboarding flow below automatically, then starts the server. For more control, use the individual commands described in the rest of this page.
+
+!!! tip "Health check"
+    Run `oktsec doctor` at any time to verify your installation. It checks the home directory, config, secrets, database, keys, port availability, and detection rules.
+
+!!! warning "Deprecated commands"
+    The `setup`, `init`, and `serve` commands still work but print a deprecation notice. Use `oktsec run` instead.
+
+---
+
 ## Discover
 
 Scans your machine for MCP server configurations, OpenClaw, and NanoClaw installations:

--- a/documentation/getting-started/quickstart.md
+++ b/documentation/getting-started/quickstart.md
@@ -22,24 +22,16 @@ Get Oktsec running in under 2 minutes. No config needed.
     docker pull ghcr.io/oktsec/oktsec:latest
     ```
 
-## One-command setup
+## Run
 
 ```bash
-oktsec setup
+oktsec run
 ```
 
-This single command:
+This single command handles everything:
 
-1. **Discovers** all MCP clients on your machine (Claude Desktop, Cursor, VS Code, etc.)
-2. **Generates** `oktsec.yaml` with one agent per MCP server
-3. **Creates** Ed25519 keypairs for each agent
-4. **Wraps** every MCP server to route through the security proxy
-
-## Start the server
-
-```bash
-oktsec serve
-```
+1. **Auto-setup** — if no config exists, discovers MCP clients, generates config and keypairs, wraps servers
+2. **Starts** the proxy server with dashboard, API, and Prometheus metrics
 
 ```
   oktsec proxy
@@ -54,6 +46,9 @@ oktsec serve
 ```
 
 Open `http://127.0.0.1:8080/dashboard` and enter the access code.
+
+!!! info "State directory"
+    All state lives in `~/.oktsec/` — config, keys, database, and secrets. Run `oktsec doctor` to verify your installation.
 
 !!! note "Observe mode"
     By default, Oktsec runs in **observe mode** — it logs everything but blocks nothing. This lets you review activity before enabling enforcement.
@@ -105,6 +100,14 @@ curl -X POST http://localhost:8080/v1/message \
 ```
 
 The first message returns `"policy_decision": "allow"`. The second triggers detection rules and returns `"policy_decision": "content_blocked"`.
+
+## Verify your setup
+
+```bash
+oktsec doctor
+```
+
+Runs 7 health checks: home directory, config, secrets, database, keys, port availability, and detection rules.
 
 ## What's next?
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -147,7 +147,7 @@ Agent CRUD, message pipeline, quarantine management, Prometheus metrics, MCP too
     The main mode. Agents send messages via REST API. Full security pipeline with dashboard.
 
     ```bash
-    oktsec serve
+    oktsec run
     ```
 
     ```bash
@@ -224,14 +224,11 @@ Agent CRUD, message pipeline, quarantine management, Prometheus metrics, MCP too
 # Install
 curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bash
 
-# One-command setup — discovers MCP servers, generates config, wraps everything
-oktsec setup
-
-# Start proxy + dashboard
-oktsec serve
+# Discover, configure, and start — all in one command
+oktsec run
 ```
 
-Open `http://127.0.0.1:8080/dashboard` with the access code printed in your terminal.
+Open `http://127.0.0.1:8080/dashboard` with the access code printed in your terminal. State lives in `~/.oktsec/`.
 
 [Full quick start guide :material-arrow-right:](getting-started/quickstart.md){ .md-button .md-button--primary }
 [View use cases :material-arrow-right:](use-cases/index.md){ .md-button }

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -1,6 +1,11 @@
 # CLI Reference
 
-All commands accept the global flag `--config <path>` (default: `oktsec.yaml`).
+All commands accept the global flag `--config <path>`. Config is resolved using a 4-step cascade:
+
+1. `--config` flag (explicit path)
+2. `$OKTSEC_CONFIG` environment variable
+3. `./oktsec.yaml` (current directory)
+4. `~/.oktsec/config.yaml` (centralized home directory)
 
 ```bash
 oktsec [command] [flags]
@@ -8,9 +13,60 @@ oktsec [command] [flags]
 
 ---
 
+## Primary Commands
+
+### `run`
+
+The unified command for running Oktsec. If no config exists, performs auto-setup (discovery, config generation, key creation, wrapping) before starting the server.
+
+```bash
+oktsec run
+oktsec run --port 9090 --bind 0.0.0.0
+oktsec run --config /path/to/config.yaml
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--port` | int | config value | Override server port |
+| `--bind` | string | config value | Override bind address |
+| `--config` | string | resolved via cascade | Config file path |
+| `--enforce` | bool | `false` | Start in enforcement mode (block malicious requests) |
+
+What `run` does:
+
+1. Resolves config using the 4-step cascade
+2. If no config exists: discovers MCP clients, generates config and keypairs, wraps servers
+3. Starts the proxy server with dashboard, API, gateway (if configured), and Prometheus metrics
+4. Prints access code and endpoints
+
+### `doctor`
+
+Run 7 health checks to verify your Oktsec installation.
+
+```bash
+oktsec doctor
+```
+
+Checks:
+
+| # | Check | What it verifies |
+|---|-------|------------------|
+| 1 | Home directory | `~/.oktsec/` exists with correct permissions |
+| 2 | Config | Config file is valid and loadable |
+| 3 | Secrets | `.env` file exists with `OKTSEC_API_KEY` |
+| 4 | Database | SQLite database is accessible |
+| 5 | Keys | Ed25519 keypairs exist for all configured agents |
+| 6 | Port | Configured port is available |
+| 7 | Rules | Detection rules load without errors |
+
+---
+
 ## Setup & Onboarding
 
-### `setup`
+### `setup` (deprecated)
+
+!!! warning "Deprecated"
+    Use `oktsec run` instead. The `setup` command still works but prints a deprecation notice.
 
 One-command onboarding: discover all MCP servers, generate config and keypairs, wrap everything.
 
@@ -47,7 +103,10 @@ Checks 17 clients: Claude Desktop, Cursor, VS Code, Cline, Windsurf, Claude Code
 
 Also detects OpenClaw installations and runs a risk assessment.
 
-### `init`
+### `init` (deprecated)
+
+!!! warning "Deprecated"
+    Use `oktsec run` instead. The `init` command still works but prints a deprecation notice.
 
 Generate config and keypairs from discovered servers without wrapping.
 
@@ -104,7 +163,10 @@ oktsec unwrap cursor
 
 ## Server Modes
 
-### `serve`
+### `serve` (deprecated)
+
+!!! warning "Deprecated"
+    Use `oktsec run` instead. The `serve` command still works but prints a deprecation notice.
 
 Start the proxy server with dashboard, API, and Prometheus metrics.
 

--- a/documentation/reference/configuration.md
+++ b/documentation/reference/configuration.md
@@ -1,6 +1,47 @@
 # Configuration Reference
 
-Oktsec is configured via `oktsec.yaml`. All commands accept `--config <path>` (default: `oktsec.yaml`).
+Oktsec is configured via YAML. All commands accept `--config <path>` to specify the config file explicitly.
+
+## Config resolution cascade
+
+When no explicit `--config` flag is provided, Oktsec resolves the config file using this 4-step cascade (first match wins):
+
+| Priority | Source | Path |
+|----------|--------|------|
+| 1 | `--config` flag | Explicit path passed on the command line |
+| 2 | `$OKTSEC_CONFIG` env var | Path from the environment variable |
+| 3 | Working directory | `./oktsec.yaml` |
+| 4 | Home directory | `~/.oktsec/config.yaml` |
+
+## Centralized home directory
+
+Oktsec stores all state in `~/.oktsec/`:
+
+```
+~/.oktsec/
+  config.yaml    # Main configuration
+  .env           # Secrets (API keys)
+  keys/          # Ed25519 keypairs
+  oktsec.db      # SQLite audit database
+```
+
+The `oktsec run` command creates this directory structure automatically on first run. Run `oktsec doctor` to verify it.
+
+## Secrets separation
+
+Sensitive values are stored in `~/.oktsec/.env`, separate from the main config:
+
+```bash
+OKTSEC_API_KEY=oks_a1b2c3d4e5f6...
+```
+
+This file is auto-generated on first run with a random `OKTSEC_API_KEY`. Keeping secrets out of the YAML config makes it safe to commit `config.yaml` to version control.
+
+## Config backup
+
+When Oktsec writes to the config file (e.g., via dashboard settings or `oktsec wrap`), it creates a `.bak` backup of the previous version in the same directory before writing.
+
+---
 
 ## Minimal config
 

--- a/internal/auditcheck/auditcheck_test.go
+++ b/internal/auditcheck/auditcheck_test.go
@@ -377,6 +377,11 @@ func TestRunChecks_SecureConfig(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.pub"), []byte("key"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "agent-a.key"), []byte("priv"), 0o600))
 
+	// Override MCP scanner to avoid scanning real host configs.
+	orig := mcpScanFunc
+	mcpScanFunc = func() (*discover.Result, error) { return nil, nil }
+	t.Cleanup(func() { mcpScanFunc = orig })
+
 	cfg := secureBaseline()
 	cfg.Identity.KeysDir = keysDir
 

--- a/internal/auditcheck/checks_mcp.go
+++ b/internal/auditcheck/checks_mcp.go
@@ -13,8 +13,12 @@ var suspiciousCommands = []string{"curl", "wget", "nc", "bash -c", "eval"}
 // secretEnvKeys are substrings in env var names that indicate plaintext secrets.
 var secretEnvKeys = []string{"TOKEN", "SECRET", "KEY", "PASSWORD", "API_KEY"}
 
+// mcpScanFunc is the function used to discover MCP servers.
+// Override in tests to avoid scanning real host configs.
+var mcpScanFunc = discover.Scan
+
 func auditMCPServers() []Finding {
-	result, err := discover.Scan()
+	result, err := mcpScanFunc()
 	if err != nil || result == nil || result.TotalServers() == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Update README and docs site to reflect the unified `oktsec run` flow introduced in #53-#54
- Fix env-dependent `TestRunChecks_SecureConfig` that failed when real MCP configs existed on the host
- Document config resolution cascade, `~/.oktsec/` centralization, `oktsec doctor`, deprecated commands

## Changes

**README.md**
- Quick start uses `oktsec run` (single command) instead of `setup` + `serve`
- Added config resolution cascade (4-step) in Configuration section
- CLI reference: added `run`, `doctor`; marked `setup`/`init` as deprecated
- Dashboard section uses `oktsec run`

**Docs site** (5 files)
- `quickstart.md`: updated to `oktsec run`
- `onboarding.md`: added `doctor` command section
- `cli.md`: full `run` and `doctor` documentation with flags/options
- `configuration.md`: config cascade, `~/.oktsec/` home directory, `.env` secrets, backup on write
- `index.md`: updated quick start example

**Test fix**
- `checks_mcp.go`: extracted `mcpScanFunc` variable for MCP discovery
- `auditcheck_test.go`: `TestRunChecks_SecureConfig` overrides `mcpScanFunc` to avoid scanning real host configs

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all packages, race detector)
- [x] `make lint` passes (0 issues)
- [x] `TestRunChecks_SecureConfig` now passes regardless of host MCP configs