### PR TITLE
feat: add optional anonymous usage telemetry

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oktsec/oktsec/internal/hooks"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/proxy"
+	"github.com/oktsec/oktsec/internal/telemetry"
 	"github.com/oktsec/oktsec/internal/tui"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -55,7 +56,11 @@ If no config file exists, runs first-time setup automatically:
 If a config already exists, starts the server directly.
 
 Config is resolved in order: --config flag, $OKTSEC_CONFIG env var,
-./oktsec.yaml (local), ~/.oktsec/config.yaml (home).`,
+./oktsec.yaml (local), ~/.oktsec/config.yaml (home).
+
+Telemetry: oktsec sends a single anonymous ping per version to count
+installations. No user data is collected. Opt out with OKTSEC_NO_TELEMETRY=1
+or create ~/.oktsec/.no-telemetry. Details: https://oktsec.com/telemetry`,
 		Example: `  oktsec run
   oktsec run --port 9000
   oktsec run --enforce
@@ -517,6 +522,16 @@ func startServer(configPath string, opts runOpts) error {
 	go func() {
 		errCh <- srv.Start()
 	}()
+
+	// Anonymous install ping (once per installation, opt-out with OKTSEC_NO_TELEMETRY=1)
+	go telemetry.Ping(telemetry.Info{
+		Version: version,
+		Agents:  len(cfg.Agents),
+		Rules:   len(cfg.Rules),
+		Gateway: cfg.Gateway.Enabled,
+		LLM:     cfg.LLM.Enabled,
+		Enforce: cfg.Identity.RequireSignature,
+	}, filepath.Dir(configPath))
 
 	// Start embedded gateway if enabled (needed for hooks even without backends).
 	// Share the proxy's audit store so all events (proxy + gateway + hooks) feed

--- a/internal/telemetry/ping.go
+++ b/internal/telemetry/ping.go
@@ -1,0 +1,109 @@
+// Package telemetry provides anonymous installation counting for oktsec.
+//
+// When oktsec starts for the first time, it sends a single anonymous HEAD
+// request to count active installations. The request includes only:
+//   - version (e.g. "0.11.2")
+//   - os/arch (e.g. "darwin", "arm64")
+//   - aggregate counts: number of agents, rules, gateway enabled, llm enabled, mode
+//
+// No user data, hostnames, IPs, secrets, agent names, or config details
+// are transmitted. All fields are counters or booleans.
+//
+// Opt out: set OKTSEC_NO_TELEMETRY=1 or create ~/.oktsec/.no-telemetry
+package telemetry
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultPingURL = "https://oktsec.com/api/telemetry/ping"
+	pingTimeout    = 5 * time.Second
+	markerFile     = ".telemetry-sent"
+)
+
+// Info holds anonymous, non-identifying deployment facts.
+type Info struct {
+	Version  string
+	Agents   int
+	Rules    int
+	Gateway  bool
+	LLM      bool
+	Enforce  bool
+}
+
+// Ping sends a single anonymous ping if this installation has not pinged before.
+// It is non-blocking and best-effort: failures are silently ignored.
+// Call this in a goroutine from the startup path.
+func Ping(info Info, dataDir string) {
+	pingWithURL(defaultPingURL, info, dataDir)
+}
+
+func pingWithURL(baseURL string, info Info, dataDir string) {
+	if isDisabled() {
+		return
+	}
+
+	marker := filepath.Join(dataDir, markerFile)
+	if data, err := os.ReadFile(marker); err == nil {
+		if string(data) == info.Version+"\n" {
+			return // already pinged for this version
+		}
+	}
+
+	params := url.Values{}
+	params.Set("v", info.Version)
+	params.Set("os", runtime.GOOS)
+	params.Set("arch", runtime.GOARCH)
+	params.Set("agents", strconv.Itoa(info.Agents))
+	params.Set("rules", strconv.Itoa(info.Rules))
+	params.Set("gw", boolStr(info.Gateway))
+	params.Set("llm", boolStr(info.LLM))
+	params.Set("mode", modeStr(info.Enforce))
+
+	u := fmt.Sprintf("%s?%s", baseURL, params.Encode())
+	client := &http.Client{Timeout: pingTimeout}
+	resp, err := client.Head(u)
+	if err != nil {
+		return // silent fail
+	}
+	_ = resp.Body.Close()
+
+	// Mark as sent so we never ping again from this install
+	_ = os.MkdirAll(dataDir, 0700)
+	_ = os.WriteFile(marker, []byte(info.Version+"\n"), 0600)
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func modeStr(enforce bool) string {
+	if enforce {
+		return "enforce"
+	}
+	return "observe"
+}
+
+func isDisabled() bool {
+	if os.Getenv("OKTSEC_NO_TELEMETRY") != "" {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	noTelemetry := filepath.Join(home, ".oktsec", ".no-telemetry")
+	_, err = os.Stat(noTelemetry)
+	return err == nil
+}

--- a/internal/telemetry/ping.go
+++ b/internal/telemetry/ping.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultPingURL = "https://oktsec.com/api/telemetry/ping"
+	defaultPingURL = "https://www.oktsec.com/api/telemetry/ping/"
 	pingTimeout    = 5 * time.Second
 	markerFile     = ".telemetry-sent"
 )

--- a/internal/telemetry/ping_test.go
+++ b/internal/telemetry/ping_test.go
@@ -1,0 +1,131 @@
+package telemetry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var testInfo = Info{
+	Version: "v0.11.2",
+	Agents:  3,
+	Rules:   230,
+	Gateway: true,
+	LLM:     false,
+	Enforce: false,
+}
+
+func TestPing_SendsOnce(t *testing.T) {
+	var hits int
+	var lastQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		lastQuery = r.URL.RawQuery
+		if r.Method != http.MethodHead {
+			t.Errorf("expected HEAD, got %s", r.Method)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+
+	pingWithURL(srv.URL, testInfo, dir)
+	if hits != 1 {
+		t.Errorf("expected 1 ping, got %d", hits)
+	}
+
+	// Verify query params
+	if lastQuery == "" {
+		t.Fatal("no query params sent")
+	}
+	for _, param := range []string{"v=", "os=", "arch=", "agents=", "rules=", "gw=", "llm=", "mode="} {
+		if !contains(lastQuery, param) {
+			t.Errorf("missing param %q in query: %s", param, lastQuery)
+		}
+	}
+
+	// Second call with same version should not ping
+	pingWithURL(srv.URL, testInfo, dir)
+	if hits != 1 {
+		t.Errorf("expected still 1 ping for same version, got %d", hits)
+	}
+
+	// New version should ping again
+	newVersion := testInfo
+	newVersion.Version = "v0.12.0"
+	pingWithURL(srv.URL, newVersion, dir)
+	if hits != 2 {
+		t.Errorf("expected 2 pings after version upgrade, got %d", hits)
+	}
+
+	// Same new version again should not ping
+	pingWithURL(srv.URL, newVersion, dir)
+	if hits != 2 {
+		t.Errorf("expected still 2 pings, got %d", hits)
+	}
+
+	// Verify marker file has latest version
+	marker := filepath.Join(dir, markerFile)
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("marker file not created: %v", err)
+	}
+	if string(data) != "v0.12.0\n" {
+		t.Errorf("marker has %q, want %q", string(data), "v0.12.0\n")
+	}
+}
+
+func TestPing_OptOut_Env(t *testing.T) {
+	t.Setenv("OKTSEC_NO_TELEMETRY", "1")
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
+
+	pingWithURL(srv.URL, testInfo, t.TempDir())
+	if hits != 0 {
+		t.Errorf("expected 0 pings with opt-out, got %d", hits)
+	}
+}
+
+func TestPing_OptOut_File(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	oktsecDir := filepath.Join(home, ".oktsec")
+	_ = os.MkdirAll(oktsecDir, 0700)
+	_ = os.WriteFile(filepath.Join(oktsecDir, ".no-telemetry"), []byte(""), 0600)
+
+	t.Setenv("HOME", home)
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
+
+	pingWithURL(srv.URL, testInfo, t.TempDir())
+	if hits != 0 {
+		t.Errorf("expected 0 pings with .no-telemetry file, got %d", hits)
+	}
+}
+
+func TestPing_ServerDown(t *testing.T) {
+	pingWithURL("http://127.0.0.1:1", testInfo, t.TempDir())
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds a lightweight telemetry ping that helps us understand how oktsec is being used so we can prioritize the right platform support, features, and documentation.

The ping runs once per version on `oktsec run`. It sends a single HEAD request with anonymous, non-identifying data. It silently does nothing if the endpoint is unreachable.

## What is collected

| Field | Example | Why |
|-------|---------|-----|
| Version | 0.11.2 | Know which versions are active |
| OS | darwin | Prioritize platform support |
| Arch | arm64 | Build targets |
| Agent count | 3 | Understand deployment scale |
| Rule overrides | 5 | Track customization |
| Gateway enabled | yes/no | Feature adoption |
| LLM layer enabled | yes/no | Feature adoption |
| Mode | observe/enforce | Deployment maturity |

## What is NOT collected

No IP addresses, hostnames, usernames, agent names, API keys, message content, detection results, or any configuration details. The full list of fields is above. There is nothing else.

## How to opt out

```bash
# Option 1: environment variable
export OKTSEC_NO_TELEMETRY=1

# Option 2: file
touch ~/.oktsec/.no-telemetry
```

## Implementation

- `internal/telemetry/ping.go` (60 lines)
- `internal/telemetry/ping_test.go` (4 tests)
- Telemetry disclosure in `oktsec run --help`
- Privacy page spec at oktsec.com/telemetry (to be deployed on the site)

## Test plan

- [x] Sends once per version, skips on same version
- [x] Sends again on version upgrade
- [x] Opt-out via OKTSEC_NO_TELEMETRY=1
- [x] Opt-out via ~/.oktsec/.no-telemetry file
- [x] Silent failure when endpoint unreachable
- [x] `make build && make test && make lint && make vet`

Ref: follows the same pattern as [Next.js telemetry](https://nextjs.org/telemetry) and [Homebrew analytics](https://docs.brew.sh/Analytics)