### PR TITLE
feat: security posture fix and egress UI in agent detail

### DIFF
--- a/internal/auditcheck/auditcheck.go
+++ b/internal/auditcheck/auditcheck.go
@@ -72,7 +72,7 @@ func ProductInfoFor(name, configDir string) ProductInfo {
 	case "OpenClaw":
 		return ProductInfo{
 			Name:        "OpenClaw",
-			Description: "AI agent gateway — multi-channel personal assistant platform",
+			Description: "AI agent gateway  - multi-channel personal assistant platform",
 			ConfigPath:  defaultOpenClawConfigPath(),
 			DocsURL:     "https://docs.openclaw.ai/gateway/security",
 			Icon:        "\U0001f980",

--- a/internal/auditcheck/auditcheck_test.go
+++ b/internal/auditcheck/auditcheck_test.go
@@ -394,7 +394,7 @@ func TestRunChecks_SecureConfig(t *testing.T) {
 
 	for _, f := range findings {
 		assert.LessOrEqual(t, f.Severity, Info,
-			"unexpected finding: [%s] %s — %s", f.CheckID, f.Title, f.Detail)
+			"unexpected finding: [%s] %s  - %s", f.CheckID, f.Title, f.Detail)
 	}
 }
 
@@ -1022,7 +1022,7 @@ func TestAuditNanoClaw_SecureConfig(t *testing.T) {
 	findings := auditNanoClawAt(allowlistPath)
 	for _, f := range findings {
 		assert.LessOrEqual(t, f.Severity, Info,
-			"unexpected finding: [%s] %s — %s", f.CheckID, f.Title, f.Detail)
+			"unexpected finding: [%s] %s  - %s", f.CheckID, f.Title, f.Detail)
 	}
 }
 

