### PR TITLE
feat: security posture page redesign with auto-fix and AI enrichment

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -262,6 +262,61 @@ type auditProductGroup struct {
 }
 
 // topRemediations returns up to n critical/high findings that have remediation text.
+// fixableChecks maps check IDs to functions that apply the recommended fix.
+// Only additive/enabling fixes - never disables security or removes agents.
+var fixableChecks = map[string]func(cfg *config.Config) string{
+	"SIG-001": func(cfg *config.Config) string {
+		cfg.Identity.RequireSignature = true
+		return "Enabled message signing"
+	},
+	"ACL-001": func(cfg *config.Config) string {
+		cfg.DefaultPolicy = "deny"
+		return "Set default policy to deny"
+	},
+	"RET-001": func(cfg *config.Config) string {
+		cfg.Quarantine.Enabled = true
+		return "Enabled quarantine queue"
+	},
+	"MON-001": func(cfg *config.Config) string {
+		cfg.RateLimit.PerAgent = 100
+		cfg.RateLimit.WindowS = 60
+		return "Set rate limit to 100/min"
+	},
+	"MON-003": func(cfg *config.Config) string {
+		cfg.Anomaly.RiskThreshold = 80
+		cfg.Anomaly.MinMessages = 10
+		return "Enabled anomaly detection"
+	},
+	"RET-002": func(cfg *config.Config) string {
+		cfg.Quarantine.RetentionDays = 90
+		return "Set audit retention to 90 days"
+	},
+	"GRD-001": func(cfg *config.Config) string {
+		cfg.Guard.Enabled = true
+		return "Enabled filesystem guard"
+	},
+	"MEM-001": func(cfg *config.Config) string {
+		for name, agent := range cfg.Agents {
+			has := false
+			for _, bc := range agent.BlockedContent {
+				if bc == "memory-poisoning" {
+					has = true
+					break
+				}
+			}
+			if !has {
+				agent.BlockedContent = append(agent.BlockedContent, "memory-poisoning")
+				cfg.Agents[name] = agent
+			}
+		}
+		return "Added memory-poisoning blocking"
+	},
+	"NET-002": func(cfg *config.Config) string {
+		cfg.ForwardProxy.ScanResponses = true
+		return "Enabled egress response scanning"
+	},
+}
+
 func topRemediations(findings []auditcheck.Finding, n int) []auditcheck.Finding {
 	var out []auditcheck.Finding
 	for _, sev := range []auditcheck.Severity{auditcheck.Critical, auditcheck.High} {
@@ -314,6 +369,25 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 
 	topFixes := topRemediations(findings, 3)
 
+	fixableCount := 0
+	for _, f := range findings {
+		if _, ok := fixableChecks[f.CheckID]; ok && f.Severity > auditcheck.Info {
+			fixableCount++
+		}
+	}
+
+	// Sort findings: critical first, then high, then fixable before non-fixable
+	allSorted := make([]auditcheck.Finding, len(findings))
+	copy(allSorted, findings)
+	sort.SliceStable(allSorted, func(i, j int) bool {
+		if allSorted[i].Severity != allSorted[j].Severity {
+			return allSorted[i].Severity > allSorted[j].Severity
+		}
+		_, fi := fixableChecks[allSorted[i].CheckID]
+		_, fj := fixableChecks[allSorted[j].CheckID]
+		return fi && !fj
+	})
+
 	// Verify audit chain integrity (lightweight — last 100 entries)
 	chainEntries, _ := s.audit.QueryChainEntries(100)
 
@@ -346,8 +420,10 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		"Grade":       grade,
 		"Groups":      groups,
 		"Summary":     summary,
-		"TopFixes":    topFixes,
-		"TotalChecks": len(findings),
+		"TopFixes":      topFixes,
+		"FixableCount":  fixableCount,
+		"AllFindings":   allSorted,
+		"TotalChecks":   len(findings),
 		"HasCritical": summary.Critical > 0,
 		"ChainValid":            chainResult.Valid,
 		"ChainCount":            chainResult.Entries,
@@ -360,6 +436,22 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		"LLMModel":      s.cfg.LLM.Model,
 		"LLMThreats":    llmThreats,
 		"LLMConfirmed":  llmConfirmed,
+		"SavedAnalysis": func() string {
+			if store, ok := s.audit.(*audit.Store); ok {
+				if r := store.QuerySessionAnalysis("posture-analysis"); r != nil {
+					return r.Text
+				}
+			}
+			return ""
+		}(),
+		"AnalysisModel": func() string {
+			if store, ok := s.audit.(*audit.Store); ok {
+				if r := store.QuerySessionAnalysis("posture-analysis"); r != nil {
+					return r.Model
+				}
+			}
+			return ""
+		}(),
 	}
 
 	s.renderTemplate(w, auditTmpl, data)
@@ -395,16 +487,22 @@ func (s *Server) handleAuditSandbox(w http.ResponseWriter, r *http.Request) {
 	}}
 
 	data := map[string]any{
-		"Active":      "audit",
-		"RequireSig":  s.cfg.Identity.RequireSignature,
-		"Score":       score,
-		"Grade":       grade,
-		"Groups":      groups,
-		"Summary":     summary,
-		"TopFixes":    topRemediations(findings, 3),
-		"TotalChecks": len(findings),
-		"HasCritical": summary.Critical > 0,
-		"Sandbox":     true,
+		"Active":       "audit",
+		"RequireSig":   s.cfg.Identity.RequireSignature,
+		"Score":        score,
+		"Grade":        grade,
+		"Groups":       groups,
+		"Summary":      summary,
+		"TopFixes":     topRemediations(findings, 3),
+		"FixableCount": 0,
+		"AllFindings":  findings,
+		"TotalChecks":  len(findings),
+		"HasCritical":        summary.Critical > 0,
+		"Sandbox":            true,
+		"LLMEnabled":         s.cfg.LLM.Enabled,
+		"ChainValid":         false,
+		"ChainCount":         0,
+		"SignatureVerified":  false,
 	}
 
 	s.renderTemplate(w, auditTmpl, data)
