### PR TITLE
feat: agent hierarchy tracking (human -> agent -> sub-agent)

### DIFF
--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -23,6 +23,25 @@ type Entry struct {
 	ProxySignature      string `json:"proxy_signature,omitempty"`       // Ed25519 signature by proxy
 	DelegationChainHash string `json:"delegation_chain_hash,omitempty"` // SHA-256 of verified delegation chain
 	DelegationChain     string `json:"delegation_chain,omitempty"`      // human-readable chain: "human -> agent-a -> agent-b"
+	ParentAgent         string `json:"parent_agent,omitempty"`          // who spawned this agent (empty = root)
+	AgentInstanceID     string `json:"agent_instance_id,omitempty"`     // unique sub-agent instance ID from client
+	RootAgent           string `json:"root_agent,omitempty"`            // original initiator of the chain
+	AgentDepth          int    `json:"agent_depth,omitempty"`           // 0=root, 1=sub-agent, 2=sub-sub-agent
+}
+
+// HierarchyEntry tracks parent-child agent relationships within a session.
+type HierarchyEntry struct {
+	ID          string `json:"id"`
+	SessionID   string `json:"session_id"`
+	AgentName   string `json:"agent_name"`
+	AgentID     string `json:"agent_id,omitempty"`
+	ParentAgent string `json:"parent_agent"`
+	RootAgent   string `json:"root_agent"`
+	Depth       int    `json:"depth"`
+	SpawnedAt   string `json:"spawned_at"`
+	LastSeen    string `json:"last_seen"`
+	ToolCount   int    `json:"tool_count"`
+	BlockCount  int    `json:"block_count"`
 }
 
 // ReasoningEntry captures the model's chain-of-thought for a tool call.

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -492,7 +492,7 @@ func (s *Store) Log(entry Entry) {
 
 // auditSelectCols is the shared SELECT column list for audit queries.
 // Update this constant (and the corresponding Scan calls) when adding columns.
-const auditSelectCols = "id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,'')"
+const auditSelectCols = "id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,''), COALESCE(parent_agent,''), COALESCE(agent_instance_id,''), COALESCE(root_agent,''), COALESCE(agent_depth,0)"
 
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
@@ -561,7 +561,7 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		var fp, rules sql.NullString
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain); err != nil {
+			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		e.PubkeyFingerprint = fp.String
@@ -644,7 +644,7 @@ func (s *Store) QueryByID(id string) (*Entry, error) {
 	var fp, rules sql.NullString
 	if err := row.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain); err != nil {
+		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -54,7 +54,11 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	entry_hash TEXT DEFAULT '',
 	proxy_signature TEXT DEFAULT '',
 	delegation_chain_hash TEXT DEFAULT '',
-	delegation_chain TEXT DEFAULT ''
+	delegation_chain TEXT DEFAULT '',
+	parent_agent TEXT DEFAULT '',
+	agent_instance_id TEXT DEFAULT '',
+	root_agent TEXT DEFAULT '',
+	agent_depth INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);
@@ -88,6 +92,23 @@ CREATE INDEX IF NOT EXISTS idx_quarantine_expires ON quarantine_queue(expires_at
 CREATE INDEX IF NOT EXISTS idx_audit_ts_agent_status ON audit_log(timestamp, from_agent, status);
 CREATE INDEX IF NOT EXISTS idx_audit_ts_from_to_status ON audit_log(timestamp, from_agent, to_agent, status);
 CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id) WHERE session_id <> '';
+
+CREATE TABLE IF NOT EXISTS agent_hierarchy (
+	id TEXT PRIMARY KEY,
+	session_id TEXT NOT NULL,
+	agent_name TEXT NOT NULL,
+	agent_id TEXT DEFAULT '',
+	parent_agent TEXT DEFAULT '',
+	root_agent TEXT DEFAULT '',
+	depth INTEGER DEFAULT 0,
+	spawned_at TEXT NOT NULL,
+	last_seen TEXT NOT NULL,
+	tool_count INTEGER DEFAULT 0,
+	block_count INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_hierarchy_session ON agent_hierarchy(session_id);
+CREATE INDEX IF NOT EXISTS idx_hierarchy_parent ON agent_hierarchy(parent_agent);
+CREATE INDEX IF NOT EXISTS idx_hierarchy_agent ON agent_hierarchy(agent_name);
 `
 
 // Hub broadcasts new audit entries to connected SSE clients.
@@ -311,6 +332,16 @@ func (s *Store) migrateSchema() {
 	CREATE INDEX IF NOT EXISTS idx_reasoning_audit ON reasoning_log(audit_entry_id);`
 	if _, err := s.db.Exec(reasoningSchema); err != nil {
 		s.logger.Warn("reasoning_log table creation skipped", "error", err)
+	}
+
+	// Add hierarchy columns to existing audit_log tables (idempotent).
+	for _, col := range []string{
+		"ALTER TABLE audit_log ADD COLUMN parent_agent TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN agent_instance_id TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN root_agent TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN agent_depth INTEGER DEFAULT 0",
+	} {
+		_, _ = s.db.Exec(col) // ignore "duplicate column" errors
 	}
 
 	// Backfill: old entries stored tool names in to_agent with empty tool_name.
@@ -768,7 +799,7 @@ func (s *Store) writeLoop() {
 			continue
 		}
 
-		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash, delegation_chain) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash, delegation_chain, parent_agent, agent_instance_id, root_agent, agent_depth) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			s.logger.Error("audit batch prepare failed", "error", err)
 			_ = tx.Rollback()
