### PR TITLE
chore: bump aguara to v0.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
-	github.com/garagon/aguara v0.11.0
+	github.com/garagon/aguara v0.11.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/garagon/aguara v0.11.0 h1:8ORKMDdykLKTkbUR1e5v+JxriKVBkLgKvl9vpNaXpF4=
-github.com/garagon/aguara v0.11.0/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
+github.com/garagon/aguara v0.11.1 h1:3+QnVu3ptGItHCCs3scBMx6tkcOH112BObh2/FoXvG4=
+github.com/garagon/aguara v0.11.1/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
Adds aguara check/clean incident response commands for litellm compromise detection and cleanup.