### PR TITLE
feat: dashboard UX redesign + Aguara v0.13.0 cached scanner

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2835,6 +2835,9 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		"PGSSLMode":            parsePGField(s.cfg.DBDSN, "sslmode"),
 		"GatewayEnabled":       s.cfg.Gateway.Enabled,
 		"GatewayPort":          s.cfg.Gateway.Port,
+
+		"TrustBoundariesInternal": s.cfg.TrustBoundaries.Internal,
+		"TrustBoundariesCount":    len(s.cfg.TrustBoundaries.Internal),
 	}
 
 	s.renderTemplate(w, settingsTmpl, data)
@@ -3220,6 +3223,7 @@ func (s *Server) handleSaveLLM(w http.ResponseWriter, r *http.Request) {
 	s.cfg.LLM.Analyze.Flagged = r.FormValue("analyze_flagged") == "true"
 	s.cfg.LLM.Analyze.Quarantined = r.FormValue("analyze_quarantined") == "true"
 	s.cfg.LLM.Analyze.Blocked = r.FormValue("analyze_blocked") == "true"
+	s.cfg.LLM.TwoStage = r.FormValue("two_stage") == "true"
 
 	// Budget limits
 	if v := r.FormValue("budget_daily"); v != "" {
@@ -3585,6 +3589,12 @@ func (s *Server) populateLLMStats(data map[string]any) {
 		data["LLMAvgRisk"] = 0.0
 		data["LLMTokens"] = 0
 		data["LLMRulesGen"] = 0
+	}
+	data["LLMTwoStage"] = s.cfg.LLM.TwoStage
+	if s.llmQueue != nil {
+		qs := s.llmQueue.Stats()
+		data["LLMStage1Clean"] = qs.Stage1Clean
+		data["LLMStage1Flagged"] = qs.Stage1Flagged
 	}
 }
 
@@ -4013,20 +4023,22 @@ type toolInventoryServer struct {
 // --- Gateway handlers ---
 
 type mcpServerRow struct {
-	Name      string
-	Transport string
-	Command   string
-	URL       string
+	Name          string
+	Transport     string
+	Command       string
+	URL           string
+	EgressSandbox bool
 }
 
 func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 	var servers []mcpServerRow
 	for name, srv := range s.cfg.MCPServers {
 		servers = append(servers, mcpServerRow{
-			Name:      name,
-			Transport: srv.Transport,
-			Command:   srv.Command,
-			URL:       srv.URL,
+			Name:          name,
+			Transport:     srv.Transport,
+			Command:       srv.Command,
+			URL:           srv.URL,
+			EgressSandbox: srv.EgressSandbox,
 		})
 	}
 	sort.Slice(servers, func(i, j int) bool { return servers[i].Name < servers[j].Name })
@@ -4060,11 +4072,12 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 
 	gw := s.cfg.Gateway
 	data := map[string]any{
-		"Active":     "gateway",
-		"Gateway":    gw,
-		"Servers":    servers,
-		"Discovered": discovered,
-		"Tab":        r.URL.Query().Get("tab"),
+		"Active":          "gateway",
+		"Gateway":         gw,
+		"Servers":         servers,
+		"Discovered":      discovered,
+		"Tab":             r.URL.Query().Get("tab"),
+		"DepCheckEnabled": s.cfg.Gateway.DepCheck,
 	}
 	s.renderTemplate(w, gatewayTmpl, data)
 }
@@ -4075,6 +4088,7 @@ func (s *Server) handleSaveGatewaySettings(w http.ResponseWriter, r *http.Reques
 
 	s.cfg.Gateway.Enabled = nowEnabled
 	s.cfg.Gateway.ScanResponses = r.FormValue("scan_responses") == "true"
+	s.cfg.Gateway.DepCheck = r.FormValue("dep_check") == "true"
 
 	if p := strings.TrimSpace(r.FormValue("port")); p != "" {
 		if port, err := strconv.Atoi(p); err == nil && port > 0 && port <= 65535 {

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -1025,6 +1025,7 @@ a.ov-metric:hover{background:var(--surface2)}
       <span class="k">AI analysis</span>
       <span class="v {{if gt .LLMThreats 5}}warn{{else if gt .LLMThreats 0}}text-secondary{{end}}">{{.LLMThreats}} <span style="color:var(--text3);font-size:var(--text-xs);font-weight:400">findings</span></span>
     </a>
+    {{if .LLMTwoStage}}<div class="ov-metric"><span class="k">Stage 1 savings</span><span class="v"><span style="color:var(--success)">{{.LLMStage1Clean}}</span> skipped full analysis</span></div>{{end}}
     {{end}}
   </div>
 </div>
@@ -3269,6 +3270,18 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     </div>
     <div class="st-item-value"><span style="font-size:0.68rem;color:var(--text3)">restart to change</span></div>
   </div>
+  <div class="st-item" style="flex-wrap:wrap">
+    <div class="st-item-info">
+      <div class="st-item-name">Trust Boundaries</div>
+      <div class="st-item-desc">Internal domains and CIDRs used by scope-based egress policies</div>
+    </div>
+    <div class="st-item-value"><span class="val">{{.TrustBoundariesCount}} defined</span></div>
+  </div>
+  {{if .TrustBoundariesInternal}}
+  <div style="padding:0 16px 12px;display:flex;flex-wrap:wrap;gap:6px">
+    {{range .TrustBoundariesInternal}}<code style="font-size:0.7rem;padding:2px 6px;background:var(--bg);border:1px solid var(--border);border-radius:4px">{{.}}</code>{{end}}
+  </div>
+  {{end}}
 </div>
 
 <!-- Protection -->
@@ -4049,6 +4062,12 @@ tqApply();
       <label style="display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:6px;border:1px solid {{if .Cfg.Analyze.Blocked}}var(--danger){{else}}var(--border){{end}};cursor:pointer;{{if .Cfg.Analyze.Blocked}}background:rgba(239,68,68,0.06){{end}}">
         <span class="toggle"><input type="checkbox" name="analyze_blocked" value="true" {{if .Cfg.Analyze.Blocked}}checked{{end}}><span class="toggle-slider"></span></span>
         <div><div style="font-size:0.82rem;font-weight:500">Blocked</div></div>
+      </label>
+    </div>
+    <div style="margin-top:14px">
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="two_stage" value="true" {{if .Cfg.TwoStage}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Two-stage classification (fast filter before full analysis)</span>
       </label>
     </div>
   </div>
@@ -5493,6 +5512,10 @@ function gwTab(name){
       <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Backends</span>
       <div style="font-size:1rem;font-weight:600;margin-top:4px">{{len .Servers}}</div>
     </div>
+    <div>
+      <span style="color:var(--text3);font-size:0.72rem;text-transform:uppercase;letter-spacing:1px">Dep Check</span>
+      <div style="font-size:1rem;font-weight:600;margin-top:4px">{{if .DepCheckEnabled}}<span style="color:var(--success)">active</span>{{else}}<span style="color:var(--text3)">off</span>{{end}}</div>
+    </div>
   </div>
 </div>
 
@@ -5510,6 +5533,10 @@ function gwTab(name){
       <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
         <span class="toggle"><input type="checkbox" name="scan_responses" value="true" {{if .Gateway.ScanResponses}}checked{{end}}><span class="toggle-slider"></span></span>
         <span style="font-size:0.85rem;color:var(--text2)">Scan backend responses</span>
+      </label>
+      <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+        <span class="toggle"><input type="checkbox" name="dep_check" value="true" {{if .Gateway.DepCheck}}checked{{end}}><span class="toggle-slider"></span></span>
+        <span style="font-size:0.85rem;color:var(--text2)">Dependency audit on startup</span>
       </label>
     </div>
     <div class="form-row">
@@ -5537,13 +5564,14 @@ function gwTab(name){
   </p>
   {{if .Servers}}
   <table>
-    <thead><tr><th>Name</th><th>Transport</th><th>Target</th><th></th></tr></thead>
+    <thead><tr><th>Name</th><th>Transport</th><th>Target</th><th>Sandbox</th><th></th></tr></thead>
     <tbody>
     {{range .Servers}}
     <tr id="server-row-{{.Name}}" class="clickable" onclick="window.location='/dashboard/gateway/servers/{{.Name}}'">
       <td style="font-weight:600"><a href="/dashboard/gateway/servers/{{.Name}}" style="color:var(--accent-light);text-decoration:none">{{.Name}}</a></td>
       <td><span class="badge-{{if eq .Transport "stdio"}}delivered{{else}}quarantined{{end}}" style="font-size:0.7rem">{{.Transport}}</span></td>
       <td style="color:var(--text3);font-family:var(--mono);font-size:0.8rem">{{if eq .Transport "stdio"}}{{.Command}}{{else}}{{.URL}}{{end}}</td>
+      <td>{{if .EgressSandbox}}<span style="color:var(--success)">&#9679;</span>{{else}}<span style="color:var(--text3)">&mdash;</span>{{end}}</td>
       <td style="text-align:right" onclick="event.stopPropagation()"><button class="btn btn-sm btn-danger" hx-delete="/dashboard/gateway/servers/{{.Name}}" hx-confirm="Delete server {{.Name}}?" hx-target="#server-row-{{.Name}}" hx-swap="outerHTML swap:200ms">delete</button></td>
     </tr>
     {{end}}
@@ -5630,6 +5658,8 @@ var mcpServerDetailTmpl = template.Must(template.New("mcpServerDetail").Funcs(tm
     {{if .Server.Headers}}<tr><td style="color:var(--text3);font-weight:600">Headers</td><td>{{range $k, $v := .Server.Headers}}<code style="background:var(--surface);padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.78rem">{{$k}}: {{$v}}</code><br>{{end}}</td></tr>{{end}}
     {{end}}
     {{if .Server.Env}}<tr><td style="color:var(--text3);font-weight:600">Env vars</td><td>{{range $k, $v := .Server.Env}}<code style="background:var(--surface);padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.78rem">{{$k}}={{$v}}</code><br>{{end}}</td></tr>{{end}}
+    {{if .Server.EgressSandbox}}<tr><td style="color:var(--text3);font-weight:600">Egress Sandbox</td><td><span style="color:var(--success);font-weight:600">enabled</span> &middot; HTTP traffic routes through proxy</td></tr>{{else}}<tr><td style="color:var(--text3);font-weight:600">Egress Sandbox</td><td><span style="color:var(--text3)">disabled</span></td></tr>{{end}}
+    {{if .Server.WorkingDir}}<tr><td style="color:var(--text3);font-weight:600">Working Dir</td><td><code style="font-size:0.72rem">{{.Server.WorkingDir}}</code></td></tr>{{end}}
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
## Summary

Complete dashboard UX redesign for non-technical users plus migration to Aguara v0.13.0 cached scanner API.

### Dashboard Settings
- Sections reordered: System Status > Access Control > Threat Response > Infrastructure
- Labels simplified for non-technical users (Protection Active, Block Unknown, Internal Networks, Purpose Verification, Outbound Traffic)
- Trust boundaries editable from dashboard (textarea + Save)
- Database: pill buttons with dynamic descriptions
- Outbound Traffic sub-controls hidden when toggle OFF

### Dashboard Gateway
- Status card: 3 equal cards in grid, "Add tool server" when empty
- Master toggle hierarchy (secondary toggles dim when gateway OFF)
- Labels: Connected Tools, Auto-detected Tools, Local process (stdio) / Remote server (HTTP)
- "Add to Gateway" button per discovered server

### Dashboard Graph
- All terminology simplified (Agents, Active Connections, Unmonitored Routes)
- Connection Health: TOTAL column removed, HEALTH visible
- "Add rule" link per unmonitored route
- Risk score legend (0-100 scale with color dots)
- Time selector with active/inactive pill styling

### Aguara v0.13.0 cached scanner
- Rules compiled once at startup, reused across all requests
- Engine tests: 240s to 8.5s. Dashboard tests: 90s to 9.5s.
- Per-scan latency: ~40-60ms to ~2-5ms
- Full suite: ~7min to ~2min

## Test plan
- [x] `make build && make test && make lint && make vet`
- [x] All dashboard tests updated for renamed labels
- [x] Engine tests pass with cached scanner
- [ ] CI
- [ ] Visual verification of Settings, Gateway, Graph pages