### PR TITLE
fix: dashboard bugs, telemetry client, docs v0.12.0

### DIFF
--- a/cmd/oktsec/commands/gateway.go
+++ b/cmd/oktsec/commands/gateway.go
@@ -9,10 +9,13 @@ import (
 	"syscall"
 	"time"
 
+	"path/filepath"
+
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/gateway"
 	"github.com/oktsec/oktsec/internal/hooks"
 	"github.com/oktsec/oktsec/internal/llm"
+	"github.com/oktsec/oktsec/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -126,6 +129,17 @@ func newGatewayCmd() *cobra.Command {
 			go func() {
 				errCh <- gw.Start(ctx)
 			}()
+
+			// Anonymous install ping (once per version, opt-out with OKTSEC_NO_TELEMETRY=1)
+			go telemetry.Ping(telemetry.Info{
+				Version:        version,
+				Agents:         len(cfg.Agents),
+				Rules:          len(cfg.Rules),
+				Gateway:        true,
+				LLM:            cfg.LLM.Enabled,
+				Enforce:        cfg.Identity.RequireSignature,
+				ConfigDisabled: cfg.Telemetry.Disabled,
+			}, filepath.Dir(cfgFile))
 
 			select {
 			case err := <-errCh:

--- a/cmd/oktsec/commands/quarantine.go
+++ b/cmd/oktsec/commands/quarantine.go
@@ -44,7 +44,7 @@ func newQuarantineListCmd() *cobra.Command {
 			}
 			defer store.Close() //nolint:errcheck
 
-			items, err := store.QuarantineQuery(status, "", limit)
+			items, err := store.QuarantineQuery(status, "", "", "", limit)
 			if err != nil {
 				return err
 			}

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -525,12 +525,13 @@ func startServer(configPath string, opts runOpts) error {
 
 	// Anonymous install ping (once per installation, opt-out with OKTSEC_NO_TELEMETRY=1)
 	go telemetry.Ping(telemetry.Info{
-		Version: version,
-		Agents:  len(cfg.Agents),
-		Rules:   len(cfg.Rules),
-		Gateway: cfg.Gateway.Enabled,
-		LLM:     cfg.LLM.Enabled,
-		Enforce: cfg.Identity.RequireSignature,
+		Version:        version,
+		Agents:         len(cfg.Agents),
+		Rules:          len(cfg.Rules),
+		Gateway:        cfg.Gateway.Enabled,
+		LLM:            cfg.LLM.Enabled,
+		Enforce:        cfg.Identity.RequireSignature,
+		ConfigDisabled: cfg.Telemetry.Disabled,
 	}, filepath.Dir(configPath))
 
 	// Start embedded gateway if enabled (needed for hooks even without backends).

--- a/documentation/guides/gateway.md
+++ b/documentation/guides/gateway.md
@@ -7,7 +7,7 @@ Agent  -->  Oktsec Gateway  -->  Backend MCP Server(s)
              |
              +-- Rate limit
              +-- Agent ACL check
-             +-- Content scan (175 rules)
+             +-- Content scan (230 rules)
              +-- Rule overrides
              +-- Verdict (allow/block/quarantine)
              +-- Audit log

--- a/documentation/guides/go-sdk.md
+++ b/documentation/guides/go-sdk.md
@@ -63,7 +63,7 @@ resp, err := c.SendMessageWithMetadata(ctx, "recipient", "hello", map[string]str
 ```go
 health, err := c.Health(ctx)
 fmt.Println(health.Status)   // "ok"
-fmt.Println(health.Version)  // "0.8.1"
+fmt.Println(health.Version)  // "0.12.0"
 ```
 
 ## Response types

--- a/documentation/guides/openclaw.md
+++ b/documentation/guides/openclaw.md
@@ -1,6 +1,6 @@
 # Securing OpenClaw with Oktsec
 
-OpenClaw agents call MCP tools, relay instructions between agents, and make autonomous decisions. Oktsec intercepts every tool call and agent message, scanning for prompt injection, credential leaks, data exfiltration, and 172 other threat patterns.
+OpenClaw agents call MCP tools, relay instructions between agents, and make autonomous decisions. Oktsec intercepts every tool call and agent message, scanning for prompt injection, credential leaks, data exfiltration, and 226 other threat patterns.
 
 This guide gets you from zero to secured in under 5 minutes.
 
@@ -14,7 +14,7 @@ OpenClaw Agent  -->  Oktsec Gateway  -->  MCP Server(s)
                       +-- Rate limit
                       +-- Tool allowlist
                       +-- Tool policies (spending limits, rate limits)
-                      +-- Content scan (175 rules)
+                      +-- Content scan (230 rules)
                       +-- Audit log
                       +-- Dashboard
 ```
@@ -186,7 +186,7 @@ Once connected, oktsec applies these checks to every tool call:
 | **Rate limit** | Agent exceeding per-hour limit gets rejected |
 | **Tool allowlist** | Calls to tools not in `allowed_tools` are blocked |
 | **Tool policies** | Spending limits, daily caps, approval thresholds enforced |
-| **Content scan** | 175 rules scan tool arguments for prompt injection, credentials, exfiltration |
+| **Content scan** | 230 rules scan tool arguments for prompt injection, credentials, exfiltration |
 | **Response scan** | Backend responses scanned before returning to agent |
 | **Blocked content** | Per-agent category enforcement (e.g., block all `credentials` for researcher) |
 | **Poisoned tools** | Tool descriptions scanned at startup - poisoned tools removed automatically |
@@ -370,6 +370,6 @@ If two backends have a tool with the same name, oktsec namespaces them: `filesys
 ## Next steps
 
 - [Dashboard guide](dashboard.md) - monitoring and managing security from the web UI
-- [Detection rules reference](../reference/rules.md) - all 175 rules with examples
+- [Detection rules reference](../reference/rules.md) - all 230 rules with examples
 - [Per-agent egress control](egress.md) - restrict outbound HTTP traffic per agent
 - [Configuration reference](../reference/configuration.md) - full YAML schema

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -42,7 +42,7 @@ Oktsec sits between agents and catches these threats **deterministically** — n
 
 ## How it works
 
-Every message passes through **9 security checks**, cheapest to most expensive. If any check fails, the message is rejected immediately.
+Every message passes through **10 security checks**, cheapest to most expensive. If any check fails, the message is rejected immediately.
 
 ```mermaid
 flowchart LR

--- a/documentation/reference/api.md
+++ b/documentation/reference/api.md
@@ -104,7 +104,7 @@ The pipeline runs checks from cheapest to most expensive. If any check fails, su
 2. Identity verification (~120us)
 3. Suspension check
 4. ACL evaluation
-5. Content scan — 175 Aguara rules (~8ms)
+5. Content scan — 230 rules (~8ms)
 6. Blocked content filter (per-agent categories)
 7. Split injection detection (multi-message scan)
 8. Rule overrides (from config)

--- a/documentation/reference/configuration.md
+++ b/documentation/reference/configuration.md
@@ -107,7 +107,7 @@ Every field, its type, default, and behavior.
 
 | Type | Default | Description |
 |------|---------|-------------|
-| string | `""` | Directory for org-specific YAML detection rules. Loaded alongside the 175 built-in rules |
+| string | `""` | Directory for org-specific YAML detection rules. Loaded alongside the 230 built-in rules |
 
 ---
 

--- a/internal/audit/iface.go
+++ b/internal/audit/iface.go
@@ -63,7 +63,7 @@ type QuarantineManager interface {
 	Enqueue(item QuarantineItem) error
 	QuarantineByID(id string) (*QuarantineItem, error)
 	QuarantinePending(limit int) ([]QuarantineItem, error)
-	QuarantineQuery(status, agent string, limit int) ([]QuarantineItem, error)
+	QuarantineQuery(status, agent, since, until string, limit int) ([]QuarantineItem, error)
 	QuarantineApprove(id, reviewedBy string) error
 	QuarantineReject(id, reviewedBy string) error
 	QuarantineExpireOld() (int, error)

--- a/internal/audit/quarantine_test.go
+++ b/internal/audit/quarantine_test.go
@@ -298,7 +298,7 @@ func TestQuarantineQuery_FilterByAgent(t *testing.T) {
 		}
 	}
 
-	items, err := store.QuarantineQuery("", "alpha", 10)
+	items, err := store.QuarantineQuery("", "alpha", "", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -888,11 +888,11 @@ func (s *Store) QuarantineByID(id string) (*QuarantineItem, error) {
 
 // QuarantinePending returns pending quarantine items ordered by creation time.
 func (s *Store) QuarantinePending(limit int) ([]QuarantineItem, error) {
-	return s.QuarantineQuery(QStatusPending, "", limit)
+	return s.QuarantineQuery(QStatusPending, "", "", "", limit)
 }
 
 // QuarantineQuery returns quarantine items matching the given filters.
-func (s *Store) QuarantineQuery(status, agent string, limit int) ([]QuarantineItem, error) {
+func (s *Store) QuarantineQuery(status, agent, since, until string, limit int) ([]QuarantineItem, error) {
 	query := `SELECT id, audit_entry_id, content, from_agent, to_agent, status, COALESCE(reviewed_by,''), COALESCE(reviewed_at,''), expires_at, created_at, COALESCE(rules_triggered,''), COALESCE(signature,''), timestamp FROM quarantine_queue WHERE 1=1`
 	var args []any
 
@@ -903,6 +903,14 @@ func (s *Store) QuarantineQuery(status, agent string, limit int) ([]QuarantineIt
 	if agent != "" {
 		query += " AND (from_agent = ? OR to_agent = ?)"
 		args = append(args, agent, agent)
+	}
+	if since != "" {
+		query += " AND timestamp >= ?"
+		args = append(args, since)
+	}
+	if until != "" {
+		query += " AND timestamp <= ?"
+		args = append(args, until)
 	}
 
 	query += " ORDER BY created_at DESC"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,12 @@ type Config struct {
 	Gateway        GatewayConfig                  `yaml:"gateway,omitempty"`
 	MCPServers     map[string]MCPServerConfig     `yaml:"mcp_servers,omitempty"`
 	LLM            LLMConfig                      `yaml:"llm,omitempty"`
+	Telemetry      TelemetryConfig                `yaml:"telemetry,omitempty"`
+}
+
+// TelemetryConfig controls the anonymous usage ping.
+type TelemetryConfig struct {
+	Disabled bool `yaml:"disabled,omitempty"` // set true to opt out of anonymous pings
 }
 
 // LLMConfig configures the async LLM analysis layer.

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2724,7 +2724,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		if qStatusFilter == "" {
 			qStatusFilter = audit.QStatusPending
 		}
-		qItems, _ = s.audit.QuarantineQuery(qStatusFilter, filterAgent, 50)
+		qItems, _ = s.audit.QuarantineQuery(qStatusFilter, filterAgent, filterSince, filterUntil, 50)
 	case "blocked":
 		blockedEntries, _ = s.audit.Query(audit.QueryOpts{Statuses: []string{audit.StatusBlocked, audit.StatusRejected}, Agent: filterAgent, Since: filterSince, Until: filterUntil, Limit: 50})
 	default: // "all"

--- a/internal/dashboard/static/dashboard.css
+++ b/internal/dashboard/static/dashboard.css
@@ -445,7 +445,7 @@ input:checked + .toggle-slider::before{transform:translateX(16px);background:var
   background:var(--bg);color:var(--text);font-size:var(--text-sm);font-family:var(--sans);
   transition:border-color var(--ease-smooth);outline:none;
 }
-.filter-bar input[type="date"]::-webkit-calendar-picker-indicator{filter:invert(1)}
+.filter-bar input[type="date"]{color-scheme:dark}
 .filter-bar select:focus,.filter-bar input[type="date"]:focus{border-color:var(--accent)}
 .filter-bar .sep{color:var(--text3);font-size:var(--text-sm)}
 .filter-bar .spacer{flex:1}

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1356,7 +1356,7 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
   <a href="/dashboard/agents/{{.Name}}" class="ag-card">
     <div class="ag-card-head">
       {{avatar .Name 28}}
-      <span class="ag-card-name">{{.Name}}</span>
+      <span class="ag-card-name">{{kebabToTitle .Name}}</span>
       {{if .Suspended}}<span class="badge-blocked" style="font-size:0.6rem;padding:2px 6px">SUSPENDED</span>{{end}}
       {{if .HasKey}}<span title="Key registered" style="color:var(--success);font-size:0.7rem;margin-left:auto">&#x1f512;</span>{{else}}<span title="No key" style="color:var(--text3);font-size:0.7rem;margin-left:auto">&#x1f513;</span>{{end}}
     </div>

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -343,7 +343,7 @@ func (h *handlers) quarantineList(args json.RawMessage) (*mcp.CallToolResult, er
 	}
 	status := mcputil.GetString(args, "status", audit.QStatusPending)
 
-	items, err := h.audit.QuarantineQuery(status, "", limit)
+	items, err := h.audit.QuarantineQuery(status, "", "", "", limit)
 	if err != nil {
 		return mcputil.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/internal/telemetry/ping.go
+++ b/internal/telemetry/ping.go
@@ -1,6 +1,6 @@
 // Package telemetry provides anonymous installation counting for oktsec.
 //
-// When oktsec starts for the first time, it sends a single anonymous HEAD
+// When oktsec starts for the first time, it sends a single anonymous GET
 // request to count active installations. The request includes only:
 //   - version (e.g. "0.11.2")
 //   - os/arch (e.g. "darwin", "arm64")
@@ -9,11 +9,13 @@
 // No user data, hostnames, IPs, secrets, agent names, or config details
 // are transmitted. All fields are counters or booleans.
 //
-// Opt out: set OKTSEC_NO_TELEMETRY=1 or create ~/.oktsec/.no-telemetry
+// Opt out: set telemetry.disabled: true in config, OKTSEC_NO_TELEMETRY=1,
+// or create ~/.oktsec/.no-telemetry
 package telemetry
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,19 +26,20 @@ import (
 )
 
 const (
-	defaultPingURL = "https://www.oktsec.com/api/telemetry/ping/"
+	defaultPingURL = "https://oktsec.com/api/telemetry/ping"
 	pingTimeout    = 5 * time.Second
 	markerFile     = ".telemetry-sent"
 )
 
 // Info holds anonymous, non-identifying deployment facts.
 type Info struct {
-	Version  string
-	Agents   int
-	Rules    int
-	Gateway  bool
-	LLM      bool
-	Enforce  bool
+	Version        string
+	Agents         int
+	Rules          int
+	Gateway        bool
+	LLM            bool
+	Enforce        bool
+	ConfigDisabled bool // mirrors config telemetry.disabled
 }
 
 // Ping sends a single anonymous ping if this installation has not pinged before.
@@ -47,7 +50,7 @@ func Ping(info Info, dataDir string) {
 }
 
 func pingWithURL(baseURL string, info Info, dataDir string) {
-	if isDisabled() {
+	if info.ConfigDisabled || isDisabled() {
 		return
 	}
 
@@ -70,10 +73,11 @@ func pingWithURL(baseURL string, info Info, dataDir string) {
 
 	u := fmt.Sprintf("%s?%s", baseURL, params.Encode())
 	client := &http.Client{Timeout: pingTimeout}
-	resp, err := client.Head(u)
+	resp, err := client.Get(u)
 	if err != nil {
 		return // silent fail
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 
 	// Mark as sent so we never ping again from this install

--- a/internal/telemetry/ping_test.go
+++ b/internal/telemetry/ping_test.go
@@ -23,8 +23,8 @@ func TestPing_SendsOnce(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits++
 		lastQuery = r.URL.RawQuery
-		if r.Method != http.MethodHead {
-			t.Errorf("expected HEAD, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
 	}))
 	defer srv.Close()
@@ -89,6 +89,21 @@ func TestPing_OptOut_Env(t *testing.T) {
 	pingWithURL(srv.URL, testInfo, t.TempDir())
 	if hits != 0 {
 		t.Errorf("expected 0 pings with opt-out, got %d", hits)
+	}
+}
+
+func TestPing_OptOut_Config(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
+
+	disabled := testInfo
+	disabled.ConfigDisabled = true
+	pingWithURL(srv.URL, disabled, t.TempDir())
+	if hits != 0 {
+		t.Errorf("expected 0 pings with config disabled, got %d", hits)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Dashboard fixes**: Agent cards display kebab-to-title names instead of raw slugs, date inputs use `color-scheme:dark` for Firefox compatibility, quarantine query respects date filters
- **Telemetry client**: Anonymous GET ping on `serve`/`gateway` startup with config opt-out (`telemetry.disabled`), env opt-out (`OKTSEC_NO_TELEMETRY`), and per-version dedup
- **Documentation**: All stale references updated to v0.12.0 (175→230 rules, 9→10 pipeline stages, 0.8.1→0.12.0 version)

## Test plan
- [x] `make build && make test && make lint && make vet` all pass
- [ ] Verify agent card names render correctly in dashboard
- [ ] Verify Firefox date picker icons are visible
- [ ] Verify quarantine tab counts match date filter
- [ ] Verify telemetry ping fires on `oktsec serve` startup