@@ -783,6 +814,7 @@ func (s *Store) writeLoop() {
 				batch[i].SignatureVerified, batch[i].PubkeyFingerprint, batch[i].Status, batch[i].RulesTriggered,
 				batch[i].PolicyDecision, batch[i].LatencyMs, batch[i].Intent, batch[i].SessionID,
 				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature, batch[i].DelegationChainHash, batch[i].DelegationChain,
+				batch[i].ParentAgent, batch[i].AgentInstanceID, batch[i].RootAgent, batch[i].AgentDepth,
 			)
 			if err != nil {
 				s.logger.Error("audit write failed", "id", batch[i].ID, "error", err)
@@ -1340,6 +1372,53 @@ func (s *Store) QuerySessions(since string, limit int) ([]SessionSummary, error)
 		result = append(result, ss)
 	}
 	return result, rows.Err()
+}
+
+// UpsertHierarchy inserts or updates an agent hierarchy entry for a session.
+func (s *Store) UpsertHierarchy(h HierarchyEntry) error {
+	_, err := s.db.Exec(`
+		INSERT INTO agent_hierarchy (id, session_id, agent_name, agent_id, parent_agent, root_agent, depth, spawned_at, last_seen, tool_count, block_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			last_seen = excluded.last_seen,
+			tool_count = agent_hierarchy.tool_count + 1,
+			block_count = CASE WHEN excluded.block_count > 0 THEN agent_hierarchy.block_count + 1 ELSE agent_hierarchy.block_count END`,
+		h.ID, h.SessionID, h.AgentName, h.AgentID, h.ParentAgent, h.RootAgent, h.Depth, h.SpawnedAt, h.LastSeen, h.ToolCount, h.BlockCount,
+	)
+	return err
+}
+
+// QueryHierarchy returns the agent tree for a session, ordered by depth.
+func (s *Store) QueryHierarchy(sessionID string) ([]HierarchyEntry, error) {
+	rows, err := s.db.Query(
+		`SELECT id, session_id, agent_name, COALESCE(agent_id,''), COALESCE(parent_agent,''), COALESCE(root_agent,''), depth, spawned_at, last_seen, tool_count, block_count
+		FROM agent_hierarchy WHERE session_id = ? ORDER BY depth, spawned_at`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []HierarchyEntry
+	for rows.Next() {
+		var h HierarchyEntry
+		if err := rows.Scan(&h.ID, &h.SessionID, &h.AgentName, &h.AgentID, &h.ParentAgent, &h.RootAgent, &h.Depth, &h.SpawnedAt, &h.LastSeen, &h.ToolCount, &h.BlockCount); err != nil {
+			continue
+		}
+		result = append(result, h)
+	}
+	return result, rows.Err()
+}
+
+// QueryRootAgent returns the root agent (human/initiator) for a session.
+func (s *Store) QueryRootAgent(sessionID string) string {
+	var root string
+	_ = s.db.QueryRow(
+		`SELECT root_agent FROM agent_hierarchy WHERE session_id = ? AND depth = 0 LIMIT 1`,
+		sessionID,
+	).Scan(&root)
+	return root
 }
 
 // parseTS tries RFC3339Nano then RFC3339.

--- a/internal/audit/trace.go
+++ b/internal/audit/trace.go
@@ -23,18 +23,20 @@ type SessionTrace struct {
 
 // TraceStep is a single tool call in a session trace.
 type TraceStep struct {
-	ToolName   string `json:"tool_name"`
-	ToolInput  string `json:"tool_input"`
-	FromAgent  string `json:"from_agent"`
-	Reasoning  string `json:"reasoning,omitempty"`
-	Verdict    string `json:"verdict"`
-	Decision   string `json:"decision"`
-	Timestamp  string `json:"timestamp"`
-	GapMs      int64  `json:"gap_ms"`
-	LatencyMs  int64  `json:"latency_ms"`
-	EventID    string `json:"event_id"`
-	PlanStep   int    `json:"plan_step,omitempty"`
-	PlanTotal  int    `json:"plan_total,omitempty"`
+	ToolName    string `json:"tool_name"`
+	ToolInput   string `json:"tool_input"`
+	FromAgent   string `json:"from_agent"`
+	ParentAgent string `json:"parent_agent,omitempty"`
+	AgentDepth  int    `json:"agent_depth,omitempty"`
+	Reasoning   string `json:"reasoning,omitempty"`
+	Verdict     string `json:"verdict"`
+	Decision    string `json:"decision"`
+	Timestamp   string `json:"timestamp"`
+	GapMs       int64  `json:"gap_ms"`
+	LatencyMs   int64  `json:"latency_ms"`
+	EventID     string `json:"event_id"`
+	PlanStep    int    `json:"plan_step,omitempty"`
+	PlanTotal   int    `json:"plan_total,omitempty"`
 }
 
 // BuildSessionTrace constructs a timeline of tool calls for a session.
@@ -91,14 +93,16 @@ func (s *Store) BuildSessionTrace(sessionID string) (*SessionTrace, error) {
 			intent = intent[1 : len(intent)-1]
 		}
 		step := TraceStep{
-			ToolName:  e.ToolName,
-			ToolInput: truncateStr(intent, 200),
-			FromAgent: e.FromAgent,
-			Verdict:   e.Status,
-			Decision:  e.PolicyDecision,
-			Timestamp: e.Timestamp,
-			LatencyMs: e.LatencyMs,
-			EventID:   e.ID,
+			ToolName:    e.ToolName,
+			ToolInput:   truncateStr(intent, 200),
+			FromAgent:   e.FromAgent,
+			ParentAgent: e.ParentAgent,
+			AgentDepth:  e.AgentDepth,
+			Verdict:     e.Status,
+			Decision:    e.PolicyDecision,
+			Timestamp:   e.Timestamp,
+			LatencyMs:   e.LatencyMs,
+			EventID:     e.ID,
 		}
 
 		// Calculate gap from previous step

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1703,6 +1703,7 @@ func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
 
 	// Load saved AI analysis if it exists
 	var savedAnalysis, analysisModel, analysisDate string
+	var hierarchy []audit.HierarchyEntry
 	if store, ok := s.audit.(*audit.Store); ok {
 		if result := store.QuerySessionAnalysis(sessionID); result != nil {
 			savedAnalysis = result.Text
@@ -1713,6 +1714,7 @@ func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
 				analysisDate = result.Timestamp
 			}
 		}
+		hierarchy, _ = store.QueryHierarchy(sessionID)
 	}
 
 	data := map[string]any{
@@ -1722,6 +1724,7 @@ func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
 		"SavedAnalysis": savedAnalysis,
 		"AnalysisModel": analysisModel,
 		"AnalysisDate":  analysisDate,
+		"Hierarchy":     hierarchy,
 	}
 	s.renderTemplate(w, sessionTraceTmpl, data)
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -935,6 +935,8 @@ func (s *Server) handleAgentDetail(w http.ResponseWriter, r *http.Request) {
 		"CommPartners":   commPartners,
 		"Presets":        presetsList(),
 		"AgentSessions":  agentSessions(s.audit, name),
+		"SubAgents":      agentSubAgents(s.audit, name),
+		"ParentAgentName": agentParent(s.audit, name),
 	}
 
 	s.renderTemplate(w, agentDetailTmpl, data)
@@ -1812,6 +1814,47 @@ func agentSessions(store audit.AuditStore, agentName string) []audit.SessionSumm
 		}
 	}
 	return result
