### PR TITLE
fix: false positive reduction, TUI accuracy and polish

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -205,14 +205,7 @@ func autoSetup(configPath string, opts runOpts) error {
 		},
 		"db_path": dbPath,
 		"agents":  agents,
-		"rules": []map[string]any{
-			{
-				"id":             "TC-005",
-				"severity":       "critical",
-				"action":         "block",
-				"apply_to_tools": []string{"Bash"},
-			},
-		},
+		"rules":   []map[string]any{},
 		"gateway": map[string]any{
 			"enabled":       true,
 			"port":          9090,
@@ -422,14 +415,7 @@ func writeMinimalConfig(configPath string) error {
 		},
 		"db_path": dbPath,
 		"agents": map[string]any{},
-		"rules": []map[string]any{
-			{
-				"id":             "TC-005",
-				"severity":       "critical",
-				"action":         "block",
-				"apply_to_tools": []string{"Bash"},
-			},
-		},
+		"rules":      []map[string]any{},
 		"quarantine": map[string]any{
 			"enabled":        true,
 			"expiry_hours":   24,
@@ -460,7 +446,30 @@ func writeMinimalConfig(configPath string) error {
 	return os.WriteFile(configPath, append([]byte(header), data...), 0o600)
 }
 
+// killExistingInstance checks if another oktsec process is already running
+// and kills it to avoid port conflicts and zombie sessions.
+func killExistingInstance() {
+	pid := os.Getpid()
+	out, err := exec.Command("pgrep", "-x", "oktsec").Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		var other int
+		if _, err := fmt.Sscanf(line, "%d", &other); err == nil && other != pid {
+			_ = syscall.Kill(other, syscall.SIGTERM)
+			// Brief wait for graceful shutdown.
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+}
+
 func startServer(configPath string, opts runOpts) error {
+	killExistingInstance()
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n  Warning: could not load %s (%v)\n", configPath, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,9 +234,17 @@ const (
 )
 
 // ContentTools are tools that handle file content (not execution).
+// Their arguments contain file content, search queries, etc.
 var ContentTools = map[string]bool{
 	"Edit": true, "Write": true, "MultiEdit": true,
 	"Read": true, "Glob": true, "Grep": true, "NotebookEdit": true,
+}
+
+// DevWorkflowTools are tools used for developer workflow where arguments
+// contain descriptive text (commit messages, task descriptions, prompts).
+// NLP rules are exempt on these because the text is authored content.
+var DevWorkflowTools = map[string]bool{
+	"Agent": true, "TaskCreate": true, "TaskUpdate": true, "TaskOutput": true,
 }
 
 // MinimalEnforceRules are the only rules enforced in minimal profile.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -432,8 +432,19 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			outcome = &engine.ScanOutcome{Verdict: engine.VerdictClean}
 		}
 
-		// 6. Apply rule overrides
-		verdict.ApplyRuleOverrides(g.cfg.Rules, outcome)
+		// 6. Apply tool-scoped rule overrides (uses tool name to drop
+		// false positives, e.g. shell injection rules on Bash tool).
+		verdict.ApplyToolScopedOverrides(g.cfg.Rules, outcome, m.OriginalName)
+
+		// 6b. Apply agent scan profile if explicitly configured.
+		if agentCfg, ok := g.cfg.Agents[agent]; ok && agentCfg.ScanProfile != "" {
+			verdict.ApplyScanProfile(agentCfg.ScanProfile, outcome, m.OriginalName)
+		}
+
+		// If all findings were removed by tool scoping, reset to clean.
+		if len(outcome.Findings) == 0 {
+			outcome.Verdict = engine.VerdictClean
+		}
 
 		// 7. Apply blocked content
 		if agentCfg, ok := g.cfg.Agents[agent]; ok {
@@ -501,7 +512,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			if respContent != "" {
 				respOutcome, err := g.scanner.ScanContent(scanCtx, respContent)
 				if err == nil && respOutcome != nil {
-					verdict.ApplyRuleOverrides(g.cfg.Rules, respOutcome)
+					verdict.ApplyToolScopedOverrides(g.cfg.Rules, respOutcome, m.OriginalName)
 					if respOutcome.Verdict == engine.VerdictBlock || respOutcome.Verdict == engine.VerdictQuarantine {
 						g.logger.Warn("backend response blocked",
 							"tool", m.OriginalName, "backend", m.BackendName, "verdict", respOutcome.Verdict)

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -166,21 +166,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Apply tool-scoped rule overrides from config.
 		verdict.ApplyToolScopedOverrides(h.cfg.Rules, outcome, ev.ToolName)
 
-		// Apply agent scan profile. Default to content-aware for
-		// unknown agents (auto-registered via hooks).
-		profile := config.ScanProfileContentAware
-		if agent, ok := h.cfg.Agents[ev.Agent]; ok && agent.ScanProfile != "" {
-			profile = agent.ScanProfile
+		// Apply scan profile only for content tools (Write, Edit, etc.)
+		// where file content naturally contains patterns that match rules.
+		// Execution tools (Bash, Agent, WebFetch) keep strict scanning
+		// so real threats are detected.
+		if config.ContentTools[ev.ToolName] {
+			profile := config.ScanProfileContentAware
+			if agent, ok := h.cfg.Agents[ev.Agent]; ok && agent.ScanProfile != "" {
+				profile = agent.ScanProfile
+			}
+			verdict.ApplyScanProfile(profile, outcome, ev.ToolName)
 		}
-		verdict.ApplyScanProfile(profile, outcome, ev.ToolName)
 
 		// If all findings were removed by tool scoping, reset to clean.
 		if len(outcome.Findings) == 0 {
 			outcome.Verdict = engine.VerdictClean
 		}
 
-		fj, _ := json.Marshal(outcome.Findings)
-		findingsJSON = string(fj)
+		findingsJSON = verdict.EncodeFindings(outcome.Findings)
 
 		status, decision = verdict.ToAuditStatus(outcome.Verdict)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -386,12 +386,12 @@ func (m Model) View() string {
 			if isCursor {
 				prefix = ">"
 			}
-			line := fmt.Sprintf("%s%s %-14s %s %-10s %5s",
+			line := fmt.Sprintf("%s%s %s %s %s %s",
 				prefix,
 				dimStyle.Render(ev.Time),
-				agentStyle.Render(truncate(ev.Agent, 14)),
+				agentStyle.Width(16).Render(truncate(ev.Agent, 16)),
 				renderStatus(ev.Status),
-				toolStyle.Render(truncate(ev.Tool, 10)),
+				toolStyle.Width(10).Render(truncate(ev.Tool, 10)),
 				dimStyle.Render(ev.Latency),
 			)
 			if isCursor {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -32,10 +32,11 @@ type EventRow struct {
 	Rule      string
 	RawRules  string
 	Decision  string
-	EventID   string
-	SessionID string
-	ToAgent   string
-	Content   string
+	EventID     string
+	SessionID   string
+	ToAgent     string
+	Content     string
+	ContentHash string
 }
 
 // Model is the Bubbletea model for the oktsec TUI.
@@ -67,10 +68,11 @@ type Model struct {
 	hub *audit.Hub
 
 	// UI
-	spinner spinner.Model
-	width   int
-	height  int
-	started time.Time
+	spinner       spinner.Model
+	width         int
+	height        int
+	started       time.Time
+	lastEventTime time.Time
 }
 
 type auditEntryMsg audit.Entry
@@ -203,6 +205,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		entry := audit.Entry(msg)
 		if !m.paused {
 			m.totalScanned++
+			m.lastEventTime = time.Now()
 
 			if entry.ToAgent != "" && !strings.HasPrefix(entry.ToAgent, "gateway/") {
 				if entry.SessionID != "" {
@@ -248,7 +251,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				EventID:   entry.ID,
 				SessionID: entry.SessionID,
 				ToAgent:   entry.ToAgent,
-				Content:   truncate(entry.Intent, 300),
+				Content:     truncate(entry.Intent, 300),
+				ContentHash: entry.ContentHash,
 			}
 			m.events = append(m.events, row)
 			if len(m.events) > m.maxEvents {
@@ -318,12 +322,16 @@ func (m Model) View() string {
 	}
 	contentWidth := min(w-4, 90)
 
-	// Animated hexagons
+	// Animated hexagons — light up when agents are active
 	lit := lipgloss.NewStyle().Foreground(lipgloss.Color(colorPrimary))
 	dm := lipgloss.NewStyle().Foreground(lipgloss.Color(colorDim))
-	a := (int(time.Since(m.started).Milliseconds()) / 400) % 4
+	active := !m.lastEventTime.IsZero() && time.Since(m.lastEventTime) < 3*time.Second
 	hx := [4]string{dm.Render("⏣"), dm.Render("⏣"), dm.Render("⏣"), dm.Render("⏣")}
-	hx[a] = lit.Render("⏣")
+	if active {
+		// Original animation: all dim, one lit violet cycling
+		a := (int(time.Since(m.started).Milliseconds()) / 400) % 4
+		hx[a] = lit.Render("⏣")
+	}
 
 	header := lipgloss.JoinVertical(lipgloss.Left,
 		hx[0]+" "+hx[1]+"  "+headerStyle.Render("oktsec")+" "+dimStyle.Render(m.cfg.Version),
@@ -435,7 +443,7 @@ func (m Model) renderDetail() string {
 	contentWidth := min(w-4, 90)
 
 	ev := m.events[m.selectedIdx]
-	detailBox := boxStyle.Width(contentWidth).BorderForeground(lipgloss.Color(colorPrimary))
+	detailBox := boxStyle.Width(contentWidth).BorderForeground(lipgloss.Color(colorDim))
 	sepW := contentWidth - 8
 	if sepW < 10 {
 		sepW = 10
@@ -485,6 +493,7 @@ func (m Model) renderDetail() string {
 			sep,
 			labelStyle.Render("Event ID")+eventID,
 			labelStyle.Render("Session")+sessionID,
+			labelStyle.Render("Hash")+dimStyle.Render(truncate(ev.ContentHash, 36)),
 			"",
 			dimStyle.Render("Esc or Enter to go back"),
 		),
@@ -512,7 +521,7 @@ func classifyStatus(e audit.Entry) string {
 	case "rejected":
 		return "rejected"
 	default:
-		if e.RulesTriggered != "" && e.RulesTriggered != "[]" {
+		if e.PolicyDecision == audit.DecisionContentFlagged {
 			return "flagged"
 		}
 		return "clean"

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -2,6 +2,7 @@ package verdict
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
@@ -30,8 +31,10 @@ func TopSeverity(findings []engine.FindingSummary) string {
 
 // DefaultSeverityVerdict maps a severity string to the default verdict.
 // Mirrors the logic in engine.buildOutcome but operates on string severity.
+// Case-insensitive because Aguara reports "CRITICAL" while audit constants
+// use "critical".
 func DefaultSeverityVerdict(severity string) engine.ScanVerdict {
-	switch severity {
+	switch strings.ToLower(severity) {
 	case audit.SeverityCritical:
 		return engine.VerdictBlock
 	case audit.SeverityHigh:
@@ -130,7 +133,7 @@ func ApplyRuleOverrides(rules []config.RuleAction, outcome *engine.ScanOutcome) 
 // keeps default severity verdict). Similarly, if ExemptTools is set and
 // the tool IS in the list, the override is skipped.
 func ApplyToolScopedOverrides(rules []config.RuleAction, outcome *engine.ScanOutcome, toolName string) {
-	if len(rules) == 0 || len(outcome.Findings) == 0 {
+	if len(outcome.Findings) == 0 {
 		return
 	}
 
@@ -149,8 +152,13 @@ func ApplyToolScopedOverrides(rules []config.RuleAction, outcome *engine.ScanOut
 		overrides[ra.ID] = ruleOvr{action: ra.Action, scoped: scoped}
 	}
 
-	var kept []engine.FindingSummary
+	kept := make([]engine.FindingSummary, 0, len(outcome.Findings))
 	newVerdict := engine.VerdictClean
+
+	// Content tools: only enforce minimal rules (file content matches many patterns).
+	// Dev workflow tools: exempt NLP rules (commit messages, prompts contain descriptive text).
+	isContentTool := config.ContentTools[toolName]
+	isDevTool := config.DevWorkflowTools[toolName]
 
 	for _, f := range outcome.Findings {
 		ovr, hasOverride := overrides[f.RuleID]
@@ -159,6 +167,30 @@ func ApplyToolScopedOverrides(rules []config.RuleAction, outcome *engine.ScanOut
 		if hasOverride && !ovr.scoped {
 			continue
 		}
+
+		// Content tools: only enforce critical rules (path traversal,
+		// system directory write, credential leak). Everything else is
+		// expected file content, not an attack.
+		if isContentTool && !hasOverride && !config.MinimalEnforceRules[f.RuleID] {
+			continue
+		}
+
+		// NLP rules exempt on Bash and dev workflow tools — these contain
+		// descriptive text (commit messages, prompts, task descriptions)
+		// that triggers semantic classifiers but isn't an attack.
+		if !hasOverride && (toolName == "Bash" || isDevTool) && strings.HasPrefix(f.RuleID, "NLP_") {
+			continue
+		}
+
+		// Apply built-in tool exemptions when no user override exists.
+		if !hasOverride {
+			if exemptTools, ok := BuiltinToolExemptions[f.RuleID]; ok {
+				if containsTool(exemptTools, toolName) {
+					continue
+				}
+			}
+		}
+
 		if hasOverride && ovr.scoped && ovr.action == "ignore" {
 			continue
 		}
@@ -232,6 +264,19 @@ func ApplyScanProfile(profile string, outcome *engine.ScanOutcome, toolName stri
 			outcome.Verdict = engine.VerdictFlag
 		}
 	}
+}
+
+// BuiltinToolExemptions maps rule IDs to tools where those rules should
+// NOT fire because the detected pattern is the tool's intended behavior.
+// For example, shell metacharacters in a Bash tool call are expected,
+// not a shell injection. These defaults apply only when the user hasn't
+// configured an explicit override for the rule.
+var BuiltinToolExemptions = map[string][]string{
+	"TC-005":         {"Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "Agent"}, // Shell patterns in content/agent tools are not injection
+	"MCPCFG_002":     {"Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "Agent"}, // Shell metacharacters in content/agent tools
+	"MCPCFG_004":     {"WebFetch", "Fetch", "WebSearch"},                     // Remote URLs — expected in web tools
+	"MCPCFG_006":     {"Bash", "Write", "Edit", "MultiEdit", "NotebookEdit"}, // Inline code execution in content tools
+	"THIRDPARTY_001": {"WebFetch", "Fetch", "WebSearch"},                     // Runtime URL — expected in web tools
 }
 
 func containsTool(tools []string, name string) bool {

--- a/internal/verdict/verdict_test.go
+++ b/internal/verdict/verdict_test.go
@@ -1,0 +1,146 @@
+package verdict
+
+import (
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+)
+
+func TestApplyToolScopedOverrides_BuiltinExemptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		ruleID       string
+		severity     string
+		toolName     string
+		wantDropped  bool
+		wantVerdict  engine.ScanVerdict
+	}{
+		{
+			name:        "TC-005 dropped on Bash",
+			ruleID:      "TC-005",
+			severity:    audit.SeverityCritical,
+			toolName:    "Bash",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+		{
+			name:        "TC-005 dropped on Edit (content tool)",
+			ruleID:      "TC-005",
+			severity:    audit.SeverityCritical,
+			toolName:    "Edit",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+		{
+			name:        "MCPCFG_002 dropped on Bash",
+			ruleID:      "MCPCFG_002",
+			severity:    audit.SeverityHigh,
+			toolName:    "Bash",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+		{
+			name:        "MCPCFG_004 dropped on WebFetch",
+			ruleID:      "MCPCFG_004",
+			severity:    audit.SeverityLow,
+			toolName:    "WebFetch",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+		{
+			name:        "MCPCFG_004 kept on Bash",
+			ruleID:      "MCPCFG_004",
+			severity:    audit.SeverityLow,
+			toolName:    "Bash",
+			wantDropped: false,
+			wantVerdict: engine.VerdictClean, // LOW → clean verdict
+		},
+		{
+			name:        "THIRDPARTY_001 dropped on WebSearch",
+			ruleID:      "THIRDPARTY_001",
+			severity:    audit.SeverityLow,
+			toolName:    "WebSearch",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+		{
+			name:        "THIRDPARTY_001 dropped on Read (content tool)",
+			ruleID:      "THIRDPARTY_001",
+			severity:    audit.SeverityLow,
+			toolName:    "Read",
+			wantDropped: true,
+			wantVerdict: engine.VerdictClean,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome := &engine.ScanOutcome{
+				Verdict: DefaultSeverityVerdict(tt.severity),
+				Findings: []engine.FindingSummary{
+					{RuleID: tt.ruleID, Severity: tt.severity},
+				},
+			}
+
+			// No user-configured rules — only built-in exemptions apply.
+			ApplyToolScopedOverrides(nil, outcome, tt.toolName)
+
+			if tt.wantDropped && len(outcome.Findings) != 0 {
+				t.Errorf("expected finding %s to be dropped on %s, got %d findings",
+					tt.ruleID, tt.toolName, len(outcome.Findings))
+			}
+			if !tt.wantDropped && len(outcome.Findings) == 0 {
+				t.Errorf("expected finding %s to be kept on %s, got 0 findings",
+					tt.ruleID, tt.toolName)
+			}
+			if outcome.Verdict != tt.wantVerdict {
+				t.Errorf("verdict = %q, want %q", outcome.Verdict, tt.wantVerdict)
+			}
+		})
+	}
+}
+
+func TestApplyToolScopedOverrides_UserOverrideTakesPrecedence(t *testing.T) {
+	// User explicitly configures TC-005 to block even on Bash.
+	// This should override the built-in exemption.
+	rules := []config.RuleAction{
+		{ID: "TC-005", Action: "block", ApplyToTools: []string{"Bash", "Edit"}},
+	}
+
+	outcome := &engine.ScanOutcome{
+		Verdict: engine.VerdictBlock,
+		Findings: []engine.FindingSummary{
+			{RuleID: "TC-005", Severity: audit.SeverityCritical},
+		},
+	}
+
+	ApplyToolScopedOverrides(rules, outcome, "Bash")
+
+	if len(outcome.Findings) == 0 {
+		t.Error("user override should keep TC-005 on Bash")
+	}
+	if outcome.Verdict != engine.VerdictBlock {
+		t.Errorf("verdict = %q, want block (user override)", outcome.Verdict)
+	}
+}
+
+func TestApplyToolScopedOverrides_NilRulesStillAppliesBuiltins(t *testing.T) {
+	outcome := &engine.ScanOutcome{
+		Verdict: engine.VerdictBlock,
+		Findings: []engine.FindingSummary{
+			{RuleID: "TC-005", Severity: audit.SeverityCritical},
+			{RuleID: "MCPCFG_002", Severity: audit.SeverityHigh},
+		},
+	}
+
+	ApplyToolScopedOverrides(nil, outcome, "Bash")
+
+	if len(outcome.Findings) != 0 {
+		t.Errorf("expected all findings dropped on Bash, got %d", len(outcome.Findings))
+	}
+	if outcome.Verdict != engine.VerdictClean {
+		t.Errorf("verdict = %q, want clean", outcome.Verdict)
+	}
+}


### PR DESCRIPTION
## Summary

- **False positive elimination**: Built-in tool exemptions drop rules that match expected tool behavior (shell patterns on Bash, URLs on WebFetch). Content tools (Write/Edit/Read) only enforce 3 critical rules. NLP rules exempt on Bash and dev workflow tools
- **TUI accuracy**: Status from PolicyDecision instead of RulesTriggered JSON -- scan profile downgrades no longer cause false flags
- **Gateway parity**: ApplyToolScopedOverrides replaces ApplyRuleOverrides, passing tool name for exemption matching
- **TUI polish**: Feed column alignment, event detail Hash field, logo hexagons activate only during traffic, dim detail border
- **Operational**: Auto-kill previous instance on startup, remove TC-005 from auto-setup defaults

## Test plan

- [x] All tests pass with race detector
- [x] Lint clean
- [x] Legitimate operations (Write, Edit, Read, Bash, WebFetch, Agent) show clean
- [x] Malicious payloads correctly blocked (EXTDL_013, SUPPLY_003)
- [x] Git commits not blocked by NLP rules
- [x] Feed columns aligned, logo animation on traffic