### PR TITLE
fix: session trace quote stripping and multi-agent display

### DIFF
--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -102,9 +102,14 @@ func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
 
 	var prevTime time.Time
 	for _, e := range entries {
+		// Strip wrapping quotes from intent (hooks handler JSON-encodes simple strings)
+		intent := e.Intent
+		if len(intent) >= 2 && intent[0] == '"' && intent[len(intent)-1] == '"' {
+			intent = intent[1 : len(intent)-1]
+		}
 		step := TraceStep{
 			ToolName:  e.ToolName,
-			ToolInput: truncateStr(e.Intent, 200),
+			ToolInput: truncateStr(intent, 200),
 			FromAgent: e.FromAgent,
 			Verdict:   e.Status,
 			Decision:  e.PolicyDecision,


### PR DESCRIPTION
## Summary
- Strip JSON wrapping quotes from tool input in session trace display
- Show FromAgent in each trace step for multi-agent conversations
- Collect all participating agents in session header
- Reverse trace order (newest first)

## Test plan
- [x] Session trace shows content without wrapping quotes
- [x] Multi-agent sessions show all participants
- [x] HUMAN/AGENT badges render correctly
- [x] Newest events appear first in timeline