### PR TITLE
feat: delegation chains, session traces, TUI polish

### DIFF
--- a/cmd/oktsec/commands/delegate.go
+++ b/cmd/oktsec/commands/delegate.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/identity"
+	"github.com/spf13/cobra"
+)
+
+func newDelegateCmd() *cobra.Command {
+	var (
+		delegator    string
+		delegate     string
+		scope        []string
+		tools        []string
+		ttl          string
+		keysDir      string
+		parentToken  string
+		chainDepth   int
+		maxDepth     int
+		outputFormat string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delegate",
+		Short: "Create a signed delegation token",
+		Long: `Creates a cryptographically signed delegation token that authorizes
+one agent to act on behalf of another. Tokens can be chained to create
+a verifiable authorization path from human to any sub-agent.
+
+The delegator's private key (from --keys-dir) signs the token.`,
+		Example: `  # Root delegation: human authorizes agent-a
+  oktsec delegate --from human --to agent-a --scope "*" --ttl 4h
+
+  # Chained: agent-a delegates to agent-b with narrower scope
+  oktsec delegate --from agent-a --to agent-b --scope target-x --tools Read,Write \
+    --parent <token-id-from-previous> --depth 1
+
+  # Output as base64 for X-Oktsec-Delegation header
+  oktsec delegate --from human --to agent-a --scope "*" --format header`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if delegator == "" || delegate == "" {
+				return fmt.Errorf("--from and --to are required")
+			}
+
+			dir := keysDir
+			if dir == "" {
+				dir = "keys"
+			}
+
+			// Load delegator's private key
+			kp, err := identity.LoadKeypair(dir, delegator)
+			if err != nil {
+				return fmt.Errorf("loading %s keypair from %s: %w", delegator, dir, err)
+			}
+
+			// Parse TTL
+			ttlDur := 4 * time.Hour
+			if ttl != "" {
+				ttlDur, err = time.ParseDuration(ttl)
+				if err != nil {
+					return fmt.Errorf("invalid TTL %q: %w", ttl, err)
+				}
+			}
+
+			if len(scope) == 0 {
+				scope = []string{"*"}
+			}
+
+			token := identity.CreateChainedDelegation(
+				kp.PrivateKey, delegator, delegate,
+				scope, tools, ttlDur,
+				parentToken, chainDepth, maxDepth,
+			)
+
+			switch outputFormat {
+			case "header":
+				// Output as base64 for use in X-Oktsec-Delegation header
+				chain := identity.DelegationChain{*token}
+				data, _ := json.Marshal(chain)
+				fmt.Println(base64.StdEncoding.EncodeToString(data))
+			case "json":
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(token)
+			default:
+				fmt.Printf("Token ID:    %s\n", token.TokenID)
+				fmt.Printf("Delegator:   %s\n", token.Delegator)
+				fmt.Printf("Delegate:    %s\n", token.Delegate)
+				fmt.Printf("Scope:       %v\n", token.Scope)
+				if len(token.AllowedTools) > 0 {
+					fmt.Printf("Tools:       %v\n", token.AllowedTools)
+				}
+				fmt.Printf("Depth:       %d / %d\n", token.ChainDepth, token.MaxDepth)
+				fmt.Printf("Expires:     %s\n", token.ExpiresAt.Format(time.RFC3339))
+				if token.ParentTokenID != "" {
+					fmt.Printf("Parent:      %s\n", token.ParentTokenID[:16]+"...")
+				}
+				fmt.Printf("\nUse --format json or --format header for machine output.\n")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&delegator, "from", "", "delegator agent name (must have keypair)")
+	cmd.Flags().StringVar(&delegate, "to", "", "delegate agent name")
+	cmd.Flags().StringSliceVar(&scope, "scope", nil, "allowed recipients (default: *)")
+	cmd.Flags().StringSliceVar(&tools, "tools", nil, "allowed tools (default: all)")
+	cmd.Flags().StringVar(&ttl, "ttl", "4h", "token TTL (e.g., 1h, 30m)")
+	cmd.Flags().StringVar(&keysDir, "keys-dir", "", "directory with agent keypairs")
+	cmd.Flags().StringVar(&parentToken, "parent", "", "parent token ID for chain linking")
+	cmd.Flags().IntVar(&chainDepth, "depth", 0, "chain depth (0 for root)")
+	cmd.Flags().IntVar(&maxDepth, "max-depth", 3, "maximum delegation depth")
+	cmd.Flags().StringVar(&outputFormat, "format", "text", "output format: text, json, header")
+
+	return cmd
+}

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -104,6 +104,8 @@ func NewRoot() *cobra.Command {
 	keygenCmd.Hidden = true
 	root.AddCommand(keygenCmd)
 
+	root.AddCommand(newDelegateCmd())
+
 	keysCmd := newKeysCmd()
 	keysCmd.Hidden = true
 	root.AddCommand(keysCmd)

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -573,6 +573,7 @@ func startServer(configPath string, opts runOpts) error {
 			DashCode:   srv.DashboardCode(),
 			AgentCount: len(cfg.Agents),
 			Hub:        auditHub,
+			LiveCfg:    cfg,
 		})
 
 		p := tea.NewProgram(tuiModel, tea.WithAltScreen())

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -415,7 +416,7 @@ func writeMinimalConfig(configPath string) error {
 		},
 		"db_path": dbPath,
 		"agents": map[string]any{},
-		"rules":      []map[string]any{},
+		"rules":  []map[string]any{},
 		"quarantine": map[string]any{
 			"enabled":        true,
 			"expiry_hours":   24,
@@ -504,7 +505,18 @@ func startServer(configPath string, opts runOpts) error {
 		level = slog.LevelError
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+	// When TUI is active, redirect logs to a file to prevent display corruption.
+	// Otherwise, log to stderr as usual.
+	var logWriter io.Writer = os.Stderr
+	var logFile *os.File
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		lf, err := os.OpenFile(filepath.Join(filepath.Dir(configPath), "oktsec.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err == nil {
+			logWriter = lf
+			logFile = lf
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(logWriter, &slog.HandlerOptions{Level: level}))
 
 	dashboard.Version = version
 	proxy.Version = version
@@ -541,6 +553,8 @@ func startServer(configPath string, opts runOpts) error {
 			hh := hooks.NewHandler(gw.Scanner(), gw.AuditStore(), cfg, logger)
 			gw.SetHooksHandler(hh)
 			auditHub = gw.AuditStore().Hub
+			// Share audit store so proxy rejections appear in the same feed.
+			srv.SetAuditStore(gw.AuditStore())
 			go func() {
 				if e := gw.Start(ctx); e != nil {
 					logger.Error("gateway error", "error", e)
@@ -608,6 +622,9 @@ func startServer(configPath string, opts runOpts) error {
 			_ = gw.Shutdown(shutdownCtx)
 		}
 		_ = srv.Shutdown(shutdownCtx)
+		if logFile != nil {
+			_ = logFile.Close()
+		}
 		return nil
 	}
 }

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -20,7 +20,7 @@ type Entry struct {
 	SessionID         string `json:"session_id,omitempty"`       // MCP session ID for sub-agent tracking
 	PrevHash          string `json:"prev_hash,omitempty"`        // hash chain: previous entry hash
 	EntryHash         string `json:"entry_hash,omitempty"`       // hash chain: this entry's hash
-	ProxySignature      string `json:"proxy_signature,omitempty"`  // Ed25519 signature by proxy
+	ProxySignature      string `json:"proxy_signature,omitempty"`       // Ed25519 signature by proxy
 	DelegationChainHash string `json:"delegation_chain_hash,omitempty"` // SHA-256 of verified delegation chain
 	DelegationChain     string `json:"delegation_chain,omitempty"`      // human-readable chain: "human -> agent-a -> agent-b"
 }

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -22,6 +22,7 @@ type Entry struct {
 	EntryHash         string `json:"entry_hash,omitempty"`       // hash chain: this entry's hash
 	ProxySignature      string `json:"proxy_signature,omitempty"`  // Ed25519 signature by proxy
 	DelegationChainHash string `json:"delegation_chain_hash,omitempty"` // SHA-256 of verified delegation chain
+	DelegationChain     string `json:"delegation_chain,omitempty"`      // human-readable chain: "human -> agent-a -> agent-b"
 }
 
 // ReasoningEntry captures the model's chain-of-thought for a tool call.

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -20,7 +20,23 @@ type Entry struct {
 	SessionID         string `json:"session_id,omitempty"`       // MCP session ID for sub-agent tracking
 	PrevHash          string `json:"prev_hash,omitempty"`        // hash chain: previous entry hash
 	EntryHash         string `json:"entry_hash,omitempty"`       // hash chain: this entry's hash
-	ProxySignature    string `json:"proxy_signature,omitempty"`  // Ed25519 signature by proxy
+	ProxySignature      string `json:"proxy_signature,omitempty"`  // Ed25519 signature by proxy
+	DelegationChainHash string `json:"delegation_chain_hash,omitempty"` // SHA-256 of verified delegation chain
+}
+
+// ReasoningEntry captures the model's chain-of-thought for a tool call.
+// Stored separately from audit_log because reasoning data is large and
+// not every event has it. Linked via audit_entry_id.
+type ReasoningEntry struct {
+	ID            string `json:"id"`
+	AuditEntryID  string `json:"audit_entry_id"`
+	SessionID     string `json:"session_id"`
+	ToolUseID     string `json:"tool_use_id,omitempty"`
+	Reasoning     string `json:"reasoning"`
+	ReasoningHash string `json:"reasoning_hash"`
+	PlanStep      int    `json:"plan_step,omitempty"`
+	PlanTotal     int    `json:"plan_total,omitempty"`
+	Timestamp     string `json:"timestamp"`
 }
 
 // RevokedKey represents a revoked agent public key.

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	prev_hash TEXT DEFAULT '',
 	entry_hash TEXT DEFAULT '',
 	proxy_signature TEXT DEFAULT '',
-	delegation_chain_hash TEXT DEFAULT ''
+	delegation_chain_hash TEXT DEFAULT '',
+	delegation_chain TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);
@@ -252,6 +253,7 @@ func (s *Store) migrateSchema() {
 		"ALTER TABLE audit_log ADD COLUMN session_id TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN tool_name TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN delegation_chain_hash TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN delegation_chain TEXT DEFAULT ''",
 		"CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id)",
 	}
 
@@ -470,7 +472,7 @@ func (s *Store) Log(entry Entry) {
 
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
-	query := "SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,'') FROM audit_log WHERE 1=1"
+	query := "SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'') FROM audit_log WHERE 1=1"
 	var args []any
 
 	if opts.Status != "" {
@@ -531,7 +533,7 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		var fp, rules sql.NullString
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash); err != nil {
+			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		e.PubkeyFingerprint = fp.String
@@ -610,13 +612,13 @@ func (s *Store) QueryHourlyStats() (map[int]int, error) {
 // QueryByID fetches a single audit entry by ID.
 func (s *Store) QueryByID(id string) (*Entry, error) {
 	row := s.db.QueryRow(
-		"SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,'') FROM audit_log WHERE id = ?", id)
+		"SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'') FROM audit_log WHERE id = ?", id)
 
 	var e Entry
 	var fp, rules sql.NullString
 	if err := row.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash); err != nil {
+		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -765,7 +767,7 @@ func (s *Store) writeLoop() {
 			continue
 		}
 
-		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash, delegation_chain) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			s.logger.Error("audit batch prepare failed", "error", err)
 			_ = tx.Rollback()
@@ -779,7 +781,7 @@ func (s *Store) writeLoop() {
 				batch[i].ID, batch[i].Timestamp, batch[i].FromAgent, batch[i].ToAgent, batch[i].ToolName, batch[i].ContentHash,
 				batch[i].SignatureVerified, batch[i].PubkeyFingerprint, batch[i].Status, batch[i].RulesTriggered,
 				batch[i].PolicyDecision, batch[i].LatencyMs, batch[i].Intent, batch[i].SessionID,
-				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature, batch[i].DelegationChainHash,
+				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature, batch[i].DelegationChainHash, batch[i].DelegationChain,
 			)
 			if err != nil {
 				s.logger.Error("audit write failed", "id", batch[i].ID, "error", err)

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	tool_name TEXT DEFAULT '',
 	prev_hash TEXT DEFAULT '',
 	entry_hash TEXT DEFAULT '',
-	proxy_signature TEXT DEFAULT ''
+	proxy_signature TEXT DEFAULT '',
+	delegation_chain_hash TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);
@@ -250,6 +251,7 @@ func (s *Store) migrateSchema() {
 		"ALTER TABLE audit_log ADD COLUMN proxy_signature TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN session_id TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN tool_name TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN delegation_chain_hash TEXT DEFAULT ''",
 		"CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id)",
 	}
 
@@ -300,6 +302,24 @@ func (s *Store) migrateSchema() {
 				s.logger.Warn("migration skipped", "sql", m, "error", err)
 			}
 		}
+	}
+
+	// Reasoning log table (separate from audit_log — reasoning data is large)
+	reasoningSchema := `CREATE TABLE IF NOT EXISTS reasoning_log (
+		id TEXT PRIMARY KEY,
+		audit_entry_id TEXT NOT NULL,
+		session_id TEXT NOT NULL,
+		tool_use_id TEXT DEFAULT '',
+		reasoning TEXT NOT NULL,
+		reasoning_hash TEXT NOT NULL,
+		plan_step INTEGER DEFAULT 0,
+		plan_total INTEGER DEFAULT 0,
+		timestamp TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_reasoning_session ON reasoning_log(session_id);
+	CREATE INDEX IF NOT EXISTS idx_reasoning_audit ON reasoning_log(audit_entry_id);`
+	if _, err := s.db.Exec(reasoningSchema); err != nil {
+		s.logger.Warn("reasoning_log table creation skipped", "error", err)
 	}
 
 	// Backfill: old entries stored tool names in to_agent with empty tool_name.
@@ -450,7 +470,7 @@ func (s *Store) Log(entry Entry) {
 
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
-	query := "SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,'') FROM audit_log WHERE 1=1"
+	query := "SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,'') FROM audit_log WHERE 1=1"
 	var args []any
 
 	if opts.Status != "" {
@@ -480,6 +500,10 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		query += " AND timestamp <= ?"
 		args = append(args, opts.Until)
 	}
+	if opts.SessionID != "" {
+		query += " AND session_id = ?"
+		args = append(args, opts.SessionID)
+	}
 	if opts.Search != "" {
 		query += " AND (from_agent LIKE ? OR to_agent LIKE ? OR rules_triggered LIKE ? OR status LIKE ?)"
 		wild := "%" + opts.Search + "%"
@@ -507,7 +531,7 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		var fp, rules sql.NullString
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-			&e.Intent, &e.SessionID, &e.EntryHash); err != nil {
+			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		e.PubkeyFingerprint = fp.String
@@ -586,13 +610,13 @@ func (s *Store) QueryHourlyStats() (map[int]int, error) {
 // QueryByID fetches a single audit entry by ID.
 func (s *Store) QueryByID(id string) (*Entry, error) {
 	row := s.db.QueryRow(
-		"SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,'') FROM audit_log WHERE id = ?", id)
+		"SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,'') FROM audit_log WHERE id = ?", id)
 
 	var e Entry
 	var fp, rules sql.NullString
 	if err := row.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-		&e.Intent, &e.SessionID, &e.EntryHash); err != nil {
+		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -741,7 +765,7 @@ func (s *Store) writeLoop() {
 			continue
 		}
 
-		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			s.logger.Error("audit batch prepare failed", "error", err)
 			_ = tx.Rollback()
@@ -755,7 +779,7 @@ func (s *Store) writeLoop() {
 				batch[i].ID, batch[i].Timestamp, batch[i].FromAgent, batch[i].ToAgent, batch[i].ToolName, batch[i].ContentHash,
 				batch[i].SignatureVerified, batch[i].PubkeyFingerprint, batch[i].Status, batch[i].RulesTriggered,
 				batch[i].PolicyDecision, batch[i].LatencyMs, batch[i].Intent, batch[i].SessionID,
-				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature,
+				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature, batch[i].DelegationChainHash,
 			)
 			if err != nil {
 				s.logger.Error("audit write failed", "id", batch[i].ID, "error", err)
@@ -786,6 +810,7 @@ type QueryOpts struct {
 	Status     string
 	Statuses   []string // multi-status filter (e.g. blocked + rejected)
 	Agent      string
+	SessionID  string   // filter by MCP session ID
 	Unverified bool
 	Since      string
 	Until      string // upper bound for timestamp
@@ -1415,6 +1440,53 @@ func (s *Store) PurgeOldEntries(retentionDays int) (int, error) {
 func (s *Store) ClearAll() error {
 	_, err := s.db.Exec(`DELETE FROM audit_log`)
 	return err
+}
+
+// LogReasoning persists a reasoning entry linked to an audit event.
+func (s *Store) LogReasoning(r ReasoningEntry) error {
+	_, err := s.db.Exec(
+		`INSERT INTO reasoning_log (id, audit_entry_id, session_id, tool_use_id, reasoning, reasoning_hash, plan_step, plan_total, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.AuditEntryID, r.SessionID, r.ToolUseID, r.Reasoning, r.ReasoningHash, r.PlanStep, r.PlanTotal, r.Timestamp,
+	)
+	return err
+}
+
+// QueryReasoningBySession returns all reasoning entries for a session, ordered by timestamp.
+func (s *Store) QueryReasoningBySession(sessionID string) ([]ReasoningEntry, error) {
+	rows, err := s.db.Query(
+		`SELECT id, audit_entry_id, session_id, COALESCE(tool_use_id,''), reasoning, reasoning_hash, plan_step, plan_total, timestamp FROM reasoning_log WHERE session_id = ? ORDER BY timestamp ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []ReasoningEntry
+	for rows.Next() {
+		var r ReasoningEntry
+		if err := rows.Scan(&r.ID, &r.AuditEntryID, &r.SessionID, &r.ToolUseID, &r.Reasoning, &r.ReasoningHash, &r.PlanStep, &r.PlanTotal, &r.Timestamp); err != nil {
+			return nil, err
+		}
+		entries = append(entries, r)
+	}
+	return entries, rows.Err()
+}
+
+// QueryReasoningByAuditID returns the reasoning entry for a specific audit event.
+func (s *Store) QueryReasoningByAuditID(auditEntryID string) (*ReasoningEntry, error) {
+	row := s.db.QueryRow(
+		`SELECT id, audit_entry_id, session_id, COALESCE(tool_use_id,''), reasoning, reasoning_hash, plan_step, plan_total, timestamp FROM reasoning_log WHERE audit_entry_id = ?`,
+		auditEntryID,
+	)
+	var r ReasoningEntry
+	if err := row.Scan(&r.ID, &r.AuditEntryID, &r.SessionID, &r.ToolUseID, &r.Reasoning, &r.ReasoningHash, &r.PlanStep, &r.PlanTotal, &r.Timestamp); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &r, nil
 }
 
 // expiryLoop periodically expires old quarantine items and purges old audit entries.

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -470,9 +470,13 @@ func (s *Store) Log(entry Entry) {
 	s.writes <- entry
 }
 
+// auditSelectCols is the shared SELECT column list for audit queries.
+// Update this constant (and the corresponding Scan calls) when adding columns.
+const auditSelectCols = "id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'')"
+
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
-	query := "SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'') FROM audit_log WHERE 1=1"
+	query := "SELECT " + auditSelectCols + " FROM audit_log WHERE 1=1"
 	var args []any
 
 	if opts.Status != "" {
@@ -512,7 +516,11 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		args = append(args, wild, wild, wild, wild)
 	}
 
-	query += " ORDER BY timestamp DESC"
+	if opts.OrderASC {
+		query += " ORDER BY timestamp ASC"
+	} else {
+		query += " ORDER BY timestamp DESC"
+	}
 
 	if opts.Limit > 0 {
 		query += " LIMIT ?"
@@ -612,7 +620,7 @@ func (s *Store) QueryHourlyStats() (map[int]int, error) {
 // QueryByID fetches a single audit entry by ID.
 func (s *Store) QueryByID(id string) (*Entry, error) {
 	row := s.db.QueryRow(
-		"SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'') FROM audit_log WHERE id = ?", id)
+		"SELECT "+auditSelectCols+" FROM audit_log WHERE id = ?", id)
 
 	var e Entry
 	var fp, rules sql.NullString
@@ -812,12 +820,13 @@ type QueryOpts struct {
 	Status     string
 	Statuses   []string // multi-status filter (e.g. blocked + rejected)
 	Agent      string
-	SessionID  string   // filter by MCP session ID
+	SessionID  string // filter by MCP session ID
 	Unverified bool
 	Since      string
 	Until      string // upper bound for timestamp
 	Search     string
 	Limit      int
+	OrderASC   bool // if true, order by timestamp ASC instead of DESC
 }
 
 // --- Quarantine queue methods ---

--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -72,10 +72,23 @@ func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
 		EndedAt:   entries[len(entries)-1].Timestamp,
 	}
 
-	// Calculate duration
-	if start, err := time.Parse(time.RFC3339, trace.StartedAt); err == nil {
-		if end, err := time.Parse(time.RFC3339, trace.EndedAt); err == nil {
-			trace.Duration = end.Sub(start).Round(time.Second).String()
+	// Calculate duration (try RFC3339Nano then RFC3339)
+	parseTS := func(ts string) (time.Time, bool) {
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
+	}
+	if start, ok := parseTS(trace.StartedAt); ok {
+		if end, ok := parseTS(trace.EndedAt); ok {
+			d := end.Sub(start).Round(time.Second)
+			if d < time.Second {
+				d = end.Sub(start).Round(time.Millisecond)
+			}
+			trace.Duration = d.String()
 		}
 	}
 
@@ -92,7 +105,7 @@ func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
 		}
 
 		// Calculate gap from previous step
-		if t, err := time.Parse(time.RFC3339, e.Timestamp); err == nil {
+		if t, ok := parseTS(e.Timestamp); ok {
 			if !prevTime.IsZero() {
 				step.GapMs = t.Sub(prevTime).Milliseconds()
 			}

--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -1,0 +1,125 @@
+package audit
+
+import (
+	"time"
+)
+
+// SessionTrace reconstructs the reasoning timeline for a session.
+// Even without explicit reasoning text, the sequence of tool calls,
+// their inputs/outputs, timing, and verdicts tells the story of
+// what the agent did and why.
+type SessionTrace struct {
+	SessionID string      `json:"session_id"`
+	Agent     string      `json:"agent"`
+	Steps     []TraceStep `json:"steps"`
+	Duration  string      `json:"duration"`
+	StartedAt string      `json:"started_at"`
+	EndedAt   string      `json:"ended_at"`
+	ToolCount int         `json:"tool_count"`
+	Threats   int         `json:"threats"`
+}
+
+// TraceStep is a single tool call in a session trace.
+type TraceStep struct {
+	ToolName   string `json:"tool_name"`
+	ToolInput  string `json:"tool_input"`
+	Reasoning  string `json:"reasoning,omitempty"`
+	Verdict    string `json:"verdict"`
+	Decision   string `json:"decision"`
+	Timestamp  string `json:"timestamp"`
+	GapMs      int64  `json:"gap_ms"`
+	LatencyMs  int64  `json:"latency_ms"`
+	EventID    string `json:"event_id"`
+	PlanStep   int    `json:"plan_step,omitempty"`
+	PlanTotal  int    `json:"plan_total,omitempty"`
+}
+
+// BuildSessionTrace constructs a timeline of tool calls for a session.
+func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
+	// Get all audit entries for this session
+	entries, err := s.Query(QueryOpts{
+		SessionID: sessionID,
+		Limit:     500,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Get reasoning entries for this session
+	reasoningEntries, err := s.QueryReasoningBySession(sessionID)
+	if err != nil {
+		reasoningEntries = nil // non-fatal
+	}
+	reasoningMap := make(map[string]*ReasoningEntry, len(reasoningEntries))
+	for i := range reasoningEntries {
+		reasoningMap[reasoningEntries[i].AuditEntryID] = &reasoningEntries[i]
+	}
+
+	// Entries come back DESC from query, reverse for chronological order
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	trace := &SessionTrace{
+		SessionID: sessionID,
+		Agent:     entries[0].FromAgent,
+		ToolCount: len(entries),
+		StartedAt: entries[0].Timestamp,
+		EndedAt:   entries[len(entries)-1].Timestamp,
+	}
+
+	// Calculate duration
+	if start, err := time.Parse(time.RFC3339, trace.StartedAt); err == nil {
+		if end, err := time.Parse(time.RFC3339, trace.EndedAt); err == nil {
+			trace.Duration = end.Sub(start).Round(time.Second).String()
+		}
+	}
+
+	var prevTime time.Time
+	for _, e := range entries {
+		step := TraceStep{
+			ToolName:  e.ToolName,
+			ToolInput: truncateStr(e.Intent, 200),
+			Verdict:   e.Status,
+			Decision:  e.PolicyDecision,
+			Timestamp: e.Timestamp,
+			LatencyMs: e.LatencyMs,
+			EventID:   e.ID,
+		}
+
+		// Calculate gap from previous step
+		if t, err := time.Parse(time.RFC3339, e.Timestamp); err == nil {
+			if !prevTime.IsZero() {
+				step.GapMs = t.Sub(prevTime).Milliseconds()
+			}
+			prevTime = t
+		}
+
+		// Attach reasoning if available
+		if r, ok := reasoningMap[e.ID]; ok {
+			step.Reasoning = truncateStr(r.Reasoning, 500)
+			step.PlanStep = r.PlanStep
+			step.PlanTotal = r.PlanTotal
+		}
+
+		// Count threats
+		if e.Status == StatusBlocked || e.Status == StatusQuarantined {
+			trace.Threats++
+		}
+
+		trace.Steps = append(trace.Steps, step)
+	}
+
+	return trace, nil
+}
+
+func truncateStr(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -36,10 +36,11 @@ type TraceStep struct {
 
 // BuildSessionTrace constructs a timeline of tool calls for a session.
 func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
-	// Get all audit entries for this session
+	// Get all audit entries for this session in chronological order
 	entries, err := s.Query(QueryOpts{
 		SessionID: sessionID,
 		Limit:     500,
+		OrderASC:  true,
 	})
 	if err != nil {
 		return nil, err
@@ -57,11 +58,6 @@ func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
 	reasoningMap := make(map[string]*ReasoningEntry, len(reasoningEntries))
 	for i := range reasoningEntries {
 		reasoningMap[reasoningEntries[i].AuditEntryID] = &reasoningEntries[i]
-	}
-
-	// Entries come back DESC from query, reverse for chronological order
-	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
-		entries[i], entries[j] = entries[j], entries[i]
 	}
 
 	trace := &SessionTrace{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,8 +144,16 @@ type ServerConfig struct {
 
 // IdentityConfig configures agent identity verification.
 type IdentityConfig struct {
-	KeysDir          string `yaml:"keys_dir"`
-	RequireSignature bool   `yaml:"require_signature"`
+	KeysDir          string          `yaml:"keys_dir"`
+	RequireSignature bool            `yaml:"require_signature"`
+	Ephemeral        EphemeralConfig `yaml:"ephemeral,omitempty"`
+}
+
+// EphemeralConfig controls task-scoped ephemeral key issuance.
+type EphemeralConfig struct {
+	Enabled    bool   `yaml:"enabled"`
+	MaxTTL     string `yaml:"max_ttl,omitempty"`      // duration string, default "4h"
+	MaxPerTask int    `yaml:"max_per_task,omitempty"`  // default 10
 }
 
 // Agent defines per-agent access control and metadata.

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1394,6 +1394,13 @@ func (s *Server) buildEventData(entry *audit.Entry) map[string]any {
 		data["RuleCount"] = len(s.scanner.ListRules())
 	}
 
+	// Reasoning chain
+	if s.audit != nil && entry.ID != "" {
+		if re, _ := s.audit.QueryReasoningByAuditID(entry.ID); re != nil {
+			data["Reasoning"] = re
+		}
+	}
+
 	return data
 }
 
@@ -1415,6 +1422,158 @@ func (s *Server) handleEventPage(w http.ResponseWriter, r *http.Request) {
 	data := s.buildEventData(entry)
 	data["Active"] = "events"
 	s.renderTemplate(w, eventPageTmpl, data)
+}
+
+func (s *Server) handleSessionExport(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	trace, err := s.audit.BuildSessionTrace(sessionID)
+	if err != nil || trace == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="session-%s.json"`, truncateID(sessionID)))
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(trace)
+}
+
+func (s *Server) handleSessionCSV(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	trace, err := s.audit.BuildSessionTrace(sessionID)
+	if err != nil || trace == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="session-%s.csv"`, truncateID(sessionID)))
+
+	fmt.Fprintf(w, "# Session Trace Report\r\n")
+	fmt.Fprintf(w, "# Generated: %s\r\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(w, "# Session ID: %s\r\n", trace.SessionID)
+	fmt.Fprintf(w, "# Agent: %s\r\n", trace.Agent)
+	fmt.Fprintf(w, "# Duration: %s\r\n", trace.Duration)
+	fmt.Fprintf(w, "# Tool Calls: %d\r\n", trace.ToolCount)
+	fmt.Fprintf(w, "# Threats: %d\r\n", trace.Threats)
+	fmt.Fprintf(w, "\r\n")
+	fmt.Fprintf(w, "Step,Timestamp,Tool,Verdict,Decision,Latency_ms,Gap_ms,Plan_Step,Event_ID,Reasoning\r\n")
+
+	for i, step := range trace.Steps {
+		reasoning := csvEscape(step.Reasoning)
+		fmt.Fprintf(w, "%d,%s,%s,%s,%s,%d,%d,%d/%d,%s,%s\r\n",
+			i+1, step.Timestamp, step.ToolName, step.Verdict, step.Decision,
+			step.LatencyMs, step.GapMs, step.PlanStep, step.PlanTotal,
+			step.EventID, reasoning,
+		)
+	}
+}
+
+func (s *Server) handleSessionSARIF(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	trace, err := s.audit.BuildSessionTrace(sessionID)
+	if err != nil || trace == nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="session-%s.sarif"`, truncateID(sessionID)))
+
+	// Build SARIF results from threat steps
+	results := make([]map[string]any, 0)
+	for _, step := range trace.Steps {
+		if step.Verdict == "blocked" || step.Verdict == "quarantined" {
+			result := map[string]any{
+				"ruleId": step.Verdict,
+				"level":  "error",
+				"message": map[string]string{
+					"text": fmt.Sprintf("Agent %s: tool %s was %s (decision: %s)", trace.Agent, step.ToolName, step.Verdict, step.Decision),
+				},
+				"properties": map[string]any{
+					"eventId":   step.EventID,
+					"tool":      step.ToolName,
+					"timestamp": step.Timestamp,
+					"latencyMs": step.LatencyMs,
+					"sessionId": trace.SessionID,
+					"agent":     trace.Agent,
+				},
+			}
+			if step.Reasoning != "" {
+				result["properties"].(map[string]any)["reasoning"] = step.Reasoning
+			}
+			results = append(results, result)
+		}
+	}
+
+	sarif := map[string]any{
+		"version": "2.1.0",
+		"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+		"runs": []map[string]any{
+			{
+				"tool": map[string]any{
+					"driver": map[string]any{
+						"name":           "oktsec",
+						"semanticVersion": Version,
+						"informationUri": "https://github.com/oktsec/oktsec",
+						"rules": []map[string]any{
+							{"id": "blocked", "shortDescription": map[string]string{"text": "Tool call blocked by security pipeline"}},
+							{"id": "quarantined", "shortDescription": map[string]string{"text": "Tool call quarantined for review"}},
+						},
+					},
+				},
+				"results": results,
+				"properties": map[string]any{
+					"sessionId":  trace.SessionID,
+					"agent":      trace.Agent,
+					"duration":   trace.Duration,
+					"toolCalls":  trace.ToolCount,
+					"threats":    trace.Threats,
+					"startedAt":  trace.StartedAt,
+					"endedAt":    trace.EndedAt,
+				},
+			},
+		},
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(sarif)
+}
+
+func truncateID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+func csvEscape(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Wrap in quotes and escape internal quotes
+	s = strings.ReplaceAll(s, `"`, `""`)
+	return `"` + s + `"`
+}
+
+func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if sessionID == "" {
+		s.handleNotFound(w, r)
+		return
+	}
+
+	trace, err := s.audit.BuildSessionTrace(sessionID)
+	if err != nil || trace == nil {
+		s.handleNotFound(w, r)
+		return
+	}
+
+	data := map[string]any{
+		"Active":     "events",
+		"Trace":      trace,
+		"RequireSig": s.cfg.Identity.RequireSignature,
+	}
+	s.renderTemplate(w, sessionTraceTmpl, data)
 }
 
 func parseTriggeredRules(raw string) []triggeredRule {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -295,6 +295,12 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/api/event/{id}", s.handleEventDetail)
 	s.mux.HandleFunc("GET /dashboard/events/{id...}", s.handleEventPage)
 
+	// Session trace page + exports
+	s.mux.HandleFunc("GET /dashboard/sessions/{id...}", s.handleSessionTrace)
+	s.mux.HandleFunc("GET /dashboard/api/session/{id}/export", s.handleSessionExport)
+	s.mux.HandleFunc("GET /dashboard/api/session/{id}/csv", s.handleSessionCSV)
+	s.mux.HandleFunc("GET /dashboard/api/session/{id}/sarif", s.handleSessionSARIF)
+
 	// Rule detail panel
 	s.mux.HandleFunc("GET /dashboard/api/rule/{id}", s.handleRuleDetail)
 	s.mux.HandleFunc("POST /dashboard/api/rule/{id}/test", s.handleTestRule)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -2317,14 +2317,19 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
 .ed-close{background:none;border:none;color:var(--text3);font-size:1.2rem;cursor:pointer;padding:var(--sp-1) var(--sp-2);border-radius:var(--radius-sm);line-height:1}
 .ed-close:hover{background:var(--surface-hover);color:var(--text)}
 .ed-body{padding:0}
-.ed-section{border-bottom:1px solid var(--border);padding:var(--sp-5) var(--sp-5)}
-.ed-section:last-child{border-bottom:none}
+.ed-section{padding:var(--sp-4) var(--sp-5)}
 .ed-slbl{font-size:var(--text-xs);font-weight:600;color:var(--text3);text-transform:uppercase;letter-spacing:var(--ls-caps);margin-bottom:var(--sp-3)}
 .ed-row{display:flex;justify-content:space-between;align-items:baseline;padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle)}
 .ed-row:last-child{border-bottom:none}
 .ed-row .k{color:var(--text3);font-size:var(--text-sm)}
 .ed-row .v{font-family:var(--mono);font-size:var(--text-sm);color:var(--text);text-align:right;max-width:60%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ed-row .v a{color:var(--accent-light)}
+.ed-tabs{display:flex;border-bottom:1px solid var(--border);padding:0 var(--sp-5)}
+.ed-tab{padding:var(--sp-3) var(--sp-4);font-size:var(--text-xs);font-weight:500;color:var(--text3);cursor:pointer;border-bottom:2px solid transparent;text-transform:uppercase;letter-spacing:0.5px;transition:color 0.15s,border-color 0.15s}
+.ed-tab:hover{color:var(--text2)}
+.ed-tab.active{color:var(--accent-light);border-bottom-color:var(--accent)}
+.ed-tab-content{display:none}
+.ed-tab-content.active{display:block}
 </style>
 <div class="ed-hdr">
   <div style="display:flex;align-items:center;gap:8px">
@@ -2339,29 +2344,31 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
   <button class="ed-close" onclick="closePanel()">&times;</button>
 </div>
 <div style="font-size:var(--text-sm);color:var(--text3);padding:var(--sp-2) var(--sp-5);border-bottom:1px solid var(--border);font-family:var(--mono)" data-ts="{{.Entry.Timestamp}}">{{.Entry.Timestamp}}</div>
+
+<!-- Tabs -->
+<div class="ed-tabs">
+  <div class="ed-tab active" onclick="edSwitchTab('overview',this)">Overview</div>
+  <div class="ed-tab" onclick="edSwitchTab('content',this)">Content{{if .Rules}} <span style="color:var(--warn)">({{len .Rules}})</span>{{end}}</div>
+  <div class="ed-tab" onclick="edSwitchTab('forensics',this)">Forensics{{if .Reasoning}} &bull;{{end}}</div>
+</div>
+
 <div class="ed-body">
 
-  <!-- Agent -->
+<!-- TAB: Overview -->
+<div class="ed-tab-content active" data-ed-tab="overview">
   <div class="ed-section">
-    <div class="ed-slbl">Agent</div>
-    <div class="ed-row"><span class="k">Name</span><span class="v"><a href="/dashboard/agents/{{.Entry.FromAgent}}">{{.Entry.FromAgent}}</a></span></div>
-    {{if .AgentDesc}}<div class="ed-row"><span class="k">Description</span><span class="v" style="font-family:var(--sans)" title="{{.AgentDesc}}">{{truncate .AgentDesc 40}}</span></div>{{end}}
-    {{if .AgentLocation}}<div class="ed-row"><span class="k">Location</span><span class="v">{{.AgentLocation}}</span></div>{{end}}
-    {{if .ToolConstraintCount}}<div class="ed-row"><span class="k">Constraints</span><span class="v"><span style="color:var(--warn)">{{.ToolConstraintCount}} rules</span></span></div>{{end}}
+    <div class="ed-row"><span class="k">Agent</span><span class="v"><a href="/dashboard/agents/{{.Entry.FromAgent}}">{{.Entry.FromAgent}}</a></span></div>
+    <div class="ed-row"><span class="k">Tool</span><span class="v">{{if .Entry.ToolName}}{{toolDot .Entry.ToolName}}{{else}}{{.Entry.ToAgent}}{{end}}</span></div>
+    <div class="ed-row"><span class="k">Latency</span><span class="v" style="color:{{if lt .Entry.LatencyMs 100}}var(--text2){{else}}var(--warn){{end}}">{{.Entry.LatencyMs}}ms</span></div>
+    {{if .Entry.SessionID}}<div class="ed-row"><span class="k">Session</span><span class="v"><a href="/dashboard/sessions/{{.Entry.SessionID}}" style="color:var(--accent);text-decoration:none;font-size:0.72rem" title="View session trace">{{truncate .Entry.SessionID 20}} &rarr;</a></span></div>{{end}}
     {{if .AgentSuspended}}<div class="ed-row"><span class="k">Status</span><span class="v"><span style="color:var(--danger);font-weight:600">Suspended</span></span></div>{{end}}
   </div>
-
-  <!-- Message received -->
   <div class="ed-section">
-    <div class="ed-slbl">Message received</div>
-    <div class="ed-row"><span class="k">Event ID</span><span class="v" title="{{.Entry.ID}}">{{.Entry.ID}}</span></div>
-    <div class="ed-row"><span class="k">From</span><span class="v"><a href="/dashboard/agents/{{.Entry.FromAgent}}">{{.Entry.FromAgent}}</a></span></div>
-    <div class="ed-row"><span class="k">To</span><span class="v">{{if .Entry.ToolName}}{{toolDot .Entry.ToolName}}{{else}}{{.Entry.ToAgent}}{{end}}</span></div>
-    <div class="ed-row"><span class="k">Latency</span><span class="v" style="color:{{if lt .Entry.LatencyMs 100}}var(--text2){{else}}var(--warn){{end}}">{{.Entry.LatencyMs}}ms</span></div>
-    {{if .Entry.SessionID}}<div class="ed-row"><span class="k">Session</span><span class="v" title="{{.Entry.SessionID}}">{{truncate .Entry.SessionID 24}}</span></div>{{end}}
+    <div class="ed-slbl">Authorization</div>
+    {{if .Entry.DelegationChain}}<div class="ed-row"><span class="k">Delegation</span><span class="v" style="font-size:0.72rem;color:var(--success);font-family:var(--sans)">{{.Entry.DelegationChain}}</span></div>{{else}}<div class="ed-row"><span class="k">Delegation</span><span class="v" style="font-size:0.72rem;color:var(--text3)">Direct (no delegation)</span></div>{{end}}
+    {{if .AgentCreatedBy}}<div class="ed-row"><span class="k">Registered by</span><span class="v" style="font-family:var(--sans)">{{.AgentCreatedBy}}</span></div>{{end}}
+    {{if .AgentCreatedAt}}<div class="ed-row"><span class="k">Registered</span><span class="v" style="font-size:0.72rem" data-ts="{{.AgentCreatedAt}}">{{.AgentCreatedAt}}</span></div>{{end}}
   </div>
-
-  <!-- Pipeline -->
   <div class="ed-section">
     <div class="ed-slbl">Security pipeline</div>
     <div class="ed-row">
@@ -2374,17 +2381,19 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
     </div>
     <div class="ed-row">
       <span class="k" style="display:flex;align-items:center;gap:6px"><span style="width:6px;height:6px;border-radius:50%;background:{{if eq .Entry.Status "delivered"}}var(--success){{else if eq .Entry.Status "blocked"}}var(--danger){{else}}var(--warn){{end}};flex-shrink:0"></span>Verdict</span>
-      <span class="v">{{if eq .Entry.Status "delivered"}}<span style="color:var(--success)">Allowed</span>{{else if eq .Entry.Status "blocked"}}<span style="color:var(--danger);font-weight:600">Blocked</span>{{else if eq .Entry.Status "quarantined"}}<span style="color:var(--warn);font-weight:600">Quarantined</span>{{else}}<span style="color:var(--warn)">Rejected</span>{{end}}</span>
+      <span class="v">{{.Decision}}</span>
     </div>
     {{if ge .LLMRiskScore 0.0}}
     <div class="ed-row">
-      <span class="k" style="display:flex;align-items:center;gap:6px"><span style="width:6px;height:6px;border-radius:50%;background:{{if ge .LLMRiskScore 51.0}}var(--danger){{else if ge .LLMRiskScore 31.0}}var(--warn){{else}}var(--success){{end}};flex-shrink:0"></span>LLM analysis</span>
+      <span class="k" style="display:flex;align-items:center;gap:6px"><span style="width:6px;height:6px;border-radius:50%;background:{{if ge .LLMRiskScore 51.0}}var(--danger){{else if ge .LLMRiskScore 31.0}}var(--warn){{else}}var(--success){{end}};flex-shrink:0"></span>LLM</span>
       <span class="v" style="{{if ge .LLMRiskScore 76.0}}color:#f85149{{else if ge .LLMRiskScore 51.0}}color:#fb923c{{else if ge .LLMRiskScore 31.0}}color:#d29922{{else}}color:var(--success){{end}}">{{printf "%.0f" .LLMRiskScore}}/100{{if .LLMAction}} &middot; {{.LLMAction}}{{end}}</span>
     </div>
     {{end}}
   </div>
+</div>
 
-  <!-- Rules triggered -->
+<!-- TAB: Content -->
+<div class="ed-tab-content" data-ed-tab="content">
   {{if .Rules}}
   <div class="ed-section">
     <div class="ed-slbl">Rules triggered ({{len .Rules}})</div>
@@ -2401,48 +2410,57 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
     {{end}}
   </div>
   {{end}}
-
-  <!-- Intercepted content -->
   {{if .Entry.Intent}}
   <div class="ed-section">
     <div class="ed-slbl">Intercepted content</div>
     <div id="ed-content-raw" style="display:none">{{.Entry.Intent}}</div>
-    <pre id="ed-content-pretty" style="background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;font-family:var(--mono);font-size:var(--text-xs);line-height:1.6;color:var(--text2);white-space:pre-wrap;word-break:break-all;max-height:200px;overflow-y:auto;margin:0"></pre>
+    <pre id="ed-content-pretty" style="background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 12px;font-family:var(--mono);font-size:var(--text-xs);line-height:1.6;color:var(--text2);white-space:pre-wrap;word-break:break-all;max-height:240px;overflow-y:auto;margin:0"></pre>
     <script>
     (function(){
-      var raw=document.getElementById('ed-content-raw').textContent.trim();
-      var el=document.getElementById('ed-content-pretty');
-      try{
-        var obj=JSON.parse(raw);
-        el.innerHTML=syntaxHL(JSON.stringify(obj,null,2));
-      }catch(e){
-        el.textContent=raw;
-      }
-      function syntaxHL(json){
-        return json.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
-          .replace(/"([^"]*)"(\s*:)/g,'<span style="color:#79c0ff">"$1"</span>$2')
-          .replace(/"([^"]*)"/g,'<span style="color:#a5d6ff">"$1"</span>')
-          .replace(/\b(true|false|null)\b/g,'<span style="color:#ff7b72">$1</span>')
-          .replace(/\b(-?\d+\.?\d*)\b/g,'<span style="color:#d2a8ff">$1</span>');
-      }
+      var raw=document.getElementById('ed-content-raw');if(!raw)return;
+      var el=document.getElementById('ed-content-pretty');if(!el)return;
+      var txt=raw.textContent.trim();
+      try{el.innerHTML=syntaxHL(JSON.stringify(JSON.parse(txt),null,2));}catch(e){el.textContent=txt;}
+      function syntaxHL(j){return j.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"([^"]*)"(\s*:)/g,'<span style="color:#79c0ff">"$1"</span>$2').replace(/"([^"]*)"/g,'<span style="color:#a5d6ff">"$1"</span>').replace(/\b(true|false|null)\b/g,'<span style="color:#ff7b72">$1</span>').replace(/\b(-?\d+\.?\d*)\b/g,'<span style="color:#d2a8ff">$1</span>');}
     })();
     </script>
   </div>
+  {{else}}
+  <div class="ed-section"><div style="color:var(--text3);font-size:var(--text-sm);padding:var(--sp-3) 0">No content captured</div></div>
   {{end}}
+</div>
 
-  <!-- Forensics -->
+<!-- TAB: Forensics -->
+<div class="ed-tab-content" data-ed-tab="forensics">
+  {{if .Reasoning}}
   <div class="ed-section">
-    <div class="ed-slbl">Forensics</div>
+    <div class="ed-slbl">Reasoning</div>
+    <div style="font-size:var(--text-sm);color:var(--text2);line-height:1.6;padding:4px 0 8px">{{.Reasoning.Reasoning}}</div>
+    {{if gt .Reasoning.PlanStep 0}}<div class="ed-row"><span class="k">Plan</span><span class="v">Step {{.Reasoning.PlanStep}} of {{.Reasoning.PlanTotal}}</span></div>{{end}}
+    <div class="ed-row"><span class="k">Reasoning hash</span><span class="v" style="font-size:0.68rem" title="{{.Reasoning.ReasoningHash}}">{{truncate .Reasoning.ReasoningHash 28}}</span></div>
+  </div>
+  {{end}}
+  <div class="ed-section">
+    <div class="ed-slbl">Integrity</div>
     <div class="ed-row"><span class="k">Event ID</span><span class="v" title="{{.Entry.ID}}" style="font-size:0.68rem">{{truncate .Entry.ID 28}}</span></div>
     {{if .Entry.ContentHash}}<div class="ed-row"><span class="k">Content hash</span><span class="v" title="{{.Entry.ContentHash}}" style="font-size:0.68rem">{{truncate .Entry.ContentHash 28}}</span></div>{{end}}
     {{if .Entry.EntryHash}}<div class="ed-row"><span class="k">Chain hash</span><span class="v" title="{{.Entry.EntryHash}}" style="font-size:0.68rem">{{truncate .Entry.EntryHash 28}}</span></div>{{end}}
-    {{if .Entry.PrevHash}}<div class="ed-row"><span class="k">Prev hash</span><span class="v" title="{{.Entry.PrevHash}}" style="font-size:0.68rem">{{truncate .Entry.PrevHash 28}}</span></div>{{end}}
-    {{if .Entry.PubkeyFingerprint}}<div class="ed-row"><span class="k">Key fingerprint</span><span class="v" title="{{.Entry.PubkeyFingerprint}}" style="font-size:0.68rem">{{truncate .Entry.PubkeyFingerprint 28}}</span></div>{{end}}
-    {{if .Entry.ProxySignature}}<div class="ed-row"><span class="k">Proxy signature</span><span class="v" style="color:var(--success);font-size:0.68rem" title="{{.Entry.ProxySignature}}">signed</span></div>{{end}}
+    {{if .Entry.ProxySignature}}<div class="ed-row"><span class="k">Proxy signature</span><span class="v" style="color:var(--success);font-size:0.68rem">signed</span></div>{{end}}
+    {{if .Entry.DelegationChainHash}}<div class="ed-row"><span class="k">Delegation</span><span class="v" style="font-size:0.68rem" title="{{.Entry.DelegationChainHash}}">{{truncate .Entry.DelegationChainHash 28}}</span></div>{{end}}
   </div>
+</div>
 
-</div>`))
-
+</div>
+<script>
+function edSwitchTab(name,el){
+  document.querySelectorAll('.ed-tab').forEach(function(t){t.classList.remove('active')});
+  document.querySelectorAll('.ed-tab-content').forEach(function(c){c.classList.remove('active')});
+  el.classList.add('active');
+  var target=document.querySelector('[data-ed-tab="'+name+'"]');
+  if(target)target.classList.add('active');
+}
+</script>
+`))
 // ciCSS is the shared CSS for "case investigation" style pages (Threat Intel, Event Detail).
 const ciCSS = `
 .ci-back{color:var(--text3);text-decoration:none;font-size:var(--text-sm);display:inline-flex;align-items:center;gap:6px;transition:color var(--ease-default);touch-action:manipulation}
@@ -2582,7 +2600,7 @@ var eventPageTmpl = template.Must(template.New("event-page").Funcs(tmplFuncs).Pa
         <div class="ep-row"><span class="k">From</span><span class="v"><a href="/dashboard/agents/{{.Entry.FromAgent}}">{{.Entry.FromAgent}}</a>{{if .AgentSuspended}} <span style="color:var(--danger);font-size:0.58rem;font-weight:600">SUSPENDED</span>{{end}}</span></div>
         <div class="ep-row"><span class="k">To</span><span class="v">{{if .Entry.ToolName}}{{toolDot .Entry.ToolName}}{{else}}{{.Entry.ToAgent}}{{end}}</span></div>
         <div class="ep-row"><span class="k">Latency</span><span class="v" style="color:{{if ge .Entry.LatencyMs 500}}var(--danger){{else if ge .Entry.LatencyMs 100}}var(--warn){{else}}var(--text2){{end}}">{{.Entry.LatencyMs}}ms</span></div>
-        {{if .Entry.SessionID}}<div class="ep-row"><span class="k">Session</span><span class="v" title="{{.Entry.SessionID}}">{{truncate .Entry.SessionID 24}}</span></div>{{end}}
+        {{if .Entry.SessionID}}<div class="ep-row"><span class="k">Session</span><span class="v"><a href="/dashboard/sessions/{{.Entry.SessionID}}" style="color:var(--accent);text-decoration:none" title="View session trace">{{truncate .Entry.SessionID 24}} &rarr;</a></span></div>{{end}}
         <div class="ep-row"><span class="k">Decision</span><span class="v" style="font-family:var(--sans);color:{{if eq .Entry.Status "delivered"}}var(--success){{else if eq .Entry.Status "blocked"}}var(--danger){{else}}var(--warn){{end}}">{{.Decision}}</span></div>
       </div>
     </div>
@@ -4107,7 +4125,7 @@ updateExportLinks();
   <div id="search-results">
   {{if .Entries}}
   <table>
-    <thead><tr><th>Time</th><th>From</th><th>To</th><th>Status</th><th style="text-align:right">Latency</th><th style="text-align:right">Rules</th></tr></thead>
+    <thead><tr><th>Time</th><th>From</th><th>To</th><th>Status</th><th>Session</th><th style="text-align:right">Latency</th><th style="text-align:right">Rules</th></tr></thead>
     <tbody id="events-body">
     {{range .Entries}}
     <tr class="ev-row clickable{{if hasRules .RulesTriggered}} has-rules{{end}}" hx-get="/dashboard/api/event/{{.ID}}" hx-target="#panel-content" hx-swap="innerHTML" ondblclick="event.preventDefault();event.stopPropagation();window.location='/dashboard/events/{{.ID}}'">
@@ -4115,6 +4133,7 @@ updateExportLinks();
       <td>{{agentCell .FromAgent}}</td>
       <td>{{if .ToolName}}{{toolDot .ToolName}}{{else}}{{agentCell .ToAgent}}{{end}}</td>
       <td><span class="badge-{{.Status}}">{{.Status}}</span>{{if ne .PolicyDecision "allowed"}} <span style="font-family:var(--sans);font-size:var(--text-xs);color:var(--text3);margin-left:4px">{{humanDecision .PolicyDecision}}</span>{{end}}</td>
+      <td style="font-size:var(--text-xs)">{{if .SessionID}}<a href="/dashboard/sessions/{{.SessionID}}" style="color:var(--accent);text-decoration:none;font-family:var(--mono)" title="{{.SessionID}}">{{truncate .SessionID 12}}</a>{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
       <td style="text-align:right;font-family:var(--mono);font-size:var(--text-xs);color:{{if ge .LatencyMs 500}}var(--danger){{else if ge .LatencyMs 100}}var(--warn){{else}}var(--text3){{end}}">{{.LatencyMs}}ms</td>
       <td style="text-align:right;font-family:var(--mono);font-size:var(--text-xs)">{{if hasRules .RulesTriggered}}<span style="color:var(--warn);font-weight:600">&#x26A0;</span>{{else}}<span style="color:var(--text3)">-</span>{{end}}</td>
     </tr>
@@ -4303,7 +4322,10 @@ updateExportLinks();
         var labels={'content_blocked':'Blocked — dangerous content','content_quarantined':'Quarantined','signature_required':'Rejected — unsigned','acl_denied':'Rejected — ACL denied'};
         decExtra=' <span style="font-family:var(--sans);font-size:var(--text-xs);color:var(--text3);margin-left:4px">'+(labels[ev.policy_decision]||ev.policy_decision)+'</span>';
       }
-      row.innerHTML = '<td data-ts="' + ev.timestamp + '">' + ev.timestamp + '</td><td>' + agentCellHTML(ev.from_agent||'') + '</td><td>' + toCell + '</td><td><span class="badge-' + ev.status + '">' + ev.status + '</span>'+decExtra+'</td>';
+      var sesCell = ev.session_id ? '<a href="/dashboard/sessions/'+ev.session_id+'" style="color:var(--accent);text-decoration:none;font-family:var(--mono)" title="'+ev.session_id+'">'+ev.session_id.substring(0,12)+'...</a>' : '<span style="color:var(--text3)">-</span>';
+      var latColor = ev.latency_ms>=500?'var(--danger)':ev.latency_ms>=100?'var(--warn)':'var(--text3)';
+      var rulesCell = hasRules ? '<span style="color:var(--warn);font-weight:600">&#x26A0;</span>' : '<span style="color:var(--text3)">-</span>';
+      row.innerHTML = '<td data-ts="' + ev.timestamp + '">' + ev.timestamp + '</td><td>' + agentCellHTML(ev.from_agent||'') + '</td><td>' + toCell + '</td><td><span class="badge-' + ev.status + '">' + ev.status + '</span>'+decExtra+'</td><td style="font-size:var(--text-xs)">'+sesCell+'</td><td style="text-align:right;font-family:var(--mono);font-size:var(--text-xs);color:'+latColor+'">'+(ev.latency_ms||0)+'ms</td><td style="text-align:right;font-family:var(--mono);font-size:var(--text-xs)">'+rulesCell+'</td>';
       tbody.insertBefore(row, tbody.firstChild);
       htmx.process(row);
       if(typeof humanizeTimestamps==='function')humanizeTimestamps();

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -1,0 +1,118 @@
+package dashboard
+
+import "html/template"
+
+var sessionTraceTmpl = template.Must(template.New("session-trace").Funcs(tmplFuncs).Parse(layoutHead + `
+<style>
+/* ── Session Trace ────────────────────────────────────── */
+.st-meta{font-size:var(--text-sm);color:var(--text3);margin-bottom:20px}
+.st-meta span{margin-right:16px}
+.st-meta .val{color:var(--text2);font-weight:500}
+
+.st-actions{display:flex;gap:8px;margin-bottom:20px}
+
+.st-stats{display:flex;gap:24px;margin-bottom:24px;padding:16px 20px;background:var(--surface);border:1px solid var(--border);border-radius:10px}
+.st-stat .label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:2px}
+.st-stat .value{font-size:1.1rem;font-weight:600;color:var(--text)}
+.st-stat .value.v-danger{color:var(--danger)}
+.st-stat .value.v-success{color:var(--success)}
+
+/* Timeline */
+.st-timeline{position:relative;padding-left:32px}
+.st-timeline::before{content:'';position:absolute;left:11px;top:8px;bottom:8px;width:2px;background:var(--border)}
+
+.st-step{position:relative;margin-bottom:16px;padding:14px 18px;background:var(--surface);border:1px solid var(--border);border-radius:8px;transition:border-color 0.15s}
+.st-step:hover{border-color:var(--text3)}
+.st-step.s-blocked{border-left:3px solid var(--danger)}
+.st-step.s-quarantined{border-left:3px solid var(--warn)}
+
+/* Timeline dot */
+.st-step::before{content:'';position:absolute;left:-25px;top:18px;width:10px;height:10px;border-radius:50%;background:var(--success);border:2px solid var(--bg)}
+.st-step.s-blocked::before{background:var(--danger)}
+.st-step.s-quarantined::before{background:var(--warn)}
+
+.st-step-header{display:flex;align-items:center;gap:12px;margin-bottom:6px}
+.st-tool{font-weight:600;color:var(--text);font-size:var(--text-sm)}
+.st-verdict{font-size:var(--text-xs);padding:2px 8px;border-radius:4px;font-weight:500}
+.st-verdict.v-clean{color:var(--success);background:rgba(63,185,80,0.1)}
+.st-verdict.v-blocked{color:var(--danger);background:rgba(248,81,73,0.1)}
+.st-verdict.v-quarantined{color:var(--warn);background:rgba(210,153,34,0.1)}
+.st-time{font-size:var(--text-xs);color:var(--text3);margin-left:auto}
+.st-gap{font-size:var(--text-xs);color:var(--text3);opacity:0.7}
+.st-latency{font-size:var(--text-xs);color:var(--text3)}
+
+.st-content{font-size:var(--text-xs);color:var(--text3);max-height:40px;overflow:hidden;font-family:var(--mono);word-break:break-all}
+
+.st-reasoning{margin-top:8px;padding:10px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;font-size:var(--text-xs);color:var(--text2);line-height:1.5}
+.st-reasoning .label{font-weight:600;color:var(--text3);text-transform:uppercase;letter-spacing:var(--ls-caps);font-size:0.65rem;margin-bottom:4px}
+.st-plan{font-size:var(--text-xs);color:var(--accent);font-weight:500;margin-left:8px}
+
+.st-link{font-size:var(--text-xs);color:var(--accent);text-decoration:none;margin-top:6px;display:inline-block}
+.st-link:hover{text-decoration:underline}
+
+.st-empty{padding:40px;text-align:center;color:var(--text3)}
+</style>
+
+<div class="page-header" style="margin-bottom:8px">
+  <h1 style="margin-bottom:4px">Session Trace</h1>
+</div>
+<p style="color:var(--text3);font-size:var(--text-sm);margin:0 0 16px">Timeline of agent tool calls within a session</p>
+
+<div class="st-meta">
+  <span>Agent: <span class="val">{{.Trace.Agent}}</span></span>
+  <span>Session: <span class="val" style="font-family:var(--mono);font-size:var(--text-xs)">{{.Trace.SessionID}}</span></span>
+</div>
+
+<div class="st-actions">
+  <a href="/dashboard/api/session/{{.Trace.SessionID}}/csv" class="btn btn-sm btn-outline" style="font-size:var(--text-xs)">CSV</a>
+  <a href="/dashboard/api/session/{{.Trace.SessionID}}/sarif" class="btn btn-sm btn-outline" style="font-size:var(--text-xs)">SARIF</a>
+  <a href="/dashboard/api/session/{{.Trace.SessionID}}/export" class="btn btn-sm btn-outline" style="font-size:var(--text-xs)">JSON</a>
+</div>
+
+<div class="st-stats">
+  <div class="st-stat">
+    <div class="label">Tool Calls</div>
+    <div class="value">{{.Trace.ToolCount}}</div>
+  </div>
+  <div class="st-stat">
+    <div class="label">Duration</div>
+    <div class="value">{{.Trace.Duration}}</div>
+  </div>
+  <div class="st-stat">
+    <div class="label">Started</div>
+    <div class="value" data-ts="{{.Trace.StartedAt}}">{{.Trace.StartedAt}}</div>
+  </div>
+  <div class="st-stat">
+    <div class="label">Threats</div>
+    <div class="value{{if gt .Trace.Threats 0}} v-danger{{else}} v-success{{end}}">{{.Trace.Threats}}</div>
+  </div>
+</div>
+
+{{if .Trace.Steps}}
+<div class="st-timeline">
+  {{range .Trace.Steps}}
+  <div class="st-step{{if eq .Verdict "blocked"}} s-blocked{{end}}{{if eq .Verdict "quarantined"}} s-quarantined{{end}}">
+    <div class="st-step-header">
+      <span class="st-tool">{{.ToolName}}</span>
+      <span class="st-verdict{{if eq .Verdict "blocked"}} v-blocked{{else if eq .Verdict "quarantined"}} v-quarantined{{else}} v-clean{{end}}">{{.Verdict}}</span>
+      {{if gt .PlanStep 0}}<span class="st-plan">Step {{.PlanStep}}/{{.PlanTotal}}</span>{{end}}
+      <span class="st-time" data-ts="{{.Timestamp}}">{{.Timestamp}}</span>
+      {{if gt .GapMs 1000}}<span class="st-gap">+{{printf "%.1f" (divf .GapMs 1000)}}s</span>{{else if gt .GapMs 0}}<span class="st-gap">+{{.GapMs}}ms</span>{{end}}
+      <span class="st-latency">{{.LatencyMs}}ms</span>
+    </div>
+    {{if .ToolInput}}<div class="st-content">{{.ToolInput}}</div>{{end}}
+    {{if .Reasoning}}
+    <div class="st-reasoning">
+      <div class="label">Reasoning</div>
+      {{.Reasoning}}
+    </div>
+    {{end}}
+    <a href="/dashboard/events/{{.EventID}}" class="st-link">View event detail</a>
+  </div>
+  {{end}}
+</div>
+{{else}}
+<div class="st-empty">No events found for this session.</div>
+{{end}}
+
+` + layoutFoot))

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -366,11 +366,15 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 1d. Verify delegation chain if present
-		var delegationChainHash string
+		var delegationChainHash, delegationChainSummary string
 		if delHeader, _ := ctx.Value(delegationContextKey).(string); delHeader != "" {
 			chainResult := g.verifyDelegationHeader(delHeader)
 			if chainResult.Valid {
 				delegationChainHash = chainResult.ChainHash
+				delegationChainSummary = chainResult.Root + " -> " + chainResult.Delegate
+				if chainResult.Depth > 2 {
+					delegationChainSummary = fmt.Sprintf("%s -> ... -> %s (%d hops)", chainResult.Root, chainResult.Delegate, chainResult.Depth)
+				}
 				g.logger.Debug("delegation chain verified",
 					"root", chainResult.Root, "delegate", chainResult.Delegate,
 					"depth", chainResult.Depth)
@@ -483,8 +487,8 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		findingsJSON := verdict.EncodeFindings(outcome.Findings)
 		status, decision := verdictToGateway(outcome.Verdict)
 
-		// 9. Audit log (with delegation chain hash if verified)
-		g.logAudit(msgID, agent, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start, delegationChainHash)
+		// 9. Audit log (with delegation chain if verified)
+		g.logAudit(msgID, agent, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start, delegationChainHash, delegationChainSummary)
 
 		// 9a. Record tool call for constraint chain rule tracking
 		if g.constraintChecker != nil {
@@ -647,9 +651,12 @@ func (g *Gateway) autoRegisterAgent(name string) {
 // logAudit writes an audit entry for a gateway tool call.
 // Optional extra strings: first is delegation_chain_hash.
 func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time, extra ...string) {
-	var delHash string
+	var delHash, delChain string
 	if len(extra) > 0 {
 		delHash = extra[0]
+	}
+	if len(extra) > 1 {
+		delChain = extra[1]
 	}
 	g.audit.Log(audit.Entry{
 		ID:                  msgID,
@@ -665,6 +672,7 @@ func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, t
 		Intent:              toolArgs,
 		SessionID:           sessionID,
 		DelegationChainHash: delHash,
+		DelegationChain:     delChain,
 	})
 }
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -12,9 +12,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"crypto/ed25519"
+	"encoding/base64"
+
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/llm"
 	"github.com/oktsec/oktsec/internal/mcputil"
 	"github.com/oktsec/oktsec/internal/netutil"
@@ -29,6 +33,7 @@ type contextKey string
 
 const agentContextKey contextKey = "oktsec-agent"
 const sessionContextKey contextKey = "oktsec-session"
+const delegationContextKey contextKey = "oktsec-delegation"
 
 // toolMapping maps a frontend tool name to its backend.
 type toolMapping struct {
@@ -167,6 +172,9 @@ func (g *Gateway) Start(ctx context.Context) error {
 		ctx := context.WithValue(r.Context(), agentContextKey, agent)
 		if sid := r.Header.Get("Mcp-Session-Id"); sid != "" {
 			ctx = context.WithValue(ctx, sessionContextKey, sid)
+		}
+		if del := r.Header.Get("X-Oktsec-Delegation"); del != "" {
+			ctx = context.WithValue(ctx, delegationContextKey, del)
 		}
 		streamable.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -357,6 +365,21 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			sessionID = req.Session.ID()
 		}
 
+		// 1d. Verify delegation chain if present
+		var delegationChainHash string
+		if delHeader, _ := ctx.Value(delegationContextKey).(string); delHeader != "" {
+			chainResult := g.verifyDelegationHeader(delHeader)
+			if chainResult.Valid {
+				delegationChainHash = chainResult.ChainHash
+				g.logger.Debug("delegation chain verified",
+					"root", chainResult.Root, "delegate", chainResult.Delegate,
+					"depth", chainResult.Depth)
+			} else {
+				g.logger.Warn("delegation chain invalid",
+					"agent", agent, "reason", chainResult.Reason)
+			}
+		}
+
 		// 2. Rate limit check
 		if !g.rateLimiter.Allow(agent) {
 			g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionRateLimited, "[]", toolArgs, sessionID, start)
@@ -460,8 +483,8 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		findingsJSON := verdict.EncodeFindings(outcome.Findings)
 		status, decision := verdictToGateway(outcome.Verdict)
 
-		// 9. Audit log
-		g.logAudit(msgID, agent, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start)
+		// 9. Audit log (with delegation chain hash if verified)
+		g.logAudit(msgID, agent, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start, delegationChainHash)
 
 		// 9a. Record tool call for constraint chain rule tracking
 		if g.constraintChecker != nil {
@@ -622,20 +645,26 @@ func (g *Gateway) autoRegisterAgent(name string) {
 }
 
 // logAudit writes an audit entry for a gateway tool call.
-func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time) {
+// Optional extra strings: first is delegation_chain_hash.
+func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time, extra ...string) {
+	var delHash string
+	if len(extra) > 0 {
+		delHash = extra[0]
+	}
 	g.audit.Log(audit.Entry{
-		ID:             msgID,
-		Timestamp:      time.Now().UTC().Format(time.RFC3339),
-		FromAgent:      agent,
-		ToAgent:        agent,
-		ToolName:       tool,
-		ContentHash:    "",
-		Status:         status,
-		RulesTriggered: findingsJSON,
-		PolicyDecision: decision,
-		LatencyMs:      time.Since(start).Milliseconds(),
-		Intent:         toolArgs,
-		SessionID:      sessionID,
+		ID:                  msgID,
+		Timestamp:           time.Now().UTC().Format(time.RFC3339),
+		FromAgent:           agent,
+		ToAgent:             agent,
+		ToolName:            tool,
+		ContentHash:         "",
+		Status:              status,
+		RulesTriggered:      findingsJSON,
+		PolicyDecision:      decision,
+		LatencyMs:           time.Since(start).Milliseconds(),
+		Intent:              toolArgs,
+		SessionID:           sessionID,
+		DelegationChainHash: delHash,
 	})
 }
 
@@ -891,4 +920,35 @@ func buildConstraintMaps(cfg *config.Config) (map[string][]ToolConstraint, map[s
 
 // verdictToGateway maps a verdict to (status, policyDecision).
 var verdictToGateway = verdict.ToAuditStatus
+
+// verifyDelegationHeader decodes and verifies a base64-encoded delegation chain
+// from the X-Oktsec-Delegation HTTP header. Uses the gateway's keystore to
+// resolve public keys for each delegator in the chain.
+func (g *Gateway) verifyDelegationHeader(header string) identity.ChainVerifyResult {
+	data, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		return identity.ChainVerifyResult{Valid: false, Reason: "invalid base64 encoding"}
+	}
+
+	var chain identity.DelegationChain
+	if err := json.Unmarshal(data, &chain); err != nil {
+		return identity.ChainVerifyResult{Valid: false, Reason: "invalid chain JSON"}
+	}
+
+	// Resolve public keys from the identity keystore
+	resolver := func(agent string) ed25519.PublicKey {
+		if g.cfg.Identity.KeysDir == "" {
+			return nil
+		}
+		ks := identity.NewKeyStore()
+		_ = ks.LoadFromDir(g.cfg.Identity.KeysDir)
+		pub, ok := ks.Get(agent)
+		if !ok {
+			return nil
+		}
+		return pub
+	}
+
+	return identity.VerifyChain(chain, resolver)
+}
 

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -50,6 +50,15 @@ type ToolEvent struct {
 
 	// Claude Code specific (auto-normalized)
 	HookEventName string `json:"hook_event_name,omitempty"` // "PreToolUse" / "PostToolUse"
+
+	// Delegation chain (optional) — cryptographic proof of authorization lineage
+	DelegationChain json.RawMessage `json:"delegation_chain,omitempty"`
+
+	// Reasoning capture (optional) — chain-of-thought for audit/compliance
+	Reasoning     string `json:"reasoning,omitempty"`      // model's reasoning for this tool call
+	ReasoningHash string `json:"reasoning_hash,omitempty"` // SHA-256 of reasoning (if client sends hash-only)
+	PlanStep      int    `json:"plan_step,omitempty"`      // position in a multi-step plan
+	PlanTotal     int    `json:"plan_total,omitempty"`     // total steps in plan
 }
 
 // normalize fills generic fields from client-specific ones.
@@ -208,20 +217,48 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		toAgent = h.extractSubagentName(ev.ToolInput)
 	}
 
+	// Compute delegation chain hash if provided.
+	var delegationHash string
+	if len(ev.DelegationChain) > 0 && string(ev.DelegationChain) != "null" {
+		dh := sha256.Sum256(ev.DelegationChain)
+		delegationHash = fmt.Sprintf("%x", dh)
+	}
+
 	h.store.Log(audit.Entry{
-		ID:             msgID,
-		Timestamp:      time.Now().UTC().Format(time.RFC3339),
-		FromAgent:      ev.Agent,
-		ToAgent:        toAgent,
-		ToolName:       ev.ToolName,
-		ContentHash:    ev.contentHash(),
-		Status:         status,
-		RulesTriggered: findingsJSON,
-		PolicyDecision: decision,
-		LatencyMs:      time.Since(start).Milliseconds(),
-		Intent:         toolArgs,
-		SessionID:      ev.SessionID,
+		ID:                  msgID,
+		Timestamp:           time.Now().UTC().Format(time.RFC3339),
+		FromAgent:           ev.Agent,
+		ToAgent:             toAgent,
+		ToolName:            ev.ToolName,
+		ContentHash:         ev.contentHash(),
+		Status:              status,
+		RulesTriggered:      findingsJSON,
+		PolicyDecision:      decision,
+		LatencyMs:           time.Since(start).Milliseconds(),
+		Intent:              toolArgs,
+		SessionID:           ev.SessionID,
+		DelegationChainHash: delegationHash,
 	})
+
+	// Log reasoning if provided (separate table for large data).
+	if ev.Reasoning != "" {
+		rHash := ev.ReasoningHash
+		if rHash == "" {
+			rh := sha256.Sum256([]byte(ev.Reasoning))
+			rHash = fmt.Sprintf("%x", rh)
+		}
+		_ = h.store.LogReasoning(audit.ReasoningEntry{
+			ID:            uuid.New().String(),
+			AuditEntryID:  msgID,
+			SessionID:     ev.SessionID,
+			ToolUseID:     ev.ToolUseID,
+			Reasoning:     ev.Reasoning,
+			ReasoningHash: rHash,
+			PlanStep:      ev.PlanStep,
+			PlanTotal:     ev.PlanTotal,
+			Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		})
+	}
 
 	h.logger.Debug("hook event",
 		"event", ev.Event,

--- a/internal/identity/delegation.go
+++ b/internal/identity/delegation.go
@@ -2,7 +2,10 @@ package identity
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +13,10 @@ import (
 
 // DelegationToken represents a cryptographically signed authorization from one
 // agent (delegator) to another (delegate), granting scoped messaging permissions.
-// Inspired by Verifiable Intent's 3-layer delegation chain model.
+//
+// Tokens can be chained: Human -> Agent A -> Agent B -> Agent C. Each hop
+// narrows scope and carries a reference to the parent token, creating a
+// cryptographically verifiable chain back to the original human authorization.
 type DelegationToken struct {
 	Delegator string    `json:"delegator"`           // parent agent name
 	Delegate  string    `json:"delegate"`            // child agent name
@@ -18,11 +24,39 @@ type DelegationToken struct {
 	IssuedAt  time.Time `json:"issued_at"`
 	ExpiresAt time.Time `json:"expires_at"`
 	Signature string    `json:"signature,omitempty"` // base64(ed25519 sig by delegator)
+
+	// Chain fields — enable multi-hop delegation with cryptographic binding.
+	TokenID       string   `json:"token_id,omitempty"`        // SHA-256 of canonical payload (computed on create)
+	ParentTokenID string   `json:"parent_token_id,omitempty"` // TokenID of the parent delegation (empty for root)
+	ChainDepth    int      `json:"chain_depth"`               // 0 = human/root, 1 = first agent hop, etc.
+	MaxDepth      int      `json:"max_depth"`                 // maximum allowed re-delegation depth
+	AllowedTools  []string `json:"allowed_tools,omitempty"`   // tool scope narrows per hop (nil = all tools)
 }
 
+// DelegationChain is an ordered list of tokens forming a delegation path
+// from a root authorizer (typically human) to the current agent.
+// Tokens are ordered oldest-first: chain[0] is the root delegation.
+type DelegationChain []DelegationToken
+
 // delegationPayload builds the canonical byte payload for signing/verification.
-// Format: delegator\ndelegate\nscope_csv\nissuedAt\nexpiresAt
-func delegationPayload(delegator, delegate string, scope []string, issuedAt, expiresAt time.Time) []byte {
+// Includes chain fields so they can't be tampered with after signing.
+func delegationPayload(t *DelegationToken) []byte {
+	scopeCSV := strings.Join(t.Scope, ",")
+	toolsCSV := strings.Join(t.AllowedTools, ",")
+	s := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%d\n%d\n%s",
+		t.Delegator, t.Delegate, scopeCSV,
+		t.IssuedAt.UTC().Format(time.RFC3339),
+		t.ExpiresAt.UTC().Format(time.RFC3339),
+		t.ParentTokenID,
+		t.ChainDepth, t.MaxDepth,
+		toolsCSV,
+	)
+	return []byte(s)
+}
+
+// legacyPayload preserves the original 5-field format for backward
+// compatibility with tokens created before chain support.
+func legacyPayload(delegator, delegate string, scope []string, issuedAt, expiresAt time.Time) []byte {
 	scopeCSV := strings.Join(scope, ",")
 	s := fmt.Sprintf("%s\n%s\n%s\n%s\n%s",
 		delegator, delegate, scopeCSV,
@@ -32,19 +66,49 @@ func delegationPayload(delegator, delegate string, scope []string, issuedAt, exp
 	return []byte(s)
 }
 
+// computeTokenID returns the SHA-256 hex digest of the canonical payload.
+func computeTokenID(t *DelegationToken) string {
+	h := sha256.Sum256(delegationPayload(t))
+	return hex.EncodeToString(h[:])
+}
+
 // CreateDelegation creates a signed delegation token from delegator to delegate.
 // The delegator's private key signs the canonical payload.
+// For backward compatibility, creates a depth-0, max-depth-0 token (no chaining).
 func CreateDelegation(delegatorKey ed25519.PrivateKey, delegator, delegate string, scope []string, ttl time.Duration) *DelegationToken {
+	return CreateChainedDelegation(delegatorKey, delegator, delegate, scope, nil, ttl, "", 0, 3)
+}
+
+// CreateChainedDelegation creates a delegation token that is part of a chain.
+// parentTokenID links to the parent delegation (empty for root/human).
+// chainDepth is this token's position (0 for root). maxDepth caps re-delegation.
+// allowedTools restricts which tools the delegate can use (nil = all).
+func CreateChainedDelegation(
+	delegatorKey ed25519.PrivateKey,
+	delegator, delegate string,
+	scope, allowedTools []string,
+	ttl time.Duration,
+	parentTokenID string,
+	chainDepth, maxDepth int,
+) *DelegationToken {
 	now := time.Now().UTC()
 	token := &DelegationToken{
-		Delegator: delegator,
-		Delegate:  delegate,
-		Scope:     scope,
-		IssuedAt:  now,
-		ExpiresAt: now.Add(ttl),
+		Delegator:     delegator,
+		Delegate:      delegate,
+		Scope:         scope,
+		IssuedAt:      now,
+		ExpiresAt:     now.Add(ttl),
+		ParentTokenID: parentTokenID,
+		ChainDepth:    chainDepth,
+		MaxDepth:      maxDepth,
+		AllowedTools:  allowedTools,
 	}
 
-	payload := delegationPayload(delegator, delegate, scope, token.IssuedAt, token.ExpiresAt)
+	// Compute token ID from unsigned payload
+	token.TokenID = computeTokenID(token)
+
+	// Sign the canonical payload (includes all chain fields)
+	payload := delegationPayload(token)
 	sig := ed25519.Sign(delegatorKey, payload)
 	token.Signature = base64.StdEncoding.EncodeToString(sig)
 
@@ -57,7 +121,18 @@ type DelegationVerifyResult struct {
 	Reason string
 }
 
-// VerifyDelegation checks that a delegation token is valid:
+// ChainVerifyResult holds the outcome of a full chain verification.
+type ChainVerifyResult struct {
+	Valid      bool
+	Reason     string
+	Depth      int      // total chain depth
+	Root       string   // root delegator (human/origin)
+	Delegate   string   // final delegate (current agent)
+	Tools      []string // effective tool scope (intersection of all hops)
+	ChainHash  string   // SHA-256 of the serialized chain for audit
+}
+
+// VerifyDelegation checks that a single delegation token is valid:
 // 1. Signature is valid against the delegator's public key
 // 2. Token is not expired
 // 3. The target recipient is within the delegation scope
@@ -76,15 +151,19 @@ func VerifyDelegation(delegatorPub ed25519.PublicKey, token *DelegationToken, re
 		return DelegationVerifyResult{Valid: false, Reason: "delegation issued in the future"}
 	}
 
-	// Verify signature
+	// Verify signature — try chain payload first, fall back to legacy
 	sig, err := base64.StdEncoding.DecodeString(token.Signature)
 	if err != nil {
 		return DelegationVerifyResult{Valid: false, Reason: "invalid signature encoding"}
 	}
 
-	payload := delegationPayload(token.Delegator, token.Delegate, token.Scope, token.IssuedAt, token.ExpiresAt)
+	payload := delegationPayload(token)
 	if !ed25519.Verify(delegatorPub, payload, sig) {
-		return DelegationVerifyResult{Valid: false, Reason: "signature verification failed"}
+		// Try legacy payload for backward compatibility with pre-chain tokens
+		legacy := legacyPayload(token.Delegator, token.Delegate, token.Scope, token.IssuedAt, token.ExpiresAt)
+		if !ed25519.Verify(delegatorPub, legacy, sig) {
+			return DelegationVerifyResult{Valid: false, Reason: "signature verification failed"}
+		}
 	}
 
 	// Check scope
@@ -98,6 +177,143 @@ func VerifyDelegation(delegatorPub ed25519.PublicKey, token *DelegationToken, re
 	return DelegationVerifyResult{Valid: true, Reason: "valid delegation"}
 }
 
+// VerifyChain verifies a complete delegation chain from root to leaf.
+// keyResolver maps agent names to their public keys.
+//
+// Checks per hop:
+//  1. Signature valid (delegator's key signs the token)
+//  2. Token not expired
+//  3. Chain linkage: token.ParentTokenID matches previous token.TokenID
+//  4. Depth within MaxDepth
+//  5. Scope narrows or stays equal (delegate can't escalate privileges)
+//  6. Tool scope narrows or stays equal
+//  7. Delegate of hop N == Delegator of hop N+1 (continuity)
+func VerifyChain(chain DelegationChain, keyResolver func(agent string) ed25519.PublicKey) ChainVerifyResult {
+	if len(chain) == 0 {
+		return ChainVerifyResult{Valid: false, Reason: "empty delegation chain"}
+	}
+
+	effectiveTools := chain[0].AllowedTools
+	prevTokenID := ""
+
+	for i, token := range chain {
+		// Resolve delegator's public key
+		pub := keyResolver(token.Delegator)
+		if pub == nil {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: unknown delegator %q (no public key)", i, token.Delegator),
+			}
+		}
+
+		// Verify signature
+		sig, err := base64.StdEncoding.DecodeString(token.Signature)
+		if err != nil {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: invalid signature encoding", i),
+			}
+		}
+		payload := delegationPayload(&token)
+		if !ed25519.Verify(pub, payload, sig) {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: signature verification failed for %q", i, token.Delegator),
+			}
+		}
+
+		// Check expiry
+		if time.Now().UTC().After(token.ExpiresAt) {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: delegation from %q expired", i, token.Delegator),
+			}
+		}
+
+		// Check depth
+		if token.ChainDepth != i {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: expected chain_depth %d, got %d", i, i, token.ChainDepth),
+			}
+		}
+		if token.ChainDepth > token.MaxDepth {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: chain_depth %d exceeds max_depth %d", i, token.ChainDepth, token.MaxDepth),
+			}
+		}
+
+		// Check parent linkage
+		if i == 0 {
+			if token.ParentTokenID != "" {
+				return ChainVerifyResult{
+					Valid:  false,
+					Reason: "hop 0: root token must have empty parent_token_id",
+				}
+			}
+		} else {
+			if token.ParentTokenID != prevTokenID {
+				return ChainVerifyResult{
+					Valid:  false,
+					Reason: fmt.Sprintf("hop %d: parent_token_id mismatch (expected %s)", i, prevTokenID[:16]+"..."),
+				}
+			}
+		}
+
+		// Check continuity: previous delegate == current delegator
+		if i > 0 && chain[i-1].Delegate != token.Delegator {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: delegator %q != previous delegate %q", i, token.Delegator, chain[i-1].Delegate),
+			}
+		}
+
+		// Check scope doesn't escalate (each hop must be subset of parent)
+		if i > 0 && !scopeIsSubset(token.Scope, chain[i-1].Scope) {
+			return ChainVerifyResult{
+				Valid:  false,
+				Reason: fmt.Sprintf("hop %d: scope escalation (not subset of parent)", i),
+			}
+		}
+
+		// Narrow effective tools
+		if len(token.AllowedTools) > 0 {
+			effectiveTools = intersectTools(effectiveTools, token.AllowedTools)
+		}
+
+		prevTokenID = token.TokenID
+	}
+
+	// Compute chain hash for audit
+	chainData, _ := json.Marshal(chain)
+	chainHash := sha256.Sum256(chainData)
+
+	last := chain[len(chain)-1]
+	return ChainVerifyResult{
+		Valid:     true,
+		Reason:    "valid delegation chain",
+		Depth:     len(chain),
+		Root:      chain[0].Delegator,
+		Delegate:  last.Delegate,
+		Tools:     effectiveTools,
+		ChainHash: hex.EncodeToString(chainHash[:]),
+	}
+}
+
+// FormatChain returns a human-readable chain summary like "human -> agent-a -> agent-b".
+func FormatChain(chain DelegationChain) string {
+	if len(chain) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(chain)+1)
+	parts = append(parts, chain[0].Delegator)
+	for _, t := range chain {
+		parts = append(parts, t.Delegate)
+	}
+	return strings.Join(parts, " -> ")
+}
+
 // scopeAllows checks if recipient is covered by the scope list.
 func scopeAllows(scope []string, recipient string) bool {
 	for _, s := range scope {
@@ -106,4 +322,54 @@ func scopeAllows(scope []string, recipient string) bool {
 		}
 	}
 	return false
+}
+
+// scopeIsSubset checks if child scope is a subset of parent scope.
+// Wildcard parent allows anything. Wildcard child with non-wildcard parent = escalation.
+func scopeIsSubset(child, parent []string) bool {
+	// Wildcard parent allows everything
+	for _, p := range parent {
+		if p == "*" {
+			return true
+		}
+	}
+	// Wildcard child with non-wildcard parent = escalation
+	for _, c := range child {
+		if c == "*" {
+			return false
+		}
+	}
+	// Every child scope must exist in parent
+	parentSet := make(map[string]bool, len(parent))
+	for _, p := range parent {
+		parentSet[p] = true
+	}
+	for _, c := range child {
+		if !parentSet[c] {
+			return false
+		}
+	}
+	return true
+}
+
+// intersectTools returns the intersection of two tool lists.
+// If either is nil/empty, the other is returned (nil = all tools).
+func intersectTools(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	set := make(map[string]bool, len(a))
+	for _, t := range a {
+		set[t] = true
+	}
+	var result []string
+	for _, t := range b {
+		if set[t] {
+			result = append(result, t)
+		}
+	}
+	return result
 }

--- a/internal/identity/delegation_test.go
+++ b/internal/identity/delegation_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// --- Legacy single-hop tests (backward compat) ---
+
 func TestCreateAndVerifyDelegation(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -107,5 +109,279 @@ func TestScopeAllows(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("scopeAllows(%v, %q) = %v, want %v", tt.scope, tt.recipient, got, tt.want)
 		}
+	}
+}
+
+// --- Chain tests ---
+
+// testKeys generates n named keypairs and returns a resolver function.
+func testKeys(names ...string) (map[string]ed25519.PrivateKey, func(string) ed25519.PublicKey) {
+	privKeys := make(map[string]ed25519.PrivateKey, len(names))
+	pubKeys := make(map[string]ed25519.PublicKey, len(names))
+	for _, name := range names {
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		privKeys[name] = priv
+		pubKeys[name] = pub
+	}
+	resolver := func(agent string) ed25519.PublicKey {
+		return pubKeys[agent]
+	}
+	return privKeys, resolver
+}
+
+func TestVerifyChain_TwoHop(t *testing.T) {
+	keys, resolver := testKeys("human", "agent-a", "agent-b")
+
+	// Human delegates to Agent A
+	hop0 := CreateChainedDelegation(
+		keys["human"], "human", "agent-a",
+		[]string{"*"}, nil, time.Hour, "", 0, 3,
+	)
+
+	// Agent A delegates to Agent B (narrower scope)
+	hop1 := CreateChainedDelegation(
+		keys["agent-a"], "agent-a", "agent-b",
+		[]string{"target-x", "target-y"}, []string{"Bash", "Read"}, time.Hour,
+		hop0.TokenID, 1, 3,
+	)
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if !result.Valid {
+		t.Fatalf("expected valid chain, got: %s", result.Reason)
+	}
+	if result.Root != "human" {
+		t.Errorf("root = %q, want human", result.Root)
+	}
+	if result.Delegate != "agent-b" {
+		t.Errorf("delegate = %q, want agent-b", result.Delegate)
+	}
+	if result.Depth != 2 {
+		t.Errorf("depth = %d, want 2", result.Depth)
+	}
+	if len(result.Tools) != 2 {
+		t.Errorf("tools = %v, want [Bash Read]", result.Tools)
+	}
+	if result.ChainHash == "" {
+		t.Error("chain hash should not be empty")
+	}
+}
+
+func TestVerifyChain_ThreeHop(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b", "c")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 5)
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, []string{"Bash", "Read", "Write"}, time.Hour, hop0.TokenID, 1, 5)
+	hop2 := CreateChainedDelegation(keys["b"], "b", "c", []string{"target-z"}, []string{"Read"}, time.Hour, hop1.TokenID, 2, 5)
+
+	chain := DelegationChain{*hop0, *hop1, *hop2}
+	result := VerifyChain(chain, resolver)
+
+	if !result.Valid {
+		t.Fatalf("3-hop chain should be valid: %s", result.Reason)
+	}
+	if result.Root != "human" {
+		t.Errorf("root = %q", result.Root)
+	}
+	if result.Delegate != "c" {
+		t.Errorf("delegate = %q", result.Delegate)
+	}
+	// Tools should narrow: nil -> [Bash,Read,Write] -> [Read] = [Read]
+	if len(result.Tools) != 1 || result.Tools[0] != "Read" {
+		t.Errorf("tools = %v, want [Read]", result.Tools)
+	}
+}
+
+func TestVerifyChain_Empty(t *testing.T) {
+	_, resolver := testKeys("a")
+	result := VerifyChain(nil, resolver)
+	if result.Valid {
+		t.Fatal("empty chain should be invalid")
+	}
+}
+
+func TestVerifyChain_BrokenLinkage(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 3)
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, nil, time.Hour, "wrong-parent-id", 1, 3)
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if result.Valid {
+		t.Fatal("broken linkage should be invalid")
+	}
+	if result.Reason == "" {
+		t.Fatal("should have a reason")
+	}
+}
+
+func TestVerifyChain_ScopeEscalation(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"target-x"}, nil, time.Hour, "", 0, 3)
+	// Agent A tries to delegate with broader scope than it received
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, nil, time.Hour, hop0.TokenID, 1, 3)
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if result.Valid {
+		t.Fatal("scope escalation should be rejected")
+	}
+}
+
+func TestVerifyChain_DepthExceeded(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 1) // max_depth=1
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, nil, time.Hour, hop0.TokenID, 1, 1)
+	// depth 1 == max_depth 1, so this is OK
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+	if !result.Valid {
+		t.Fatalf("depth 1 with max 1 should be valid: %s", result.Reason)
+	}
+
+	// Now try depth 2 with max_depth 1
+	keys2, resolver2 := testKeys("human", "a", "b", "c")
+	h0 := CreateChainedDelegation(keys2["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 1)
+	h1 := CreateChainedDelegation(keys2["a"], "a", "b", []string{"*"}, nil, time.Hour, h0.TokenID, 1, 1)
+	h2 := CreateChainedDelegation(keys2["b"], "b", "c", []string{"*"}, nil, time.Hour, h1.TokenID, 2, 1) // exceeds
+
+	chain2 := DelegationChain{*h0, *h1, *h2}
+	result2 := VerifyChain(chain2, resolver2)
+	if result2.Valid {
+		t.Fatal("depth 2 with max 1 should be rejected")
+	}
+}
+
+func TestVerifyChain_ContinuityBreak(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b", "rogue")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 3)
+	// Rogue signs as if it were "a" delegating to "b", but uses wrong key
+	hop1 := CreateChainedDelegation(keys["rogue"], "a", "b", []string{"*"}, nil, time.Hour, hop0.TokenID, 1, 3)
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if result.Valid {
+		t.Fatal("impersonation should be rejected (wrong key for delegator)")
+	}
+}
+
+func TestVerifyChain_ExpiredHop(t *testing.T) {
+	keys, resolver := testKeys("human", "a", "b")
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 3)
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, nil, -time.Hour, hop0.TokenID, 1, 3) // expired
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if result.Valid {
+		t.Fatal("expired hop should invalidate chain")
+	}
+}
+
+func TestVerifyChain_UnknownDelegator(t *testing.T) {
+	keys, _ := testKeys("human", "a")
+	// Resolver that only knows "human"
+	resolver := func(agent string) ed25519.PublicKey {
+		if agent == "human" {
+			return keys["human"].Public().(ed25519.PublicKey)
+		}
+		return nil
+	}
+
+	hop0 := CreateChainedDelegation(keys["human"], "human", "a", []string{"*"}, nil, time.Hour, "", 0, 3)
+	hop1 := CreateChainedDelegation(keys["a"], "a", "b", []string{"*"}, nil, time.Hour, hop0.TokenID, 1, 3)
+
+	chain := DelegationChain{*hop0, *hop1}
+	result := VerifyChain(chain, resolver)
+
+	if result.Valid {
+		t.Fatal("unknown delegator should be rejected")
+	}
+}
+
+func TestFormatChain(t *testing.T) {
+	chain := DelegationChain{
+		{Delegator: "human", Delegate: "agent-a"},
+		{Delegator: "agent-a", Delegate: "agent-b"},
+		{Delegator: "agent-b", Delegate: "agent-c"},
+	}
+	got := FormatChain(chain)
+	want := "human -> agent-a -> agent-b -> agent-c"
+	if got != want {
+		t.Errorf("FormatChain = %q, want %q", got, want)
+	}
+}
+
+func TestFormatChain_Empty(t *testing.T) {
+	if FormatChain(nil) != "" {
+		t.Error("empty chain should return empty string")
+	}
+}
+
+// --- Helper tests ---
+
+func TestScopeIsSubset(t *testing.T) {
+	tests := []struct {
+		child, parent []string
+		want          bool
+	}{
+		{[]string{"a"}, []string{"a", "b"}, true},
+		{[]string{"a", "b"}, []string{"a", "b"}, true},
+		{[]string{"c"}, []string{"a", "b"}, false},
+		{[]string{"a"}, []string{"*"}, true},
+		{[]string{"*"}, []string{"a"}, false}, // escalation
+		{[]string{"*"}, []string{"*"}, true},
+		{nil, []string{"a"}, true},
+		{[]string{}, []string{"a"}, true},
+	}
+	for _, tt := range tests {
+		got := scopeIsSubset(tt.child, tt.parent)
+		if got != tt.want {
+			t.Errorf("scopeIsSubset(%v, %v) = %v, want %v", tt.child, tt.parent, got, tt.want)
+		}
+	}
+}
+
+func TestIntersectTools(t *testing.T) {
+	tests := []struct {
+		a, b []string
+		want int
+	}{
+		{nil, []string{"Bash"}, 1},
+		{[]string{"Bash"}, nil, 1},
+		{[]string{"Bash", "Read"}, []string{"Read", "Write"}, 1},
+		{[]string{"Bash", "Read"}, []string{"Bash", "Read"}, 2},
+		{[]string{"Bash"}, []string{"Read"}, 0},
+	}
+	for _, tt := range tests {
+		got := intersectTools(tt.a, tt.b)
+		if len(got) != tt.want {
+			t.Errorf("intersectTools(%v, %v) = %v (len %d), want len %d", tt.a, tt.b, got, len(got), tt.want)
+		}
+	}
+}
+
+func TestTokenID_Deterministic(t *testing.T) {
+	keys, _ := testKeys("human")
+
+	t1 := CreateChainedDelegation(keys["human"], "human", "agent", []string{"*"}, nil, time.Hour, "", 0, 3)
+	if t1.TokenID == "" {
+		t.Fatal("token ID should not be empty")
+	}
+
+	// Recompute should match
+	recomputed := computeTokenID(t1)
+	if recomputed != t1.TokenID {
+		t.Errorf("recomputed token ID %q != original %q", recomputed, t1.TokenID)
 	}
 }

--- a/internal/identity/ephemeral.go
+++ b/internal/identity/ephemeral.go
@@ -1,0 +1,240 @@
+package identity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// EphemeralKeypair is a task-scoped keypair that expires automatically.
+// Reduces blast radius of compromised keys — an attacker can only use
+// the key until it expires, not indefinitely.
+type EphemeralKeypair struct {
+	Keypair
+	TaskID    string    `json:"task_id"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	ParentKey string    `json:"parent_key"` // fingerprint of the fixed key that issued this
+}
+
+// IsExpired returns true if the ephemeral key has expired.
+func (ek *EphemeralKeypair) IsExpired() bool {
+	return time.Now().UTC().After(ek.ExpiresAt)
+}
+
+// TTLRemaining returns the time until expiry (negative if expired).
+func (ek *EphemeralKeypair) TTLRemaining() time.Duration {
+	return time.Until(ek.ExpiresAt)
+}
+
+// EphemeralKeyStore is an in-memory store for task-scoped ephemeral keys.
+// Keys are automatically evicted when they expire. No disk persistence —
+// ephemeral keys live only in memory and die with the process.
+type EphemeralKeyStore struct {
+	mu         sync.RWMutex
+	keys       map[string]*EphemeralKeypair // keyed by fingerprint
+	byTask     map[string][]string          // taskID -> fingerprints
+	maxPerTask int
+	maxTTL     time.Duration
+	stopCh     chan struct{}
+}
+
+// NewEphemeralKeyStore creates a store with eviction loop.
+func NewEphemeralKeyStore(maxPerTask int, maxTTL time.Duration) *EphemeralKeyStore {
+	if maxPerTask <= 0 {
+		maxPerTask = 10
+	}
+	if maxTTL <= 0 {
+		maxTTL = 24 * time.Hour
+	}
+	ek := &EphemeralKeyStore{
+		keys:       make(map[string]*EphemeralKeypair),
+		byTask:     make(map[string][]string),
+		maxPerTask: maxPerTask,
+		maxTTL:     maxTTL,
+		stopCh:     make(chan struct{}),
+	}
+	go ek.evictLoop()
+	return ek
+}
+
+// Issue generates a new ephemeral keypair bound to a task.
+// parentFingerprint is the fixed key that authorized this issuance.
+// Returns the keypair (caller sends the private key to the agent).
+func (s *EphemeralKeyStore) Issue(taskID, parentFingerprint string, ttl time.Duration) (*EphemeralKeypair, error) {
+	if ttl > s.maxTTL {
+		ttl = s.maxTTL
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("TTL must be positive")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check per-task limit
+	if len(s.byTask[taskID]) >= s.maxPerTask {
+		return nil, fmt.Errorf("task %q has %d ephemeral keys (max %d)", taskID, len(s.byTask[taskID]), s.maxPerTask)
+	}
+
+	// Generate keypair
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating ephemeral key: %w", err)
+	}
+
+	now := time.Now().UTC()
+	kp := &EphemeralKeypair{
+		Keypair: Keypair{
+			Name:       fmt.Sprintf("ephemeral-%s-%d", taskID, now.UnixMilli()),
+			PublicKey:  pub,
+			PrivateKey: priv,
+		},
+		TaskID:    taskID,
+		CreatedAt: now,
+		ExpiresAt: now.Add(ttl),
+		ParentKey: parentFingerprint,
+	}
+
+	fp := Fingerprint(pub)
+	s.keys[fp] = kp
+	s.byTask[taskID] = append(s.byTask[taskID], fp)
+
+	return kp, nil
+}
+
+// Verify checks if a public key is a valid, non-expired ephemeral key.
+// Returns the keypair if valid, nil if not found or expired.
+func (s *EphemeralKeyStore) Verify(pub ed25519.PublicKey) *EphemeralKeypair {
+	fp := Fingerprint(pub)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	kp, ok := s.keys[fp]
+	if !ok {
+		return nil
+	}
+	if kp.IsExpired() {
+		return nil
+	}
+	return kp
+}
+
+// VerifyByFingerprint checks if a fingerprint belongs to a valid ephemeral key.
+func (s *EphemeralKeyStore) VerifyByFingerprint(fingerprint string) *EphemeralKeypair {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	kp, ok := s.keys[fingerprint]
+	if !ok || kp.IsExpired() {
+		return nil
+	}
+	return kp
+}
+
+// RevokeByTask removes all ephemeral keys for a task.
+func (s *EphemeralKeyStore) RevokeByTask(taskID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fps := s.byTask[taskID]
+	for _, fp := range fps {
+		delete(s.keys, fp)
+	}
+	delete(s.byTask, taskID)
+	return len(fps)
+}
+
+// Revoke removes a specific ephemeral key by fingerprint.
+func (s *EphemeralKeyStore) Revoke(fingerprint string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	kp, ok := s.keys[fingerprint]
+	if !ok {
+		return false
+	}
+
+	delete(s.keys, fingerprint)
+
+	// Remove from byTask
+	fps := s.byTask[kp.TaskID]
+	for i, fp := range fps {
+		if fp == fingerprint {
+			s.byTask[kp.TaskID] = append(fps[:i], fps[i+1:]...)
+			break
+		}
+	}
+	if len(s.byTask[kp.TaskID]) == 0 {
+		delete(s.byTask, kp.TaskID)
+	}
+
+	return true
+}
+
+// ActiveCount returns the number of non-expired ephemeral keys.
+func (s *EphemeralKeyStore) ActiveCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, kp := range s.keys {
+		if !kp.IsExpired() {
+			count++
+		}
+	}
+	return count
+}
+
+// TaskCount returns the number of tasks with active ephemeral keys.
+func (s *EphemeralKeyStore) TaskCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.byTask)
+}
+
+// Close stops the eviction loop.
+func (s *EphemeralKeyStore) Close() {
+	close(s.stopCh)
+}
+
+// evictLoop periodically removes expired keys.
+func (s *EphemeralKeyStore) evictLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.evictExpired()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *EphemeralKeyStore) evictExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for fp, kp := range s.keys {
+		if kp.IsExpired() {
+			delete(s.keys, fp)
+
+			// Clean byTask
+			fps := s.byTask[kp.TaskID]
+			for i, f := range fps {
+				if f == fp {
+					s.byTask[kp.TaskID] = append(fps[:i], fps[i+1:]...)
+					break
+				}
+			}
+			if len(s.byTask[kp.TaskID]) == 0 {
+				delete(s.byTask, kp.TaskID)
+			}
+		}
+	}
+}

--- a/internal/identity/ephemeral.go
+++ b/internal/identity/ephemeral.go
@@ -159,18 +159,7 @@ func (s *EphemeralKeyStore) Revoke(fingerprint string) bool {
 	}
 
 	delete(s.keys, fingerprint)
-
-	// Remove from byTask
-	fps := s.byTask[kp.TaskID]
-	for i, fp := range fps {
-		if fp == fingerprint {
-			s.byTask[kp.TaskID] = append(fps[:i], fps[i+1:]...)
-			break
-		}
-	}
-	if len(s.byTask[kp.TaskID]) == 0 {
-		delete(s.byTask, kp.TaskID)
-	}
+	s.removeTaskFingerprint(kp.TaskID, fingerprint)
 
 	return true
 }
@@ -223,18 +212,22 @@ func (s *EphemeralKeyStore) evictExpired() {
 	for fp, kp := range s.keys {
 		if kp.IsExpired() {
 			delete(s.keys, fp)
-
-			// Clean byTask
-			fps := s.byTask[kp.TaskID]
-			for i, f := range fps {
-				if f == fp {
-					s.byTask[kp.TaskID] = append(fps[:i], fps[i+1:]...)
-					break
-				}
-			}
-			if len(s.byTask[kp.TaskID]) == 0 {
-				delete(s.byTask, kp.TaskID)
-			}
+			s.removeTaskFingerprint(kp.TaskID, fp)
 		}
+	}
+}
+
+// removeTaskFingerprint removes a fingerprint from the byTask index.
+// Caller must hold s.mu.
+func (s *EphemeralKeyStore) removeTaskFingerprint(taskID, fingerprint string) {
+	fps := s.byTask[taskID]
+	for i, f := range fps {
+		if f == fingerprint {
+			s.byTask[taskID] = append(fps[:i], fps[i+1:]...)
+			break
+		}
+	}
+	if len(s.byTask[taskID]) == 0 {
+		delete(s.byTask, taskID)
 	}
 }

--- a/internal/identity/ephemeral_test.go
+++ b/internal/identity/ephemeral_test.go
@@ -1,0 +1,148 @@
+package identity
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEphemeralKeyStore_Issue(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	kp, err := store.Issue("task-1", "parent-fp", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kp.TaskID != "task-1" {
+		t.Errorf("task = %q, want task-1", kp.TaskID)
+	}
+	if kp.ParentKey != "parent-fp" {
+		t.Errorf("parent = %q", kp.ParentKey)
+	}
+	if kp.IsExpired() {
+		t.Error("should not be expired")
+	}
+	if kp.TTLRemaining() < 59*time.Minute {
+		t.Errorf("TTL = %v, want ~1h", kp.TTLRemaining())
+	}
+	if store.ActiveCount() != 1 {
+		t.Errorf("active = %d, want 1", store.ActiveCount())
+	}
+}
+
+func TestEphemeralKeyStore_Verify(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	kp, _ := store.Issue("task-1", "parent-fp", time.Hour)
+
+	// Verify by public key
+	found := store.Verify(kp.PublicKey)
+	if found == nil {
+		t.Fatal("should find ephemeral key")
+	}
+	if found.TaskID != "task-1" {
+		t.Errorf("task = %q", found.TaskID)
+	}
+
+	// Verify by fingerprint
+	fp := Fingerprint(kp.PublicKey)
+	found2 := store.VerifyByFingerprint(fp)
+	if found2 == nil {
+		t.Fatal("should find by fingerprint")
+	}
+}
+
+func TestEphemeralKeyStore_NegativeTTLRejected(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	_, err := store.Issue("task-1", "parent-fp", -time.Hour)
+	if err == nil {
+		t.Fatal("negative TTL should be rejected")
+	}
+}
+
+func TestEphemeralKeyStore_MaxPerTask(t *testing.T) {
+	store := NewEphemeralKeyStore(2, 24*time.Hour) // max 2 per task
+	defer store.Close()
+
+	_, err := store.Issue("task-1", "fp", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Issue("task-1", "fp", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Issue("task-1", "fp", time.Hour)
+	if err == nil {
+		t.Fatal("should reject 3rd key for same task")
+	}
+
+	// Different task should work
+	_, err = store.Issue("task-2", "fp", time.Hour)
+	if err != nil {
+		t.Fatalf("different task should work: %v", err)
+	}
+}
+
+func TestEphemeralKeyStore_MaxTTLCapped(t *testing.T) {
+	store := NewEphemeralKeyStore(10, time.Hour) // max 1h
+	defer store.Close()
+
+	kp, _ := store.Issue("task-1", "fp", 48*time.Hour) // request 48h
+
+	// Should be capped to 1h
+	if kp.TTLRemaining() > time.Hour+time.Second {
+		t.Errorf("TTL = %v, should be capped to 1h", kp.TTLRemaining())
+	}
+}
+
+func TestEphemeralKeyStore_Revoke(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	kp, _ := store.Issue("task-1", "fp", time.Hour)
+	fp := Fingerprint(kp.PublicKey)
+
+	if !store.Revoke(fp) {
+		t.Fatal("revoke should return true")
+	}
+	if store.ActiveCount() != 0 {
+		t.Errorf("active = %d after revoke", store.ActiveCount())
+	}
+	if store.Verify(kp.PublicKey) != nil {
+		t.Error("revoked key should not verify")
+	}
+}
+
+func TestEphemeralKeyStore_RevokeByTask(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	_, _ = store.Issue("task-1", "fp", time.Hour)
+	_, _ = store.Issue("task-1", "fp", time.Hour)
+	_, _ = store.Issue("task-2", "fp", time.Hour)
+
+	revoked := store.RevokeByTask("task-1")
+	if revoked != 2 {
+		t.Errorf("revoked = %d, want 2", revoked)
+	}
+	if store.ActiveCount() != 1 {
+		t.Errorf("active = %d, want 1 (task-2)", store.ActiveCount())
+	}
+	if store.TaskCount() != 1 {
+		t.Errorf("tasks = %d, want 1", store.TaskCount())
+	}
+}
+
+func TestEphemeralKeyStore_RevokeNonExistent(t *testing.T) {
+	store := NewEphemeralKeyStore(10, 24*time.Hour)
+	defer store.Close()
+
+	if store.Revoke("nonexistent") {
+		t.Error("revoking nonexistent key should return false")
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -37,11 +37,11 @@ type Server struct {
 	keys          *identity.KeyStore
 	scanner       *engine.Scanner
 	audit         *audit.Store
+	handler       *Handler
 	webhooks      *WebhookNotifier
 	dashboard     *dashboard.Server
 	llmQueue           *llm.Queue              // nil if LLM disabled
 	escalationTracker  *llm.EscalationTracker  // nil if LLM escalation disabled
-	handler            *Handler
 	logger             *slog.Logger
 	anomalyCancel context.CancelFunc
 	fwdSrv        *http.Server   // forward proxy (nil if disabled)
@@ -368,6 +368,15 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 // AuditStore returns the audit store for CLI queries.
 func (s *Server) AuditStore() *audit.Store {
 	return s.audit
+}
+
+// SetAuditStore replaces the audit store (used to share a single store
+// between proxy and gateway so all events feed into one Hub).
+func (s *Server) SetAuditStore(store *audit.Store) {
+	s.audit = store
+	if s.handler != nil {
+		s.handler.audit = store
+	}
 }
 
 // DashboardCode returns the one-time access code for the dashboard.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -10,16 +10,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
 )
 
 // Config holds initialization parameters for the TUI.
 type Config struct {
 	Version    string
-	Mode       string // "observe" or "enforce"
+	Mode       string           // "observe" or "enforce" (initial value)
 	DashURL    string
 	DashCode   string
 	AgentCount int
 	Hub        *audit.Hub
+	LiveCfg    *config.Config   // live config pointer — TUI reads current mode on each render
 }
 
 // EventRow is a displayable event in the live feed.
@@ -338,8 +340,16 @@ func (m Model) View() string {
 		hx[2]+" "+hx[3]+"  "+taglineStyle.Render("See everything your AI agents execute"),
 	)
 
+	currentMode := m.cfg.Mode
+	if m.cfg.LiveCfg != nil {
+		if m.cfg.LiveCfg.Identity.RequireSignature {
+			currentMode = "enforce"
+		} else {
+			currentMode = "observe"
+		}
+	}
 	mode := observeStyle.Render("observe")
-	if m.cfg.Mode == "enforce" {
+	if currentMode == "enforce" {
 		mode = enforceStyle.Render("enforce")
 	}
 	agentCount := len(m.agentsSeen)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -225,7 +225,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			status := classifyStatus(entry)
 			switch status {
-			case "blocked":
+			case "blocked", "rejected":
 				m.blockedCount++
 				m.threatsFound++
 			case "quarantined", "flagged":
@@ -558,7 +558,9 @@ func renderStatus(s string) string {
 	case "blocked":
 		return blockedStatusStyle.Render("blocked")
 	case "quarantined":
-		return quarantinedStatusStyle.Render("quarantine")
+		return quarantinedStatusStyle.Render("quar")
+	case "rejected":
+		return blockedStatusStyle.Render("rejected")
 	default:
 		return dimStyle.Render(s)
 	}


### PR DESCRIPTION
## Summary
- **Delegation chains**: Ed25519-signed delegation tokens with chained authorization (human -> agent-a -> agent-b), scope narrowing, and TTL enforcement. New `delegate` CLI command.
- **Ephemeral keys**: Task-scoped keypairs that auto-expire, reducing blast radius of compromised keys. In-memory store with eviction loop.
- **Session traces**: Reconstructs agent reasoning timelines from audit data. Dashboard page with tool call sequence, gaps, and reasoning capture.
- **Scan profiles & tool-scoped rules**: Content-aware scanning profiles that adjust rule sensitivity per tool type. Tool policy rule overrides in config.
- **Verdict engine**: Severity-based verdict mapping, scan profile support, and configurable per-agent overrides.
- **TUI improvements**: Real-time mode sync from dashboard, accurate threat/blocked counting (including rejected), shortened status labels, live config reference.
- **Code cleanup**: Deduplicated SQL column lists, extracted helpers, fixed struct alignment, added OrderASC query option.

## Changed packages
`audit`, `config`, `dashboard`, `gateway`, `hooks`, `identity`, `tui`, `verdict`, `commands`

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all packages, race detector)
- [x] `make lint` passes (0 issues)
- [x] Delegation chain creation and verification (unit tests)
- [x] Ephemeral key issuance, expiry, and revocation (unit tests)
- [x] Verdict engine severity mapping (unit tests)
- [x] TUI live feed with enforce mode, quarantine, and rejected events
- [x] Session trace page renders in dashboard