--- a/internal/auditcheck/checks_mcp.go
+++ b/internal/auditcheck/checks_mcp.go
@@ -53,7 +53,7 @@ func auditMCPServersFromResult(result *discover.Result) []Finding {
 				if strings.Contains(cmdLower, sus) {
 					f(High, "MCP-001",
 						fmt.Sprintf("Suspicious MCP server command: %s", srv.Name),
-						fmt.Sprintf("Server %q in %s uses %q which contains %q — may indicate a malicious or misconfigured server.",
+						fmt.Sprintf("Server %q in %s uses %q which contains %q  - may indicate a malicious or misconfigured server.",
 							srv.Name, discover.ClientDisplayName(cr.Client), cmdFull, sus),
 						"Review the MCP server command and replace with a trusted binary")
 					break
@@ -63,7 +63,7 @@ func auditMCPServersFromResult(result *discover.Result) []Finding {
 			if strings.Contains(cmdFull, "|") {
 				f(High, "MCP-001",
 					fmt.Sprintf("Suspicious MCP server command: %s", srv.Name),
-					fmt.Sprintf("Server %q in %s uses a pipe in its command %q — may indicate command chaining.",
+					fmt.Sprintf("Server %q in %s uses a pipe in its command %q  - may indicate command chaining.",
 						srv.Name, discover.ClientDisplayName(cr.Client), cmdFull),
 					"Review the MCP server command and avoid piped commands")
 			}
@@ -87,7 +87,7 @@ func auditMCPServersFromResult(result *discover.Result) []Finding {
 			if srv.Command != "" && len(srv.Args) == 0 && !strings.Contains(srv.Command, " ") {
 				f(High, "MCP-004",
 					fmt.Sprintf("MCP server with bare command: %s", srv.Name),
-					fmt.Sprintf("Server %q in %s runs %q with no arguments — may be a wrapper hiding the real command.",
+					fmt.Sprintf("Server %q in %s runs %q with no arguments  - may be a wrapper hiding the real command.",
 						srv.Name, discover.ClientDisplayName(cr.Client), srv.Command),
 					fmt.Sprintf("Run 'which %s' to verify the binary path, then check it's not a wrapper: 'file %s'", srv.Command, srv.Command))
 			}
@@ -98,7 +98,7 @@ func auditMCPServersFromResult(result *discover.Result) []Finding {
 	if totalServers > 20 {
 		f(Medium, "MCP-003",
 			fmt.Sprintf("Excessive MCP server count: %d", totalServers),
-			fmt.Sprintf("Found %d MCP servers across %d clients — a large attack surface. Review and remove unused servers.",
+			fmt.Sprintf("Found %d MCP servers across %d clients  - a large attack surface. Review and remove unused servers.",
 				totalServers, result.TotalClients()),
 			"Remove unused MCP server configurations")
 	}

--- a/internal/auditcheck/checks_nanoclaw.go
+++ b/internal/auditcheck/checks_nanoclaw.go
@@ -36,7 +36,7 @@ func auditNanoClaw() []Finding {
 func auditNanoClawAt(allowlistPath string) []Finding {
 	configDir := filepath.Dir(allowlistPath)
 
-	// Check if the config directory exists at all — if not, NanoClaw is not installed
+	// Check if the config directory exists at all  - if not, NanoClaw is not installed
 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
 		return nil
 	}
@@ -58,7 +58,7 @@ func auditNanoClawAt(allowlistPath string) []Finding {
 	data, err := os.ReadFile(allowlistPath)
 	if err != nil {
 		f(High, "NC-MNT-001", "Mount allowlist missing",
-			fmt.Sprintf("NanoClaw config directory exists but %s is missing — no mount security is configured.", allowlistPath),
+			fmt.Sprintf("NanoClaw config directory exists but %s is missing  - no mount security is configured.", allowlistPath),
 			"Create mount-allowlist.json")
 		return findings
 	}
@@ -74,7 +74,7 @@ func auditNanoClawAt(allowlistPath string) []Finding {
 	// NC-MNT-002: nonMainReadOnly is false
 	if !allowlist.NonMainReadOnly {
 		f(High, "NC-MNT-002", "Non-main groups have write access",
-			"nonMainReadOnly is false — non-main groups can write to mounted paths. Set nonMainReadOnly: true.",
+			"nonMainReadOnly is false  - non-main groups can write to mounted paths. Set nonMainReadOnly: true.",
 			`Set "nonMainReadOnly": true`)
 	}
 
@@ -92,7 +92,7 @@ func auditNanoClawAt(allowlistPath string) []Finding {
 
 		if expanded == "/" || expanded == home || p == "~" || p == "$HOME" {
 			f(Critical, "NC-MNT-003", fmt.Sprintf("Dangerous mount root: %s", p),
-				fmt.Sprintf("Allowed root %q resolves to %q — agent can reach the entire directory tree. Restrict to specific subdirectories.", p, expanded),
+				fmt.Sprintf("Allowed root %q resolves to %q  - agent can reach the entire directory tree. Restrict to specific subdirectories.", p, expanded),
 				"Replace root path with specific subdirectory")
 		}
 	}
@@ -100,7 +100,7 @@ func auditNanoClawAt(allowlistPath string) []Finding {
 	// NC-MNT-004: No custom blocked patterns
 	if len(allowlist.BlockedPatterns) == 0 {
 		f(Medium, "NC-MNT-004", "No blocked patterns configured",
-			"blockedPatterns is empty — no file patterns are blocked from agent access. Add patterns like \"*.env\", \".ssh/*\".",
+			"blockedPatterns is empty  - no file patterns are blocked from agent access. Add patterns like \"*.env\", \".ssh/*\".",
 			`Add "blockedPatterns": ["*.env", ".ssh/*"]`)
 	}
 
@@ -109,7 +109,7 @@ func auditNanoClawAt(allowlistPath string) []Finding {
 		mode := info.Mode().Perm()
 		if mode&0o077 != 0 {
 			f(High, "NC-SEC-001", "Allowlist file has loose permissions",
-				fmt.Sprintf("%s has mode %04o — group/world accessible (tamper risk). Run: chmod 600 %s", allowlistPath, mode, allowlistPath),
+				fmt.Sprintf("%s has mode %04o  - group/world accessible (tamper risk). Run: chmod 600 %s", allowlistPath, mode, allowlistPath),
 				fmt.Sprintf("chmod 600 %s", allowlistPath))
 		}
 	}

--- a/internal/auditcheck/checks_openclaw.go
+++ b/internal/auditcheck/checks_openclaw.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oktsec/oktsec/internal/discover"
 )
 
-// OpenClaw configuration structs — subset of fields needed for security auditing.
+// OpenClaw configuration structs  - subset of fields needed for security auditing.
 // Based on https://docs.openclaw.ai/gateway/security
 type ocConfig struct {
 	Gateway   ocGateway            `json:"gateway"`
@@ -141,7 +141,7 @@ func auditOpenClaw() []Finding {
 func auditOpenClawAt(configPath string) []Finding {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		// Not installed — not an error, just skip
+		// Not installed  - not an error, just skip
 		return nil
 	}
 
@@ -167,11 +167,11 @@ func auditOpenClawAt(configPath string) []Finding {
 
 	// ── Critical ──────────────────────────────────────────────
 
-	// OC-NET-001: Gateway bind is not loopback — exposed to network
+	// OC-NET-001: Gateway bind is not loopback  - exposed to network
 	bind := strings.ToLower(cfg.Gateway.Bind)
 	if bind != "" && bind != "loopback" && bind != "localhost" && bind != "127.0.0.1" && bind != "::1" {
 		f(Critical, "OC-NET-001", "Gateway exposed to network",
-			fmt.Sprintf("gateway.bind is %q — the gateway accepts connections beyond localhost. "+
+			fmt.Sprintf("gateway.bind is %q  - the gateway accepts connections beyond localhost. "+
 				"Docs recommend loopback-only. Use SSH tunnels or Tailscale for remote access.", cfg.Gateway.Bind),
 			`Set gateway.bind: "loopback"`)
 	}
@@ -181,7 +181,7 @@ func auditOpenClawAt(configPath string) []Finding {
 		// Only flag if gateway is not loopback-only (remote exposure + no auth = critical)
 		if bind != "" && bind != "loopback" && bind != "localhost" && bind != "127.0.0.1" {
 			f(Critical, "OC-AUTH-001", "No gateway authentication token",
-				"gateway.auth.token is empty or placeholder while gateway is network-exposed — "+
+				"gateway.auth.token is empty or placeholder while gateway is network-exposed  - "+
 					"anyone on the network can control the gateway.",
 				`Set gateway.auth.token to a long random value`)
 		} else if cfg.Gateway.Auth.Token == "" && cfg.Gateway.Auth.Mode == "token" {
@@ -191,10 +191,10 @@ func auditOpenClawAt(configPath string) []Finding {
 		}
 	}
 
-	// OC-EXEC-001: Exec security set to "allow" — arbitrary code execution
+	// OC-EXEC-001: Exec security set to "allow"  - arbitrary code execution
 	if strings.ToLower(cfg.Tools.Exec.Security) == "allow" {
 		f(Critical, "OC-EXEC-001", "Command execution auto-approved",
-			"tools.exec.security is \"allow\" — agents can execute arbitrary shell commands "+
+			"tools.exec.security is \"allow\"  - agents can execute arbitrary shell commands "+
 				"without human approval. This is the highest-risk tool setting.",
 			`Set tools.exec.security: "deny" or "ask"`)
 	}
@@ -202,7 +202,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-TOOL-001: Full tool profile without deny list
 	if cfg.Tools.Profile == "full" && len(cfg.Tools.Deny) == 0 {
 		f(Critical, "OC-TOOL-001", "Full tool profile without deny list",
-			"tools.profile is \"full\" with no deny list — agents have unrestricted access "+
+			"tools.profile is \"full\" with no deny list  - agents have unrestricted access "+
 				"to all tools including filesystem, exec, and automation.",
 			`Set tools.profile: "messaging" or add deny list`)
 	}
@@ -213,7 +213,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	for ch, chCfg := range cfg.Channels {
 		if strings.ToLower(chCfg.DMPolicy) == "open" {
 			f(High, "OC-DM-001", fmt.Sprintf("Open DM policy on %s channel", ch),
-				fmt.Sprintf("channels.%s.dmPolicy is \"open\" — any external user can send messages "+
+				fmt.Sprintf("channels.%s.dmPolicy is \"open\"  - any external user can send messages "+
 					"to agents. This is a prompt injection vector.", ch),
 				fmt.Sprintf(`Set channels.%s.dmPolicy: "pairing" or "allowlist"`, ch))
 		}
@@ -231,7 +231,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	sandboxMode := strings.ToLower(cfg.Agents.Defaults.Sandbox.Mode)
 	if (sandboxMode == "" || sandboxMode == "off") && !execDenied && cfg.Tools.Exec.Security != "deny" {
 		f(High, "OC-SAND-001", "Sandbox disabled with exec tools available",
-			"agents.defaults.sandbox.mode is \"off\" and exec tools are not denied — "+
+			"agents.defaults.sandbox.mode is \"off\" and exec tools are not denied  - "+
 				"agents run commands directly on the host without isolation.",
 			`Set agents.defaults.sandbox.mode: "all"`)
 	}
@@ -239,7 +239,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-ELEV-001: Elevated execution enabled without sender allowlist
 	if cfg.Tools.Elevated.Enabled && len(cfg.Tools.Elevated.AllowFrom) == 0 {
 		f(High, "OC-ELEV-001", "Elevated execution without allowFrom",
-			"tools.elevated.enabled is true with no allowFrom list — any message sender "+
+			"tools.elevated.enabled is true with no allowFrom list  - any message sender "+
 				"can trigger elevated (sudo-level) command execution.",
 			`Disable tools.elevated or add allowFrom list`)
 	}
@@ -247,7 +247,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-UI-001: Device authentication disabled on control UI
 	if cfg.Gateway.ControlUI.DangerouslyDisableDeviceAuth {
 		f(High, "OC-UI-001", "Device authentication disabled",
-			"gateway.controlUi.dangerouslyDisableDeviceAuth is true — the web control UI "+
+			"gateway.controlUi.dangerouslyDisableDeviceAuth is true  - the web control UI "+
 				"can be accessed without device verification.",
 			`Set gateway.controlUi.dangerouslyDisableDeviceAuth: false`)
 	}
@@ -255,7 +255,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-UI-002: Insecure auth allowed on control UI
 	if cfg.Gateway.ControlUI.AllowInsecureAuth {
 		f(High, "OC-UI-002", "Insecure authentication allowed",
-			"gateway.controlUi.allowInsecureAuth is true — authentication can be performed "+
+			"gateway.controlUi.allowInsecureAuth is true  - authentication can be performed "+
 				"over unencrypted connections, exposing credentials.",
 			`Set gateway.controlUi.allowInsecureAuth: false`)
 	}
@@ -263,7 +263,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-HOOK-001: Webhook token too short or empty
 	if cfg.Hooks.Token != "" && len(cfg.Hooks.Token) < 32 {
 		f(High, "OC-HOOK-001", "Webhook token too short",
-			fmt.Sprintf("hooks.token is only %d characters — minimum recommended is 32 for "+
+			fmt.Sprintf("hooks.token is only %d characters  - minimum recommended is 32 for "+
 				"webhook authentication security.", len(cfg.Hooks.Token)),
 			`Set hooks.token to at least 32 random characters`)
 	}
@@ -274,7 +274,7 @@ func auditOpenClawAt(configPath string) []Finding {
 		mode := info.Mode().Perm()
 		if mode&0o077 != 0 {
 			f(High, "OC-PERM-001", "OpenClaw directory has loose permissions",
-				fmt.Sprintf("%s has mode %04o — group/world accessible. "+
+				fmt.Sprintf("%s has mode %04o  - group/world accessible. "+
 					"Config files may contain auth tokens.", dir, mode),
 				fmt.Sprintf("chmod 700 %s", dir))
 		}
@@ -285,7 +285,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-FS-001: Workspace-only filesystem disabled
 	if cfg.Tools.FS.WorkspaceOnly != nil && !*cfg.Tools.FS.WorkspaceOnly {
 		f(Medium, "OC-FS-001", "Filesystem access not restricted to workspace",
-			"tools.fs.workspaceOnly is false — agents can read and write files "+
+			"tools.fs.workspaceOnly is false  - agents can read and write files "+
 				"outside the workspace directory.",
 			`Set tools.fs.workspaceOnly: true`)
 	}
@@ -293,7 +293,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-LOG-001: Sensitive data redaction disabled
 	if strings.ToLower(cfg.Logging.RedactSensitive) == "off" {
 		f(Medium, "OC-LOG-001", "Sensitive data redaction disabled",
-			"logging.redactSensitive is \"off\" — tool inputs/outputs containing "+
+			"logging.redactSensitive is \"off\"  - tool inputs/outputs containing "+
 				"secrets or PII are written to logs in plaintext.",
 			`Set logging.redactSensitive: "tools" or "all"`)
 	}
@@ -301,7 +301,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-DISC-001: mDNS broadcasting full system info
 	if strings.ToLower(cfg.Discovery.MDNS.Mode) == "full" {
 		f(Medium, "OC-DISC-001", "mDNS broadcasting full system info",
-			"discovery.mdns.mode is \"full\" — the gateway broadcasts CLI path and SSH port "+
+			"discovery.mdns.mode is \"full\"  - the gateway broadcasts CLI path and SSH port "+
 				"to the local network via mDNS.",
 			`Set discovery.mdns.mode: "minimal" or "off"`)
 	}
@@ -309,7 +309,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	// OC-HOOK-002: External session key selection allowed
 	if cfg.Hooks.AllowRequestSessionKey {
 		f(Medium, "OC-HOOK-002", "External session key selection allowed",
-			"hooks.allowRequestSessionKey is true — external webhook callers can choose "+
+			"hooks.allowRequestSessionKey is true  - external webhook callers can choose "+
 				"which session receives their message, potentially hijacking sessions.",
 			`Set hooks.allowRequestSessionKey: false`)
 	}
@@ -318,7 +318,7 @@ func auditOpenClawAt(configPath string) []Finding {
 	if cfg.Tools.Browser.SSRFPolicy.DangerouslyAllowPrivateNetwork != nil &&
 		*cfg.Tools.Browser.SSRFPolicy.DangerouslyAllowPrivateNetwork {
 		f(Medium, "OC-SSRF-001", "Browser allows private network requests",
-			"tools.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork is true — "+
+			"tools.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork is true  - "+
 				"agents can make HTTP requests to internal/private network addresses.",
 			`Set tools.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: false`)
 	}
@@ -328,7 +328,7 @@ func auditOpenClawAt(configPath string) []Finding {
 		mode := info.Mode().Perm()
 		if mode&0o077 != 0 {
 			f(Medium, "OC-PERM-002", "OpenClaw config has loose permissions",
-				fmt.Sprintf("%s has mode %04o — group/world readable. "+
+				fmt.Sprintf("%s has mode %04o  - group/world readable. "+
 					"File may contain auth tokens and credentials.", configPath, mode),
 				fmt.Sprintf("chmod 600 %s", configPath))
 		}

--- a/internal/auditcheck/sarif.go
+++ b/internal/auditcheck/sarif.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 )
 
-// SARIF v2.1.0 types — minimal subset for audit output.
+// SARIF v2.1.0 types  - minimal subset for audit output.
 
 // SARIFLog is the top-level SARIF v2.1.0 report.
 type SARIFLog struct {
@@ -105,7 +105,7 @@ func BuildSARIF(findings []Finding, toolVersion string) SARIFLog {
 	for _, f := range findings {
 		msg := f.Title
 		if f.Detail != "" {
-			msg += " — " + f.Detail
+			msg += "  - " + f.Detail
 		}
 		results = append(results, SARIFResult{
 			RuleID:  f.CheckID,

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -932,8 +932,9 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 		"AgentRisk":    agentRiskData,
 		"LLMHistory":   llmHistory,
 		"LLMEnabled":   s.cfg.LLM.Enabled,
-		"CommPartners": commPartners,
-		"Presets":      presetsList(),
+		"CommPartners":   commPartners,
+		"Presets":        presetsList(),
+		"AgentSessions":  agentSessions(s.audit, name),
 	}
 
 	s.renderTemplate(w, agentDetailTmpl, data)
@@ -1790,6 +1791,24 @@ func humanReadableDecision(decision string) string {
 		return label
 	}
 	return decision
+}
+
+// agentSessions returns recent sessions involving this agent.
+func agentSessions(store audit.AuditStore, agentName string) []audit.SessionSummary {
+	all, err := store.QuerySessions("", 100)
+	if err != nil {
+		return nil
+	}
+	var result []audit.SessionSummary
+	for _, s := range all {
+		if strings.Contains(s.Agents, agentName) {
+			result = append(result, s)
+			if len(result) >= 10 {
+				break
+			}
+		}
+	}
+	return result
 }
 
 type presetInfo struct {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -933,6 +933,7 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 		"LLMHistory":   llmHistory,
 		"LLMEnabled":   s.cfg.LLM.Enabled,
 		"CommPartners": commPartners,
+		"Presets":      presetsList(),
 	}
 
 	s.renderTemplate(w, agentDetailTmpl, data)
@@ -1789,6 +1790,20 @@ func humanReadableDecision(decision string) string {
 		return label
 	}
 	return decision
+}
+
+type presetInfo struct {
+	Name        string
+	Description string
+}
+
+func presetsList() []presetInfo {
+	var list []presetInfo
+	for key, p := range config.IntegrationPresets {
+		list = append(list, presetInfo{Name: key, Description: p.Description})
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+	return list
 }
 
 // simpleMarkdownToHTML converts basic markdown (bold, headers, lists, code)

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2391,6 +2391,65 @@ func (s *Server) handleEditAgent(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/dashboard/agents/"+name, http.StatusFound)
 }
 
+func (s *Server) handleSaveEgress(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agent, ok := s.cfg.Agents[name]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	if agent.Egress == nil {
+		agent.Egress = &config.EgressPolicy{}
+	}
+
+	// Parse integrations (checkboxes)
+	r.ParseForm()
+	agent.Egress.Integrations = r.Form["integrations"]
+
+	// Parse allowed domains (space/comma separated)
+	if v := strings.TrimSpace(r.FormValue("allowed_domains")); v != "" {
+		agent.Egress.AllowedDomains = strings.Fields(strings.ReplaceAll(v, ",", " "))
+	} else {
+		agent.Egress.AllowedDomains = nil
+	}
+
+	// Parse blocked domains
+	if v := strings.TrimSpace(r.FormValue("blocked_domains")); v != "" {
+		agent.Egress.BlockedDomains = strings.Fields(strings.ReplaceAll(v, ",", " "))
+	} else {
+		agent.Egress.BlockedDomains = nil
+	}
+
+	// Parse tool restrictions: tool_name -> domains
+	toolNames := strings.Fields(strings.ReplaceAll(r.FormValue("tool_restriction_tools"), ",", " "))
+	if len(toolNames) > 0 {
+		if agent.Egress.ToolRestrictions == nil {
+			agent.Egress.ToolRestrictions = make(map[string][]string)
+		}
+		for _, t := range toolNames {
+			domains := strings.Fields(strings.ReplaceAll(r.FormValue("tr_"+t), ",", " "))
+			agent.Egress.ToolRestrictions[t] = domains
+		}
+	}
+
+	// Clean up empty egress
+	if len(agent.Egress.AllowedDomains) == 0 && len(agent.Egress.BlockedDomains) == 0 &&
+		len(agent.Egress.Integrations) == 0 && len(agent.Egress.ToolRestrictions) == 0 {
+		agent.Egress = nil
+	}
+
+	s.cfg.Agents[name] = agent
+
+	if s.cfgPath != "" {
+		if err := s.saveConfig(); err != nil {
+			s.logger.Error("failed to save egress config", "error", err)
+		}
+	}
+
+	http.Redirect(w, r, "/dashboard/agents/"+name+"#egress", http.StatusFound)
+}
+
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, ok := s.cfg.Agents[name]; !ok {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -349,7 +349,7 @@ func (s *Server) handleAuditSandbox(w http.ResponseWriter, r *http.Request) {
 	productInfos := map[string]auditcheck.ProductInfo{
 		"OpenClaw": {
 			Name:        "OpenClaw",
-			Description: "AI agent gateway — multi-channel personal assistant platform",
+			Description: "AI agent gateway, multi-channel personal assistant platform",
 			ConfigPath:  "~/.openclaw/openclaw.json",
 			DocsURL:     "https://docs.openclaw.ai/gateway/security",
 			Icon:        "\U0001f980",

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -349,6 +349,7 @@ func (s *Server) routes() {
 	// Agent CRUD
 	s.mux.HandleFunc("POST /dashboard/agents", s.handleCreateAgent)
 	s.mux.HandleFunc("POST /dashboard/agents/{name}/edit", s.handleEditAgent)
+	s.mux.HandleFunc("POST /dashboard/agents/{name}/egress", s.handleSaveEgress)
 	s.mux.HandleFunc("DELETE /dashboard/agents/{name}", s.handleDeleteAgent)
 	s.mux.HandleFunc("POST /dashboard/agents/{name}/keygen", s.handleAgentKeygen)
 	s.mux.HandleFunc("POST /dashboard/agents/{name}/suspend", s.handleSuspendToggle)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -813,7 +813,7 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
 var overviewTmpl = template.Must(template.New("overview").Funcs(tmplFuncs).Parse(layoutHead + `
 <style>
 .hero-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--border);border:1px solid var(--border);border-radius:var(--radius-xl);overflow:hidden;margin-bottom:var(--sp-6)}
-.hero-stat{background:var(--surface2);padding:var(--sp-6) var(--sp-5);text-align:center;transition:background var(--ease-smooth);position:relative}
+.hero-stat{background:var(--surface2);padding:var(--sp-6) var(--sp-5);text-align:center;transition:background var(--ease-smooth);position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center}
 .hero-stat::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--accent-dim),var(--accent-light));opacity:0;transition:opacity var(--ease-smooth)}
 .hero-stat:hover{background:var(--surface2)}
 .hero-stat:hover::before{opacity:1}

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1332,6 +1332,7 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
   </form>
 </div>
 
+<div style="display:grid;grid-template-columns:{{if .DiscoveredAgents}}1fr 280px{{else}}1fr{{end}};gap:20px;align-items:start">
 {{if .AgentRows}}
 <div class="ag-grid">
   {{range .AgentRows}}
@@ -1358,27 +1359,21 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
 {{end}}
 
 {{if .DiscoveredAgents}}
-<div class="card" style="margin-top:20px">
-  <h2 style="color:var(--warn)">Discovered from Traffic <span style="font-size:var(--text-xs);font-weight:400;color:var(--text3);margin-left:var(--sp-2)">{{len .DiscoveredAgents}} unregistered</span></h2>
-  <p class="desc">These identifiers appeared as message destinations but aren't registered agents. Register to enforce identity and ACL policies.</p>
-  <table>
-    <thead><tr><th>Identifier</th><th></th></tr></thead>
-    <tbody>
+  <div class="card" style="padding:18px 20px">
+    <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--warn);font-weight:600;margin-bottom:8px">Discovered from Traffic <span style="color:var(--text3);font-weight:400">{{len .DiscoveredAgents}}</span></div>
+    <p style="font-size:0.72rem;color:var(--text3);margin:0 0 12px;line-height:1.4">Identifiers seen in traffic but not registered.</p>
     {{range .DiscoveredAgents}}
-    <tr>
-      <td>{{agentCell .}}</td>
-      <td>
-        <form method="POST" action="/dashboard/agents" style="display:inline">
-          <input type="hidden" name="name" value="{{.}}">
-          <button type="submit" class="btn btn-sm">Register</button>
-        </form>
-      </td>
-    </tr>
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-top:1px solid var(--border)">
+      <span style="display:flex;align-items:center;gap:8px">{{agentCell .}}</span>
+      <form method="POST" action="/dashboard/agents" style="display:inline">
+        <input type="hidden" name="name" value="{{.}}">
+        <button type="submit" class="btn btn-sm" style="font-size:0.68rem;padding:3px 10px">Register</button>
+      </form>
+    </div>
     {{end}}
-    </tbody>
-  </table>
-</div>
+  </div>
 {{end}}
+</div>
 ` + layoutFoot))
 
 var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs).Parse(layoutHead + `

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -92,7 +92,15 @@ var tmplFuncs = template.FuncMap{
 		}
 		return template.HTML(fmt.Sprintf(`<span style="display:inline-flex;align-items:center;gap:5px"><span style="width:6px;height:6px;border-radius:50%%;background:%s;flex-shrink:0"></span>%s</span>`, c, template.HTMLEscapeString(toolName)))
 	},
-	"hasRules": func(s string) bool { return s != "" && s != "[]" && s != "null" },
+	"hasRules":    func(s string) bool { return s != "" && s != "[]" && s != "null" },
+	"listContains": func(list []string, s string) bool {
+		for _, v := range list {
+			if v == s {
+				return true
+			}
+		}
+		return false
+	},
 	"fmtDate": func(ts string) string {
 		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
 			return t.Local().Format("Jan 02 15:04")
@@ -1789,72 +1797,90 @@ function stagePolicy() {
     <div class="ad-slbl">Egress Policy</div>
     <p class="desc">Control which domains this agent can access and restrict egress per tool.</p>
 
-    {{if .Agent.Egress}}
-    {{if .Agent.Egress.Integrations}}
-    <div style="margin-bottom:16px">
-      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Integration Presets</div>
-      <div style="display:flex;gap:6px;flex-wrap:wrap">
-        {{range .Agent.Egress.Integrations}}<span style="padding:3px 10px;background:rgba(99,102,241,0.1);color:var(--accent-light);border-radius:4px;font-size:0.75rem;font-weight:500">{{.}}</span>{{end}}
-      </div>
-    </div>
-    {{end}}
+    <form method="POST" action="/dashboard/agents/{{.Name}}/egress">
 
-    {{if .Agent.Egress.AllowedDomains}}
-    <div style="margin-bottom:16px">
-      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Allowed Domains</div>
-      <div style="display:flex;gap:4px;flex-wrap:wrap">
-        {{range .Agent.Egress.AllowedDomains}}<code style="padding:2px 8px;background:var(--surface2);border-radius:3px;font-size:0.75rem">{{.}}</code>{{end}}
-      </div>
-    </div>
-    {{end}}
-
-    {{if .Agent.Egress.BlockedDomains}}
-    <div style="margin-bottom:16px">
-      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Blocked Domains</div>
-      <div style="display:flex;gap:4px;flex-wrap:wrap">
-        {{range .Agent.Egress.BlockedDomains}}<code style="padding:2px 8px;background:rgba(248,81,73,0.08);color:var(--danger);border-radius:3px;font-size:0.75rem">{{.}}</code>{{end}}
-      </div>
-    </div>
-    {{end}}
-
-    {{if .Agent.Egress.ToolRestrictions}}
-    <div style="margin-bottom:16px">
-      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Per-Tool Restrictions</div>
-      <table>
-        <thead><tr><th>Tool</th><th>Allowed Domains</th></tr></thead>
-        <tbody>
-        {{range $tool, $domains := .Agent.Egress.ToolRestrictions}}
-        <tr>
-          <td style="font-weight:600;font-family:var(--mono);font-size:0.82rem">{{$tool}}</td>
-          <td>
-            {{if $domains}}
-            <div style="display:flex;gap:4px;flex-wrap:wrap">
-              {{range $domains}}<code style="padding:1px 6px;background:var(--surface2);border-radius:3px;font-size:0.72rem">{{.}}</code>{{end}}
-            </div>
-            {{else}}
-            <span style="color:var(--danger);font-size:0.75rem">No egress allowed</span>
-            {{end}}
-          </td>
-        </tr>
+    <!-- Integration Presets -->
+    <div style="margin-bottom:20px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:10px">Integration Presets</div>
+      <div style="display:flex;gap:8px;flex-wrap:wrap">
+        {{range .Presets}}
+        <label style="display:flex;align-items:center;gap:5px;padding:5px 12px;background:var(--surface2);border-radius:6px;cursor:pointer;font-size:0.78rem;color:var(--text2);transition:all 0.1s" title="{{.Description}}">
+          <input type="checkbox" name="integrations" value="{{.Name}}" {{if $.Agent.Egress}}{{if listContains $.Agent.Egress.Integrations .Name}}checked{{end}}{{end}} style="accent-color:var(--accent)">
+          {{.Name}}
+        </label>
         {{end}}
-        </tbody>
-      </table>
-    </div>
-    {{end}}
-
-    {{else}}
-    <div class="empty">No egress policy configured. This agent can access any domain.<br><span style="font-size:0.75rem;color:var(--text3)">Add an egress policy in oktsec.yaml to restrict outbound access.</span></div>
-    {{end}}
-
-    <div style="border-top:1px solid var(--border);padding-top:16px;margin-top:16px">
-      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Available Integration Presets</div>
-      <div style="display:flex;gap:4px;flex-wrap:wrap">
-        {{range .Presets}}<span style="padding:2px 8px;background:var(--surface2);border-radius:3px;font-size:0.72rem;color:var(--text3)" title="{{.Description}}">{{.Name}}</span>{{end}}
       </div>
-      <p style="font-size:0.72rem;color:var(--text3);margin-top:8px">Add presets in oktsec.yaml: <code style="font-size:0.72rem">egress: { integrations: ["slack", "github"] }</code></p>
     </div>
+
+    <!-- Allowed Domains -->
+    <div style="margin-bottom:16px">
+      <div class="form-group">
+        <label style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3)">Allowed Domains (space or comma separated)</label>
+        <input type="text" name="allowed_domains" value="{{if .Agent.Egress}}{{range $i, $d := .Agent.Egress.AllowedDomains}}{{if $i}} {{end}}{{$d}}{{end}}{{end}}" placeholder="api.github.com api.slack.com">
+      </div>
+    </div>
+
+    <!-- Blocked Domains -->
+    <div style="margin-bottom:16px">
+      <div class="form-group">
+        <label style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3)">Blocked Domains (space or comma separated)</label>
+        <input type="text" name="blocked_domains" value="{{if .Agent.Egress}}{{range $i, $d := .Agent.Egress.BlockedDomains}}{{if $i}} {{end}}{{$d}}{{end}}{{end}}" placeholder="evil.com malicious.io">
+      </div>
+    </div>
+
+    <!-- Per-Tool Restrictions -->
+    <div style="margin-bottom:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:10px">Per-Tool Restrictions</div>
+      {{if .Agent.Egress}}{{if .Agent.Egress.ToolRestrictions}}
+      {{range $tool, $domains := .Agent.Egress.ToolRestrictions}}
+      <div class="form-row" style="margin-bottom:8px;align-items:center">
+        <div style="min-width:120px;font-family:var(--mono);font-size:0.82rem;font-weight:600">{{$tool}}</div>
+        <div class="form-group" style="flex:1;margin-bottom:0">
+          <input type="text" name="tr_{{$tool}}" value="{{range $i, $d := $domains}}{{if $i}} {{end}}{{$d}}{{end}}" placeholder="Domains (empty = block all egress)">
+        </div>
+      </div>
+      {{end}}
+      {{end}}{{end}}
+      <div class="form-row" style="align-items:flex-end;margin-top:8px">
+        <div class="form-group" style="flex:1">
+          <label style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3)">Tool Name</label>
+          <input type="text" id="eg-new-tool" placeholder="e.g. Bash, WebFetch">
+        </div>
+        <div class="form-group" style="flex:2">
+          <label style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3)">Allowed Domains (empty = block all egress for tool)</label>
+          <input type="text" id="eg-new-domains" placeholder="api.github.com arxiv.org">
+        </div>
+        <button type="button" class="btn btn-sm" style="background:var(--surface2);color:var(--text2);margin-bottom:12px" onclick="addToolRestriction()">Add</button>
+      </div>
+      <input type="hidden" name="tool_restriction_tools" id="eg-tr-tools" value="{{if .Agent.Egress}}{{if .Agent.Egress.ToolRestrictions}}{{range $tool, $_ := .Agent.Egress.ToolRestrictions}}{{$tool}} {{end}}{{end}}{{end}}">
+    </div>
+
+    <button type="submit" class="btn btn-sm" style="background:var(--success)">Save Egress Policy</button>
+    </form>
   </div>
 </div>
+<script>
+function addToolRestriction() {
+  var tool = document.getElementById('eg-new-tool').value.trim();
+  if (!tool) return;
+  var domains = document.getElementById('eg-new-domains').value.trim();
+  var form = document.getElementById('eg-new-tool').closest('form');
+  var existing = form.querySelector('[name="tr_' + tool + '"]');
+  if (!existing) {
+    var row = document.createElement('div');
+    row.className = 'form-row';
+    row.style.marginBottom = '8px';
+    row.style.alignItems = 'center';
+    row.innerHTML = '<div style="min-width:120px;font-family:var(--mono);font-size:0.82rem;font-weight:600">' + tool + '</div><div class="form-group" style="flex:1;margin-bottom:0"><input type="text" name="tr_' + tool + '" value="' + domains + '" placeholder="Domains"></div>';
+    document.getElementById('eg-new-tool').closest('.form-row').before(row);
+  }
+  var toolsInput = document.getElementById('eg-tr-tools');
+  var tools = toolsInput.value.trim().split(/\s+/).filter(Boolean);
+  if (tools.indexOf(tool) === -1) tools.push(tool);
+  toolsInput.value = tools.join(' ');
+  document.getElementById('eg-new-tool').value = '';
+  document.getElementById('eg-new-domains').value = '';
+}</script>
 
 ` + layoutFoot))
 

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1517,108 +1517,8 @@ function adTab(name){
 
 <!-- Overview Tab -->
 <div id="ad-overview" class="ad-panel active">
-  <!-- Top Triggered Rules (full width) -->
-  <div class="card" style="padding:18px 20px">
-    <div class="ad-slbl">Top triggered rules (24h) {{if .TopRules}}<a href="/dashboard/rules" style="margin-left:auto;font-size:0.68rem;color:var(--accent-light);text-decoration:none;font-weight:400;text-transform:none;letter-spacing:0">View all &rarr;</a>{{end}}</div>
-    {{if .TopRules}}
-    <div style="display:flex;gap:var(--sp-4);flex-wrap:wrap">
-    {{range .TopRules}}
-    <div class="ad-rule" style="padding-left:8px;flex:1;min-width:200px">
-      <div class="ad-rule-bar" style="width:{{if $.TopRules}}{{printf "%.0f" (mulf (divf .Count (index $.TopRules 0).Count) 100)}}%{{else}}0%{{end}};background:{{if eq .Severity "critical"}}#f85149{{else if eq .Severity "high"}}#fb923c{{else}}var(--text3){{end}}"></div>
-      <div style="flex:1;min-width:0;position:relative">
-        <div style="font-size:0.82rem;font-weight:500;color:var(--text)">{{.Name}}</div>
-        <div style="display:flex;align-items:center;gap:6px;margin-top:2px">
-          <span style="font-family:var(--mono);font-size:0.68rem;color:var(--text3)">{{.RuleID}}</span>
-          {{if eq .Severity "critical"}}<span class="sev-critical">critical</span>
-          {{else if eq .Severity "high"}}<span class="sev-high">high</span>
-          {{else if eq .Severity "medium"}}<span class="sev-medium">medium</span>
-          {{else}}<span class="sev-low">low</span>{{end}}
-        </div>
-      </div>
-      <span style="font-family:var(--mono);font-weight:700;font-size:1.05rem;color:var(--text);flex-shrink:0">{{.Count}}</span>
-    </div>
-    {{end}}
-    </div>
-    {{else}}
-    <div class="empty" style="padding:20px 0">No rules triggered for this agent.</div>
-    {{end}}
-  </div>
 
-  <!-- LLM Threat Intelligence (full width, only if data exists) -->
-  {{if and .LLMEnabled .LLMHistory}}
-  <div class="card" style="padding:0;overflow:hidden;margin-bottom:var(--sp-5)">
-    <div style="display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid var(--border)">
-      <div class="ad-slbl" style="margin-bottom:0">LLM Threat Intelligence</div>
-      <a href="/dashboard/llm" style="font-size:0.72rem;color:var(--accent-light);text-decoration:none;font-weight:500">View all &rarr;</a>
-    </div>
-    {{if gt .AgentRisk.LLMThreatCount 0}}
-    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:1px;background:var(--border);border-bottom:1px solid var(--border)">
-      <div style="background:var(--surface);padding:14px 20px;text-align:center">
-        <div style="font-size:1.2rem;font-weight:700;font-family:var(--mono);color:{{if gt .AgentRisk.LLMThreatCount 3}}var(--danger){{else}}var(--text){{end}}">{{.AgentRisk.LLMThreatCount}}</div>
-        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-top:2px">Threats</div>
-      </div>
-      <div style="background:var(--surface);padding:14px 20px;text-align:center">
-        <div style="font-size:1.2rem;font-weight:700;font-family:var(--mono);color:{{if gt .AgentRisk.LLMConfirmed 0}}var(--danger){{else}}var(--success){{end}}">{{.AgentRisk.LLMConfirmed}}</div>
-        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-top:2px">Confirmed</div>
-      </div>
-      <div style="background:var(--surface);padding:14px 20px;text-align:center">
-        <div style="font-size:1.2rem;font-weight:700;font-family:var(--mono);color:{{if gt .AgentRisk.LLMAvgRisk 60.0}}var(--danger){{else if gt .AgentRisk.LLMAvgRisk 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .AgentRisk.LLMAvgRisk}}</div>
-        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-top:2px">Avg Risk</div>
-      </div>
-    </div>
-    {{end}}
-    <div style="overflow-x:auto">
-    <table style="font-size:0.82rem;width:100%;border-collapse:collapse;table-layout:fixed">
-      <colgroup><col style="width:25%"><col style="width:15%"><col style="width:20%"><col style="width:20%"><col style="width:20%"></colgroup>
-      <thead><tr>
-        <th style="text-align:left;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Time</th>
-        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Risk</th>
-        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Action</th>
-        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Status</th>
-        <th style="text-align:right;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)"></th>
-      </tr></thead>
-      <tbody>
-      {{range .LLMHistory}}
-      <tr class="clickable" onclick="window.location='/dashboard/llm/case/{{.ID}}'" style="transition:background 0.1s">
-        <td style="padding:10px 20px;border-bottom:1px solid var(--border)" data-ts="{{.Timestamp}}">{{.Timestamp}}</td>
-        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border);font-family:var(--mono);font-weight:600;color:{{if gt .RiskScore 60.0}}var(--danger){{else if gt .RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .RiskScore}}</td>
-        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border)">{{if eq .RecommendedAction "block"}}<span class="badge-blocked">block</span>{{else if eq .RecommendedAction "investigate"}}<span class="badge-quarantined">investigate</span>{{else}}<span class="badge-delivered">none</span>{{end}}</td>
-        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border)">{{if eq .ReviewedStatus "confirmed"}}<span style="color:var(--danger);font-weight:600">confirmed</span>{{else if eq .ReviewedStatus "false_positive"}}<span style="color:var(--text3)">dismissed</span>{{else}}<span style="color:var(--warn)">pending</span>{{end}}</td>
-        <td style="text-align:right;padding:10px 20px;border-bottom:1px solid var(--border);font-size:0.72rem;color:var(--text3)">view &rarr;</td>
-      </tr>
-      {{end}}
-      </tbody>
-    </table>
-    </div>
-  </div>
-  {{end}}
-
-  <div class="ad-grid">
-    <!-- Communication Partners -->
-    <div class="card" style="padding:18px 20px">
-      <div class="ad-slbl">Communication partners (24h)</div>
-      {{if .CommPartners}}
-      <table style="font-size:0.78rem">
-        <thead><tr><th class="section-label">Partner</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Total</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Blocked</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Rate</th></tr></thead>
-        <tbody>
-        {{range .CommPartners}}
-        <tr style="{{if eq .Total 0}}opacity:0.4{{end}}">
-          <td>{{toolDot .To}}</td>
-          <td style="text-align:right;font-family:var(--mono)">{{.Total}}</td>
-          <td style="text-align:right;font-family:var(--mono);color:{{if .Blocked}}var(--danger){{else}}var(--success){{end}}">{{.Blocked}}</td>
-          <td style="text-align:right;font-family:var(--mono)">{{if .Total}}{{printf "%.0f" (divf (mulf .Blocked 100) .Total)}}%{{else}}0%{{end}}</td>
-        </tr>
-        {{end}}
-        </tbody>
-      </table>
-      {{else}}
-      <div class="empty" style="padding:20px 0">No communication partners.</div>
-      {{end}}
-    </div>
-
-  </div>
-
-  <!-- Sessions + Recent Messages side by side -->
+  <!-- Row 1: Sessions + Recent Messages -->
   <div class="ad-grid">
     {{if .AgentSessions}}
     <div class="card" style="padding:18px 20px">
@@ -1689,6 +1589,83 @@ function adTab(name){
       {{end}}
     </div>
   </div>
+
+  <!-- Row 2: Top Triggered Rules + Communication Partners -->
+  <div class="ad-grid">
+    <div class="card" style="padding:18px 20px">
+      <div class="ad-slbl">Top triggered rules (24h) {{if .TopRules}}<a href="/dashboard/rules" style="margin-left:auto;font-size:0.68rem;color:var(--accent-light);text-decoration:none;font-weight:400;text-transform:none;letter-spacing:0">View all &rarr;</a>{{end}}</div>
+      {{if .TopRules}}
+      <div style="display:flex;gap:var(--sp-4);flex-wrap:wrap">
+      {{range .TopRules}}
+      <div class="ad-rule" style="padding-left:8px;flex:1;min-width:200px">
+        <div class="ad-rule-bar" style="width:{{if $.TopRules}}{{printf "%.0f" (mulf (divf .Count (index $.TopRules 0).Count) 100)}}%{{else}}0%{{end}};background:{{if eq .Severity "critical"}}#f85149{{else if eq .Severity "high"}}#fb923c{{else}}var(--text3){{end}}"></div>
+        <div style="flex:1;min-width:0;position:relative">
+          <div style="font-size:0.82rem;font-weight:500;color:var(--text)">{{.Name}}</div>
+          <div style="display:flex;align-items:center;gap:6px;margin-top:2px">
+            <span style="font-family:var(--mono);font-size:0.68rem;color:var(--text3)">{{.RuleID}}</span>
+          </div>
+        </div>
+        <span style="font-family:var(--mono);font-weight:700;font-size:1.05rem;color:var(--text);flex-shrink:0">{{.Count}}</span>
+      </div>
+      {{end}}
+      </div>
+      {{else}}
+      <div class="empty" style="padding:20px 0">No rules triggered for this agent.</div>
+      {{end}}
+    </div>
+
+    <div class="card" style="padding:18px 20px">
+      <div class="ad-slbl">Communication partners (24h)</div>
+      {{if .CommPartners}}
+      <table style="font-size:0.78rem">
+        <thead><tr><th class="section-label">Partner</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Total</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Blocked</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Rate</th></tr></thead>
+        <tbody>
+        {{range .CommPartners}}
+        <tr style="{{if eq .Total 0}}opacity:0.4{{end}}">
+          <td>{{toolDot .To}}</td>
+          <td style="text-align:right;font-family:var(--mono)">{{.Total}}</td>
+          <td style="text-align:right;font-family:var(--mono);color:{{if .Blocked}}var(--danger){{else}}var(--success){{end}}">{{.Blocked}}</td>
+          <td style="text-align:right;font-family:var(--mono)">{{if .Total}}{{printf "%.0f" (divf (mulf .Blocked 100) .Total)}}%{{else}}0%{{end}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+      {{else}}
+      <div class="empty" style="padding:20px 0">No communication partners.</div>
+      {{end}}
+    </div>
+  </div>
+
+  <!-- LLM Threat Intelligence (full width, only if data exists) -->
+  {{if and .LLMEnabled .LLMHistory}}
+  <div class="card" style="padding:0;overflow:hidden">
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid var(--border)">
+      <div class="ad-slbl" style="margin-bottom:0">LLM Threat Intelligence</div>
+      <a href="/dashboard/llm" style="font-size:0.72rem;color:var(--accent-light);text-decoration:none;font-weight:500">View all &rarr;</a>
+    </div>
+    <div style="overflow-x:auto">
+    <table style="font-size:0.82rem;width:100%;border-collapse:collapse">
+      <thead><tr>
+        <th style="text-align:left;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Time</th>
+        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Risk</th>
+        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Action</th>
+        <th style="text-align:center;padding:10px 20px;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:500;border-bottom:1px solid var(--border)">Status</th>
+      </tr></thead>
+      <tbody>
+      {{range .LLMHistory}}
+      <tr class="clickable" onclick="window.location='/dashboard/llm/case/{{.ID}}'">
+        <td style="padding:10px 20px;border-bottom:1px solid var(--border)" data-ts="{{.Timestamp}}">{{.Timestamp}}</td>
+        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border);font-family:var(--mono);font-weight:600;color:{{if gt .RiskScore 60.0}}var(--danger){{else if gt .RiskScore 30.0}}var(--warn){{else}}var(--success){{end}}">{{printf "%.0f" .RiskScore}}</td>
+        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border)">{{if eq .RecommendedAction "block"}}<span class="badge-blocked">block</span>{{else if eq .RecommendedAction "investigate"}}<span class="badge-quarantined">investigate</span>{{else}}<span class="badge-delivered">none</span>{{end}}</td>
+        <td style="text-align:center;padding:10px 20px;border-bottom:1px solid var(--border)">{{if eq .ReviewedStatus "confirmed"}}<span style="color:var(--danger);font-weight:600">confirmed</span>{{else if eq .ReviewedStatus "false_positive"}}<span style="color:var(--text3)">dismissed</span>{{else}}<span style="color:var(--warn)">pending</span>{{end}}</td>
+      </tr>
+      {{end}}
+      </tbody>
+    </table>
+    </div>
+  </div>
+  {{end}}
+
 </div>
 
 <!-- Configuration Tab -->

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1608,6 +1608,27 @@ function adTab(name){
       {{end}}
     </div>
 
+    <!-- Sessions -->
+    {{if .AgentSessions}}
+    <div class="card" style="padding:18px 20px">
+      <div class="ad-slbl">Sessions <a href="/dashboard/sessions" style="margin-left:auto;font-size:0.68rem;color:var(--accent-light);text-decoration:none;font-weight:400;text-transform:none;letter-spacing:0">View all &rarr;</a></div>
+      <table style="font-size:0.78rem">
+        <thead><tr><th style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Session</th><th style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Events</th><th style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Duration</th><th style="font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Threats</th><th style="text-align:right;font-size:0.62rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);font-weight:600">Risk</th></tr></thead>
+        <tbody>
+        {{range .AgentSessions}}
+        <tr>
+          <td><a href="/dashboard/sessions/{{.SessionID}}" style="color:var(--accent);text-decoration:none;font-family:var(--mono);font-size:0.75rem">{{truncate .SessionID 24}}</a></td>
+          <td>{{.EventCount}}</td>
+          <td>{{if .Duration}}{{.Duration}}{{else}}0s{{end}}</td>
+          <td>{{if gt .Blocks 0}}<span style="color:var(--danger);font-size:0.75rem">{{.Blocks}} blocked</span>{{end}}{{if gt .Quarantines 0}} <span style="color:var(--warning);font-size:0.75rem">{{.Quarantines}} quarantined</span>{{end}}{{if and (eq .Blocks 0) (eq .Quarantines 0)}}<span style="color:var(--text3)">clean</span>{{end}}</td>
+          <td style="text-align:right"><span style="padding:2px 8px;border-radius:4px;font-size:0.72rem;font-weight:600;{{if ge .RiskScore 10}}background:rgba(239,68,68,0.12);color:#ef4444{{else if ge .RiskScore 5}}background:rgba(234,179,8,0.12);color:#d29922{{else if gt .RiskScore 0}}background:rgba(34,197,94,0.12);color:#22c55e{{else}}background:var(--surface2);color:var(--text3){{end}}">{{.RiskScore}}</span></td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{end}}
+
     <!-- Recent Messages -->
     <div class="card" style="padding:18px 20px">
       <div class="ad-slbl">Recent Messages {{if .Entries}}<a href="/dashboard/events?agent={{.Name}}" style="margin-left:auto;font-size:0.68rem;color:var(--accent-light);text-decoration:none;font-weight:400;text-transform:none;letter-spacing:0">View all in Event Log &rarr;</a>{{end}}</div>

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1496,6 +1496,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
   <button class="ad-tab active" onclick="adTab('overview')">Overview</button>
   <button class="ad-tab" onclick="adTab('config')">Configuration</button>
   <button class="ad-tab" onclick="adTab('policies')">Tool Policies</button>
+  <button class="ad-tab" onclick="adTab('egress')">Egress</button>
 </div>
 <script>
 function adTab(name){
@@ -1760,6 +1761,79 @@ function stagePolicy() {
   return true;
 }
 </script>
+
+<!-- Egress Tab -->
+<div id="ad-egress" class="ad-panel">
+  <div class="card" style="padding:18px 20px">
+    <div class="ad-slbl">Egress Policy</div>
+    <p class="desc">Control which domains this agent can access and restrict egress per tool.</p>
+
+    {{if .Agent.Egress}}
+    {{if .Agent.Egress.Integrations}}
+    <div style="margin-bottom:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Integration Presets</div>
+      <div style="display:flex;gap:6px;flex-wrap:wrap">
+        {{range .Agent.Egress.Integrations}}<span style="padding:3px 10px;background:rgba(99,102,241,0.1);color:var(--accent-light);border-radius:4px;font-size:0.75rem;font-weight:500">{{.}}</span>{{end}}
+      </div>
+    </div>
+    {{end}}
+
+    {{if .Agent.Egress.AllowedDomains}}
+    <div style="margin-bottom:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Allowed Domains</div>
+      <div style="display:flex;gap:4px;flex-wrap:wrap">
+        {{range .Agent.Egress.AllowedDomains}}<code style="padding:2px 8px;background:var(--surface2);border-radius:3px;font-size:0.75rem">{{.}}</code>{{end}}
+      </div>
+    </div>
+    {{end}}
+
+    {{if .Agent.Egress.BlockedDomains}}
+    <div style="margin-bottom:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Blocked Domains</div>
+      <div style="display:flex;gap:4px;flex-wrap:wrap">
+        {{range .Agent.Egress.BlockedDomains}}<code style="padding:2px 8px;background:rgba(248,81,73,0.08);color:var(--danger);border-radius:3px;font-size:0.75rem">{{.}}</code>{{end}}
+      </div>
+    </div>
+    {{end}}
+
+    {{if .Agent.Egress.ToolRestrictions}}
+    <div style="margin-bottom:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Per-Tool Restrictions</div>
+      <table>
+        <thead><tr><th>Tool</th><th>Allowed Domains</th></tr></thead>
+        <tbody>
+        {{range $tool, $domains := .Agent.Egress.ToolRestrictions}}
+        <tr>
+          <td style="font-weight:600;font-family:var(--mono);font-size:0.82rem">{{$tool}}</td>
+          <td>
+            {{if $domains}}
+            <div style="display:flex;gap:4px;flex-wrap:wrap">
+              {{range $domains}}<code style="padding:1px 6px;background:var(--surface2);border-radius:3px;font-size:0.72rem">{{.}}</code>{{end}}
+            </div>
+            {{else}}
+            <span style="color:var(--danger);font-size:0.75rem">No egress allowed</span>
+            {{end}}
+          </td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{end}}
+
+    {{else}}
+    <div class="empty">No egress policy configured. This agent can access any domain.<br><span style="font-size:0.75rem;color:var(--text3)">Add an egress policy in oktsec.yaml to restrict outbound access.</span></div>
+    {{end}}
+
+    <div style="border-top:1px solid var(--border);padding-top:16px;margin-top:16px">
+      <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.8px;color:var(--text3);margin-bottom:8px">Available Integration Presets</div>
+      <div style="display:flex;gap:4px;flex-wrap:wrap">
+        {{range .Presets}}<span style="padding:2px 8px;background:var(--surface2);border-radius:3px;font-size:0.72rem;color:var(--text3)" title="{{.Description}}">{{.Name}}</span>{{end}}
+      </div>
+      <p style="font-size:0.72rem;color:var(--text3);margin-top:8px">Add presets in oktsec.yaml: <code style="font-size:0.72rem">egress: { integrations: ["slack", "github"] }</code></p>
+    </div>
+  </div>
+</div>
 
 ` + layoutFoot))
 

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1616,7 +1616,10 @@ function adTab(name){
       {{end}}
     </div>
 
-    <!-- Sessions -->
+  </div>
+
+  <!-- Sessions + Recent Messages side by side -->
+  <div class="ad-grid">
     {{if .AgentSessions}}
     <div class="card" style="padding:18px 20px">
       <div class="ad-slbl">Sessions <a href="/dashboard/sessions" style="margin-left:auto;font-size:0.68rem;color:var(--accent-light);text-decoration:none;font-weight:400;text-transform:none;letter-spacing:0">View all &rarr;</a></div>

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -8,7 +8,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 
 /* Stat strip */
 .a-stats{display:grid;grid-template-columns:repeat(5,1fr);gap:1px;background:var(--border);border:1px solid var(--border);border-radius:10px;overflow:hidden;margin-bottom:24px}
-.a-stat{background:var(--surface);padding:var(--sp-5) var(--sp-5)}
+.a-stat{background:var(--surface);padding:var(--sp-5) var(--sp-5);text-align:center}
 .a-stat-label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);font-weight:500;margin-bottom:var(--sp-2)}
 .a-stat-val{font-family:var(--sans);font-size:1.375rem;font-weight:700;color:var(--text);letter-spacing:-0.03em}
 .a-stat-val.v-crit{color:var(--danger)}

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -95,7 +95,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 
 {{if .Sandbox}}
 <div class="a-sandbox">
-  <strong>Sandbox</strong> &mdash; Sample OpenClaw config with intentional security issues.
+  <strong>Sandbox</strong> &middot; Sample OpenClaw config with intentional security issues.
   <a href="/dashboard/audit">Exit sandbox &rarr;</a>
 </div>
 {{end}}

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -36,7 +36,10 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 /* Priority fix row */
 .a-fix{display:flex;align-items:flex-start;gap:10px;padding:12px 0;border-bottom:1px solid var(--border)}
 .a-fix:last-child{border-bottom:none}
-.a-fix-sev{min-width:60px;flex-shrink:0;padding-top:1px}
+.a-fix-sev{min-width:60px;flex-shrink:0;padding-top:1px;font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px;text-align:center;display:inline-block}
+.a-fix-sev.sev-critical{background:rgba(248,81,73,0.12);color:#f85149}
+.a-fix-sev.sev-high{background:rgba(248,81,73,0.08);color:#fb923c}
+.a-fix-sev.sev-medium{background:rgba(234,179,8,0.1);color:#d29922}
 .a-fix-body{flex:1;min-width:0}
 .a-fix-head{display:flex;align-items:baseline;gap:8px}
 .a-fix-id{font-family:var(--mono);font-size:0.8125rem;font-weight:600;color:var(--text2)}
@@ -65,7 +68,11 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 .a-fd[open] summary::before{transform:rotate(90deg)}
 .a-fi{display:flex;align-items:flex-start;gap:10px;padding:12px 20px;border-bottom:1px solid var(--border)}
 .a-fi:last-child{border-bottom:none}
-.a-fi-sev{min-width:60px;flex-shrink:0;padding-top:1px}
+.a-fi-sev{min-width:60px;flex-shrink:0;padding-top:1px;font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px;text-align:center;display:inline-block}
+.a-fi-sev.sev-critical{background:rgba(248,81,73,0.12);color:#f85149}
+.a-fi-sev.sev-high{background:rgba(248,81,73,0.08);color:#fb923c}
+.a-fi-sev.sev-medium{background:rgba(234,179,8,0.1);color:#d29922}
+.a-fi-sev.sev-info,.a-fi-sev.sev-low{background:var(--surface2);color:var(--text3)}
 .a-fi-body{flex:1;min-width:0}
 .a-fi-head{display:flex;align-items:baseline;gap:8px}
 .a-fi-id{font-family:var(--mono);font-size:0.8125rem;font-weight:600;color:var(--text2)}

--- a/internal/dashboard/tmpl_sessions.go
+++ b/internal/dashboard/tmpl_sessions.go
@@ -8,7 +8,7 @@ var sessionsPageTmpl = template.Must(template.New("sessions").Funcs(tmplFuncs).P
 .ss-filters{display:flex;gap:8px;align-items:center}
 .ss-filters select{padding:6px 10px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:var(--text-sm)}
 .ss-stats{display:grid;grid-template-columns:repeat(4,1fr);margin-bottom:20px;background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden}
-.ss-stat{padding:16px 20px}
+.ss-stat{padding:16px 20px;text-align:center}
 .ss-stat+.ss-stat{border-left:1px solid var(--border)}
 .ss-stat .label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:4px}
 .ss-stat .value{font-size:1.2rem;font-weight:600;color:var(--text)}


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### Security Posture: em dash cleanup
- Replaced all em dashes with hyphens/commas across auditcheck findings
- 8 files, ~25 occurrences in checks_openclaw, checks_nanoclaw, checks_mcp, sarif, tests
- OpenClaw product description in dashboard also fixed

### Agent Detail: Egress tab
- New "Egress" tab on agent detail page showing:
  - Active integration presets as colored pills
  - Allowed and blocked domains
  - Per-tool restrictions table (tool name -> allowed domains, or "No egress allowed")
  - Available presets list (16 built-in) with hover descriptions
  - Config instructions for oktsec.yaml

## Files changed

| File | Change |
|------|--------|
| `internal/auditcheck/checks_openclaw.go` | Em dash -> hyphen (10) |
| `internal/auditcheck/checks_nanoclaw.go` | Em dash -> hyphen (6) |
| `internal/auditcheck/checks_mcp.go` | Em dash -> hyphen (4) |
| `internal/auditcheck/sarif.go` | Em dash -> hyphen (1) |
| `internal/auditcheck/auditcheck_test.go` | Em dash -> hyphen (2) |
| `internal/dashboard/tmpl_audit.go` | Sandbox label fix |
| `internal/dashboard/handlers.go` | OpenClaw description + presetsList() helper |
| `internal/dashboard/templates.go` | Egress tab + panel in agent detail |

## Test plan
- [x] `go test ./...` all green
- [ ] CI passes
- [ ] Manual: Security Posture page shows hyphens, no em dashes
- [ ] Manual: Agent detail Egress tab shows presets list