+}
+
+// agentSubAgents returns sub-agents spawned by this agent.
+func agentSubAgents(store audit.AuditStore, agentName string) []audit.HierarchyEntry {
+	s, ok := store.(*audit.Store)
+	if !ok {
+		return nil
+	}
+	rows, err := s.DB().Query(
+		`SELECT DISTINCT agent_name, SUM(tool_count) as tc, SUM(block_count) as bc
+		FROM agent_hierarchy WHERE parent_agent = ? GROUP BY agent_name ORDER BY tc DESC`,
+		agentName,
+	)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var result []audit.HierarchyEntry
+	for rows.Next() {
+		var h audit.HierarchyEntry
+		if err := rows.Scan(&h.AgentName, &h.ToolCount, &h.BlockCount); err != nil {
+			continue
+		}
+		h.ParentAgent = agentName
+		result = append(result, h)
+	}
+	return result
+}
+
+// agentParent returns the parent agent name if this is a sub-agent.
+func agentParent(store audit.AuditStore, agentName string) string {
+	s, ok := store.(*audit.Store)
+	if !ok {
+		return ""
+	}
+	var parent string
+	_ = s.DB().QueryRow(
+		`SELECT parent_agent FROM agent_hierarchy WHERE agent_name = ? AND parent_agent != '' LIMIT 1`,
+		agentName,
+	).Scan(&parent)
+	return parent
 }
 
 type presetInfo struct {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2450,7 +2450,7 @@ func (s *Server) handleSaveEgress(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse integrations (checkboxes)
-	r.ParseForm()
+	_ = r.ParseForm()
 	agent.Egress.Integrations = r.Form["integrations"]
 
 	// Parse allowed domains (space/comma separated)

--- a/internal/dashboard/session_analysis.go
+++ b/internal/dashboard/session_analysis.go
@@ -104,7 +104,29 @@ func (s *Server) analyzeSession(ctx context.Context, trace *audit.SessionTrace) 
 		rolesSummary.WriteString(name)
 		first = false
 	}
-	rolesSummary.WriteString("\n\nOnly recommend suspending names listed as Human users above. Never recommend suspending AI agents that correctly blocked attacks.\n\n")
+	rolesSummary.WriteString("\n\nOnly recommend suspending names listed as Human users above. Never recommend suspending AI agents that correctly blocked attacks.\n")
+
+	// Add hierarchy tree if available
+	if store, ok := s.audit.(*audit.Store); ok {
+		if hierarchy, err := store.QueryHierarchy(trace.SessionID); err == nil && len(hierarchy) > 0 {
+			rolesSummary.WriteString("\nAgent hierarchy for this session:\n")
+			for _, h := range hierarchy {
+				indent := strings.Repeat("  ", h.Depth)
+				role := "AGENT"
+				if h.Depth == 0 {
+					role = "ROOT"
+				}
+				blocked := ""
+				if h.BlockCount > 0 {
+					blocked = fmt.Sprintf(", %d blocked", h.BlockCount)
+				}
+				fmt.Fprintf(&rolesSummary, "%s- %s [%s, depth %d, %d tool calls%s]\n", indent, h.AgentName, role, h.Depth, h.ToolCount, blocked)
+			}
+			rolesSummary.WriteString("\n")
+		}
+	}
+
+	rolesSummary.WriteString("\n")
 
 	// Build timeline text with role tags
 	var sb strings.Builder

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -93,6 +93,13 @@ var tmplFuncs = template.FuncMap{
 		return template.HTML(fmt.Sprintf(`<span style="display:inline-flex;align-items:center;gap:5px"><span style="width:6px;height:6px;border-radius:50%%;background:%s;flex-shrink:0"></span>%s</span>`, c, template.HTMLEscapeString(toolName)))
 	},
 	"hasRules":    func(s string) bool { return s != "" && s != "[]" && s != "null" },
+	"seq": func(n int) []int {
+		s := make([]int, n)
+		for i := range s {
+			s[i] = i
+		}
+		return s
+	},
 	"listContains": func(list []string, s string) bool {
 		for _, v := range list {
 			if v == s {

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1530,6 +1530,30 @@ function adTab(name){
 <!-- Overview Tab -->
 <div id="ad-overview" class="ad-panel active">
 
+  <!-- Agent hierarchy -->
+  {{if or .ParentAgentName .SubAgents}}
+  <div class="card" style="padding:18px 20px;margin-bottom:var(--sp-5)">
+    {{if .ParentAgentName}}
+    <div style="font-size:var(--text-sm);color:var(--text2);margin-bottom:8px">
+      <span style="font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3)">Sub-agent of</span>
+      <a href="/dashboard/agents/{{.ParentAgentName}}" style="color:var(--accent);text-decoration:none;margin-left:8px;font-family:var(--mono)">{{.ParentAgentName}}</a>
+    </div>
+    {{end}}
+    {{if .SubAgents}}
+    <div style="font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:8px">Sub-agents spawned</div>
+    <div style="display:flex;gap:12px;flex-wrap:wrap">
+      {{range .SubAgents}}
+      <a href="/dashboard/agents/{{.AgentName}}" style="display:flex;align-items:center;gap:6px;padding:6px 14px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;text-decoration:none;color:var(--text)">
+        <span style="font-family:var(--mono);font-size:var(--text-sm);font-weight:500">{{.AgentName}}</span>
+        <span style="font-size:var(--text-xs);color:var(--text3)">{{.ToolCount}} calls</span>
+        {{if gt .BlockCount 0}}<span style="font-size:var(--text-xs);color:var(--danger)">{{.BlockCount}} blocked</span>{{end}}
+      </a>
+      {{end}}
+    </div>
+    {{end}}
+  </div>
+  {{end}}
+
   <!-- Row 1: Sessions + Recent Messages -->
   <div class="ad-grid">
     {{if .AgentSessions}}

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -150,7 +150,7 @@ var sessionTraceTmpl = template.Must(template.New("session-trace").Funcs(tmplFun
       {{range .Trace.Steps}}
       <div class="st-step{{if eq .Verdict "blocked"}} s-blocked{{end}}{{if eq .Verdict "quarantined"}} s-quarantined{{end}}{{if eq .ToolName "message"}} s-human{{end}}">
         <div class="st-step-header">
-          {{if eq .ToolName "message"}}<span class="st-role r-human">human</span>{{else}}<span class="st-role r-agent">agent</span>{{end}}
+          {{if eq .ToolName "message"}}<span class="st-role r-human">human</span>{{else if gt .AgentDepth 0}}<span class="st-role r-agent" style="color:var(--text3)">sub-agent</span>{{else}}<span class="st-role r-agent">agent</span>{{end}}
           <span style="font-size:var(--text-xs);color:var(--text3);font-family:var(--mono)">{{.FromAgent}}</span>
           <span class="st-tool">{{.ToolName}}</span>
           <span class="st-verdict{{if eq .Verdict "blocked"}} v-blocked{{else if eq .Verdict "quarantined"}} v-quarantined{{else}} v-clean{{end}}">{{.Verdict}}</span>

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -67,6 +67,16 @@ var sessionTraceTmpl = template.Must(template.New("session-trace").Funcs(tmplFun
 
 .st-empty{padding:40px;text-align:center;color:var(--text3)}
 
+/* Agent tree */
+.st-tree{padding:16px 20px;background:var(--surface);border:1px solid var(--border);border-radius:10px;margin-bottom:20px}
+.st-tree-title{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:12px;font-weight:500}
+.st-tree-node{display:flex;align-items:center;gap:8px;padding:4px 0;font-size:var(--text-sm)}
+.st-tree-node .icon{font-size:0.9rem}
+.st-tree-node .name{font-weight:500;color:var(--text);font-family:var(--mono);font-size:0.78rem}
+.st-tree-node .meta{font-size:var(--text-xs);color:var(--text3)}
+.st-tree-node .meta .blocks{color:var(--danger)}
+.st-tree-indent{display:inline-block;width:20px;border-left:1px solid var(--border);margin-left:9px}
+
 /* AI Analysis panel */
 .st-ai-panel{position:sticky;top:20px}
 .st-ai-meta{display:flex;gap:12px;margin-top:12px;padding-top:12px;border-top:1px solid var(--border);font-size:0.68rem;color:var(--text3)}
@@ -117,6 +127,20 @@ var sessionTraceTmpl = template.Must(template.New("session-trace").Funcs(tmplFun
     <div class="value" data-ts="{{.Trace.StartedAt}}">{{.Trace.StartedAt}}</div>
   </div>
 </div>
+
+{{if .Hierarchy}}
+<div class="st-tree">
+  <div class="st-tree-title">Agent Tree</div>
+  {{range .Hierarchy}}
+  <div class="st-tree-node">
+    {{range $i := (seq .Depth)}}<span class="st-tree-indent"></span>{{end}}
+    <span class="icon">{{if eq .Depth 0}}&#x1F464;{{else}}&#x1F916;{{end}}</span>
+    <span class="name">{{.AgentName}}</span>
+    <span class="meta">{{.ToolCount}} calls{{if gt .BlockCount 0}}, <span class="blocks">{{.BlockCount}} blocked</span>{{end}}</span>
+  </div>
+  {{end}}
+</div>
+{{end}}
 
 <div class="st-layout{{if not .SavedAnalysis}} no-analysis{{end}}" id="st-layout">
   <!-- Left: Timeline -->

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -118,14 +119,23 @@ type HookStore interface {
 	audit.AuditLogger
 	audit.ReasoningStore
 	audit.QuarantineManager
+	UpsertHierarchy(h audit.HierarchyEntry) error
+}
+
+// sessionState tracks agent hierarchy within a session.
+type sessionState struct {
+	rootAgent    string
+	agentDepths  map[string]int
+	agentParents map[string]string
 }
 
 // Handler processes tool-call events from any MCP client.
 type Handler struct {
-	scanner *engine.Scanner
-	store   HookStore
-	cfg     *config.Config
-	logger  *slog.Logger
+	scanner  *engine.Scanner
+	store    HookStore
+	cfg      *config.Config
+	logger   *slog.Logger
+	sessions sync.Map // session_id -> *sessionState
 }
 
 // NewHandler creates a hooks handler wired to the security pipeline.
@@ -136,6 +146,52 @@ func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, lo
 		cfg:     cfg,
 		logger:  logger,
 	}
+}
+
+// getSessionState returns or creates the session state for tracking agent hierarchy.
+func (h *Handler) getSessionState(sessionID, agentName, agentType, agentID string) (parentAgent, rootAgent string, depth int) {
+	if sessionID == "" {
+		return "", agentName, 0
+	}
+
+	val, _ := h.sessions.LoadOrStore(sessionID, &sessionState{
+		agentDepths:  make(map[string]int),
+		agentParents: make(map[string]string),
+	})
+	state := val.(*sessionState)
+
+	if agentType == "" {
+		// Root agent (no sub-agent context)
+		if state.rootAgent == "" {
+			state.rootAgent = agentName
+		}
+		state.agentDepths[agentName] = 0
+		return "", state.rootAgent, 0
+	}
+
+	// Sub-agent
+	if state.rootAgent == "" {
+		state.rootAgent = agentName // fallback
+	}
+
+	resolved := h.resolveAgent(agentType)
+	if resolved == "" {
+		resolved = agentType
+	}
+
+	if _, seen := state.agentDepths[resolved]; !seen {
+		// First time seeing this sub-agent in this session.
+		// Parent is the root agent (or last known non-sub-agent).
+		parent := state.rootAgent
+		parentDepth := 0
+		if d, ok := state.agentDepths[parent]; ok {
+			parentDepth = d
+		}
+		state.agentDepths[resolved] = parentDepth + 1
+		state.agentParents[resolved] = parent
+	}
+
+	return state.agentParents[resolved], state.rootAgent, state.agentDepths[resolved]
 }
 
 // maxBody limits hook payloads to 1 MB.
@@ -209,6 +265,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	msgID := uuid.New().String()
 	toolArgs := truncateStr(string(ev.ToolInput), 2000)
 
+	// Resolve hierarchy: parent, root, depth.
+	originalAgent := ev.Agent
+	parentAgent, rootAgent, agentDepth := h.getSessionState(ev.SessionID, ev.Agent, ev.AgentType, ev.AgentID)
+
 	// Resolve the acting agent when running inside a subagent.
 	// Claude Code sends agent_type for tool calls within subagents.
 	if ev.AgentType != "" {
@@ -216,10 +276,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if resolved != "" {
 			ev.Agent = resolved
 		}
+		// Re-resolve hierarchy with the resolved name if different
+		if ev.Agent != originalAgent {
+			parentAgent, rootAgent, agentDepth = h.getSessionState(ev.SessionID, ev.Agent, ev.AgentType, ev.AgentID)
+		}
 	}
 
 	// For Agent tool calls, extract the subagent name from description
-	// so the graph shows claude-code → subagent instead of claude-code → gateway/Agent.
+	// so the graph shows claude-code -> subagent instead of claude-code -> gateway/Agent.
 	toAgent := "gateway/" + ev.ToolName
 	if ev.ToolName == "Agent" {
 		toAgent = h.extractSubagentName(ev.ToolInput)
@@ -232,9 +296,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		delegationHash = fmt.Sprintf("%x", dh)
 	}
 
+	now := time.Now().UTC().Format(time.RFC3339)
+
 	h.store.Log(audit.Entry{
 		ID:                  msgID,
-		Timestamp:           time.Now().UTC().Format(time.RFC3339),
+		Timestamp:           now,
 		FromAgent:           ev.Agent,
 		ToAgent:             toAgent,
 		ToolName:            ev.ToolName,
@@ -246,7 +312,32 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Intent:              toolArgs,
 		SessionID:           ev.SessionID,
 		DelegationChainHash: delegationHash,
+		ParentAgent:         parentAgent,
+		AgentInstanceID:     ev.AgentID,
+		RootAgent:           rootAgent,
+		AgentDepth:          agentDepth,
 	})
+
+	// Update agent hierarchy table
+	if ev.SessionID != "" {
+		blockInc := 0
+		if status == audit.StatusBlocked || status == audit.StatusQuarantined {
+			blockInc = 1
+		}
+		_ = h.store.UpsertHierarchy(audit.HierarchyEntry{
+			ID:          ev.SessionID + ":" + ev.Agent,
+			SessionID:   ev.SessionID,
+			AgentName:   ev.Agent,
+			AgentID:     ev.AgentID,
+			ParentAgent: parentAgent,
+			RootAgent:   rootAgent,
+			Depth:       agentDepth,
+			SpawnedAt:   now,
+			LastSeen:    now,
+			ToolCount:   1,
+			BlockCount:  blockInc,
+		})
+	}
 
 	// Enqueue quarantined items for human review
 	if status == audit.StatusQuarantined {

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -79,9 +79,12 @@ func (e *ToolEvent) normalize(r *http.Request) {
 		e.Event = "pre_tool_use" // default
 	}
 
-	// Agent from header (fallback for non-subagent tool calls)
-	if hdr := r.Header.Get("X-Oktsec-Agent"); hdr != "" {
-		e.Agent = hdr
+	// Agent identity: agent_type (sub-agent) takes precedence over header.
+	// Claude Code sends agent_type only when running inside a sub-agent.
+	if e.Agent == "" {
+		if hdr := r.Header.Get("X-Oktsec-Agent"); hdr != "" {
+			e.Agent = hdr
+		}
 	}
 	if e.Agent == "" {
 		e.Agent = "unknown"
@@ -265,10 +268,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	msgID := uuid.New().String()
 	toolArgs := truncateStr(string(ev.ToolInput), 2000)
 
-	// Resolve hierarchy: parent, root, depth.
-	originalAgent := ev.Agent
-	parentAgent, rootAgent, agentDepth := h.getSessionState(ev.SessionID, ev.Agent, ev.AgentType, ev.AgentID)
-
 	// Resolve the acting agent when running inside a subagent.
 	// Claude Code sends agent_type for tool calls within subagents.
 	if ev.AgentType != "" {
@@ -276,10 +275,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if resolved != "" {
 			ev.Agent = resolved
 		}
-		// Re-resolve hierarchy with the resolved name if different
-		if ev.Agent != originalAgent {
-			parentAgent, rootAgent, agentDepth = h.getSessionState(ev.SessionID, ev.Agent, ev.AgentType, ev.AgentID)
-		}
+	}
+
+	// Detect sub-agent: compare resolved agent name with the header value.
+	// The header (X-Oktsec-Agent) is always the root agent (e.g. "claude-code").
+	// If ev.Agent differs from header, this is a sub-agent.
+	headerAgent := r.Header.Get("X-Oktsec-Agent")
+	isSubAgent := headerAgent != "" && ev.Agent != headerAgent
+	agentType := ev.AgentType
+	if isSubAgent && agentType == "" {
+		agentType = ev.Agent // use resolved name as type indicator
+	}
+
+	// Resolve hierarchy: parent, root, depth.
+	parentAgent, rootAgent, agentDepth := h.getSessionState(ev.SessionID, ev.Agent, agentType, ev.AgentID)
+	if isSubAgent && parentAgent == "" {
+		parentAgent = headerAgent
+		rootAgent = headerAgent
+		agentDepth = 1
 	}
 
 	// For Agent tool calls, extract the subagent name from description

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -491,42 +491,40 @@ func (m Model) renderDetail() string {
 		sessionID = dimStyle.Render(truncate(ev.SessionID, 36))
 	}
 
-	return "\n" + detailBox.Render(
-		lipgloss.JoinVertical(lipgloss.Left,
-			headerStyle.Render("EVENT DETAIL"),
-			"",
-			labelStyle.Render("Agent")+agentStyle.Render(ev.Agent)+func() string {
-				if ev.AgentDepth > 0 {
-					return dimStyle.Render(fmt.Sprintf(" (sub-agent, depth %d)", ev.AgentDepth))
-				}
-				return ""
-			}(),
-			func() string {
-				if ev.ParentAgent != "" {
-					return labelStyle.Render("Parent") + agentStyle.Render(ev.ParentAgent)
-				}
-				return ""
-			}(),
-			labelStyle.Render("Target")+target,
-			labelStyle.Render("Tool")+toolStyle.Render(ev.Tool),
-			labelStyle.Render("Time")+mutedStyle.Render(ev.Time),
-			labelStyle.Render("Latency")+mutedStyle.Render(ev.Latency),
-			labelStyle.Render("Status")+renderStatus(ev.Status),
-			labelStyle.Render("Decision")+mutedStyle.Render(ev.Decision),
-			sep,
-			mutedStyle.Render("RULES"),
-			rulesContent,
-			sep,
-			mutedStyle.Render("CONTENT"),
-			contentPreview,
-			sep,
-			labelStyle.Render("Event ID")+eventID,
-			labelStyle.Render("Session")+sessionID,
-			labelStyle.Render("Hash")+dimStyle.Render(truncate(ev.ContentHash, 36)),
-			"",
-			dimStyle.Render("Esc or Enter to go back"),
-		),
-	) + "\n"
+	lines := []string{
+		headerStyle.Render("EVENT DETAIL"),
+		"",
+		labelStyle.Render("Agent") + agentStyle.Render(ev.Agent) + func() string {
+			if ev.AgentDepth > 0 {
+				return dimStyle.Render(fmt.Sprintf(" (sub-agent, depth %d)", ev.AgentDepth))
+			}
+			return ""
+		}(),
+	}
+	if ev.ParentAgent != "" {
+		lines = append(lines, labelStyle.Render("Parent")+agentStyle.Render(ev.ParentAgent))
+	}
+	lines = append(lines,
+		labelStyle.Render("Target")+target,
+		labelStyle.Render("Tool")+toolStyle.Render(ev.Tool),
+		labelStyle.Render("Time")+mutedStyle.Render(ev.Time),
+		labelStyle.Render("Latency")+mutedStyle.Render(ev.Latency),
+		labelStyle.Render("Status")+renderStatus(ev.Status),
+		labelStyle.Render("Decision")+mutedStyle.Render(ev.Decision),
+		sep,
+		mutedStyle.Render("RULES"),
+		rulesContent,
+		sep,
+		mutedStyle.Render("CONTENT"),
+		contentPreview,
+		sep,
+		labelStyle.Render("Event ID")+eventID,
+		labelStyle.Render("Session")+sessionID,
+		labelStyle.Render("Hash")+dimStyle.Render(truncate(ev.ContentHash, 36)),
+		"",
+		dimStyle.Render("Esc or Enter to go back"),
+	)
+	return "\n" + detailBox.Render(lipgloss.JoinVertical(lipgloss.Left, lines...)) + "\n"
 }
 
 // Helpers

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,19 +26,21 @@ type Config struct {
 
 // EventRow is a displayable event in the live feed.
 type EventRow struct {
-	Time      string
-	Agent     string
-	Tool      string
-	Status    string
-	Latency   string
-	Rule      string
-	RawRules  string
-	Decision  string
+	Time        string
+	Agent       string
+	Tool        string
+	Status      string
+	Latency     string
+	Rule        string
+	RawRules    string
+	Decision    string
 	EventID     string
 	SessionID   string
 	ToAgent     string
 	Content     string
 	ContentHash string
+	ParentAgent string
+	AgentDepth  int
 }
 
 // Model is the Bubbletea model for the oktsec TUI.
@@ -242,19 +244,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			row := EventRow{
-				Time:      parseTime(entry.Timestamp),
-				Agent:     agent,
-				Tool:      entry.ToolName,
-				Status:    status,
-				Latency:   fmt.Sprintf("%dms", entry.LatencyMs),
-				Rule:      formatRules(entry.RulesTriggered),
-				RawRules:  entry.RulesTriggered,
-				Decision:  entry.PolicyDecision,
-				EventID:   entry.ID,
-				SessionID: entry.SessionID,
-				ToAgent:   entry.ToAgent,
+				Time:        parseTime(entry.Timestamp),
+				Agent:       agent,
+				Tool:        entry.ToolName,
+				Status:      status,
+				Latency:     fmt.Sprintf("%dms", entry.LatencyMs),
+				Rule:        formatRules(entry.RulesTriggered),
+				RawRules:    entry.RulesTriggered,
+				Decision:    entry.PolicyDecision,
+				EventID:     entry.ID,
+				SessionID:   entry.SessionID,
+				ToAgent:     entry.ToAgent,
 				Content:     truncate(entry.Intent, 300),
 				ContentHash: entry.ContentHash,
+				ParentAgent: entry.ParentAgent,
+				AgentDepth:  entry.AgentDepth,
 			}
 			m.events = append(m.events, row)
 			if len(m.events) > m.maxEvents {
@@ -404,10 +408,14 @@ func (m Model) View() string {
 			if isCursor {
 				prefix = ">"
 			}
+			agentDisplay := ev.Agent
+			if ev.AgentDepth > 0 {
+				agentDisplay = "  └ " + ev.Agent
+			}
 			line := fmt.Sprintf("%s%s %s %s %s %s",
 				prefix,
 				dimStyle.Render(ev.Time),
-				agentStyle.Width(16).Render(truncate(ev.Agent, 16)),
+				agentStyle.Width(20).Render(truncate(agentDisplay, 20)),
 				renderStatus(ev.Status),
 				toolStyle.Width(10).Render(truncate(ev.Tool, 10)),
 				dimStyle.Render(ev.Latency),
@@ -487,7 +495,18 @@ func (m Model) renderDetail() string {
 		lipgloss.JoinVertical(lipgloss.Left,
 			headerStyle.Render("EVENT DETAIL"),
 			"",
-			labelStyle.Render("Agent")+agentStyle.Render(ev.Agent),
+			labelStyle.Render("Agent")+agentStyle.Render(ev.Agent)+func() string {
+				if ev.AgentDepth > 0 {
+					return dimStyle.Render(fmt.Sprintf(" (sub-agent, depth %d)", ev.AgentDepth))
+				}
+				return ""
+			}(),
+			func() string {
+				if ev.ParentAgent != "" {
+					return labelStyle.Render("Parent") + agentStyle.Render(ev.ParentAgent)
+				}
+				return ""
+			}(),
 			labelStyle.Render("Target")+target,
 			labelStyle.Render("Tool")+toolStyle.Render(ev.Tool),
 			labelStyle.Render("Time")+mutedStyle.Render(ev.Time),


### PR DESCRIPTION
## Summary

Track parent-child relationships between agents. When Claude Code spawns sub-agents (Explore, Plan, custom), oktsec records the hierarchy.

### Data layer
- 4 new fields on audit Entry: parent_agent, agent_instance_id, root_agent, agent_depth
- New agent_hierarchy table, UpsertHierarchy, QueryHierarchy, QueryRootAgent
- auditSelectCols reads all hierarchy fields from DB
- Schema migration: additive (zero downtime)

### Detection
- Session state tracking in hooks handler (sync.Map per session)
- Sub-agent detected by comparing resolved agent name with X-Oktsec-Agent header
- If they differ, event is from sub-agent with parent = header value

### Dashboard
- Agent Tree panel in session trace (above timeline)
- Sub-agent tag in timeline (SUB-AGENT vs AGENT)
- Agent detail: shows "Sub-agent of" with link, and "Sub-agents spawned" as cards
- AI analysis prompt includes hierarchy tree

### TUI
- Sub-agents show with └ indent in live feed
- Event detail shows Parent and depth for sub-agents
- No empty line when no parent

### Known issues (follow-up)
- resolveAgent keyword matching can be too aggressive with common words
- Agent page lists sub-agents as top-level (needs filtering)

## Test plan
- [x] go test ./... all green
- [x] Verified: explore, plan, general-purpose detected as sub-agents of claude-code
- [x] Hierarchy table populated correctly
- [ ] CI passes