@@ -4005,6 +4103,233 @@ func (s *Server) handleAuditClear(w http.ResponseWriter, r *http.Request) {
 	// They auto-register again when the gateway receives traffic.
 	s.cfg.Agents = make(map[string]config.Agent)
 	s.renderJSON(w, map[string]string{"status": "cleared"})
+}
+
+// handleAuditFix applies an auto-fix for a single finding and returns an HTML
+// fragment that HTMX swaps in place of the finding row + OOB score update.
+func (s *Server) handleAuditFix(w http.ResponseWriter, r *http.Request) {
+	checkID := r.PathValue("checkID")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	fixer, ok := fixableChecks[checkID]
+	if !ok {
+		fmt.Fprintf(w, `<div class="ps-finding" id="f-%s"><div class="ps-f-body" style="color:var(--danger)">No auto-fix available for %s</div></div>`,
+			template.HTMLEscapeString(checkID), template.HTMLEscapeString(checkID))
+		return
+	}
+	desc := fixer(s.cfg)
+	if err := s.saveConfig(); err != nil {
+		fmt.Fprintf(w, `<div class="ps-finding" id="f-%s"><div class="ps-f-body" style="color:var(--danger)">Error: %s</div></div>`,
+			template.HTMLEscapeString(checkID), template.HTMLEscapeString(err.Error()))
+		return
+	}
+	s.logger.Info("auto-fix applied", "check", checkID, "action", desc)
+
+	findings, _, _ := s.cachedRunChecks()
+	score, grade := auditcheck.ComputeHealthScore(findings)
+
+	// Fixed row
+	fmt.Fprintf(w, `<div class="ps-finding ps-fixed" id="f-%s">
+<div class="ps-f-sev"><span class="ps-sev sev-fixed">FIXED</span></div>
+<div class="ps-f-body"><span class="ps-f-title">%s</span></div>
+<div class="ps-f-act"><span style="color:var(--success);font-size:1.1rem">&#10003;</span></div>
+</div>`, template.HTMLEscapeString(checkID), template.HTMLEscapeString(desc))
+	// OOB score update
+	s.writeScoreOOB(w, score, grade)
+}
+
+// handleAuditFixAll applies all available auto-fixes and returns an HTML summary.
+func (s *Server) handleAuditFixAll(w http.ResponseWriter, r *http.Request) {
+	findings, _, _ := s.cachedRunChecks()
+	var applied []string
+	for _, f := range findings {
+		if f.Severity <= auditcheck.Info {
+			continue
+		}
+		if fixer, ok := fixableChecks[f.CheckID]; ok {
+			applied = append(applied, fixer(s.cfg))
+		}
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if len(applied) == 0 {
+		fmt.Fprint(w, `<div style="padding:24px;text-align:center;color:var(--text3)">No fixable findings.</div>`)
+		return
+	}
+	if err := s.saveConfig(); err != nil {
+		fmt.Fprintf(w, `<div style="padding:24px;color:var(--danger)">Error: %s</div>`, template.HTMLEscapeString(err.Error()))
+		return
+	}
+	s.logger.Info("auto-fix-all applied", "count", len(applied))
+
+	newFindings, _, _ := s.cachedRunChecks()
+	score, grade := auditcheck.ComputeHealthScore(newFindings)
+
+	// Celebration
+	fmt.Fprintf(w, `<div class="ps-celebrate">
+<div class="ps-celebrate-score">%d</div>
+<div class="ps-celebrate-grade">Grade %s</div>
+<div class="ps-celebrate-msg">%d fixes applied. <a href="/dashboard/audit">Reload to see remaining findings.</a></div>
+</div>`, score, grade, len(applied))
+	s.writeScoreOOB(w, score, grade)
+}
+
+// handleAuditEnrich calls the LLM to generate one-line risk descriptions for each finding.
+func (s *Server) handleAuditEnrich(w http.ResponseWriter, r *http.Request) {
+	cfg := s.cfg.LLM
+	if !cfg.Enabled {
+		http.Error(w, "LLM not configured", http.StatusServiceUnavailable)
+		return
+	}
+	apiKey := cfg.APIKey
+	if apiKey == "" && cfg.APIKeyEnv != "" {
+		apiKey = os.Getenv(cfg.APIKeyEnv)
+	}
+	if apiKey == "" {
+		http.Error(w, "LLM API key not set", http.StatusServiceUnavailable)
+		return
+	}
+
+	allFindings, _, _ := s.cachedRunChecks()
+	var findings []auditcheck.Finding
+	for _, f := range allFindings {
+		if f.Severity <= auditcheck.Info {
+			continue
+		}
+		findings = append(findings, f)
+	}
+
+	score, grade := auditcheck.ComputeHealthScore(findings)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "You are a security advisor. Deployment: %d agents, policy=%s, score=%d/%s.\n\n",
+		len(s.cfg.Agents), s.cfg.DefaultPolicy, score, grade)
+	sb.WriteString("Findings:\n")
+	for _, f := range findings {
+		fixable := ""
+		if _, ok := fixableChecks[f.CheckID]; ok {
+			fixable = " [AUTO-FIXABLE]"
+		}
+		fmt.Fprintf(&sb, "- %s [%s]: %s. Detail: %s%s\n", f.CheckID, f.Severity, f.Title, f.Detail, fixable)
+		if f.Remediation != "" {
+			fmt.Fprintf(&sb, "  Remediation: %s\n", f.Remediation)
+		}
+	}
+	sb.WriteString("\nReturn JSON:\n")
+	sb.WriteString(`{"summary":"Max 2 sentences. First: what is the single biggest risk. Second: what to do first.","findings":[{"id":"XXX","risk":"What attack this enables and the exact fix (config key=value or command to run). Max 25 words."},...]}`)
+	sb.WriteString("\n\nRules: no markdown, plain English, specific config keys and values. Summary max 40 words. Valid JSON only, no preamble, no explanation outside JSON.")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	var result string
+	var err error
+	switch cfg.Provider {
+	case "claude":
+		result, err = s.callClaude(ctx, apiKey, cfg.Model, sb.String())
+	case "openai":
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://api.openai.com/v1"
+		}
+		result, err = s.callOpenAI(ctx, apiKey, baseURL, cfg.Model, sb.String())
+	default:
+		err = fmt.Errorf("unsupported provider %q", cfg.Provider)
+	}
+
+	var summary string
+	riskMap := make(map[string]string)
+	if err == nil {
+		start := strings.Index(result, "{")
+		end := strings.LastIndex(result, "}")
+		if start >= 0 && end > start {
+			var parsed struct {
+				Summary  string `json:"summary"`
+				Findings []struct {
+					ID   string `json:"id"`
+					Risk string `json:"risk"`
+				} `json:"findings"`
+			}
+			if jsonErr := json.Unmarshal([]byte(result[start:end+1]), &parsed); jsonErr == nil {
+				summary = parsed.Summary
+				for _, r := range parsed.Findings {
+					riskMap[r.ID] = r.Risk
+				}
+			}
+		}
+	}
+
+	// Persist only the summary (per-finding risks are shown inline)
+	if store, ok := s.audit.(*audit.Store); ok && summary != "" {
+		_ = store.SaveSessionAnalysis("posture-analysis", summary, cfg.Model)
+	}
+
+	// Render: global summary + enriched findings
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if summary != "" {
+		fmt.Fprintf(w, `<div class="ps-ai-summary">
+<div class="ps-ai-hdr"><span>AI Assessment</span><span class="ps-ai-model">%s</span></div>
+<div class="ps-ai-text">%s</div>
+</div>`, template.HTMLEscapeString(cfg.Model), template.HTMLEscapeString(summary))
+	}
+	for _, f := range findings {
+		risk := riskMap[f.CheckID]
+		s.writeEnrichedFinding(w, f, risk)
+	}
+}
+
+func (s *Server) writeScoreOOB(w http.ResponseWriter, score int, grade string) {
+	color := "var(--danger)"
+	if score >= 90 {
+		color = "var(--success)"
+	} else if score >= 60 {
+		color = "var(--warn)"
+	}
+	fmt.Fprintf(w, `<div id="posture-score" hx-swap-oob="true" class="ps-hero-score">
+<div class="ps-ring" style="--pct:%d;--clr:%s"><span class="ps-num">%d</span></div>
+<div class="ps-grade-label">Grade %s</div>
+</div>`, score, color, score, grade)
+}
+
+func (s *Server) writeEnrichedFinding(w http.ResponseWriter, f auditcheck.Finding, risk string) {
+	sevClass := strings.ToLower(f.Severity.String())
+	riskHTML := ""
+	if risk != "" {
+		riskHTML = fmt.Sprintf(`<div class="ps-f-risk">%s</div>`, template.HTMLEscapeString(risk))
+	}
+	remHTML := ""
+	fixBtn := ""
+	if _, ok := fixableChecks[f.CheckID]; ok {
+		fixBtn = fmt.Sprintf(`<button class="ps-fix-btn" hx-post="/dashboard/api/audit/fix/%s" hx-target="#f-%s" hx-swap="outerHTML">Fix</button>`, f.CheckID, f.CheckID)
+	} else {
+		if f.Remediation != "" {
+			remHTML = fmt.Sprintf(`<div class="ps-f-rem"><code>%s</code></div>`, template.HTMLEscapeString(f.Remediation))
+		}
+		if f.FixURL != "" {
+			fixBtn = fmt.Sprintf(`<a href="%s" class="ps-cfg-btn">Configure</a>`, f.FixURL)
+		}
+	}
+
+	fmt.Fprintf(w, `<div class="ps-finding%s" id="f-%s">
+<div class="ps-f-sev"><span class="ps-sev sev-%s">%s</span></div>
+<div class="ps-f-body">
+<span class="ps-f-title">%s</span>
+<div class="ps-f-detail">%s</div>
+%s%s
+</div>
+<div class="ps-f-act">%s</div>
+</div>`,
+		func() string {
+			if _, ok := fixableChecks[f.CheckID]; ok {
+				return " ps-fixable"
+			}
+			return ""
+		}(),
+		f.CheckID, sevClass, f.Severity,
+		template.HTMLEscapeString(f.Title),
+		template.HTMLEscapeString(f.Detail),
+		riskHTML,
+		remHTML,
+		fixBtn)
 }
 
 func (s *Server) handleEdgeDetail(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -255,6 +255,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/api/graph", s.handleAPIGraph)
 	s.mux.HandleFunc("GET /dashboard/api/graph/edge", s.handleEdgeDetail)
 	s.mux.HandleFunc("POST /dashboard/api/audit/clear", s.handleAuditClear)
+	s.mux.HandleFunc("POST /dashboard/api/audit/fix/{checkID}", s.handleAuditFix)
+	s.mux.HandleFunc("POST /dashboard/api/audit/fix-all", s.handleAuditFixAll)
+	s.mux.HandleFunc("POST /dashboard/api/audit/enrich", s.handleAuditEnrich)
 	s.mux.HandleFunc("POST /dashboard/api/db/test", s.handleDBTest)
 	s.mux.HandleFunc("POST /dashboard/api/db/save", s.handleDBSave)
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -711,8 +711,8 @@ func TestServer_AuditPageProductInfo(t *testing.T) {
 		t.Fatalf("audit page: status = %d, want 200", w.Code)
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, "Runtime security for AI agents") {
-		t.Error("audit page should contain Oktsec product description")
+	if !strings.Contains(body, "Security posture") {
+		t.Error("audit page should contain posture heading")
 	}
 	// "Priority Remediations" section only shown when there are critical/high
 	// findings — the test config triggers some, so at least verify the page

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -177,7 +177,8 @@ var tmplFuncs = template.FuncMap{
 			return 0
 		}
 	},
-	"add":    func(a, b int) int { return a + b },
+	"add":      func(a, b int) int { return a + b },
+	"isFixable": func(checkID string) bool { _, ok := fixableChecks[checkID]; return ok },
 	"safeJS":   func(s string) template.JS { return template.JS(s) },
 	"contains": strings.Contains,
 	"printf":   fmt.Sprintf,

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -4,257 +4,175 @@ import "html/template"
 
 var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layoutHead + `
 <style>
-/* ── Audit page ─────────────────────────────────────────── */
+/* ── Security Posture v2 ───────────────────────────────── */
 
-/* Stat strip */
-.a-stats{display:grid;grid-template-columns:repeat(5,1fr);gap:1px;background:var(--border);border:1px solid var(--border);border-radius:10px;overflow:hidden;margin-bottom:24px}
-.a-stat{background:var(--surface);padding:var(--sp-5) var(--sp-5);text-align:center}
-.a-stat-label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);font-weight:500;margin-bottom:var(--sp-2)}
-.a-stat-val{font-family:var(--sans);font-size:1.375rem;font-weight:700;color:var(--text);letter-spacing:-0.03em}
-.a-stat-val.v-crit{color:var(--danger)}
-.a-stat-val.v-high{color:var(--text2)}
-.a-stat-val.v-med{color:var(--text2)}
-.a-stat-val.v-dim{color:var(--text2)}
-.a-grade{display:block;font-size:0.6875rem;font-weight:500;color:var(--text3);font-family:var(--mono);margin-top:4px;letter-spacing:0.3px}
+/* Hero */
+.ps-hero{display:flex;align-items:center;gap:36px;padding:32px 36px;background:linear-gradient(135deg,var(--surface) 0%,rgba(139,92,246,0.03) 100%);border:1px solid var(--border);border-radius:14px;margin-bottom:24px;position:relative;overflow:hidden}
+.ps-hero::after{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--accent-light),transparent);opacity:0.4}
+.ps-hero-score{display:flex;flex-direction:column;align-items:center;gap:6px;flex-shrink:0}
+.ps-ring{width:110px;height:110px;border-radius:50%;background:conic-gradient(var(--clr,var(--success)) calc(var(--pct,0) * 1%),var(--surface2) 0);display:flex;align-items:center;justify-content:center;position:relative;box-shadow:0 0 24px rgba(0,0,0,0.2)}
+.ps-ring::before{content:'';position:absolute;inset:8px;border-radius:50%;background:var(--surface)}
+.ps-num{position:relative;font-size:2rem;font-weight:800;font-family:var(--sans);letter-spacing:-0.04em;color:var(--text)}
+.ps-grade-label{font-size:0.6875rem;color:var(--text3);font-family:var(--mono);letter-spacing:0.5px;text-transform:uppercase}
+.ps-hero-body{flex:1}
+.ps-hero-title{font-size:1.125rem;font-weight:700;color:var(--text);margin-bottom:4px;letter-spacing:-0.02em}
+.ps-hero-sub{font-size:0.8125rem;color:var(--text3);margin-bottom:6px}
+.ps-hero-detail{display:flex;gap:16px;margin-bottom:16px;font-size:0.72rem;color:var(--text3)}
+.ps-hero-detail span{display:flex;align-items:center;gap:4px}
+.ps-hero-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.ps-fix-all{padding:11px 28px;background:linear-gradient(135deg,#238636,#2ea043);border:none;border-radius:8px;color:#fff;font-size:0.8125rem;font-weight:600;cursor:pointer;transition:all 0.2s;font-family:var(--sans);letter-spacing:-0.01em;box-shadow:0 2px 8px rgba(35,134,54,0.3)}
+.ps-fix-all:hover{transform:translateY(-1px);box-shadow:0 4px 16px rgba(35,134,54,0.4)}
+.ps-fix-all:disabled{opacity:0.6;cursor:wait;transform:none}
+.ps-resolved{font-size:0.75rem;color:var(--success);display:flex;align-items:center;gap:6px;margin-top:8px}
 
-/* Alert strip */
-.a-alert{display:flex;align-items:center;gap:10px;padding:12px 16px;border-left:3px solid var(--danger);background:rgba(248,81,73,0.04);margin-bottom:24px;font-size:0.8125rem;color:var(--text2);border-radius:0 10px 10px 0}
-.a-alert strong{color:#f85149;font-weight:600}
-.a-alert a{margin-left:auto;color:var(--text3);font-size:0.75rem;text-decoration:none;white-space:nowrap}
-.a-alert a:hover{color:var(--text2)}
+/* Status bar */
+.ps-status{display:flex;justify-content:space-between;align-items:center;padding:10px 0;margin-bottom:20px;border-bottom:1px solid var(--border);font-size:0.75rem;color:var(--text3)}
+.ps-status a,.ps-status button{font-size:0.75rem}
 
-/* Sandbox strip */
-.a-sandbox{display:flex;align-items:center;gap:8px;padding:10px 16px;border:1px solid var(--border);border-radius:10px;margin-bottom:20px;font-size:0.8125rem;color:var(--text3)}
-.a-sandbox strong{color:var(--text2);font-weight:500}
-.a-sandbox a{color:var(--text2);text-decoration:none;margin-left:auto;font-weight:500}
-.a-sandbox a:hover{color:var(--text)}
-
-/* Section */
-.a-sec{margin-bottom:24px}
-.a-sec-title{font-size:0.6875rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text3);font-weight:500;margin-bottom:12px;padding-bottom:8px;border-bottom:1px solid var(--border)}
-
-/* Priority fix row */
-.a-fix{display:flex;align-items:flex-start;gap:10px;padding:12px 0;border-bottom:1px solid var(--border)}
-.a-fix:last-child{border-bottom:none}
-.a-fix-sev{min-width:60px;flex-shrink:0;padding-top:1px;font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px;text-align:center;display:inline-block}
-.a-fix-sev.sev-critical{background:var(--danger-muted);color:var(--danger);border:1px solid var(--danger-border)}
-.a-fix-sev.sev-high{background:var(--danger-muted);color:var(--danger);border:1px solid var(--danger-border)}
-.a-fix-sev.sev-medium{background:var(--warn-muted);color:var(--warn);border:1px solid var(--warn-border)}
-.a-fix-body{flex:1;min-width:0}
-.a-fix-head{display:flex;align-items:baseline;gap:8px}
-.a-fix-id{font-family:var(--mono);font-size:0.8125rem;font-weight:600;color:var(--text2)}
-.a-fix-title{font-size:0.8125rem;color:var(--text);font-weight:500}
-.a-fix-rem{display:flex;align-items:center;gap:6px;margin-top:6px}
-.a-fix-rem code{font-family:var(--mono);font-size:0.75rem;color:var(--text2)}
-.a-cp{background:transparent;border:1px solid var(--border);color:var(--text3);border-radius:4px;padding:2px 8px;font-size:0.6875rem;cursor:pointer;transition:all 0.12s;font-family:var(--mono);white-space:nowrap}
-.a-cp:hover{border-color:var(--border-hover);color:var(--text2);background:var(--surface2)}
-
-/* Product block */
-.a-prod{border:1px solid var(--border);border-radius:10px;margin-bottom:16px;overflow:hidden;background:var(--surface);box-shadow:0 1px 2px rgba(0,0,0,0.2)}
-.a-prod-head{padding:16px 20px;border-bottom:1px solid var(--border);display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap}
-.a-prod-icon{font-size:1.3rem;line-height:1;margin-top:1px}
-.a-prod-name{font-size:0.875rem;font-weight:600;letter-spacing:-0.01em}
-.a-prod-desc{font-size:0.75rem;color:var(--text3);margin-top:2px;line-height:1.4}
-.a-prod-path{font-family:var(--mono);font-size:0.6875rem;color:var(--text3);margin-top:6px;display:flex;align-items:center;gap:6px}
-.a-prod-path code{color:var(--text2)}
-.a-prod-counts{display:flex;gap:12px;margin-left:auto;flex-shrink:0;align-items:center}
-.a-prod-counts span{font-size:0.6875rem;font-family:var(--mono);font-weight:500}
+/* AI Assessment */
+.ps-ai-summary{padding:20px 24px;background:var(--surface);border:1px solid var(--accent-border);border-radius:12px;margin-bottom:20px;position:relative}
+.ps-ai-summary::before{content:'';position:absolute;left:0;top:12px;bottom:12px;width:3px;background:var(--accent-light);border-radius:2px}
+.ps-ai-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+.ps-ai-hdr span:first-child{font-size:0.8125rem;font-weight:600;color:var(--text);display:flex;align-items:center;gap:8px}
+.ps-ai-model{font-size:0.65rem;color:var(--text3);font-family:var(--mono);font-weight:400;padding:2px 8px;background:var(--surface2);border-radius:4px}
+.ps-ai-text{font-size:0.8125rem;color:var(--text2);line-height:1.65}
 
 /* Findings */
-.a-fd summary{cursor:pointer;padding:10px 20px;font-size:0.8125rem;color:var(--text3);list-style:none;font-weight:500;display:flex;align-items:center;gap:5px;transition:background 0.1s;border-bottom:1px solid var(--border)}
-.a-fd summary:hover{background:rgba(255,255,255,0.02)}
-.a-fd summary::-webkit-details-marker{display:none}
-.a-fd summary::before{content:'\203A';font-size:0.9rem;transition:transform 0.12s;font-weight:400;color:var(--text3)}
-.a-fd[open] summary::before{transform:rotate(90deg)}
-.a-fi{display:flex;align-items:flex-start;gap:10px;padding:12px 20px;border-bottom:1px solid var(--border)}
-.a-fi:last-child{border-bottom:none}
-.a-fi-sev{min-width:60px;flex-shrink:0;padding-top:1px;font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px;text-align:center;display:inline-block}
-.a-fi-sev.sev-critical{background:var(--danger-muted);color:var(--danger);border:1px solid var(--danger-border)}
-.a-fi-sev.sev-high{background:var(--danger-muted);color:var(--danger);border:1px solid var(--danger-border)}
-.a-fi-sev.sev-medium{background:var(--warn-muted);color:var(--warn);border:1px solid var(--warn-border)}
-.a-fi-sev.sev-info,.a-fi-sev.sev-low{background:var(--surface2);color:var(--text3);border:1px solid var(--border)}
-.a-fi-body{flex:1;min-width:0}
-.a-fi-head{display:flex;align-items:baseline;gap:8px}
-.a-fi-id{font-family:var(--mono);font-size:0.8125rem;font-weight:600;color:var(--text2)}
-.a-fi-title{font-size:0.8125rem;color:var(--text);font-weight:500}
-.a-fi-detail{font-size:0.75rem;color:var(--text3);margin-top:4px;line-height:1.5}
-.a-fi-fix{display:flex;align-items:center;gap:6px;margin-top:6px;flex-wrap:wrap}
-.a-fi-fix code{font-family:var(--mono);font-size:0.75rem;color:var(--text2)}
-.a-fi-link{font-size:0.75rem;color:#58a6ff;text-decoration:none;margin-left:4px}
-.a-fi-link:hover{text-decoration:underline}
+.ps-section-title{font-size:0.6875rem;text-transform:uppercase;letter-spacing:0.6px;color:var(--text3);font-weight:600;margin-bottom:12px;padding-left:2px}
+.ps-findings{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden;margin-bottom:24px}
+.ps-finding{display:flex;align-items:flex-start;gap:14px;padding:16px 20px;border-bottom:1px solid var(--border);transition:background 0.15s}
+.ps-finding:last-child{border-bottom:none}
+.ps-finding:hover{background:rgba(255,255,255,0.01)}
+.ps-fixable{border-left:3px solid var(--success)}
+.ps-fixed{background:rgba(63,185,80,0.04);border-left:3px solid var(--success)}
+.ps-f-sev{flex-shrink:0;min-width:70px;padding-top:2px}
+.ps-sev{display:inline-block;font-size:0.6rem;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px;text-align:center}
+.ps-sev.sev-critical{background:rgba(248,81,73,0.12);color:#f85149;border:1px solid rgba(248,81,73,0.25)}
+.ps-sev.sev-high{background:rgba(248,81,73,0.08);color:#f85149;border:1px solid rgba(248,81,73,0.2)}
+.ps-sev.sev-medium{background:rgba(210,153,34,0.1);color:#d29922;border:1px solid rgba(210,153,34,0.25)}
+.ps-sev.sev-low,.ps-sev.sev-info{background:var(--surface2);color:var(--text3);border:1px solid var(--border)}
+.ps-sev.sev-fixed{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.3)}
+.ps-f-body{flex:1;min-width:0}
+.ps-f-title{font-size:0.8125rem;font-weight:600;color:var(--text);line-height:1.4}
+.ps-f-product{display:inline-block;font-size:0.6rem;font-weight:500;color:var(--text3);background:var(--surface2);padding:1px 6px;border-radius:3px;margin-left:8px;vertical-align:middle;font-family:var(--mono);letter-spacing:0.3px}
+.ps-f-detail{font-size:0.75rem;color:var(--text3);margin-top:5px;line-height:1.55}
+.ps-f-risk{font-size:0.75rem;color:var(--accent-light);margin-top:6px;padding:6px 10px;background:rgba(139,92,246,0.04);border-radius:6px;border-left:2px solid var(--accent-light);line-height:1.5}
+.ps-f-rem{margin-top:8px}
+.ps-f-rem code{font-family:var(--mono);font-size:0.7rem;color:var(--text2);background:var(--bg);padding:4px 10px;border-radius:4px;border:1px solid var(--border);display:inline-block}
+.ps-f-act{flex-shrink:0;display:flex;align-items:center;padding-top:2px}
 
-/* Footer */
-.a-foot{text-align:center;padding:24px 0;color:var(--text3);font-size:0.6875rem;font-family:var(--mono)}
-.a-foot a{color:var(--text2);text-decoration:none}
-.a-foot a:hover{color:var(--text)}
+/* Buttons */
+.ps-fix-btn{padding:6px 18px;background:rgba(35,134,54,0.1);border:1px solid #238636;color:#3fb950;border-radius:6px;font-size:0.72rem;font-weight:600;cursor:pointer;transition:all 0.15s;font-family:var(--sans)}
+.ps-fix-btn:hover{background:rgba(35,134,54,0.2);box-shadow:0 0 8px rgba(63,185,80,0.15)}
+.ps-cfg-btn{padding:6px 14px;border:1px solid var(--border);color:var(--text3);border-radius:6px;font-size:0.72rem;font-weight:500;text-decoration:none;transition:all 0.15s}
+.ps-cfg-btn:hover{border-color:var(--border-hover);color:var(--text2);background:var(--surface2)}
+.ps-enrich-btn{padding:7px 18px;background:rgba(139,92,246,0.06);border:1px solid var(--accent-border);color:var(--accent-light);border-radius:6px;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.15s;display:flex;align-items:center;gap:6px}
+.ps-enrich-btn:hover{background:rgba(139,92,246,0.12);border-color:var(--accent-light)}
+
+/* Celebration */
+.ps-celebrate{text-align:center;padding:40px;background:linear-gradient(135deg,rgba(35,134,54,0.06),rgba(63,185,80,0.03));border:1px solid rgba(63,185,80,0.2);border-radius:14px;margin-bottom:24px}
+.ps-celebrate-score{font-size:3rem;font-weight:800;color:var(--success);font-family:var(--sans);letter-spacing:-0.04em}
+.ps-celebrate-grade{font-size:0.875rem;color:var(--text3);font-family:var(--mono);margin-top:4px}
+.ps-celebrate-msg{font-size:0.8125rem;color:var(--text2);margin-top:16px}
+.ps-celebrate-msg a{color:var(--accent-light);text-decoration:none}
+
+/* Loading */
+.htmx-indicator{display:none}
+.htmx-request .htmx-indicator,.htmx-request.htmx-indicator{display:inline}
+.ps-spinner{display:inline-block;width:14px;height:14px;border:2px solid var(--border);border-top-color:var(--accent-light);border-radius:50%;animation:spin 0.6s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* Info toggle */
+.ps-info-toggle{font-size:0.72rem;color:var(--text3);cursor:pointer;padding:8px 0;display:flex;align-items:center;gap:6px;background:none;border:none;font-family:var(--sans)}
+.ps-info-toggle:hover{color:var(--text2)}
+.ps-info-items{display:none}
+.ps-info-items.open{display:block}
 
 @media(max-width:768px){
-  .a-stats{grid-template-columns:repeat(2,1fr)}
-  .a-prod-head{flex-direction:column}
-  .a-prod-counts{margin-left:0}
-}
-@media(max-width:480px){
-  .a-stats{grid-template-columns:1fr}
+  .ps-hero{flex-direction:column;text-align:center;gap:20px;padding:24px}
+  .ps-hero-detail{justify-content:center}
+  .ps-findings .ps-finding{flex-wrap:wrap}
 }
 </style>
 
-<p class="page-desc">Security audit of your deployment. Score based on {{.TotalChecks}} checks across oktsec and detected products.</p>
+<p class="page-desc">Security posture across {{.TotalChecks}} checks. {{if gt .FixableCount 0}}{{.FixableCount}} can be auto-fixed.{{end}}</p>
 
 {{if .Sandbox}}
-<div class="a-sandbox">
-  <strong>Sandbox</strong> &middot; Sample OpenClaw config with intentional security issues.
-  <a href="/dashboard/audit">Exit sandbox &rarr;</a>
+<div style="display:flex;align-items:center;gap:8px;padding:10px 16px;border:1px solid var(--border);border-radius:10px;margin-bottom:20px;font-size:0.8125rem;color:var(--text3)">
+  <strong style="color:var(--text2)">Sandbox</strong> &middot; Sample config with intentional security issues.
+  <a href="/dashboard/audit" style="margin-left:auto;color:var(--text2);text-decoration:none;font-weight:500">Exit sandbox &rarr;</a>
 </div>
 {{end}}
 
-<div class="a-stats">
-  <div class="a-stat">
-    <div class="a-stat-label">Posture Score</div>
-    <div class="a-stat-val">{{.Score}}<span class="a-grade">Grade {{.Grade}}</span></div>
-  </div>
-  <div class="a-stat">
-    <div class="a-stat-label">Critical</div>
-    <div class="a-stat-val{{if gt .Summary.Critical 0}} v-crit{{end}}">{{.Summary.Critical}}</div>
-  </div>
-  <div class="a-stat">
-    <div class="a-stat-label">High</div>
-    <div class="a-stat-val v-high">{{.Summary.High}}</div>
-  </div>
-  <div class="a-stat">
-    <div class="a-stat-label">Medium</div>
-    <div class="a-stat-val v-med">{{.Summary.Medium}}</div>
-  </div>
-  <div class="a-stat">
-    <div class="a-stat-label">Info</div>
-    <div class="a-stat-val v-dim">{{.Summary.Info}}</div>
-  </div>
-</div>
-
-{{if .ChainCount}}
-<div class="a-alert" style="border-left-color:{{if .ChainValid}}{{if .SignatureVerified}}var(--border){{else}}rgba(210,153,34,0.5){{end}}{{else}}var(--danger){{end}};background:{{if .ChainValid}}{{if .SignatureVerified}}transparent{{else}}rgba(210,153,34,0.04){{end}}{{else}}rgba(248,81,73,0.04){{end}}">
-  {{if .ChainValid}}{{if .SignatureVerified}}&#x2713;{{else}}&#x2713;{{end}}{{else}}&#x2717;{{end}}
-  <span>{{if and .ChainValid .SignatureVerified}}Chain + Signatures: <strong style="color:var(--text2)">Verified</strong> &middot; {{.ChainCount}} entries verified{{if .SignatureFingerprint}} &middot; <span style="font-size:var(--text-xs);color:var(--text3);font-family:var(--mono)">{{slice .SignatureFingerprint 0 16}}...</span>{{end}}{{else if .ChainValid}}Chain: <strong style="color:var(--text2)">Valid</strong> | Signatures: <strong style="color:rgba(210,153,34,0.9)">Not verified</strong> <span style="color:var(--text3);font-size:var(--text-xs)">(no proxy key)</span> &middot; {{.ChainCount}} entries verified{{else}}Audit chain: <strong style="color:var(--danger)">broken</strong> &middot; {{.ChainCount}} entries verified{{end}}</span>
-</div>
-{{if and (not .ChainValid) .ChainReason}}
-<div class="card" style="border-color:rgba(248,81,73,0.2);margin-bottom:var(--sp-6)">
-  <div style="color:var(--danger);font-weight:600;margin-bottom:var(--sp-2);font-size:var(--text-md)">Chain integrity failure</div>
-  <div style="color:var(--text2);font-size:var(--text-sm);line-height:1.6;margin-bottom:var(--sp-2)"><strong>Reason:</strong> {{.ChainReason}}</div>
-  {{if .ChainBrokenID}}<div style="color:var(--text2);font-size:var(--text-sm)"><strong>Broken at entry:</strong> <code>{{.ChainBrokenID}}</code> (position {{.ChainBrokenAt}} of {{.ChainCount}})</div>{{end}}
-  <div style="color:var(--text3);font-size:var(--text-xs);margin-top:var(--sp-2)">This typically occurs when the database is modified externally, entries are deleted, or the proxy restarts with a different signing key.</div>
-</div>
-{{end}}
-{{end}}
-
-{{if .LLMEnabled}}
-<div style="display:flex;align-items:center;gap:12px;padding:12px 20px;background:rgba(56,139,253,0.06);border:1px solid rgba(56,139,253,0.15);border-radius:10px;margin-bottom:var(--sp-5)">
-  <span style="font-size:1.1rem">&#x1F9E0;</span>
-  <div style="flex:1">
-    <div style="font-size:0.82rem;font-weight:600;color:var(--text)">AI-Enhanced Analysis Active</div>
-    <div style="font-size:0.72rem;color:var(--text3);margin-top:2px">Messages are being analyzed by <span style="font-family:var(--mono);color:var(--accent-light)">{{.LLMModel}}</span> for threats that rules can't detect.{{if .LLMThreats}} {{.LLMThreats}} analyses completed{{if .LLMConfirmed}}, {{.LLMConfirmed}} confirmed threats{{end}}.{{end}}</div>
-  </div>
-  <a href="/dashboard/llm" class="btn btn-sm btn-outline" style="font-size:0.72rem;border-color:var(--accent-border);color:var(--accent-light);white-space:nowrap">View AI Analysis</a>
-</div>
-{{end}}
-
-{{if .HasCritical}}
-<div class="a-alert">
-  <strong>{{.Summary.Critical}} critical {{if eq .Summary.Critical 1}}finding{{else}}findings{{end}}</strong> require immediate action
-</div>
-{{end}}
-
-{{if .TopFixes}}
-<div class="a-prod" id="remediations">
-  <div class="a-prod-head" style="border-bottom:1px solid var(--border)">
-    <div class="a-prod-icon">&#x1F6E1;</div>
-    <div style="flex:1;min-width:0">
-      <div class="a-prod-name">Priority Remediations</div>
-      <div class="a-prod-desc">Top critical and high findings that need immediate attention.</div>
+<!-- Hero -->
+<div class="ps-hero">
+  <div class="ps-hero-score" id="posture-score">
+    <div class="ps-ring" style="--pct:{{.Score}};--clr:{{if ge .Score 90}}var(--success){{else if ge .Score 60}}var(--warn){{else}}var(--danger){{end}}">
+      <span class="ps-num">{{.Score}}</span>
     </div>
-    <div class="a-prod-counts"><span style="color:var(--text2)">{{len .TopFixes}} {{if eq (len .TopFixes) 1}}fix{{else}}fixes{{end}}</span></div>
+    <div class="ps-grade-label">Grade {{.Grade}}</div>
   </div>
-  {{range .TopFixes}}
-  <div class="a-fi">
-    <span class="a-fi-sev sev-{{lower (printf "%s" .Severity)}}">{{.Severity}}</span>
-    <div class="a-fi-body">
-      <div class="a-fi-head">
-        <span class="a-fi-id">{{.CheckID}}</span>
-        <span class="a-fi-title">{{.Title}}</span>
-      </div>
-      {{if .Remediation}}
-      <div class="a-fi-fix">
-        <code>{{.Remediation}}</code>
-        <button class="a-cp" onclick="copyText('{{.Remediation}}',this)">copy</button>
-        {{if .FixURL}}<a href="{{.FixURL}}" class="a-fi-link">Fix this &rarr;</a>{{end}}
-      </div>
-      {{end}}
+  <div class="ps-hero-body">
+    <div class="ps-hero-title">{{if ge .Score 90}}Deployment secured{{else if ge .Score 60}}Deployment needs attention{{else}}Critical security gaps detected{{end}}</div>
+    <div class="ps-hero-detail">
+      {{if gt .Summary.Critical 0}}<span><span class="ps-hero-dot" style="background:var(--danger)"></span>{{.Summary.Critical}} critical</span>{{end}}
+      {{if gt .Summary.High 0}}<span><span class="ps-hero-dot" style="background:var(--danger)"></span>{{.Summary.High}} high</span>{{end}}
+      {{if gt .Summary.Medium 0}}<span><span class="ps-hero-dot" style="background:var(--warn)"></span>{{.Summary.Medium}} medium</span>{{end}}
+      {{if gt .Summary.Info 0}}<span><span class="ps-hero-dot" style="background:var(--text3)"></span>{{.Summary.Info}} info</span>{{end}}
     </div>
+    {{if gt .FixableCount 0}}
+    <button class="ps-fix-all"
+      hx-post="/dashboard/api/audit/fix-all"
+      hx-target="#posture-findings"
+      hx-swap="innerHTML"
+      hx-confirm="Apply {{.FixableCount}} safe fixes? This enables security features in your config.">Fix {{.FixableCount}} {{if eq .FixableCount 1}}issue{{else}}issues{{end}} automatically</button>
+    {{end}}
   </div>
+</div>
+
+<!-- Status bar -->
+<div class="ps-status">
+  <div>
+    Audit trail: {{formatNum .ChainCount}} entries{{if .ChainValid}}, integrity verified{{end}}
+  </div>
+  {{if .LLMEnabled}}
+  <button class="ps-enrich-btn" hx-post="/dashboard/api/audit/enrich" hx-target="#posture-findings" hx-swap="innerHTML" hx-indicator="#enrich-spin">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a4 4 0 0 0-4 4v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-2V6a4 4 0 0 0-4-4z"/></svg>
+    {{if .SavedAnalysis}}Re-analyze with AI{{else}}Analyze with AI{{end}}
+  </button>
+  <span id="enrich-spin" class="htmx-indicator" style="margin-left:6px"><span class="ps-spinner"></span></span>
   {{end}}
 </div>
-{{end}}
 
-{{range .Groups}}
-<div class="a-prod">
-  <div class="a-prod-head">
-    {{if .Info.Icon}}<div class="a-prod-icon">{{.Info.Icon}}</div>{{end}}
-    <div style="flex:1;min-width:0">
-      <div class="a-prod-name">{{.Info.Name}}</div>
-      {{if .Info.Description}}<div class="a-prod-desc">{{.Info.Description}}</div>{{end}}
-      {{if .Info.ConfigPath}}
-      <div class="a-prod-path">
-        Config: <code>{{.Info.ConfigPath}}</code>
-        <button class="a-cp" onclick="copyText('{{.Info.ConfigPath}}',this)">copy</button>
-      </div>
-      {{end}}
-      {{if .Info.DocsURL}}<div style="font-size:0.68rem;margin-top:3px"><a href="{{.Info.DocsURL}}" target="_blank" rel="noopener" style="color:var(--text3);text-decoration:none">{{.Info.DocsURL}}</a></div>{{end}}
-    </div>
-    <div class="a-prod-counts">
-      {{if .Summary.Critical}}<span style="color:var(--danger)">{{.Summary.Critical}} critical</span>{{end}}
-      {{if .Summary.High}}<span style="color:var(--text2)">{{.Summary.High}} high</span>{{end}}
-      {{if .Summary.Medium}}<span style="color:var(--text2)">{{.Summary.Medium}} medium</span>{{end}}
-      {{if .Summary.Info}}<span style="color:var(--text3)">{{.Summary.Info}} info</span>{{end}}
-    </div>
+<!-- Findings -->
+<div class="ps-section-title">Findings</div>
+<div class="ps-findings" id="posture-findings">
+{{if .SavedAnalysis}}
+<div class="ps-ai-summary" style="margin:16px 20px;border-radius:10px">
+  <div class="ps-ai-hdr">
+    <span>AI Assessment</span>
+    <span class="ps-ai-model">{{.AnalysisModel}}</span>
   </div>
-
-  <details class="a-fd"{{if or .Summary.Critical .Summary.High}} open{{end}}>
-    <summary>{{len .Findings}} {{if eq (len .Findings) 1}}finding{{else}}findings{{end}}</summary>
-    {{range .Findings}}
-    <div class="a-fi">
-      <span class="a-fi-sev sev-{{lower (printf "%s" .Severity)}}">{{.Severity}}</span>
-      <div class="a-fi-body">
-        <div class="a-fi-head">
-          <span class="a-fi-id">{{.CheckID}}</span>
-          <span class="a-fi-title">{{.Title}}</span>
-        </div>
-        <div class="a-fi-detail">{{.Detail}}</div>
-        {{if .Remediation}}
-        <div class="a-fi-fix">
-          <code>{{.Remediation}}</code>
-          <button class="a-cp" onclick="copyText('{{.Remediation}}',this)">copy</button>
-          {{if .FixURL}}<a href="{{.FixURL}}" class="a-fi-link">Fix this →</a>{{end}}
-        </div>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
-  </details>
+  <div class="ps-ai-text">{{.SavedAnalysis}}</div>
 </div>
 {{end}}
-
-<div class="a-foot">
-  {{.TotalChecks}} findings &middot;
-  {{.Summary.Critical}} critical &middot; {{.Summary.High}} high &middot; {{.Summary.Medium}} medium &middot; {{.Summary.Info}} info
-  {{if not .Sandbox}}<br><a href="/dashboard/audit/sandbox">Try sandbox demo &rarr;</a>{{end}}
+{{range .AllFindings}}{{if ne (printf "%s" .Severity) "INFO"}}
+<div class="ps-finding{{if isFixable .CheckID}} ps-fixable{{end}}" id="f-{{.CheckID}}">
+  <div class="ps-f-sev"><span class="ps-sev sev-{{lower (printf "%s" .Severity)}}">{{.Severity}}</span></div>
+  <div class="ps-f-body">
+    <span class="ps-f-title">{{.Title}}{{if .Product}}<span class="ps-f-product">{{.Product}}</span>{{end}}</span>
+    {{if .Detail}}<div class="ps-f-detail">{{.Detail}}</div>{{end}}
+    {{if not (isFixable .CheckID)}}{{if .Remediation}}<div class="ps-f-rem"><code>{{.Remediation}}</code></div>{{end}}{{end}}
+  </div>
+  <div class="ps-f-act">
+    {{if isFixable .CheckID}}
+    <button class="ps-fix-btn" hx-post="/dashboard/api/audit/fix/{{.CheckID}}" hx-target="#f-{{.CheckID}}" hx-swap="outerHTML">Fix</button>
+    {{else if .FixURL}}
+    <a href="{{.FixURL}}" class="ps-cfg-btn">Configure</a>
+    {{end}}
+  </div>
+</div>
+{{end}}{{end}}
 </div>
 
-<script>
-function copyText(text, btn) {
-  navigator.clipboard.writeText(text).then(function() {
-    var orig = btn.textContent;
-    btn.textContent = 'copied';
-    btn.style.color = 'var(--success)';
-    setTimeout(function() { btn.textContent = orig; btn.style.color = ''; }, 1200);
-  });
-}
-</script>
 ` + layoutFoot))


### PR DESCRIPTION
## Summary

- Redesigned Security Posture page: hero score ring, flat findings list, HTMX auto-fix buttons, AI risk enrichment
- Fixed critical bug: severity string comparison filtered out HIGH/CRITICAL findings
- Fixed auth middleware: returns 401 JSON for API endpoints instead of 302 redirect
- 9 auto-fixable checks via one-click buttons, AI enrichment persists across page reloads

## Bugs fixed

- **Severity filter bug**: Template used string comparison `gt "INFO"` which excluded "HIGH" and "CRITICAL" (H < I alphabetically). Changed to `ne "INFO"`.
- **Auth middleware**: API endpoints got 302 redirect on expired session, causing HTMX/fetch to silently fail. Now returns 401 JSON.

## Test plan

- [x] `make build && make test && make lint` all pass
- [x] HIGH and CRITICAL findings now visible on page load
- [x] Auto-fix buttons apply config changes via HTMX
- [x] AI enrichment adds per-finding risk lines and global summary
- [x] Analysis persists across page reloads