### PR TITLE
fix: unify CLI audit DB path with server config

### DIFF
--- a/cmd/oktsec/commands/db_path_test.go
+++ b/cmd/oktsec/commands/db_path_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// TestDefaultDBPath_PrefersConfig locks in the fix for the CLI/server
+// mismatch: before unifying, defaultDBPath() returned ~/.oktsec/oktsec.db
+// unconditionally while the running server followed cfg.DBPath from
+// oktsec.yaml. Operators saw different CRLs / quarantine queues depending
+// on which tool they reached for. This test fails if anyone ever lets
+// defaultDBPath() drift back to config.DefaultDBPath() directly.
+func TestDefaultDBPath_PrefersConfig(t *testing.T) {
+	dir := t.TempDir()
+	wantPath := filepath.Join(dir, "custom-audit.db")
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	cfg := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: dir},
+		DBPath:   wantPath,
+	}
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = orig })
+
+	got := defaultDBPath()
+	if got != wantPath {
+		t.Fatalf("defaultDBPath() = %q, want %q (config-driven path)", got, wantPath)
+	}
+}
+
+// When the config can't be loaded (missing, malformed) or has no db_path
+// we want a sane default rather than an empty string. That behaviour is
+// shared with the previous resolveDBPath() implementation — kept tested
+// so the fallback isn't silently dropped during future refactors.
+func TestDefaultDBPath_FallsBackToDefaultWhenNoConfig(t *testing.T) {
+	orig := cfgFile
+	cfgFile = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Cleanup(func() { cfgFile = orig })
+
+	got := defaultDBPath()
+	if got == "" {
+		t.Fatal("fallback must not be empty — callers open sql.DB with this path")
+	}
+	if _, err := os.Stat(filepath.Dir(got)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("default dir should be resolvable: %v", err)
+	}
+}

--- a/cmd/oktsec/commands/proxy.go
+++ b/cmd/oktsec/commands/proxy.go
@@ -14,9 +14,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// defaultDBPath returns a shared DB location so proxy and serve share the same audit trail.
+// defaultDBPath returns the audit DB path every CLI subcommand should use.
+// It consults oktsec.yaml first (cfg.DBPath) so the CLI and the running
+// server see the same DB — otherwise operators see different CRLs /
+// quarantine state depending on which tool they reach for. Falls back to
+// the XDG default only when no config is reachable or db_path is empty.
+//
+// Kept as a thin wrapper around resolveDBPath so other CLIs can call it
+// without importing cobra helpers, and so the underlying precedence is
+// defined in exactly one place.
 func defaultDBPath() string {
-	return config.DefaultDBPath()
+	return resolveDBPath()
 }
 
 func newProxyCmd() *cobra.Command {


### PR DESCRIPTION
## Summary

Follow-up to #96 that was discovered during live validation: every CLI subcommand except \`audit verify-chain\` and \`audit archive\` opened \`~/.oktsec/oktsec.db\` unconditionally, while the running server followed \`db_path\` from \`oktsec.yaml\`. When those paths differ (the common case on this project's own setup), operators see divergent CRL / quarantine / audit history depending on whether they reach for the CLI or the HTTP API.

This PR was drafted on top of #96 but landed after that branch was merged, so it's split out here.

## Change

\`defaultDBPath()\` now delegates to \`resolveDBPath()\`, which prefers \`cfg.DBPath\` from \`oktsec.yaml\` and falls back to the XDG default only when no config is reachable. Every existing CLI caller (\`keys rotate\`, \`keys list-revoked\`, \`quarantine\`, \`logs\`, \`status\`, \`setup\`, the stdio proxy wrapper) inherits the fix without being touched.

## Test plan
- [x] \`make build\` — green
- [x] \`make test\` — all 23 packages pass (lint clean, vet clean)
- [x] New tests in \`db_path_test.go\`:
  - \`TestDefaultDBPath_PrefersConfig\` — fails if anyone regresses to \`config.DefaultDBPath()\`
  - \`TestDefaultDBPath_FallsBackToDefaultWhenNoConfig\` — pins the fallback
- [x] Live verification: \`oktsec keys list-revoked\` and \`GET /v1/revoked-keys\` now return the same state (both show \`No revoked keys\` on the same running server); before the fix they diverged.