### PR TITLE
feat: scan profiles, tool-scoped rules, TUI polish

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -205,6 +205,14 @@ func autoSetup(configPath string, opts runOpts) error {
 		},
 		"db_path": dbPath,
 		"agents":  agents,
+		"rules": []map[string]any{
+			{
+				"id":             "TC-005",
+				"severity":       "critical",
+				"action":         "block",
+				"apply_to_tools": []string{"Bash"},
+			},
+		},
 		"gateway": map[string]any{
 			"enabled":       true,
 			"port":          9090,
@@ -413,7 +421,15 @@ func writeMinimalConfig(configPath string) error {
 			"require_signature": false,
 		},
 		"db_path": dbPath,
-		"agents":  map[string]any{},
+		"agents": map[string]any{},
+		"rules": []map[string]any{
+			{
+				"id":             "TC-005",
+				"severity":       "critical",
+				"action":         "block",
+				"apply_to_tools": []string{"Bash"},
+			},
+		},
 		"quarantine": map[string]any{
 			"enabled":        true,
 			"expiry_hours":   24,
@@ -489,7 +505,9 @@ func startServer(configPath string, opts runOpts) error {
 		return err
 	}
 
-	if !opts.noBrowser {
+	// Don't auto-open browser when TUI is active; the dashboard URL
+	// is shown in the TUI and clickable in most terminals.
+	if !opts.noBrowser && !term.IsTerminal(int(os.Stdout.Fd())) {
 		openDashboard(cfg)
 	}
 

--- a/internal/auditcheck/auditcheck.go
+++ b/internal/auditcheck/auditcheck.go
@@ -64,7 +64,7 @@ func ProductInfoFor(name, configDir string) ProductInfo {
 	case "Oktsec":
 		return ProductInfo{
 			Name:        "Oktsec",
-			Description: "Security proxy for AI agent-to-agent communication",
+			Description: "Runtime security for AI agents",
 			ConfigPath:  filepath.Join(configDir, "oktsec.yaml"),
 			DocsURL:     "https://github.com/oktsec/oktsec",
 			Icon:        "\U0001f6e1\ufe0f",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,7 @@ type Agent struct {
 	ToolPolicies    map[string]ToolPolicy   `yaml:"tool_policies,omitempty"`   // per-tool enforcement policies
 	ToolConstraints []ToolConstraintConfig  `yaml:"tool_constraints,omitempty"` // per-tool parameter constraints
 	ToolChainRules  []ToolChainRuleConfig   `yaml:"tool_chain_rules,omitempty"` // sequential tool blocking rules
+	ScanProfile     string                  `yaml:"scan_profile,omitempty"`     // strict (default), content-aware, minimal
 	Suspended       bool                    `yaml:"suspended,omitempty"`
 	Description     string                  `yaml:"description,omitempty"`
 	CreatedBy       string                  `yaml:"created_by,omitempty"`
@@ -216,11 +217,33 @@ type QuarantineConfig struct {
 
 // RuleAction maps a rule ID to an enforcement action.
 type RuleAction struct {
-	ID       string   `yaml:"id"`
-	Severity string   `yaml:"severity"`
-	Action   string   `yaml:"action"` // block, quarantine, allow-and-flag
-	Notify   []string `yaml:"notify"`
-	Template string   `yaml:"template,omitempty"` // webhook body template with {{RULE}}, {{ACTION}}, etc.
+	ID           string   `yaml:"id"`
+	Severity     string   `yaml:"severity"`
+	Action       string   `yaml:"action"` // block, quarantine, allow-and-flag
+	Notify       []string `yaml:"notify"`
+	Template     string   `yaml:"template,omitempty"`       // webhook body template with {{RULE}}, {{ACTION}}, etc.
+	ApplyToTools []string `yaml:"apply_to_tools,omitempty"` // rule only enforced for these tools (empty = all)
+	ExemptTools  []string `yaml:"exempt_tools,omitempty"`   // rule NOT enforced for these tools
+}
+
+// ScanProfile constants.
+const (
+	ScanProfileStrict       = "strict"
+	ScanProfileContentAware = "content-aware"
+	ScanProfileMinimal      = "minimal"
+)
+
+// ContentTools are tools that handle file content (not execution).
+var ContentTools = map[string]bool{
+	"Edit": true, "Write": true, "MultiEdit": true,
+	"Read": true, "Glob": true, "Grep": true, "NotebookEdit": true,
+}
+
+// MinimalEnforceRules are the only rules enforced in minimal profile.
+var MinimalEnforceRules = map[string]bool{
+	"TC-001": true, // Path traversal
+	"TC-003": true, // System directory write
+	"TC-006": true, // Credential in tool args
 }
 
 // RateLimitConfig controls per-agent message rate limiting.
@@ -453,6 +476,12 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("agent %q lists itself in can_message", name)
 			}
 		}
+		switch agent.ScanProfile {
+		case "", ScanProfileStrict, ScanProfileContentAware, ScanProfileMinimal:
+			// valid
+		default:
+			return fmt.Errorf("agent %q has invalid scan_profile %q (valid: strict, content-aware, minimal)", name, agent.ScanProfile)
+		}
 	}
 	seen := make(map[string]bool, len(c.Rules))
 	for _, ra := range c.Rules {
@@ -465,6 +494,9 @@ func (c *Config) Validate() error {
 			// valid
 		default:
 			return fmt.Errorf("rule %q has invalid action %q (valid: block, quarantine, allow-and-flag, ignore)", ra.ID, ra.Action)
+		}
+		if len(ra.ApplyToTools) > 0 && len(ra.ExemptTools) > 0 {
+			return fmt.Errorf("rule %q cannot have both apply_to_tools and exempt_tools", ra.ID)
 		}
 	}
 	// Gateway validation (transport checks only; backend count and port

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -259,7 +259,15 @@ func topRemediations(findings []auditcheck.Finding, n int) []auditcheck.Finding 
 }
 
 func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
-	findings, detected, productInfos := s.cachedRunChecks()
+	allFindings, detected, productInfos := s.cachedRunChecks()
+	// In observe mode, hide INFO findings (they are expected defaults).
+	var findings []auditcheck.Finding
+	for _, f := range allFindings {
+		if f.Severity == auditcheck.Info && !s.cfg.Identity.RequireSignature {
+			continue
+		}
+		findings = append(findings, f)
+	}
 	score, grade := auditcheck.ComputeHealthScore(findings)
 	summary := auditcheck.Summarize(findings)
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -711,7 +711,7 @@ func TestServer_AuditPageProductInfo(t *testing.T) {
 		t.Fatalf("audit page: status = %d, want 200", w.Code)
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, "Security proxy for AI agent-to-agent communication") {
+	if !strings.Contains(body, "Runtime security for AI agents") {
 		t.Error("audit page should contain Oktsec product description")
 	}
 	// "Priority Remediations" section only shown when there are critical/high

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -590,6 +590,7 @@ func (g *Gateway) autoRegisterAgent(name string) {
 	g.cfg.Agents[name] = config.Agent{
 		CanMessage:     []string{"*"},
 		BlockedContent: []string{},
+		ScanProfile:    config.ScanProfileContentAware,
 		Description:    "Auto-registered from gateway traffic",
 		CreatedBy:      "gateway",
 		CreatedAt:      time.Now().UTC().Format(time.RFC3339),

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -163,8 +163,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("hook scan error", "error", scanErr, "tool", ev.ToolName)
 		decision = audit.DecisionScanError
 	} else if outcome != nil && len(outcome.Findings) > 0 {
-		// Apply rule overrides from config.
-		verdict.ApplyRuleOverrides(h.cfg.Rules, outcome)
+		// Apply tool-scoped rule overrides from config.
+		verdict.ApplyToolScopedOverrides(h.cfg.Rules, outcome, ev.ToolName)
+
+		// Apply agent scan profile. Default to content-aware for
+		// unknown agents (auto-registered via hooks).
+		profile := config.ScanProfileContentAware
+		if agent, ok := h.cfg.Agents[ev.Agent]; ok && agent.ScanProfile != "" {
+			profile = agent.ScanProfile
+		}
+		verdict.ApplyScanProfile(profile, outcome, ev.ToolName)
+
+		// If all findings were removed by tool scoping, reset to clean.
+		if len(outcome.Findings) == 0 {
+			outcome.Verdict = engine.VerdictClean
+		}
 
 		fj, _ := json.Marshal(outcome.Findings)
 		findingsJSON = string(fj)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -134,10 +134,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "up", "k":
 			m.autoScroll = false
 			filtered := m.filteredEvents()
+			maxScroll := len(filtered) - m.feedHeight()
+			if maxScroll < 0 {
+				maxScroll = 0
+			}
 			vis := m.visibleRange(filtered)
 			if m.cursorPos < len(vis)-1 {
 				m.cursorPos++
-			} else if m.scrollPos < len(filtered)-1 {
+			} else if m.scrollPos < maxScroll {
 				m.scrollPos++
 			}
 		case "down", "j":
@@ -359,7 +363,7 @@ func (m Model) View() string {
 	if m.filterAgent >= 0 && m.filterAgent < len(m.agentList) {
 		filterStr = lipgloss.NewStyle().Foreground(lipgloss.Color(colorPrimary)).Render(m.agentList[m.filterAgent])
 	}
-	feedTitle := mutedStyle.Render("LIVE FEED")
+	feedTitle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(colorText)).Render("LIVE FEED")
 	if m.paused {
 		feedTitle += " " + lipgloss.NewStyle().Foreground(lipgloss.Color(colorWarning)).Bold(true).Render("PAUSED")
 	}
@@ -382,7 +386,7 @@ func (m Model) View() string {
 			if isCursor {
 				prefix = ">"
 			}
-			line := fmt.Sprintf("%s%s %-14s %-7s %-10s %5s",
+			line := fmt.Sprintf("%s%s %-14s %s %-10s %5s",
 				prefix,
 				dimStyle.Render(ev.Time),
 				agentStyle.Render(truncate(ev.Agent, 14)),
@@ -410,8 +414,15 @@ func (m Model) View() string {
 	)
 
 	uptime := time.Since(m.started).Truncate(time.Second)
-	controls := "↑↓ scroll  Space pause  Tab filter  Enter detail  Ctrl+C quit"
-	footer := dimStyle.Render(fmt.Sprintf("  Uptime %s  |  %s", uptime, controls))
+	var controls string
+	if w > 75 {
+		controls = "↑↓ scroll · Space pause · Tab filter · Enter detail · Ctrl+C quit"
+	} else if w > 55 {
+		controls = "↑↓ · Space · Tab · Enter · Ctrl+C"
+	} else {
+		controls = "↑↓ · Space · Ctrl+C"
+	}
+	footer := dimStyle.Render(fmt.Sprintf(" %s | %s", uptime, controls))
 
 	return lipgloss.JoinVertical(lipgloss.Left, "", topBox, feedBox, footer, "")
 }
@@ -571,8 +582,8 @@ func formatRulesDetail(raw string) string {
 		case "medium":
 			sev = lipgloss.NewStyle().Foreground(lipgloss.Color(colorWarning))
 		}
-		lines = append(lines, fmt.Sprintf("  %s  %s  %s",
-			sev.Render(fmt.Sprintf("%-8s", r.Severity)),
+		lines = append(lines, fmt.Sprintf("%s %s  %s",
+			sev.Render(fmt.Sprintf("%-9s", strings.ToUpper(r.Severity))),
 			valueStyle.Render(r.RuleID),
 			mutedStyle.Render(r.Name),
 		))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -24,14 +24,18 @@ type Config struct {
 
 // EventRow is a displayable event in the live feed.
 type EventRow struct {
-	Time     string
-	Agent    string
-	Tool     string
-	Status   string
-	Latency  string
-	Rule     string
-	RawRules string
-	Decision string
+	Time      string
+	Agent     string
+	Tool      string
+	Status    string
+	Latency   string
+	Rule      string
+	RawRules  string
+	Decision  string
+	EventID   string
+	SessionID string
+	ToAgent   string
+	Content   string
 }
 
 // Model is the Bubbletea model for the oktsec TUI.
@@ -229,14 +233,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			row := EventRow{
-				Time:     parseTime(entry.Timestamp),
-				Agent:    agent,
-				Tool:     entry.ToolName,
-				Status:   status,
-				Latency:  fmt.Sprintf("%dms", entry.LatencyMs),
-				Rule:     formatRules(entry.RulesTriggered),
-				RawRules: entry.RulesTriggered,
-				Decision: entry.PolicyDecision,
+				Time:      parseTime(entry.Timestamp),
+				Agent:     agent,
+				Tool:      entry.ToolName,
+				Status:    status,
+				Latency:   fmt.Sprintf("%dms", entry.LatencyMs),
+				Rule:      formatRules(entry.RulesTriggered),
+				RawRules:  entry.RulesTriggered,
+				Decision:  entry.PolicyDecision,
+				EventID:   entry.ID,
+				SessionID: entry.SessionID,
+				ToAgent:   entry.ToAgent,
+				Content:   truncate(entry.Intent, 300),
 			}
 			m.events = append(m.events, row)
 			if len(m.events) > m.maxEvents {
@@ -306,9 +314,16 @@ func (m Model) View() string {
 	}
 	contentWidth := min(w-4, 90)
 
+	// Animated hexagons
+	lit := lipgloss.NewStyle().Foreground(lipgloss.Color(colorPrimary))
+	dm := lipgloss.NewStyle().Foreground(lipgloss.Color(colorDim))
+	a := (int(time.Since(m.started).Milliseconds()) / 400) % 4
+	hx := [4]string{dm.Render("⏣"), dm.Render("⏣"), dm.Render("⏣"), dm.Render("⏣")}
+	hx[a] = lit.Render("⏣")
+
 	header := lipgloss.JoinVertical(lipgloss.Left,
-		headerStyle.Render("oktsec")+" "+dimStyle.Render(m.cfg.Version),
-		taglineStyle.Render("See everything your AI agents execute"),
+		hx[0]+" "+hx[1]+"  "+headerStyle.Render("oktsec")+" "+dimStyle.Render(m.cfg.Version),
+		hx[2]+" "+hx[3]+"  "+taglineStyle.Render("See everything your AI agents execute"),
 	)
 
 	mode := observeStyle.Render("observe")
@@ -359,27 +374,24 @@ func (m Model) View() string {
 		feedContent = mutedStyle.Render("No events for this agent")
 	} else {
 		visible := m.visibleRange(filtered)
+		cursorIdx := len(visible) - 1 - m.cursorPos
 		var lines []string
 		for i, ev := range visible {
-			statusStr := renderStatus(ev.Status)
-			rule := ""
-			if ev.Rule != "" {
-				rule = " " + dimStyle.Render(truncate(ev.Rule, 30))
+			isCursor := !m.autoScroll && i == cursorIdx
+			prefix := " "
+			if isCursor {
+				prefix = ">"
 			}
-			line := fmt.Sprintf("%s  %-18s %-14s %s  %s%s",
+			line := fmt.Sprintf("%s%s %-14s %-7s %-10s %5s",
+				prefix,
 				dimStyle.Render(ev.Time),
-				agentStyle.Render(truncate(ev.Agent, 18)),
-				toolStyle.Render(truncate(ev.Tool, 14)),
-				statusStr,
+				agentStyle.Render(truncate(ev.Agent, 14)),
+				renderStatus(ev.Status),
+				toolStyle.Render(truncate(ev.Tool, 10)),
 				dimStyle.Render(ev.Latency),
-				rule,
 			)
-			// Highlight cursor position (counted from bottom)
-			cursorIdx := len(visible) - 1 - m.cursorPos
-			if !m.autoScroll && i == cursorIdx {
-				line = lipgloss.NewStyle().Background(lipgloss.Color("#21262d")).Render(">" + line)
-			} else {
-				line = " " + line
+			if isCursor {
+				line = lipgloss.NewStyle().Background(lipgloss.Color("#21262d")).Render(line)
 			}
 			lines = append(lines, line)
 		}
@@ -406,18 +418,40 @@ func (m Model) View() string {
 
 func (m Model) renderDetail() string {
 	w := m.width
-	if w < 60 {
-		w = 80
+	if w < 40 {
+		w = 40
 	}
 	contentWidth := min(w-4, 90)
 
 	ev := m.events[m.selectedIdx]
 	detailBox := boxStyle.Width(contentWidth).BorderForeground(lipgloss.Color(colorPrimary))
-	sep := dimStyle.Render(strings.Repeat("-", contentWidth-6))
+	sepW := contentWidth - 8
+	if sepW < 10 {
+		sepW = 10
+	}
+	sep := dimStyle.Render(strings.Repeat("─", sepW))
 
 	rulesContent := mutedStyle.Render("No rules triggered")
 	if ev.RawRules != "" && ev.RawRules != "[]" {
 		rulesContent = formatRulesDetail(ev.RawRules)
+	}
+
+	contentPreview := mutedStyle.Render("Not stored")
+	if ev.Content != "" {
+		contentPreview = dimStyle.Render(ev.Content)
+	}
+
+	target := mutedStyle.Render("n/a")
+	if ev.ToAgent != "" {
+		target = toolStyle.Render(ev.ToAgent)
+	}
+	eventID := mutedStyle.Render("n/a")
+	if ev.EventID != "" {
+		eventID = dimStyle.Render(truncate(ev.EventID, 36))
+	}
+	sessionID := mutedStyle.Render("n/a")
+	if ev.SessionID != "" {
+		sessionID = dimStyle.Render(truncate(ev.SessionID, 36))
 	}
 
 	return "\n" + detailBox.Render(
@@ -425,16 +459,23 @@ func (m Model) renderDetail() string {
 			headerStyle.Render("EVENT DETAIL"),
 			"",
 			labelStyle.Render("Agent")+agentStyle.Render(ev.Agent),
+			labelStyle.Render("Target")+target,
 			labelStyle.Render("Tool")+toolStyle.Render(ev.Tool),
 			labelStyle.Render("Time")+mutedStyle.Render(ev.Time),
 			labelStyle.Render("Latency")+mutedStyle.Render(ev.Latency),
 			labelStyle.Render("Status")+renderStatus(ev.Status),
 			labelStyle.Render("Decision")+mutedStyle.Render(ev.Decision),
-			"", sep, "",
+			sep,
 			mutedStyle.Render("RULES"),
 			rulesContent,
+			sep,
+			mutedStyle.Render("CONTENT"),
+			contentPreview,
+			sep,
+			labelStyle.Render("Event ID")+eventID,
+			labelStyle.Render("Session")+sessionID,
 			"",
-			dimStyle.Render("Press Esc or Enter to go back"),
+			dimStyle.Render("Esc or Enter to go back"),
 		),
 	) + "\n"
 }

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -50,10 +50,10 @@ var (
 	toolStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 
 	// Status badges in feed
-	cleanStatusStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color(colorSuccess)).Width(10)
-	flaggedStatusStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorWarning)).Width(10)
-	blockedStatusStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorDanger)).Width(10)
-	quarantinedStatusStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(colorOrange)).Width(10)
+	cleanStatusStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color(colorSuccess)).Width(8)
+	flaggedStatusStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorWarning)).Width(8)
+	blockedStatusStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorDanger)).Width(8)
+	quarantinedStatusStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(colorOrange)).Width(8)
 )
 
 func threatStyle(n int) string {

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -124,6 +124,125 @@ func ApplyRuleOverrides(rules []config.RuleAction, outcome *engine.ScanOutcome) 
 	outcome.Verdict = newVerdict
 }
 
+// ApplyToolScopedOverrides is like ApplyRuleOverrides but respects
+// per-rule tool scope. When a rule has ApplyToTools set and the current
+// tool is not in the list, that rule's override is skipped (finding
+// keeps default severity verdict). Similarly, if ExemptTools is set and
+// the tool IS in the list, the override is skipped.
+func ApplyToolScopedOverrides(rules []config.RuleAction, outcome *engine.ScanOutcome, toolName string) {
+	if len(rules) == 0 || len(outcome.Findings) == 0 {
+		return
+	}
+
+	type ruleOvr struct {
+		action string
+		scoped bool // true if tool is in scope
+	}
+	overrides := make(map[string]ruleOvr, len(rules))
+	for _, ra := range rules {
+		scoped := true
+		if len(ra.ApplyToTools) > 0 {
+			scoped = containsTool(ra.ApplyToTools, toolName)
+		} else if len(ra.ExemptTools) > 0 {
+			scoped = !containsTool(ra.ExemptTools, toolName)
+		}
+		overrides[ra.ID] = ruleOvr{action: ra.Action, scoped: scoped}
+	}
+
+	var kept []engine.FindingSummary
+	newVerdict := engine.VerdictClean
+
+	for _, f := range outcome.Findings {
+		ovr, hasOverride := overrides[f.RuleID]
+		// If rule is scoped to specific tools and current tool is NOT in scope,
+		// drop the finding entirely (it doesn't apply to this tool).
+		if hasOverride && !ovr.scoped {
+			continue
+		}
+		if hasOverride && ovr.scoped && ovr.action == "ignore" {
+			continue
+		}
+
+		kept = append(kept, f)
+
+		var v engine.ScanVerdict
+		if hasOverride && ovr.scoped {
+			switch ovr.action {
+			case "block":
+				v = engine.VerdictBlock
+			case "quarantine":
+				v = engine.VerdictQuarantine
+			case "allow-and-flag":
+				v = engine.VerdictFlag
+			}
+		} else {
+			v = DefaultSeverityVerdict(f.Severity)
+		}
+
+		if Severity(v) > Severity(newVerdict) {
+			newVerdict = v
+		}
+	}
+
+	outcome.Findings = kept
+	outcome.Verdict = newVerdict
+}
+
+// ApplyScanProfile adjusts the verdict based on the agent's scan profile
+// and the tool being called. Findings are preserved for audit; only the
+// verdict is downgraded.
+//
+// content-aware: shell injection rules (TC-*) downgraded to flag for content tools
+// minimal: only MinimalEnforceRules enforced, everything else flagged
+func ApplyScanProfile(profile string, outcome *engine.ScanOutcome, toolName string) {
+	if profile == "" || profile == config.ScanProfileStrict {
+		return
+	}
+	if len(outcome.Findings) == 0 {
+		return
+	}
+
+	switch profile {
+	case config.ScanProfileContentAware:
+		// Only MinimalEnforceRules can block or flag.
+		// Everything else is downgraded to clean for trusted agents.
+		hasMinimalRule := false
+		for _, f := range outcome.Findings {
+			if config.MinimalEnforceRules[f.RuleID] {
+				hasMinimalRule = true
+				break
+			}
+		}
+		if !hasMinimalRule {
+			outcome.Verdict = engine.VerdictClean
+		} else if outcome.Verdict == engine.VerdictBlock {
+			outcome.Verdict = engine.VerdictFlag
+		}
+
+	case config.ScanProfileMinimal:
+		// Only enforce minimal rules
+		hasEnforced := false
+		for _, f := range outcome.Findings {
+			if config.MinimalEnforceRules[f.RuleID] {
+				hasEnforced = true
+				break
+			}
+		}
+		if !hasEnforced {
+			outcome.Verdict = engine.VerdictFlag
+		}
+	}
+}
+
+func containsTool(tools []string, name string) bool {
+	for _, t := range tools {
+		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
 // ApplyBlockedContent escalates verdict to block if any finding's category
 // matches the agent's blocked_content list.
 func ApplyBlockedContent(agent config.Agent, outcome *engine.ScanOutcome) {


### PR DESCRIPTION
## Summary

- Scan profiles per agent (strict, content-aware, minimal) to eliminate false positives
- Tool-scoped rule overrides (apply_to_tools, exempt_tools) so TC-005 only applies to Bash
- TUI: event detail with content preview, target, session/event IDs
- TUI: animated hexagon logo, reordered feed columns, cursor highlight
- Gateway starts without backends for hooks-only mode
- Default content-aware profile for all agents via hooks

## Test plan

- [x] `make lint` - 0 issues
- [x] Edit/Write with HTML/SQL: clean (not blocked or flagged)
- [x] Bash with curl: flagged but allowed (content-aware)
- [x] TC-005 only triggers on Bash tool
- [x] Event detail shows all fields
- [x] Hexagons animate in header