### PR TITLE
feat: LLM-driven verdict escalation, session identity, dashboard UX

### DIFF
--- a/cmd/oktsec/commands/gateway.go
+++ b/cmd/oktsec/commands/gateway.go
@@ -72,8 +72,9 @@ func newGatewayCmd() *cobra.Command {
 
 			// Wire LLM analysis queue (async, optional)
 			var llmQueue *llm.Queue
+			var escalationTracker *llm.EscalationTracker
 			if cfg.LLM.Enabled {
-				llmQueue = setupGatewayLLM(cfg, gw, logger)
+				llmQueue, escalationTracker = setupGatewayLLM(cfg, gw, logger)
 			}
 
 			printGatewayBanner(cfg)
@@ -102,12 +103,17 @@ func newGatewayCmd() *cobra.Command {
 					if llmQueue != nil {
 						llmQueue.Stop()
 					}
+					if escalationTracker != nil {
+						escalationTracker.Stop()
+					}
 					llmQueue = nil
+					escalationTracker = nil
 					gw.SetLLMQueue(nil)
 					gw.SetSignalDetector(nil)
+					gw.SetEscalationTracker(nil)
 
 					if newCfg.LLM.Enabled {
-						llmQueue = setupGatewayLLM(newCfg, gw, logger)
+						llmQueue, escalationTracker = setupGatewayLLM(newCfg, gw, logger)
 						if llmQueue != nil {
 							llmQueue.Start(ctx)
 						}
@@ -126,10 +132,16 @@ func newGatewayCmd() *cobra.Command {
 				if llmQueue != nil {
 					llmQueue.Stop()
 				}
+				if escalationTracker != nil {
+					escalationTracker.Stop()
+				}
 				return err
 			case <-ctx.Done():
 				if llmQueue != nil {
 					llmQueue.Stop()
+				}
+				if escalationTracker != nil {
+					escalationTracker.Stop()
 				}
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
@@ -143,25 +155,32 @@ func newGatewayCmd() *cobra.Command {
 	return cmd
 }
 
-// setupGatewayLLM creates and wires the LLM analysis queue for the gateway.
-// Returns the queue so the caller can start/stop it.
-func setupGatewayLLM(cfg *config.Config, gw *gateway.Gateway, logger *slog.Logger) *llm.Queue {
+// setupGatewayLLM creates and wires the LLM analysis queue and optional
+// escalation tracker for the gateway. Returns (queue, tracker); either may be nil.
+func setupGatewayLLM(cfg *config.Config, gw *gateway.Gateway, logger *slog.Logger) (*llm.Queue, *llm.EscalationTracker) {
 	queue, sd := llm.SetupQueue(cfg.LLM, logger)
 	if queue == nil {
-		return nil
+		return nil, nil
 	}
 
-	// Store LLM results in audit database
+	// Create escalation tracker before OnResult so the closure can reference it
+	tracker := llm.SetupEscalation(cfg.LLM.Escalation, queue, logger)
+
+	// Store LLM results in audit database + feed escalation tracker
 	auditStore := gw.AuditStore()
 	queue.OnResult(func(result llm.AnalysisResult) {
 		_ = llm.StoreResult(auditStore, result)
+		if tracker != nil {
+			tracker.HandleResult(result)
+		}
 	})
 
 	gw.SetLLMQueue(queue)
+	gw.SetEscalationTracker(tracker)
 	if sd != nil {
 		gw.SetSignalDetector(sd)
 	}
-	return queue
+	return queue, tracker
 }
 
 func printGatewayBanner(cfg *config.Config) {

--- a/cmd/oktsec/commands/hook.go
+++ b/cmd/oktsec/commands/hook.go
@@ -49,6 +49,14 @@ func runHook(port int) error {
 	req.Header.Set("X-Oktsec-Agent", "claude-code")
 	req.Header.Set("X-Oktsec-Client", "claude-code")
 
+	// Forward session_id from the hook payload as a header.
+	var hookPayload struct {
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal(body, &hookPayload) == nil && hookPayload.SessionID != "" {
+		req.Header.Set("X-Oktsec-Session", hookPayload.SessionID)
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		// Gateway not running — silently allow.

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -221,6 +221,11 @@ func autoSetup(configPath string, opts runOpts) error {
 			"check_interval": 60,
 			"min_messages":   10,
 		},
+		"forward_proxy": map[string]any{
+			"enabled":        true,
+			"scan_requests":  true,
+			"scan_responses": false,
+		},
 	}
 
 	data, err := yaml.Marshal(cfgMap)

--- a/cmd/oktsec/commands/serve.go
+++ b/cmd/oktsec/commands/serve.go
@@ -70,6 +70,16 @@ func printBanner(cfg *config.Config, dashCode string) {
 		fmt.Println("  No agents configured. Run 'oktsec run' to get started.")
 	}
 	fmt.Println()
+	if cfg.ForwardProxy.Enabled {
+		fpBind := cfg.ForwardProxy.Bind
+		if fpBind == "" {
+			fpBind = bindAddr
+		}
+		proxyURL := fmt.Sprintf("http://%s:%d", fpBind, cfg.ForwardProxy.Port)
+		fmt.Println("  To monitor agent egress traffic, start Claude Code with:")
+		fmt.Printf("    HTTP_PROXY=%s HTTPS_PROXY=%s claude\n", proxyURL, proxyURL)
+		fmt.Println()
+	}
 }
 
 // openDashboard opens the dashboard URL in the default browser.

--- a/guides/docker-sandboxes.md
+++ b/guides/docker-sandboxes.md
@@ -10,7 +10,7 @@ Docker Sandboxes provide isolated micro VMs for AI agents. Oktsec provides conte
 | Filesystem isolation | Yes | No |
 | Network filtering | Proxy-level allow/deny | No |
 | Credential proxying | Yes (API keys never in sandbox) | No |
-| Message content scanning | No | Yes (151 rules) |
+| Message content scanning | No | Yes (188 rules) |
 | Identity verification | No | Yes (Ed25519) |
 | Agent-to-agent ACLs | No | Yes |
 | Audit trail | No | Yes (SQLite) |
@@ -46,7 +46,7 @@ Oktsec operates in two modes:
 │  │                                               │      │
 │  │  rate limit → verify → ACL → scan → verdict   │      │
 │  │                                               │      │
-│  │  151 rules · Ed25519 · audit trail            │      │
+│  │  188 rules · Ed25519 · audit trail            │      │
 │  └──────────────────────────────────────────────┘      │
 │                                                         │
 └─────────────────────────────────────────────────────────┘
@@ -182,7 +182,7 @@ Oktsec does not intercept NanoClaw's WhatsApp traffic or API calls. It only insp
 | 2. Docker credential proxy | API key theft from inside the sandbox | Docker |
 | 3. Identity verification | Agent impersonation | Oktsec (Ed25519) |
 | 4. Policy enforcement | Unauthorized agent-to-agent communication | Oktsec (ACLs) |
-| 5. Content scanning | Prompt injection, credential leaks, PII, exfiltration | Oktsec (151 rules) |
+| 5. Content scanning | Prompt injection, credential leaks, PII, exfiltration | Oktsec (188 rules) |
 | 6. Audit trail | Post-incident forensics | Oktsec (SQLite) |
 
 No single layer is sufficient. Docker Sandboxes without content inspection miss prompt injection. Oktsec without sandboxing can't prevent filesystem access. Use both.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,11 +55,21 @@ type LLMConfig struct {
 	Triage           LLMTriageConfig   `yaml:"triage,omitempty"`
 	MinContentLength int              `yaml:"min_content_length,omitempty"` // skip short messages
 
-	Budget   LLMBudgetConfig   `yaml:"budget,omitempty"`
-	Fallback LLMFallbackConfig `yaml:"fallback,omitempty"`
-	RuleGen  LLMRuleGenConfig  `yaml:"rulegen,omitempty"`
-	Intent   LLMIntentConfig   `yaml:"intent,omitempty"`
-	Webhook  LLMWebhookConfig  `yaml:"webhook,omitempty"`
+	Budget     LLMBudgetConfig     `yaml:"budget,omitempty"`
+	Fallback   LLMFallbackConfig   `yaml:"fallback,omitempty"`
+	RuleGen    LLMRuleGenConfig    `yaml:"rulegen,omitempty"`
+	Intent     LLMIntentConfig     `yaml:"intent,omitempty"`
+	Webhook    LLMWebhookConfig    `yaml:"webhook,omitempty"`
+	Escalation LLMEscalationConfig `yaml:"escalation,omitempty"`
+}
+
+// LLMEscalationConfig controls automatic verdict escalation driven by LLM
+// threat analysis. When the LLM detects a high-risk threat for an agent,
+// all future verdicts for that agent are escalated one level for a TTL window.
+type LLMEscalationConfig struct {
+	Enabled       bool    `yaml:"enabled"`
+	RiskThreshold float64 `yaml:"risk_threshold,omitempty"` // min risk score to trigger (default: 80)
+	TTLMinutes    int     `yaml:"ttl_minutes,omitempty"`    // escalation duration (default: 30)
 }
 
 // LLMFallbackConfig configures a secondary LLM provider used when the

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -918,7 +918,7 @@ func (s *Server) handleAPIGraphTables(w http.ResponseWriter, r *http.Request) {
 		rangeStr = "24h"
 	}
 	since := parseSinceRange(rangeStr)
-	g := s.buildGraph(since)
+	g := s.cachedBuildGraph(since)
 	s.renderTemplate(w, graphTablesTmpl, g)
 }
 
@@ -2926,19 +2926,9 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 		}
 	}
 
-	// Collect agents from config + discover from audit traffic.
-	agentSet := make(map[string]graph.AgentMeta)
-	for name, a := range s.cfg.Agents {
-		agentSet[name] = graph.AgentMeta{
-			Name:        name,
-			Description: a.Description,
-			Location:    a.Location,
-			Tags:        a.Tags,
-			CanMessage:  a.CanMessage,
-		}
-	}
-	// Auto-discover agents from edge stats (handles post-reset scenario).
-	// Skip slugified descriptions that didn't match config (> 25 chars = junk).
+	// Only include agents with activity in the selected time range.
+	// First pass: collect agent names that appear in edge stats.
+	activeNames := make(map[string]bool)
 	for _, es := range edgeStats {
 		for _, n := range []string{es.From, es.To} {
 			if n == "" || strings.Contains(n, ":") || strings.Count(n, ".") >= 2 {
@@ -2950,9 +2940,23 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 			if len(n) > 25 {
 				continue
 			}
-			if _, ok := agentSet[n]; !ok {
-				agentSet[n] = graph.AgentMeta{Name: n}
+			activeNames[n] = true
+		}
+	}
+
+	// Build agent metadata only for active agents.
+	agentSet := make(map[string]graph.AgentMeta)
+	for name := range activeNames {
+		if a, ok := s.cfg.Agents[name]; ok {
+			agentSet[name] = graph.AgentMeta{
+				Name:        name,
+				Description: a.Description,
+				Location:    a.Location,
+				Tags:        a.Tags,
+				CanMessage:  a.CanMessage,
 			}
+		} else {
+			agentSet[name] = graph.AgentMeta{Name: name}
 		}
 	}
 	names := make([]string, 0, len(agentSet))
@@ -3138,6 +3142,21 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 	return g
 }
 
+// cachedBuildGraph returns a cached graph if the same range was requested
+// within the last 10 seconds, otherwise rebuilds and caches the result.
+func (s *Server) cachedBuildGraph(since string) *graph.AgentGraph {
+	s.graphMu.Lock()
+	defer s.graphMu.Unlock()
+	if s.graphCache != nil && s.graphCacheRange == since && time.Since(s.graphCacheTime) < 10*time.Second {
+		return s.graphCache
+	}
+	g := s.buildGraph(since)
+	s.graphCache = g
+	s.graphCacheRange = since
+	s.graphCacheTime = time.Now()
+	return g
+}
+
 // dateOnly extracts the YYYY-MM-DD portion from an RFC3339 timestamp
 // for use in <input type="date"> value attributes.
 func dateOnly(ts string) string {
@@ -3172,7 +3191,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 		rangeStr = "24h"
 	}
 	since := parseSinceRange(rangeStr)
-	g := s.buildGraph(since)
+	g := s.cachedBuildGraph(since)
 	data := map[string]any{
 		"Active":     "graph",
 		"Graph":      g,
@@ -3186,7 +3205,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAPIGraph(w http.ResponseWriter, r *http.Request) {
 	rangeStr := r.URL.Query().Get("range")
 	since := parseSinceRange(rangeStr)
-	g := s.buildGraph(since)
+	g := s.cachedBuildGraph(since)
 	s.renderJSON(w, g)
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/dashboard/static"
 	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/graph"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/llm"
 )
@@ -48,6 +49,12 @@ type Server struct {
 	checkDetected  []string
 	checkProducts  map[string]auditcheck.ProductInfo
 	checkCacheTime time.Time
+
+	// Cached buildGraph results (expires after 10s)
+	graphMu         sync.Mutex
+	graphCache      *graph.AgentGraph
+	graphCacheRange string
+	graphCacheTime  time.Time
 }
 
 // NewServer creates a dashboard server with access-code authentication.

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -213,6 +213,26 @@ var tmplFuncs = template.FuncMap{
 			return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 		}
 	},
+	"fullThreatSummary": func(threatsJSON string, riskScore float64) string {
+		if threatsJSON == "" || threatsJSON == "null" || threatsJSON == "[]" {
+			if riskScore > 10 {
+				return "Elevated risk — review recommended"
+			}
+			return "No threats detected"
+		}
+		var threats []map[string]any
+		if err := json.Unmarshal([]byte(threatsJSON), &threats); err != nil || len(threats) == 0 {
+			return "Threat detected"
+		}
+		t := threats[0]
+		if desc, _ := t["description"].(string); desc != "" {
+			return desc
+		}
+		if typ, _ := t["type"].(string); typ != "" {
+			return snakeToTitle(typ)
+		}
+		return "Threat detected"
+	},
 	"firstThreatSummary": func(threatsJSON string, riskScore float64) string {
 		if threatsJSON == "" || threatsJSON == "null" || threatsJSON == "[]" {
 			if riskScore > 10 {
@@ -1081,15 +1101,26 @@ a.ov-metric+.ov-metric,a.ov-metric+a.ov-metric,.ov-metric+a.ov-metric{}
   {{if .AgentRisks}}
   <div class="ov-card">
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:14px"><h3 style="margin:0">Agent Risk (24h)</h3><a href="/dashboard/agents" style="font-size:0.72rem;color:var(--accent-light);text-decoration:none;font-weight:500">View all &rarr;</a></div>
-    {{range .AgentRisks}}
-    <div class="ov-metric clickable" style="cursor:pointer" onclick="window.location='/dashboard/agents/{{.Agent}}'">
-      <span class="k">{{.Agent}}<br><span style="color:var(--text3);font-size:0.68rem;font-family:var(--mono)">{{.Total}} msgs</span></span>
+    <div id="ar-list">
+    {{range $i, $a := .AgentRisks}}
+    <div class="ov-metric clickable ar-item" style="cursor:pointer" onclick="window.location='/dashboard/agents/{{$a.Agent}}'">
+      <span class="k">{{$a.Agent}}<br><span style="color:var(--text3);font-size:0.68rem;font-family:var(--mono)">{{$a.Total}} msgs</span></span>
       <span class="v">
-        <span style="display:inline-block;width:60px;height:6px;background:var(--bg2);border-radius:3px;vertical-align:middle;margin-right:6px"><span style="display:block;height:100%;width:{{printf "%.0f" .RiskScore}}%;border-radius:3px;background:{{if gt .RiskScore 60.0}}var(--danger){{else if gt .RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}"></span></span>
-        <span style="font-size:0.78rem">{{printf "%.0f" .RiskScore}}</span>
+        <span style="display:inline-block;width:60px;height:6px;background:var(--bg2);border-radius:3px;vertical-align:middle;margin-right:6px"><span style="display:block;height:100%;width:{{printf "%.0f" $a.RiskScore}}%;border-radius:3px;background:{{if gt $a.RiskScore 60.0}}var(--danger){{else if gt $a.RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}"></span></span>
+        <span style="font-size:0.78rem">{{printf "%.0f" $a.RiskScore}}</span>
       </span>
     </div>
     {{end}}
+    </div>
+    <div id="ar-pager" style="display:none;padding-top:10px;border-top:1px solid var(--border);margin-top:4px">
+      <div style="display:flex;align-items:center;justify-content:space-between">
+        <span id="ar-info" style="font-size:0.72rem;color:var(--text3)"></span>
+        <span style="display:flex;gap:6px">
+          <button id="ar-prev" onclick="arPage(-1)" style="background:var(--surface);border:1px solid var(--border);color:var(--text2);padding:3px 10px;border-radius:6px;cursor:pointer;font-size:0.72rem">&lsaquo; Prev</button>
+          <button id="ar-next" onclick="arPage(1)" style="background:var(--surface);border:1px solid var(--border);color:var(--text2);padding:3px 10px;border-radius:6px;cursor:pointer;font-size:0.72rem">Next &rsaquo;</button>
+        </span>
+      </div>
+    </div>
   </div>
   {{end}}
 </div>
@@ -1098,6 +1129,25 @@ a.ov-metric+.ov-metric,a.ov-metric+a.ov-metric,.ov-metric+a.ov-metric{}
 
 
 <script>
+// Agent Risk pagination
+(function(){
+  var items=document.querySelectorAll('.ar-item');
+  if(!items.length)return;
+  var sz=15,cur=1,total=items.length,pages=Math.ceil(total/sz);
+  var pager=document.getElementById('ar-pager');
+  var info=document.getElementById('ar-info');
+  if(pages>1&&pager)pager.style.display='block';
+  function render(){
+    var s=(cur-1)*sz,e=Math.min(s+sz,total);
+    items.forEach(function(r,i){r.style.display=(i>=s&&i<e)?'':'none'});
+    if(info)info.textContent='Showing '+(s+1)+'\u2013'+e+' of '+total;
+    var p=document.getElementById('ar-prev'),n=document.getElementById('ar-next');
+    if(p)p.disabled=cur<=1;
+    if(n)n.disabled=cur>=pages;
+  }
+  window.arPage=function(d){cur=Math.max(1,Math.min(pages,cur+d));render()};
+  render();
+})();
 (function() {
   var dot = document.getElementById('sse-dot');
   var label = document.getElementById('sse-label');
@@ -3820,184 +3870,256 @@ var llmDetailTmpl = template.Must(template.New("llm-detail").Funcs(tmplFuncs).Pa
 
 var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(layoutHead + `
 <style>` + ciCSS + `
-.ci-conf{display:inline-flex;align-items:center;gap:4px;font-size:0.68rem;color:var(--warn);font-weight:500;margin-left:6px}
-.ci-action-bar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px 20px;margin-bottom:16px;background:var(--surface);border:1px solid var(--border);border-radius:10px}
-.ci-dbtn{display:inline-flex;align-items:center;gap:6px;padding:7px 16px;border-radius:8px;font-size:0.78rem;font-weight:500;cursor:pointer;border:1px solid;transition:background 0.15s,border-color 0.15s,color 0.15s}
-.ci-dbtn-confirm{background:rgba(239,68,68,0.08);color:#ef4444;border-color:rgba(239,68,68,0.2)}
-.ci-dbtn-confirm:hover{background:rgba(239,68,68,0.15);border-color:#ef4444}
-.ci-dbtn-dismiss{background:transparent;color:var(--text2);border-color:var(--border)}
-.ci-dbtn-dismiss:hover{background:var(--bg2);border-color:var(--text3)}
-.ci-action-div{width:1px;height:24px;background:var(--border);margin:0 4px;flex-shrink:0}
-.ci-nav{display:inline-flex;align-items:center;gap:5px;padding:6px 10px;border-radius:6px;font-size:0.72rem;font-weight:500;text-decoration:none;color:var(--text3);transition:color 0.15s}
-.ci-nav:hover{color:var(--accent)}
-.ci-nav svg{width:14px;height:14px}
-.ci-reviewed{display:inline-flex;align-items:center;gap:5px;padding:6px 14px;border-radius:6px;font-size:0.75rem;font-weight:600}
-.ci-hist{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:20px}
-.ci-hist-lbl{font-size:0.68rem;color:var(--text3);font-weight:600;text-transform:uppercase;letter-spacing:0.5px;white-space:nowrap}
-.ci-ctx-pill{display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:7px;border:1px solid var(--border);font-size:0.72rem;text-decoration:none;color:var(--text2);transition:border-color 0.15s,background 0.15s}
-.ci-ctx-pill:hover{border-color:var(--accent);background:rgba(99,102,241,0.04)}
-.ci-ctx-score{font-family:var(--mono);font-weight:700;font-size:0.68rem}
-.ci-lbl{font-size:0.66rem;letter-spacing:0.5px;color:var(--text3);margin-bottom:6px;font-weight:600;text-transform:uppercase}
-.ci-int-diff{display:grid;grid-template-columns:1fr 1fr;gap:0;border:1px solid var(--border);border-radius:8px;overflow:hidden}
-.ci-int-side{padding:10px 14px}
-.ci-int-side-decl{background:transparent;border-right:1px solid var(--border)}
-.ci-int-side-act{background:transparent}
-.ci-int-side-act.ci-int-hi{background:rgba(239,68,68,0.04)}
-.ci-int-tag{display:inline-flex;align-items:center;gap:5px;font-size:0.6rem;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:var(--text3);margin-bottom:6px}
-.ci-int-tag-act{color:var(--text2)}
-.ci-int-tag-act.ci-int-warn{color:#ef4444}
-.ci-int-txt{font-size:0.8125rem;line-height:1.5;color:var(--text)}
-.ci-int-side-act .ci-int-txt{font-weight:500}
-.ci-int-side-act.ci-int-hi .ci-int-txt{color:#ef4444}
-.ci-int-align{display:inline-flex;align-items:center;gap:4px;font-family:var(--mono);font-size:0.72rem;font-weight:600;padding:2px 8px;border-radius:100px}
-.ci-int-align-ok{background:rgba(34,197,94,0.1);color:#22c55e}
-.ci-int-align-bad{background:rgba(239,68,68,0.1);color:#ef4444}
-.ci-reason{font-size:0.75rem;line-height:1.5;color:var(--text3);margin-top:8px}
-.ci-thr-fix{display:flex;align-items:center;gap:6px;margin-top:6px}
-.ci-thr-fix code{font-family:var(--mono);font-size:0.75rem;color:var(--text2)}
-.ci-thr-cp{background:transparent;border:1px solid var(--border);color:var(--text3);border-radius:4px;padding:2px 8px;font-size:0.6875rem;cursor:pointer;transition:all 0.12s;font-family:var(--mono);white-space:nowrap}
-.ci-thr-cp:hover{border-color:var(--border-hover);color:var(--text2);background:var(--surface2)}
-@media(max-width:960px){.ci-int-diff{grid-template-columns:1fr}.ci-int-side-decl{border-right:none;border-bottom:1px solid var(--border)}.ci-action-bar{padding:12px 14px}}
+/* Case page overrides */
+.cs-layout{display:grid;grid-template-columns:1fr 340px;gap:24px;align-items:start}
+.cs-main{min-width:0}
+.cs-side{display:flex;flex-direction:column;gap:16px}
+
+/* Verdict banner */
+.cs-banner{display:flex;align-items:stretch;background:var(--surface);border:1px solid var(--border);border-radius:14px;overflow:hidden;margin-bottom:24px}
+.cs-banner-score{display:flex;flex-direction:column;align-items:center;justify-content:center;min-width:90px;padding:20px 16px;flex-shrink:0}
+.cs-banner-score .n{font-size:2rem;font-weight:700;font-family:var(--mono);line-height:1;letter-spacing:-0.03em}
+.cs-banner-score .l{font-size:0.56rem;letter-spacing:0.8px;margin-top:5px;font-weight:600;text-transform:uppercase}
+.cs-banner-body{flex:1;padding:18px 22px;display:flex;flex-direction:column;justify-content:center;border-left:1px solid var(--border);min-width:0}
+.cs-banner-title{font-size:1rem;font-weight:600;margin:0 0 8px;line-height:1.45;color:var(--text);text-wrap:pretty}
+.cs-banner-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:0.75rem;color:var(--text3)}
+.cs-banner-meta .sep{color:var(--border)}
+.cs-banner-action{display:flex;align-items:center;padding:0 22px;flex-shrink:0;border-left:1px solid var(--border)}
+
+/* Action buttons */
+.cs-actions{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}
+.cs-abtn{display:inline-flex;align-items:center;gap:6px;padding:8px 18px;border-radius:8px;font-size:0.78rem;font-weight:500;cursor:pointer;border:1px solid;transition:all 0.15s;text-decoration:none}
+.cs-abtn-danger{background:rgba(239,68,68,0.08);color:#ef4444;border-color:rgba(239,68,68,0.2)}
+.cs-abtn-danger:hover{background:rgba(239,68,68,0.15);border-color:#ef4444}
+.cs-abtn-ghost{background:transparent;color:var(--text2);border-color:var(--border)}
+.cs-abtn-ghost:hover{background:var(--bg2);border-color:var(--text3)}
+.cs-abtn svg{width:14px;height:14px}
+.cs-reviewed{display:inline-flex;align-items:center;gap:6px;padding:8px 18px;border-radius:8px;font-size:0.78rem;font-weight:600}
+.cs-reviewed-ok{background:rgba(34,197,94,0.08);color:#22c55e}
+.cs-reviewed-bad{background:rgba(239,68,68,0.08);color:#ef4444}
+
+/* Side panel cards */
+.cs-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden}
+.cs-card-hdr{padding:12px 16px;border-bottom:1px solid var(--border);font-size:0.68rem;font-weight:600;color:var(--text3);text-transform:uppercase;letter-spacing:0.6px}
+.cs-card-body{padding:14px 16px}
+.cs-row{display:flex;justify-content:space-between;align-items:baseline;padding:7px 0;border-bottom:1px solid rgba(255,255,255,0.04);font-size:0.78rem}
+.cs-row:last-child{border-bottom:none}
+.cs-row .k{color:var(--text3);font-size:0.75rem}
+.cs-row .v{font-family:var(--mono);font-size:0.72rem;color:var(--text2);text-align:right}
+.cs-conf-bar{height:4px;background:var(--bg2);border-radius:2px;margin-top:4px}
+.cs-conf-fill{height:100%;border-radius:2px;transition:width 0.3s}
+
+/* History pills in sidebar */
+.cs-hist-grid{display:flex;flex-wrap:wrap;gap:4px;padding:4px 0}
+.cs-hist-pill{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:6px;font-size:0.68rem;text-decoration:none;color:var(--text3);background:var(--bg2);transition:all 0.12s}
+.cs-hist-pill:hover{color:var(--text);background:var(--bg3)}
+.cs-hist-score{font-family:var(--mono);font-weight:700;font-size:0.65rem}
+
+/* Threat cards */
+.cs-thr-card{border:1px solid var(--border);border-radius:10px;overflow:hidden;margin-bottom:12px}
+.cs-thr-card:last-child{margin-bottom:0}
+.cs-thr-top{display:flex;align-items:flex-start;gap:12px;padding:14px 18px}
+.cs-thr-num{width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.68rem;font-weight:700;font-family:var(--mono);flex-shrink:0;margin-top:1px}
+.cs-thr-num-c{background:rgba(239,68,68,0.12);color:#ef4444}
+.cs-thr-num-h{background:rgba(251,146,60,0.12);color:#fb923c}
+.cs-thr-num-m{background:rgba(251,191,36,0.1);color:#fbbf24}
+.cs-thr-num-l{background:rgba(34,197,94,0.08);color:#22c55e}
+.cs-thr-info{flex:1;min-width:0}
+.cs-thr-type{font-family:var(--mono);font-size:0.72rem;font-weight:600;color:var(--text2);text-transform:uppercase;margin-bottom:3px}
+.cs-thr-desc{font-size:0.82rem;color:var(--text);font-weight:500;line-height:1.5}
+.cs-thr-ev{padding:10px 18px 14px;background:rgba(255,255,255,0.015);border-top:1px solid var(--border);font-size:0.75rem;color:var(--text3);line-height:1.6}
+.cs-thr-rule{padding:8px 18px 12px;border-top:1px solid var(--border);font-size:0.72rem}
+
+/* Intent diff */
+.cs-intent{display:grid;grid-template-columns:1fr 1fr;gap:0;border:1px solid var(--border);border-radius:10px;overflow:hidden}
+.cs-intent-side{padding:14px 18px}
+.cs-intent-decl{border-right:1px solid var(--border)}
+.cs-intent-act.cs-intent-warn{background:rgba(239,68,68,0.03)}
+.cs-intent-lbl{font-size:0.58rem;font-weight:600;letter-spacing:0.6px;text-transform:uppercase;color:var(--text3);margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.cs-intent-lbl-warn{color:#ef4444}
+.cs-intent-txt{font-size:0.82rem;line-height:1.55;color:var(--text)}
+.cs-intent-act .cs-intent-txt{font-weight:500}
+.cs-intent-act.cs-intent-warn .cs-intent-txt{color:#ef4444}
+
+/* Evidence block */
+.cs-evidence{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:16px 18px;font-family:var(--mono);font-size:0.72rem;line-height:1.7;color:var(--text);white-space:pre-wrap;word-break:break-all;max-height:280px;overflow-y:auto}
+
+/* Generated rule */
+.cs-rule-block{background:var(--bg2);border:1px solid rgba(99,102,241,0.15);border-radius:10px;padding:14px 18px;font-family:var(--mono);font-size:0.72rem;line-height:1.7;color:var(--accent-light);white-space:pre-wrap}
+
+@media(max-width:960px){.cs-layout{grid-template-columns:1fr}.cs-banner{flex-direction:column}.cs-banner-score{min-width:unset;padding:14px}.cs-banner-body{border-left:none;border-top:1px solid var(--border)}.cs-banner-action{border-left:none;border-top:1px solid var(--border);padding:14px 22px}.cs-intent{grid-template-columns:1fr}.cs-intent-decl{border-right:none;border-bottom:1px solid var(--border)}}
 </style>
 
-<p style="margin-bottom:16px"><a href="/dashboard/llm" class="ci-back">&larr; Threat Intel</a></p>
+<p style="margin-bottom:18px"><a href="/dashboard/llm" class="ci-back">&larr; Threat Intel</a></p>
 
 {{with .Analysis}}
-<!-- 1. Verdict header -->
-<div class="ci-hdr">
-  <div class="ci-score" style="{{if ge .RiskScore 76.0}}background:rgba(239,68,68,0.12);color:#ef4444{{else if ge .RiskScore 51.0}}background:rgba(251,146,60,0.12);color:#fb923c{{else if ge .RiskScore 31.0}}background:rgba(251,191,36,0.1);color:#fbbf24{{else if gt .RiskScore 10.0}}background:rgba(34,197,94,0.08);color:#22c55e{{else}}background:var(--bg2);color:var(--text3){{end}}">
+<!-- Verdict banner -->
+<div class="cs-banner">
+  <div class="cs-banner-score" style="{{if ge .RiskScore 76.0}}background:rgba(239,68,68,0.08);color:#ef4444{{else if ge .RiskScore 51.0}}background:rgba(251,146,60,0.08);color:#fb923c{{else if ge .RiskScore 31.0}}background:rgba(251,191,36,0.06);color:#fbbf24{{else if gt .RiskScore 10.0}}background:rgba(34,197,94,0.06);color:#22c55e{{else}}background:var(--bg2);color:var(--text3){{end}}">
     <div class="n">{{printf "%.0f" .RiskScore}}</div>
     <div class="l">{{if ge .RiskScore 76.0}}CRITICAL{{else if ge .RiskScore 51.0}}HIGH{{else if ge .RiskScore 31.0}}MEDIUM{{else if gt .RiskScore 10.0}}LOW{{else}}BENIGN{{end}}</div>
   </div>
-  <div class="ci-hdr-body">
-    <h2 class="ci-title">{{firstThreatSummary .ThreatsJSON .RiskScore}}{{if and (gt .Confidence 0.0) (lt .Confidence 30.0)}}<span class="ci-conf">&#9888; Low confidence</span>{{end}}</h2>
-    <div class="ci-hdr-row">
-      {{if .FromAgent}}<a href="/dashboard/agents/{{.FromAgent}}" style="color:var(--accent-light);text-decoration:none;font-weight:500">{{.FromAgent}}</a> <span>&rarr;</span> <a href="/dashboard/agents/{{.ToAgent}}" style="color:var(--text2);text-decoration:none">{{.ToAgent}}</a><span class="sep">&middot;</span>{{end}}
+  <div class="cs-banner-body">
+    <h2 class="cs-banner-title">{{fullThreatSummary .ThreatsJSON .RiskScore}}{{if and (gt .Confidence 0.0) (lt .Confidence 30.0)}} <span style="font-size:0.68rem;color:var(--warn);font-weight:500">&#9888; Low confidence</span>{{end}}</h2>
+    <div class="cs-banner-meta">
+      {{if .FromAgent}}<a href="/dashboard/agents/{{.FromAgent}}" style="color:var(--accent-light);text-decoration:none;font-weight:500">{{.FromAgent}}</a> <span style="opacity:0.5">&rarr;</span> <a href="/dashboard/agents/{{.ToAgent}}" style="color:var(--text2);text-decoration:none">{{.ToAgent}}</a><span class="sep">&middot;</span>{{end}}
       <span>{{relativeTime .Timestamp}}</span>
       <span class="sep">&middot;</span>
-      <span>Confidence {{printf "%.0f" .Confidence}}%</span>
+      <span>{{printf "%.0f" .Confidence}}% confidence</span>
     </div>
   </div>
-  <span class="ci-badge {{if eq .RecommendedAction "block"}}ci-badge-blk{{else if eq .RecommendedAction "investigate"}}ci-badge-inv{{else if eq .RecommendedAction "quarantine"}}ci-badge-qua{{else}}ci-badge-ok{{end}}">{{.RecommendedAction}}</span>
+  <div class="cs-banner-action">
+    <span class="ci-badge {{if eq .RecommendedAction "block"}}ci-badge-blk{{else if eq .RecommendedAction "investigate"}}ci-badge-inv{{else if eq .RecommendedAction "quarantine"}}ci-badge-qua{{else}}ci-badge-ok{{end}}" style="font-size:0.75rem;padding:6px 18px">{{.RecommendedAction}}</span>
+  </div>
 </div>
 
-<!-- 2. Decision bar -->
-<div class="ci-action-bar">
+<!-- Action buttons -->
+<div class="cs-actions">
   {{if or (eq .ReviewedStatus "false_positive") (eq .ReviewedStatus "confirmed")}}
-    {{if eq .ReviewedStatus "false_positive"}}<span class="ci-reviewed" style="background:rgba(34,197,94,0.1);color:#22c55e">&#10003; Dismissed as false positive</span>
-    {{else}}<span class="ci-reviewed" style="background:rgba(239,68,68,0.1);color:#ef4444">&#10003; Confirmed as real threat</span>{{end}}
+    {{if eq .ReviewedStatus "false_positive"}}<span class="cs-reviewed cs-reviewed-ok">&#10003; Dismissed as false positive</span>
+    {{else}}<span class="cs-reviewed cs-reviewed-bad">&#10003; Confirmed as real threat</span>{{end}}
   {{else}}
-    <button class="ci-dbtn ci-dbtn-confirm" hx-post="/dashboard/api/llm/{{.ID}}/confirm" hx-target="closest .ci-action-bar" hx-swap="innerHTML" hx-confirm="Confirm this as a real threat?">Confirm threat</button>
-    <button class="ci-dbtn ci-dbtn-dismiss" hx-post="/dashboard/api/llm/{{.ID}}/dismiss" hx-target="closest .ci-action-bar" hx-swap="innerHTML" hx-confirm="Dismiss as false positive?">False positive</button>
-    <div class="ci-action-div"></div>
-    {{if .FromAgent}}<a class="ci-nav" href="/dashboard/agents/{{.FromAgent}}"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> {{.FromAgent}}</a>{{end}}
-    <a class="ci-nav" href="/dashboard/events?q={{.MessageID}}"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg> Event log</a>
-    {{if and .FromAgent (not $.AgentSuspended)}}<form method="POST" action="/dashboard/agents/{{.FromAgent}}/suspend" style="display:contents"><button type="submit" class="ci-nav" style="color:#ef4444" onclick="return confirm('Suspend agent {{.FromAgent}}?')"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg> Suspend</button></form>{{end}}
-    {{if $.AgentSuspended}}<span class="ci-nav" style="color:#ef4444;cursor:default">Agent suspended</span>{{end}}
+    <button class="cs-abtn cs-abtn-danger" hx-post="/dashboard/api/llm/{{.ID}}/confirm" hx-target="closest .cs-actions" hx-swap="innerHTML" hx-confirm="Confirm this as a real threat?"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg> Confirm threat</button>
+    <button class="cs-abtn cs-abtn-ghost" hx-post="/dashboard/api/llm/{{.ID}}/dismiss" hx-target="closest .cs-actions" hx-swap="innerHTML" hx-confirm="Dismiss as false positive?">False positive</button>
+    {{if and .FromAgent (not $.AgentSuspended)}}<form method="POST" action="/dashboard/agents/{{.FromAgent}}/suspend" style="display:contents"><button type="submit" class="cs-abtn cs-abtn-ghost" style="color:#ef4444;border-color:rgba(239,68,68,0.2)" onclick="return confirm('Suspend agent {{.FromAgent}}?')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg> Suspend agent</button></form>{{end}}
+    {{if $.AgentSuspended}}<span class="cs-abtn" style="color:#ef4444;cursor:default;border-color:rgba(239,68,68,0.2)">Agent suspended</span>{{end}}
   {{end}}
 </div>
 
-<!-- 3. Agent history — inline pills -->
-{{if $.AgentHistory}}
-<div class="ci-hist">
-  <span class="ci-hist-lbl">History ({{.FromAgent}})</span>
-  {{range $.AgentHistory}}
-  <a href="/dashboard/llm/case/{{.ID}}" class="ci-ctx-pill">
-    <span class="ci-ctx-score" style="{{if ge .RiskScore 76.0}}color:#ef4444{{else if ge .RiskScore 51.0}}color:#fb923c{{else if ge .RiskScore 31.0}}color:#fbbf24{{else}}color:var(--text3){{end}}">{{printf "%.0f" .RiskScore}}</span>
-    <span style="color:var(--text3)">&rarr; {{.ToAgent}}</span>
-    <span style="color:var(--text3);font-size:0.66rem">{{relativeTime .Timestamp}}</span>
-  </a>
-  {{end}}
-</div>
-{{end}}
+<!-- Two-column layout -->
+<div class="cs-layout">
+  <!-- LEFT: Main content -->
+  <div class="cs-main">
 
-<!-- 4. Original content that triggered the alert -->
-{{if $.ToolArgs}}
-<div class="ci-s" style="border-color:rgba(251,191,36,0.2);background:rgba(251,191,36,0.02)">
-  <h3 style="color:#fbbf24">Intercepted content</h3>
-  <div style="background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:14px 16px;font-family:var(--mono);font-size:0.75rem;line-height:1.7;color:var(--text);white-space:pre-wrap;word-break:break-all;max-height:300px;overflow-y:auto">{{$.ToolArgs}}</div>
-</div>
-{{end}}
-
-<!-- 5. Intent Analysis + Technical Details (side by side) -->
-{{$intent := parseJSONMap .IntentJSON}}
-<div class="ci-context-row">
-  {{if $intent}}
-  <div class="ci-s" style="margin-bottom:0">
-    <h3>Intent analysis {{with index $intent "alignment"}}{{$a := toString .}}<span class="ci-int-align {{if lt $a "0.5"}}ci-int-align-bad{{else}}ci-int-align-ok{{end}}">{{if lt $a "0.5"}}&#10007;{{else}}&#10003;{{end}} {{$a}}</span>{{end}}</h3>
-    <div class="ci-int-diff">
-      <div class="ci-int-side ci-int-side-decl">
-        <div class="ci-int-tag">Declared</div>
-        <div class="ci-int-txt">{{with index $intent "declared_intent"}}{{.}}{{else}}-{{end}}</div>
+    <!-- Findings -->
+    {{$threats := parseJSONArray .ThreatsJSON}}
+    <div class="ci-s">
+      <h3>Findings <span class="cnt">({{countJSONArray .ThreatsJSON}})</span></h3>
+      {{if $threats}}
+        {{range $i, $t := $threats}}
+          {{$m := toMap $t}}
+          {{if $m}}
+          <div class="cs-thr-card">
+            <div class="cs-thr-top">
+              <span class="cs-thr-num {{with index $m "severity"}}cs-thr-num-{{if eq (toString .) "critical"}}c{{else if eq (toString .) "high"}}h{{else if eq (toString .) "medium"}}m{{else}}l{{end}}{{end}}">{{inc $i}}</span>
+              <div class="cs-thr-info">
+                <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+                  <span class="cs-thr-type">{{with index $m "type"}}{{upper (toString .)}}{{else}}THREAT-{{inc $i}}{{end}}</span>
+                  {{with index $m "severity"}}<span class="ci-sev ci-sev-{{if eq (toString .) "critical"}}c{{else if eq (toString .) "high"}}h{{else if eq (toString .) "medium"}}m{{else}}l{{end}}">{{upper (toString .)}}</span>{{end}}
+                </div>
+                <div class="cs-thr-desc">{{with index $m "description"}}{{.}}{{end}}</div>
+              </div>
+            </div>
+            {{with index $m "evidence"}}<div class="cs-thr-ev">{{.}}</div>{{end}}
+            {{with index $m "suggestion"}}{{$s := toMap .}}{{if $s}}
+            <div class="cs-thr-rule">
+              <span style="color:var(--text3)">Rule:</span>
+              <code style="font-family:var(--mono);color:var(--text2);margin-left:4px">{{with index $s "name"}}{{.}}{{end}}</code>
+              {{with index $s "pattern"}}<code style="font-family:var(--mono);color:var(--text3);margin-left:4px;font-size:0.68rem">{{.}}</code>{{end}}
+              <button class="ci-thr-cp" style="margin-left:8px" onclick="ciCopyText(this.closest('.cs-thr-rule').querySelector('code').textContent,this)">copy</button>
+            </div>
+            {{end}}{{end}}
+          </div>
+          {{else}}
+          <div class="cs-thr-card"><div class="cs-thr-top"><span class="cs-thr-num cs-thr-num-m">{{inc $i}}</span><div class="cs-thr-info"><div class="cs-thr-desc">{{$t}}</div></div></div></div>
+          {{end}}
+        {{end}}
+      {{else}}
+      <div class="ci-benign">
+        <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+        No threats detected - message assessed as benign.
       </div>
-      <div class="ci-int-side ci-int-side-act{{if ge $.Analysis.RiskScore 50.0}} ci-int-hi{{end}}">
-        <div class="ci-int-tag ci-int-tag-act{{if ge $.Analysis.RiskScore 50.0}} ci-int-warn{{end}}">Actual</div>
-        <div class="ci-int-txt">{{with index $intent "actual_intent"}}{{.}}{{else}}-{{end}}</div>
-      </div>
+      {{end}}
     </div>
-    {{with index $intent "reason"}}
-    <div class="ci-reason">{{.}}</div>
-    {{end}}
-  </div>
-  {{else}}
-  <div></div>
-  {{end}}
 
-  <div class="ci-s" style="margin-bottom:0">
-    <h3>Technical details</h3>
-    <div class="ci-meta-row"><span class="mk">Model</span><span class="mv">{{.Model}}</span></div>
-    <div class="ci-meta-row"><span class="mk">Latency</span><span class="mv">{{latencySec .LatencyMs}}s</span></div>
-    <div class="ci-meta-row"><span class="mk">Tokens</span><span class="mv">{{.TokensUsed}}</span></div>
-    <div class="ci-meta-row"><span class="mk">Message</span><span class="mv"><a href="/dashboard/events?q={{.MessageID}}" style="color:var(--accent);text-decoration:none;word-break:break-all">{{.MessageID}}</a></span></div>
-    <div class="ci-meta-row"><span class="mk">Confidence</span><span class="mv">{{printf "%.0f" .Confidence}}%</span></div>
-    <div class="ci-meta-row"><span class="mk">Risk score</span><span class="mv">{{printf "%.0f" .RiskScore}} / 100</span></div>
-  </div>
-</div>
-
-<!-- 5. Threats — full width, can grow -->
-{{$threats := parseJSONArray .ThreatsJSON}}
-<div class="ci-s">
-  <h3>Threats <span class="cnt">({{countJSONArray .ThreatsJSON}})</span></h3>
-  {{if $threats}}
-    {{range $i, $t := $threats}}
-      {{$m := toMap $t}}
-      {{if $m}}
-      <div class="ci-thr">
-        <span class="ci-thr-sev">{{with index $m "severity"}}<span class="ci-sev ci-sev-{{if eq (toString .) "critical"}}c{{else if eq (toString .) "high"}}h{{else if eq (toString .) "medium"}}m{{else}}l{{end}}">{{upper (toString .)}}</span>{{end}}</span>
-        <div class="ci-thr-body">
-          <div class="ci-thr-head">
-            <span class="ci-thr-id">{{with index $m "type"}}{{upper (toString .)}}{{else}}THREAT-{{inc $i}}{{end}}</span>
-            <span class="ci-thr-name">{{with index $m "description"}}{{.}}{{end}}</span>
-          </div>
-          {{with index $m "evidence"}}<div class="ci-thr-detail">{{.}}</div>{{end}}
-          {{with index $m "suggestion"}}{{$s := toMap .}}{{if $s}}
-          <div class="ci-thr-fix">
-            <code>{{with index $s "name"}}{{.}}{{end}}{{with index $s "pattern"}} &#8212; {{.}}{{end}}</code>
-            <button class="ci-thr-cp" onclick="ciCopyText(this.previousElementSibling.textContent,this)">copy</button>
-          </div>
-          {{end}}{{end}}
+    <!-- Intent Analysis -->
+    {{$intent := parseJSONMap .IntentJSON}}
+    {{if $intent}}
+    <div class="ci-s">
+      <h3>Intent Analysis {{with index $intent "alignment"}}{{$a := toString .}}<span style="display:inline-flex;align-items:center;gap:4px;font-family:var(--mono);font-size:0.72rem;font-weight:600;padding:2px 10px;border-radius:100px;{{if lt $a "0.5"}}background:rgba(239,68,68,0.1);color:#ef4444{{else}}background:rgba(34,197,94,0.1);color:#22c55e{{end}}">{{if lt $a "0.5"}}&#10007;{{else}}&#10003;{{end}} {{$a}}</span>{{end}}</h3>
+      <div class="cs-intent">
+        <div class="cs-intent-side cs-intent-decl">
+          <div class="cs-intent-lbl">Declared intent</div>
+          <div class="cs-intent-txt">{{with index $intent "declared_intent"}}{{.}}{{else}}-{{end}}</div>
+        </div>
+        <div class="cs-intent-side cs-intent-act{{if ge $.Analysis.RiskScore 50.0}} cs-intent-warn{{end}}">
+          <div class="cs-intent-lbl{{if ge $.Analysis.RiskScore 50.0}} cs-intent-lbl-warn{{end}}">Actual behavior</div>
+          <div class="cs-intent-txt">{{with index $intent "actual_intent"}}{{.}}{{else}}-{{end}}</div>
         </div>
       </div>
-      {{else}}
-      <div class="ci-thr"><span class="ci-thr-sev"></span><div class="ci-thr-body"><div class="ci-thr-head"><span class="ci-thr-name">{{$t}}</span></div></div></div>
+      {{with index $intent "reason"}}
+      <p style="font-size:0.75rem;line-height:1.55;color:var(--text3);margin-top:10px">{{.}}</p>
       {{end}}
+    </div>
     {{end}}
-  {{else}}
-  <div class="ci-benign">
-    <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-    No threats detected &#8212; message assessed as benign.
-  </div>
-  {{end}}
-</div>
 
-<!-- 6. Generated Rule -->
-{{if .RuleGenerated}}
-<div class="ci-s" style="border-color:rgba(99,102,241,0.2);background:rgba(99,102,241,0.02)">
-  <h3 style="color:var(--accent-light)">Generated rule</h3>
-  <p style="font-size:0.78rem;color:var(--text2);margin-bottom:10px">Deterministic rule created from this analysis. Catches future matches in &lt;1ms.</p>
-  <div style="background:var(--bg2);border:1px solid rgba(99,102,241,0.15);border-radius:8px;padding:12px 14px;font-family:var(--mono);font-size:0.72rem;line-height:1.7;color:var(--accent-light);white-space:pre-wrap">{{.RuleGenerated}}</div>
+    <!-- Intercepted content -->
+    {{if $.ToolArgs}}
+    <div class="ci-s">
+      <h3>Intercepted Content</h3>
+      <div class="cs-evidence">{{$.ToolArgs}}</div>
+    </div>
+    {{end}}
+
+    <!-- Generated Rule -->
+    {{if .RuleGenerated}}
+    <div class="ci-s" style="border-color:rgba(99,102,241,0.15)">
+      <h3 style="color:var(--accent-light)">Generated Rule</h3>
+      <p style="font-size:0.78rem;color:var(--text2);margin-bottom:10px">Deterministic rule created from this analysis. Catches future matches in &lt;1ms.</p>
+      <div class="cs-rule-block">{{.RuleGenerated}}</div>
+    </div>
+    {{end}}
+
+  </div>
+
+  <!-- RIGHT: Sidebar -->
+  <div class="cs-side">
+
+    <!-- Assessment card -->
+    <div class="cs-card">
+      <div class="cs-card-hdr">Assessment</div>
+      <div class="cs-card-body">
+        <div class="cs-row"><span class="k">Risk score</span><span class="v" style="font-weight:700;font-size:0.82rem;{{if ge .RiskScore 76.0}}color:#ef4444{{else if ge .RiskScore 51.0}}color:#fb923c{{else if ge .RiskScore 31.0}}color:#fbbf24{{else}}color:#22c55e{{end}}">{{printf "%.0f" .RiskScore}}</span></div>
+        <div class="cs-row">
+          <span class="k">Confidence</span>
+          <span class="v">{{printf "%.0f" .Confidence}}%</span>
+        </div>
+        <div class="cs-conf-bar"><div class="cs-conf-fill" style="width:{{printf "%.0f" .Confidence}}%;background:{{if ge .Confidence 80.0}}#22c55e{{else if ge .Confidence 50.0}}#fbbf24{{else}}#ef4444{{end}}"></div></div>
+        <div class="cs-row" style="margin-top:6px"><span class="k">Latency</span><span class="v">{{latencySec .LatencyMs}}s</span></div>
+        <div class="cs-row"><span class="k">Model</span><span class="v" style="font-size:0.68rem">{{.Model}}</span></div>
+        <div class="cs-row"><span class="k">Tokens</span><span class="v">{{.TokensUsed}}</span></div>
+      </div>
+    </div>
+
+    <!-- Quick links -->
+    <div class="cs-card">
+      <div class="cs-card-hdr">Related</div>
+      <div class="cs-card-body" style="display:flex;flex-direction:column;gap:2px">
+        {{if .FromAgent}}<a href="/dashboard/agents/{{.FromAgent}}" class="cs-row" style="text-decoration:none;color:inherit;border-radius:6px;padding:8px 10px;margin:-4px -10px;transition:background 0.1s"><span class="k">Agent</span><span class="v" style="color:var(--accent-light)">{{.FromAgent}}</span></a>{{end}}
+        <a href="/dashboard/events?q={{.MessageID}}" class="cs-row" style="text-decoration:none;color:inherit;border-radius:6px;padding:8px 10px;margin:-4px -10px;transition:background 0.1s"><span class="k">Event</span><span class="v" style="color:var(--accent-light)">View &rarr;</span></a>
+        <div class="cs-row"><span class="k">Message ID</span><span class="v" style="font-size:0.58rem;max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="{{.MessageID}}">{{.MessageID}}</span></div>
+      </div>
+    </div>
+
+    <!-- Agent history -->
+    {{if $.AgentHistory}}
+    <div class="cs-card">
+      <div class="cs-card-hdr">Agent History ({{.FromAgent}})</div>
+      <div class="cs-card-body">
+        <div class="cs-hist-grid">
+          {{range $.AgentHistory}}
+          <a href="/dashboard/llm/case/{{.ID}}" class="cs-hist-pill">
+            <span class="cs-hist-score" style="{{if ge .RiskScore 76.0}}color:#ef4444{{else if ge .RiskScore 51.0}}color:#fb923c{{else if ge .RiskScore 31.0}}color:#fbbf24{{else}}color:var(--text3){{end}}">{{printf "%.0f" .RiskScore}}</span>
+            <span>{{relativeTime .Timestamp}}</span>
+          </a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+    {{end}}
+
+  </div>
 </div>
-{{end}}
 
 <script>
 function ciCopyText(text, btn) {
@@ -4676,8 +4798,14 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
     }
     updateEdges();
 
-    // Particle animation
+    // Particle animation (pauses when tab hidden to save CPU)
+    var tabVisible=true, animId=null;
+    document.addEventListener('visibilitychange',function(){
+      tabVisible=!document.hidden;
+      if(tabVisible&&!animId) animId=requestAnimationFrame(animParticles);
+    });
     function animParticles(){
+      if(!tabVisible){animId=null;return;}
       particles.forEach(function(p){
         p.t+=p.speed; if(p.t>1) p.t-=1;
         var s=nodes[p.link.from],t=nodes[p.link.to];
@@ -4692,9 +4820,9 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
         } else { x=s.x+(ex-s.x)*tt; y=s.y+(ey-s.y)*tt; }
         p.dot.setAttribute('cx',x); p.dot.setAttribute('cy',y);
       });
-      requestAnimationFrame(animParticles);
+      animId=requestAnimationFrame(animParticles);
     }
-    requestAnimationFrame(animParticles);
+    animId=requestAnimationFrame(animParticles);
 
     // ── Focus/Dim state ──
     var focusedNode=null;
@@ -4933,7 +5061,16 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
     }).catch(function(){});
   }
   pollGraph();
-  setInterval(pollGraph,5000);
+  function schedulePoll(){
+    setTimeout(function(){
+      if(!document.hidden) pollGraph();
+      schedulePoll();
+    },15000);
+  }
+  schedulePoll();
+  document.addEventListener('visibilitychange',function(){
+    if(!document.hidden) pollGraph();
+  });
 })();
 </script>
 ` + layoutFoot))

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -53,6 +53,7 @@ type Gateway struct {
 	constraintChecker *ConstraintChecker
 	llmQueue          *llm.Queue
 	signalDetector    *llm.SignalDetector
+	escalationTracker *llm.EscalationTracker
 	hooksHandler      http.Handler
 	logger            *slog.Logger
 	registeredAgents  map[string]bool
@@ -438,6 +439,11 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			verdict.ApplyBlockedContent(agentCfg, outcome)
 		}
 
+		// 7b. LLM-driven agent escalation (async feedback loop)
+		if g.escalationTracker != nil && g.escalationTracker.IsEscalated(agent) {
+			outcome.Verdict = verdict.EscalateOneLevel(outcome.Verdict)
+		}
+
 		// 8. Determine verdict
 		findingsJSON := verdict.EncodeFindings(outcome.Findings)
 		status, decision := verdictToGateway(outcome.Verdict)
@@ -638,6 +644,11 @@ func (g *Gateway) SetLLMQueue(q *llm.Queue) {
 // SetSignalDetector sets the triage pre-filter for LLM analysis.
 func (g *Gateway) SetSignalDetector(sd *llm.SignalDetector) {
 	g.signalDetector = sd
+}
+
+// SetEscalationTracker sets the LLM-driven verdict escalation tracker.
+func (g *Gateway) SetEscalationTracker(t *llm.EscalationTracker) {
+	g.escalationTracker = t
 }
 
 // SetHooksHandler sets the handler for /hooks/event (tool-call telemetry).

--- a/internal/llm/escalation.go
+++ b/internal/llm/escalation.go
@@ -1,0 +1,173 @@
+package llm
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// EscalationEntry tracks an active LLM-driven escalation for an agent.
+type EscalationEntry struct {
+	Agent     string    `json:"agent"`
+	RiskScore float64   `json:"risk_score"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+	MessageID string    `json:"message_id"` // LLM analysis that triggered escalation
+}
+
+// EscalationTracker manages TTL-based verdict escalation entries driven by
+// async LLM threat analysis. When the LLM detects a high-risk threat for an
+// agent (risk_score >= threshold), all future verdicts for that agent are
+// escalated one level for a configurable TTL window.
+//
+// Thread-safe for concurrent use by LLM result callbacks and the proxy/gateway
+// security pipeline.
+type EscalationTracker struct {
+	mu        sync.RWMutex
+	entries   map[string]EscalationEntry // agent -> entry
+	threshold float64
+	ttl       time.Duration
+	logger    *slog.Logger
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+}
+
+// NewEscalationTracker creates a tracker with the given risk threshold and TTL.
+// Starts a background goroutine to evict expired entries every 30 seconds.
+func NewEscalationTracker(threshold float64, ttl time.Duration, logger *slog.Logger) *EscalationTracker {
+	t := &EscalationTracker{
+		entries:   make(map[string]EscalationEntry),
+		threshold: threshold,
+		ttl:       ttl,
+		logger:    logger,
+		stopCh:    make(chan struct{}),
+	}
+	go t.evictLoop()
+	return t
+}
+
+// HandleResult is an OnResult callback for the LLM queue.
+// If the result's RiskScore >= threshold, an escalation entry is created
+// (or refreshed) for the agent.
+func (t *EscalationTracker) HandleResult(result AnalysisResult) {
+	if result.RiskScore < t.threshold {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	entry := EscalationEntry{
+		Agent:     result.FromAgent,
+		RiskScore: result.RiskScore,
+		ExpiresAt: now.Add(t.ttl),
+		CreatedAt: now,
+		MessageID: result.MessageID,
+	}
+
+	existing, exists := t.entries[result.FromAgent]
+	t.entries[result.FromAgent] = entry
+
+	if !exists {
+		escalationsActive.Inc()
+	}
+	escalationsTotal.Inc()
+
+	if exists {
+		t.logger.Info("llm escalation refreshed",
+			"agent", result.FromAgent,
+			"risk_score", result.RiskScore,
+			"previous_risk", existing.RiskScore,
+			"ttl", t.ttl,
+		)
+	} else {
+		t.logger.Warn("llm escalation activated",
+			"agent", result.FromAgent,
+			"risk_score", result.RiskScore,
+			"message_id", result.MessageID,
+			"ttl", t.ttl,
+		)
+	}
+}
+
+// IsEscalated returns true if the agent currently has an active escalation.
+func (t *EscalationTracker) IsEscalated(agent string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	entry, ok := t.entries[agent]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(entry.ExpiresAt)
+}
+
+// ActiveEntries returns a snapshot of all active (non-expired) escalation entries.
+func (t *EscalationTracker) ActiveEntries() []EscalationEntry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	now := time.Now()
+	var result []EscalationEntry
+	for _, e := range t.entries {
+		if now.Before(e.ExpiresAt) {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// ActiveCount returns the number of currently active escalation entries.
+func (t *EscalationTracker) ActiveCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	now := time.Now()
+	count := 0
+	for _, e := range t.entries {
+		if now.Before(e.ExpiresAt) {
+			count++
+		}
+	}
+	return count
+}
+
+// Stop terminates the background eviction goroutine.
+func (t *EscalationTracker) Stop() {
+	t.stopOnce.Do(func() {
+		close(t.stopCh)
+	})
+}
+
+// evictLoop runs every 30 seconds to remove expired entries.
+func (t *EscalationTracker) evictLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.stopCh:
+			return
+		case <-ticker.C:
+			t.evict()
+		}
+	}
+}
+
+func (t *EscalationTracker) evict() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	for agent, entry := range t.entries {
+		if now.After(entry.ExpiresAt) {
+			delete(t.entries, agent)
+			escalationsActive.Dec()
+			t.logger.Info("llm escalation expired",
+				"agent", agent,
+				"risk_score", entry.RiskScore,
+			)
+		}
+	}
+}

--- a/internal/llm/escalation_test.go
+++ b/internal/llm/escalation_test.go
@@ -1,0 +1,173 @@
+package llm
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestEscalationTracker_HandleResult_BelowThreshold(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 50,
+		MessageID: "msg-1",
+	})
+
+	if tracker.IsEscalated("agent-a") {
+		t.Fatal("agent should not be escalated when risk_score < threshold")
+	}
+}
+
+func TestEscalationTracker_HandleResult_AboveThreshold(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 85,
+		MessageID: "msg-1",
+	})
+
+	if !tracker.IsEscalated("agent-a") {
+		t.Fatal("agent should be escalated when risk_score >= threshold")
+	}
+	if tracker.IsEscalated("agent-b") {
+		t.Fatal("unrelated agent should not be escalated")
+	}
+}
+
+func TestEscalationTracker_HandleResult_ExactThreshold(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 80,
+		MessageID: "msg-1",
+	})
+
+	if !tracker.IsEscalated("agent-a") {
+		t.Fatal("agent should be escalated when risk_score == threshold")
+	}
+}
+
+func TestEscalationTracker_TTLExpiry(t *testing.T) {
+	tracker := NewEscalationTracker(80, 50*time.Millisecond, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 90,
+		MessageID: "msg-1",
+	})
+
+	if !tracker.IsEscalated("agent-a") {
+		t.Fatal("agent should be escalated immediately after high-risk result")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if tracker.IsEscalated("agent-a") {
+		t.Fatal("escalation should have expired after TTL")
+	}
+}
+
+func TestEscalationTracker_Refresh(t *testing.T) {
+	tracker := NewEscalationTracker(80, 100*time.Millisecond, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 85,
+		MessageID: "msg-1",
+	})
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Refresh before TTL expires
+	tracker.HandleResult(AnalysisResult{
+		FromAgent: "agent-a",
+		RiskScore: 90,
+		MessageID: "msg-2",
+	})
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Should still be escalated because the second result refreshed the TTL
+	if !tracker.IsEscalated("agent-a") {
+		t.Fatal("escalation should be refreshed by a new high-risk result")
+	}
+}
+
+func TestEscalationTracker_ActiveEntries(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{FromAgent: "agent-a", RiskScore: 85, MessageID: "msg-1"})
+	tracker.HandleResult(AnalysisResult{FromAgent: "agent-b", RiskScore: 90, MessageID: "msg-2"})
+	tracker.HandleResult(AnalysisResult{FromAgent: "agent-c", RiskScore: 50, MessageID: "msg-3"}) // below threshold
+
+	entries := tracker.ActiveEntries()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 active entries, got %d", len(entries))
+	}
+	if tracker.ActiveCount() != 2 {
+		t.Fatalf("expected ActiveCount 2, got %d", tracker.ActiveCount())
+	}
+}
+
+func TestEscalationTracker_Eviction(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Millisecond, testLogger())
+	defer tracker.Stop()
+
+	tracker.HandleResult(AnalysisResult{FromAgent: "agent-a", RiskScore: 85, MessageID: "msg-1"})
+
+	// Manually trigger eviction after expiry
+	time.Sleep(50 * time.Millisecond)
+	tracker.evict()
+
+	tracker.mu.RLock()
+	_, exists := tracker.entries["agent-a"]
+	tracker.mu.RUnlock()
+
+	if exists {
+		t.Fatal("expired entry should be evicted")
+	}
+}
+
+func TestEscalationTracker_ConcurrentAccess(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	defer tracker.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			tracker.HandleResult(AnalysisResult{
+				FromAgent: "agent-a",
+				RiskScore: float64(50 + n%60), // some above, some below threshold
+				MessageID: "msg",
+			})
+			tracker.IsEscalated("agent-a")
+			tracker.ActiveEntries()
+			tracker.ActiveCount()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestEscalationTracker_StopIdempotent(t *testing.T) {
+	tracker := NewEscalationTracker(80, 30*time.Minute, testLogger())
+	tracker.Stop()
+	tracker.Stop() // should not panic
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -126,13 +126,14 @@ type Config struct {
 // internal/config to keep YAML tags in one place. Using aliases (not
 // type definitions) makes the types fully interchangeable.
 type (
-	AnalyzeConfig  = config.LLMAnalyzeConfig
-	RuleGenConfig  = config.LLMRuleGenConfig
-	IntentConfig   = config.LLMIntentConfig
-	WebhookConfig  = config.LLMWebhookConfig
-	FallbackConfig = config.LLMFallbackConfig
-	TriageConfig   = config.LLMTriageConfig
-	BudgetConfig   = config.LLMBudgetConfig
+	AnalyzeConfig    = config.LLMAnalyzeConfig
+	RuleGenConfig    = config.LLMRuleGenConfig
+	IntentConfig     = config.LLMIntentConfig
+	WebhookConfig    = config.LLMWebhookConfig
+	FallbackConfig   = config.LLMFallbackConfig
+	TriageConfig     = config.LLMTriageConfig
+	BudgetConfig     = config.LLMBudgetConfig
+	EscalationConfig = config.LLMEscalationConfig
 )
 
 // ParseTimeout returns the configured timeout as a time.Duration.

--- a/internal/llm/metrics.go
+++ b/internal/llm/metrics.go
@@ -69,4 +69,18 @@ var (
 		Name:      "fallback_total",
 		Help:      "Number of times the fallback LLM provider was used.",
 	})
+
+	escalationsActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "oktsec",
+		Subsystem: "llm",
+		Name:      "escalations_active",
+		Help:      "Number of agents currently under LLM-driven verdict escalation.",
+	})
+
+	escalationsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "oktsec",
+		Subsystem: "llm",
+		Name:      "escalations_total",
+		Help:      "Total LLM-driven verdict escalations applied.",
+	})
 )

--- a/internal/llm/setup.go
+++ b/internal/llm/setup.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/oktsec/oktsec/internal/config"
 )
@@ -69,4 +70,32 @@ func SetupQueue(cfg config.LLMConfig, logger *slog.Logger) (*Queue, *SignalDetec
 		"model", cfg.Model,
 	)
 	return queue, sd
+}
+
+// SetupEscalation creates an EscalationTracker from config. Returns nil if
+// escalation is disabled. The caller is responsible for calling
+// tracker.HandleResult(result) inside their OnResult callback chain,
+// and calling tracker.Stop() on shutdown.
+func SetupEscalation(cfg config.LLMEscalationConfig, queue *Queue, logger *slog.Logger) *EscalationTracker {
+	if !cfg.Enabled || queue == nil {
+		return nil
+	}
+
+	threshold := cfg.RiskThreshold
+	if threshold <= 0 {
+		threshold = 80
+	}
+	ttlMin := cfg.TTLMinutes
+	if ttlMin <= 0 {
+		ttlMin = 30
+	}
+	ttl := time.Duration(ttlMin) * time.Minute
+
+	tracker := NewEscalationTracker(threshold, ttl, logger)
+
+	logger.Info("llm escalation enabled",
+		"risk_threshold", threshold,
+		"ttl_minutes", ttlMin,
+	)
+	return tracker
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1,12 +1,15 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -20,18 +23,30 @@ import (
 // ForwardProxy implements an HTTP forward proxy that scans traffic with Aguara.
 // It handles CONNECT tunneling (HTTPS) and plain HTTP forwarding.
 type ForwardProxy struct {
-	cfg           *config.ForwardProxyConfig
-	scanner       *engine.Scanner
-	audit         *audit.Store
-	rateLimiter   *RateLimiter
-	egressEval    *EgressEvaluator
-	agentLimiters map[string]*RateLimiter
-	logger        *slog.Logger
-	transport     *http.Transport
+	cfg             *config.ForwardProxyConfig
+	scanner         *engine.Scanner
+	audit           *audit.Store
+	rateLimiter     *RateLimiter
+	egressEval      *EgressEvaluator
+	agentLimiters   map[string]*RateLimiter
+	logger          *slog.Logger
+	transport       *http.Transport
+	upstreamProxy   bool // true when HTTP_PROXY/HTTPS_PROXY is set
 }
 
 // NewForwardProxy creates a forward proxy with scanning and audit capabilities.
 func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, auditStore *audit.Store, rateLimiter *RateLimiter, agents map[string]config.Agent, logger *slog.Logger) *ForwardProxy {
+	// When an upstream proxy is configured (e.g., inside Docker Sandbox),
+	// the transport dials the proxy, not the target. Use standard dialer
+	// for proxy connections; SSRF checks are applied at handler level.
+	upstream := hasUpstreamProxy()
+	dialFn := safeDialContext
+	if upstream {
+		d := &net.Dialer{Timeout: 5 * time.Second}
+		dialFn = d.DialContext
+		logger.Info("forward proxy: upstream proxy detected, SSRF checks at handler level")
+	}
+
 	fp := &ForwardProxy{
 		cfg:           cfg,
 		scanner:       scanner,
@@ -40,8 +55,10 @@ func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, au
 		egressEval:    NewEgressEvaluator(cfg, agents),
 		agentLimiters: make(map[string]*RateLimiter),
 		logger:        logger,
+		upstreamProxy: upstream,
 		transport: &http.Transport{
-			DialContext:           safeDialContext,
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dialFn,
 			TLSHandshakeTimeout:  5 * time.Second,
 			ResponseHeaderTimeout: 30 * time.Second,
 			MaxIdleConns:          100,
@@ -86,16 +103,24 @@ func extractAgent(r *http.Request) string {
 	return strings.TrimSpace(agent)
 }
 
+// extractSession reads and strips the X-Oktsec-Session header.
+func extractSession(r *http.Request) string {
+	session := r.Header.Get("X-Oktsec-Session")
+	r.Header.Del("X-Oktsec-Session")
+	return strings.TrimSpace(session)
+}
+
 // handleConnect handles HTTPS tunneling via the CONNECT method.
 func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	host := r.Host
 	agent := extractAgent(r)
+	session := extractSession(r)
 
 	policy := fp.resolvePolicy(agent)
 	if !policy.DomainAllowed(host) {
 		fp.logger.Warn("forward proxy: blocked CONNECT domain", "host", host, "agent", agent, "remote", r.RemoteAddr)
-		fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, audit.StatusBlocked, "proxy_blocked_domain", "", 0, start)
+		fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start)
 		http.Error(w, "Forbidden: domain blocked by proxy policy", http.StatusForbidden)
 		return
 	}
@@ -112,13 +137,13 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := ValidateHost(connectHost); err != nil {
 		fp.logger.Warn("forward proxy: SSRF blocked CONNECT", "host", host, "error", err)
-		fp.logProxyEntry(r.RemoteAddr, "CONNECT", host, audit.StatusBlocked, "proxy_ssrf_blocked", "", 0, start)
+		fp.logProxyEntry(r.RemoteAddr, "CONNECT", host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start)
 		http.Error(w, "Forbidden: SSRF protection", http.StatusForbidden)
 		return
 	}
 
-	// Dial the target using SSRF-safe dialer
-	targetConn, err := safeDialContext(r.Context(), "tcp", host)
+	// Dial the target — chain through upstream proxy if configured
+	targetConn, err := fp.dialTarget(r.Context(), host)
 	if err != nil {
 		fp.logger.Error("forward proxy: CONNECT dial failed", "host", host, "error", err)
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
@@ -163,7 +188,7 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Wait for either direction to finish
 	<-done
 
-	fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, "tunneled", "proxy_allowed", "", clientBytes+targetBytes, start)
+	fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, "tunneled", "proxy_allowed", "", session, clientBytes+targetBytes, start)
 }
 
 // handleHTTP handles plain HTTP forward proxying with content scanning.
@@ -174,12 +199,13 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		host = r.Host
 	}
 	agent := extractAgent(r)
+	session := extractSession(r)
 	logAgent := fp.logAgent(agent, r.RemoteAddr)
 
 	policy := fp.resolvePolicy(agent)
 	if !policy.DomainAllowed(host) {
 		fp.logger.Warn("forward proxy: blocked HTTP domain", "host", host, "agent", agent, "remote", r.RemoteAddr)
-		fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_domain", "", 0, start)
+		fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start)
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "domain blocked by proxy policy"})
 		return
 	}
@@ -187,6 +213,22 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if !fp.allowRate(agent, r.RemoteAddr) {
 		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		return
+	}
+
+	// SSRF: validate target host when using upstream proxy (safeDialContext
+	// handles this for direct connections, but with an upstream proxy the
+	// transport dials the proxy, not the target).
+	if fp.upstreamProxy {
+		ssrfHost := host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			ssrfHost = h
+		}
+		if err := ValidateHost(ssrfHost); err != nil {
+			fp.logger.Warn("forward proxy: SSRF blocked HTTP", "host", host, "error", err)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start)
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "Forbidden: SSRF protection"})
+			return
+		}
 	}
 
 	maxBody := fp.cfg.MaxBodySize
@@ -216,7 +258,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			rulesJSON := verdict.EncodeFindings(outcome.Findings)
 			fp.logger.Warn("forward proxy: blocked request content",
 				"host", host, "agent", agent, "remote", r.RemoteAddr, "findings", len(outcome.Findings))
-			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_content", rulesJSON, 0, start)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_content", rulesJSON, session, 0, start)
 			writeJSON(w, http.StatusForbidden, map[string]string{
 				"error":  "request blocked by content scan",
 				"detail": fmt.Sprintf("%d security finding(s) detected", len(outcome.Findings)),
@@ -261,7 +303,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			rulesJSON := verdict.EncodeFindings(outcome.Findings)
 			fp.logger.Warn("forward proxy: blocked response content",
 				"host", host, "agent", agent, "remote", r.RemoteAddr, "findings", len(outcome.Findings))
-			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_response", rulesJSON, 0, start)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_response", rulesJSON, session, 0, start)
 			writeJSON(w, http.StatusForbidden, map[string]string{
 				"error":  "response blocked by content scan",
 				"detail": fmt.Sprintf("%d security finding(s) detected", len(outcome.Findings)),
@@ -275,7 +317,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(respBody)
 
-	fp.logProxyEntry(logAgent, r.Method, host, "forwarded", "proxy_allowed", "", int64(len(bodyBytes)+len(respBody)), start)
+	fp.logProxyEntry(logAgent, r.Method, host, "forwarded", "proxy_allowed", "", session, int64(len(bodyBytes)+len(respBody)), start)
 }
 
 // resolvePolicy returns the merged egress policy for an agent.
@@ -326,7 +368,7 @@ func (fp *ForwardProxy) hasCategoryBlock(outcome *engine.ScanOutcome, policy *Re
 }
 
 // logProxyEntry writes an audit log entry for proxy traffic.
-func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDecision, rulesTriggered string, bytesTransferred int64, start time.Time) {
+func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDecision, rulesTriggered, sessionID string, bytesTransferred int64, start time.Time) {
 	entry := audit.Entry{
 		ID:             uuid.New().String(),
 		Timestamp:      time.Now().UTC().Format(time.RFC3339),
@@ -336,9 +378,73 @@ func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDe
 		Status:         status,
 		PolicyDecision: policyDecision,
 		RulesTriggered: rulesTriggered,
+		SessionID:      sessionID,
 		LatencyMs:      time.Since(start).Milliseconds(),
 	}
 	fp.audit.Log(entry)
+}
+
+// dialTarget connects to the target host, chaining through the upstream proxy
+// when one is configured (e.g., inside Docker Sandbox). Without an upstream
+// proxy, it dials the target directly using the SSRF-safe dialer.
+func (fp *ForwardProxy) dialTarget(ctx context.Context, host string) (net.Conn, error) {
+	if !fp.upstreamProxy {
+		return safeDialContext(ctx, "tcp", host)
+	}
+
+	// Chain through upstream proxy via CONNECT
+	proxyURL := upstreamProxyURL()
+	if proxyURL == nil {
+		return safeDialContext(ctx, "tcp", host)
+	}
+
+	d := &net.Dialer{Timeout: 5 * time.Second}
+	proxyConn, err := d.DialContext(ctx, "tcp", proxyURL.Host)
+	if err != nil {
+		return nil, fmt.Errorf("dial upstream proxy %s: %w", proxyURL.Host, err)
+	}
+
+	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", host, host)
+	if _, err := proxyConn.Write([]byte(connectReq)); err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("CONNECT to upstream proxy: %w", err)
+	}
+
+	br := bufio.NewReader(proxyConn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("read CONNECT response from upstream proxy: %w", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("upstream proxy CONNECT returned %d", resp.StatusCode)
+	}
+
+	return proxyConn, nil
+}
+
+// upstreamProxyURL returns the configured upstream proxy URL, if any.
+func upstreamProxyURL() *url.URL {
+	for _, key := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"} {
+		if v := os.Getenv(key); v != "" {
+			if u, err := url.Parse(v); err == nil {
+				return u
+			}
+		}
+	}
+	return nil
+}
+
+// hasUpstreamProxy checks if an upstream HTTP proxy is configured via environment.
+func hasUpstreamProxy() bool {
+	for _, key := range []string{"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // copyHeaders copies HTTP headers, skipping hop-by-hop headers.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -53,9 +53,10 @@ type Handler struct {
 	webhooks    *WebhookNotifier
 	rateLimiter *RateLimiter
 	window      *MessageWindow
-	llmQueue       *llm.Queue          // nil if LLM disabled
-	signalDetector *llm.SignalDetector // nil if triage disabled
-	logger         *slog.Logger
+	llmQueue            *llm.Queue              // nil if LLM disabled
+	signalDetector      *llm.SignalDetector     // nil if triage disabled
+	escalationTracker   *llm.EscalationTracker  // nil if LLM escalation disabled
+	logger              *slog.Logger
 }
 
 // NewHandler creates a message handler with all dependencies.
@@ -87,6 +88,11 @@ func (h *Handler) SetLLMQueue(q *llm.Queue) {
 // SetSignalDetector attaches the pre-LLM triage filter.
 func (h *Handler) SetSignalDetector(d *llm.SignalDetector) {
 	h.signalDetector = d
+}
+
+// SetEscalationTracker attaches the LLM-driven verdict escalation tracker.
+func (h *Handler) SetEscalationTracker(t *llm.EscalationTracker) {
+	h.escalationTracker = t
 }
 
 // ServeHTTP handles POST /v1/message.
@@ -207,6 +213,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Step 7: Multi-message verdict escalation
 	h.escalateByHistory(req.From, outcome)
+
+	// Step 7b: LLM-driven agent escalation (async feedback loop)
+	if h.escalationTracker != nil && h.escalationTracker.IsEscalated(req.From) {
+		outcome.Verdict = verdict.EscalateOneLevel(outcome.Verdict)
+	}
 
 	// Step 8: Apply verdict
 	status, policyDecision, httpStatus := verdictToResponse(outcome.Verdict)

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -39,9 +39,10 @@ type Server struct {
 	audit         *audit.Store
 	webhooks      *WebhookNotifier
 	dashboard     *dashboard.Server
-	llmQueue      *llm.Queue // nil if LLM disabled
-	handler       *Handler
-	logger        *slog.Logger
+	llmQueue           *llm.Queue              // nil if LLM disabled
+	escalationTracker  *llm.EscalationTracker  // nil if LLM escalation disabled
+	handler            *Handler
+	logger             *slog.Logger
 	anomalyCancel context.CancelFunc
 	fwdSrv        *http.Server   // forward proxy (nil if disabled)
 	fwdLn         net.Listener   // forward proxy listener
@@ -123,6 +124,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	// LLM analysis queue (async, optional)
 	var llmQueue *llm.Queue
 	var ruleGen *llm.RuleGenerator
+	var escalationTracker *llm.EscalationTracker
 	if cfg.LLM.Enabled {
 		var sd *llm.SignalDetector
 		llmQueue, sd = llm.SetupQueue(cfg.LLM, logger)
@@ -140,6 +142,10 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 					})
 				}
 			}
+
+			// Wire LLM-driven escalation tracker (created before OnResult so
+			// it can be referenced in the closure)
+			escalationTracker = llm.SetupEscalation(cfg.LLM.Escalation, llmQueue, logger)
 
 			llmQueue.OnResult(func(result llm.AnalysisResult) {
 				// Store in audit database
@@ -173,9 +179,15 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 						Timestamp: time.Now().UTC().Format(time.RFC3339),
 					})
 				}
+
+				// Feed escalation tracker
+				if escalationTracker != nil {
+					escalationTracker.HandleResult(result)
+				}
 			})
 
 			handler.SetLLMQueue(llmQueue)
+			handler.SetEscalationTracker(escalationTracker)
 			if sd != nil {
 				handler.SetSignalDetector(sd)
 			}
@@ -305,18 +317,19 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	}
 
 	s := &Server{
-		cfg:       cfg,
-		cfgPath:   cfgPath,
-		srv:       srv,
-		ln:        ln,
-		keys:      keys,
-		scanner:   scanner,
-		audit:     auditStore,
-		webhooks:  webhooks,
-		handler:   handler,
-		dashboard: dash,
-		llmQueue:  llmQueue,
-		logger:    logger,
+		cfg:               cfg,
+		cfgPath:           cfgPath,
+		srv:               srv,
+		ln:                ln,
+		keys:              keys,
+		scanner:           scanner,
+		audit:             auditStore,
+		webhooks:          webhooks,
+		handler:           handler,
+		dashboard:         dash,
+		llmQueue:          llmQueue,
+		escalationTracker: escalationTracker,
+		logger:            logger,
 	}
 
 	// Forward proxy on dedicated port (separate from dashboard/API)
@@ -502,6 +515,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Debug("shutting down")
 	if s.llmQueue != nil {
 		s.llmQueue.Stop()
+	}
+	if s.escalationTracker != nil {
+		s.escalationTracker.Stop()
 	}
 	if s.anomalyCancel != nil {
 		s.anomalyCancel()

--- a/internal/proxy/ssrf.go
+++ b/internal/proxy/ssrf.go
@@ -140,7 +140,16 @@ func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error
 		}
 	}
 
+	// Prefer IPv4 addresses to avoid IPv6 connectivity issues
+	connectIP := ips[0].IP
+	for _, ip := range ips {
+		if ip.IP.To4() != nil {
+			connectIP = ip.IP
+			break
+		}
+	}
+
 	// Connect directly to validated IP (prevents re-resolution TOCTOU)
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
-	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	return dialer.DialContext(ctx, network, net.JoinHostPort(connectIP.String(), port))
 }

--- a/internal/verdict/escalate.go
+++ b/internal/verdict/escalate.go
@@ -1,0 +1,22 @@
+package verdict
+
+import "github.com/oktsec/oktsec/internal/engine"
+
+// EscalateOneLevel bumps a verdict one severity level:
+// clean → flag, flag → quarantine, quarantine → block.
+// Block remains block (already at maximum).
+//
+// This is a pure function with no side effects, suitable for use by both
+// the proxy handler and the gateway security pipeline.
+func EscalateOneLevel(v engine.ScanVerdict) engine.ScanVerdict {
+	switch v {
+	case engine.VerdictClean:
+		return engine.VerdictFlag
+	case engine.VerdictFlag:
+		return engine.VerdictQuarantine
+	case engine.VerdictQuarantine:
+		return engine.VerdictBlock
+	default:
+		return v // block stays block
+	}
+}

--- a/internal/verdict/escalate_test.go
+++ b/internal/verdict/escalate_test.go
@@ -1,0 +1,35 @@
+package verdict
+
+import (
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/engine"
+)
+
+func TestEscalateOneLevel(t *testing.T) {
+	tests := []struct {
+		input engine.ScanVerdict
+		want  engine.ScanVerdict
+	}{
+		{engine.VerdictClean, engine.VerdictFlag},
+		{engine.VerdictFlag, engine.VerdictQuarantine},
+		{engine.VerdictQuarantine, engine.VerdictBlock},
+		{engine.VerdictBlock, engine.VerdictBlock}, // already max
+	}
+
+	for _, tt := range tests {
+		got := EscalateOneLevel(tt.input)
+		if got != tt.want {
+			t.Errorf("EscalateOneLevel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestEscalateOneLevel_IsPure(t *testing.T) {
+	// Calling EscalateOneLevel should not modify any external state
+	v1 := EscalateOneLevel(engine.VerdictClean)
+	v2 := EscalateOneLevel(engine.VerdictClean)
+	if v1 != v2 {
+		t.Errorf("EscalateOneLevel is not pure: %q != %q", v1, v2)
+	}
+}


### PR DESCRIPTION
## Summary

- **LLM verdict escalation**: async feedback loop where high-risk LLM analysis (risk >= threshold) automatically escalates all future verdicts for that agent one level for a configurable TTL window. Integrated in both proxy and gateway pipelines with Prometheus metrics (`oktsec_llm_escalations_active`, `oktsec_llm_escalations_total`) and background eviction
- **Session identity**: forward proxy extracts `X-Oktsec-Session` from hook payloads, enabling per-session attribution in audit logs (differentiates multiple Claude Code sessions on the same machine)
- **Dashboard UX**: Agent Risk paginated (max 15/page), Threat Intel case page redesigned with 2-column layout, graph page performance fixes (cached queries, active-only nodes, visibility-aware animation/polling)
- **Forward proxy**: auto-enabled in `oktsec run`, SSRF dialer prefers IPv4, upstream proxy chaining via CONNECT for Docker Sandbox environments

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race` passes for llm, verdict, proxy, gateway, config packages
- [x] Escalation tracker: 9 tests covering threshold, TTL expiry, refresh, eviction, concurrency, idempotent stop
- [x] Verdict escalate: 2 tests covering all transitions + purity
- [x] Dashboard verified locally at http://127.0.0.1:8082/dashboard