### PR TITLE
fix: dashboard polish + README rewrite for customer readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+<h1 align="center">Oktsec</h1>
+
 <p align="center">
-  <strong>Oktsec</strong> — Runtime security for AI agent tool calls
+  <strong>The firewall that controls, audits and secures everything AI agents execute on your systems — in real time.</strong>
 </p>
 
 <p align="center">
@@ -11,20 +13,32 @@
 </p>
 
 <p align="center">
-  <a href="#installation">Installation</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#hooks">Hooks</a> &middot;
-  <a href="#mcp-gateway">Gateway</a> &middot;
-  <a href="#threat-intel">Threat Intel</a> &middot;
-  <a href="#openclaw-support">OpenClaw</a> &middot;
+  <a href="#why-oktsec">Why Oktsec</a> &middot;
+  <a href="#how-it-compares">Compare</a> &middot;
   <a href="#dashboard">Dashboard</a> &middot;
+  <a href="#mcp-gateway">Gateway</a> &middot;
   <a href="#detection-rules">Rules</a> &middot;
   <a href="#configuration">Config</a>
 </p>
 
 ---
 
-See everything your AI agents execute. Monitors MCP tool calls and CLI operations in real-time - intercept, detect, block, audit. **255 detection rules** across 17 categories. Delegation chains with Ed25519-signed authorization tokens. Egress sandboxing for MCP server processes. Dependency auditing against OSV.dev. Tamper-evident audit trail with offline CLI verification. Optional LLM threat intelligence. Discovers and secures **17 MCP clients** automatically. Deterministic 10-stage pipeline. Single binary. Built on the [official MCP SDK](https://github.com/modelcontextprotocol/go-sdk). Aligned with the [OWASP Top 10 for Agentic Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications/).
+## The problem
+
+AI agents don't just chat — they execute. They run shells, write to disks, transfer funds, hit internal APIs and spawn sub-agents. Every tool call is a production action with no default oversight: no rate limit on how fast Claude can `rm -rf`, no signature on who actually issued the command, no audit trail that survives a tampered log, no backpressure when prompt injection slips through.
+
+Oktsec sits between agents and their tools and runs every call through a deterministic 10-stage security pipeline: identity verification (Ed25519), ACL enforcement, 268 detection rules, intent validation, tamper-evident audit chain, and real-time anomaly scoring. One Go binary, zero LLM dependency on the hot path, Apache 2.0.
+
+## What's new (v0.15)
+
+- **Tamper-evident audit chain v2** — SHA-256 chain now commits to policy decisions, triggered rules and signature status. Tampering any field of an audit row invalidates the chain. Read-only verification path so `oktsec audit verify-chain` can't silently auto-repair a forged log.
+- **Distributed rate limiting (Redis-backed)** — sliding-window Lua script, atomic across N proxy replicas. Memory-backed default for single-node.
+- **Key rotation with version pinning** — `oktsec keys rotate --agent <name>` bumps `Agent.KeyVersion`; post-rotation v1 signatures fail-closed.
+- **OpenTelemetry tracing** — W3C traceparent propagation end-to-end, pluggable exporter. Off by default; enable in `oktsec.yaml`.
+- **Gateway per-agent caps** — `MaxConcurrentCalls` and `MaxDelegationDepth` limit blast radius of a compromised sub-agent.
+- **Tool classification (UK AISI taxonomy)** — every MCP tool in the gateway gets an impact × generality risk tier, visible in the dashboard.
+- **CSRF defense-in-depth** — Origin/Referer guard on the dashboard, on top of SameSite=Strict cookies.
 
 ## What it does
 
@@ -34,7 +48,7 @@ Oktsec sits between AI agents and enforces a 10-stage security pipeline:
 2. **Identity** — Ed25519 signatures verify every message sender. No valid signature, no processing (ASI03).
 3. **Agent suspension** — Suspended agents are immediately rejected, no further processing (ASI10).
 4. **Policy** — YAML-based ACLs control which agent can message which. Default-deny mode rejects unknown senders (ASI03).
-5. **Content scanning** — 255 detection rules catch prompt injection, credential leaks, PII exposure, data exfiltration, MCP attacks, tool-call threats, supply chain risks, and more (ASI01, ASI02, ASI05).
+5. **Content scanning** — 268 detection rules catch prompt injection, credential leaks, PII exposure, data exfiltration, MCP attacks, tool-call threats, supply chain risks, and more (ASI01, ASI02, ASI05).
 6. **Intent validation** — Declared intent vs actual content alignment check. Detects agents that say one thing and do another (ASI01).
 7. **BlockedContent enforcement** — Per-agent category-based content blocking escalates verdicts when findings match blocked categories (ASI02).
 8. **Multi-message escalation** — Agents with repeated blocks get their verdicts escalated automatically (ASI01, ASI10).
@@ -82,7 +96,7 @@ curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bas
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-VERSION=v0.11.0 curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bash
+VERSION=v0.15.0 curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bash
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bash
 ```
 
@@ -211,12 +225,12 @@ Response:
 
 ## Hooks
 
-Oktsec intercepts tool calls from any MCP client that supports HTTP hooks — not just MCP traffic. Every `Read`, `Write`, `Bash`, `WebSearch`, and any other tool call passes through the 255-rule security pipeline before execution.
+Oktsec intercepts tool calls from any MCP client that supports HTTP hooks — not just MCP traffic. Every `Read`, `Write`, `Bash`, `WebSearch`, and any other tool call passes through the 268-rule security pipeline before execution.
 
 ```
 Claude Code (any tool call)
     │
-    ├── PreToolUse → POST /hooks/event → 255 rules → allow/block
+    ├── PreToolUse → POST /hooks/event → 268 rules → allow/block
     │
     ├── Tool executes (if allowed)
     │
@@ -254,7 +268,7 @@ Agent  ──►  Oktsec Gateway  ──►  Backend MCP Server(s)
              │
              ├─ Rate limit
              ├─ Agent ACL check
-             ├─ Content scan (255 rules)
+             ├─ Content scan (268 rules)
              ├─ Tool policies (spend limits, rate limits, approval)
              ├─ Rule overrides
              ├─ Verdict (allow/block/quarantine)
@@ -813,7 +827,7 @@ oktsec verify --config oktsec.yaml
 
 ## Detection rules
 
-Oktsec includes **255 detection rules** across 17 categories:
+Oktsec includes **268 detection rules** across 17 categories:
 
 | Source | Count | Categories |
 |--------|-------|------------|
@@ -886,7 +900,7 @@ Oktsec includes **255 detection rules** across 17 categories:
 15 rules in the `openclaw-config` category (OCLAW-001 through OCLAW-015), covering full tool profiles, exposed gateways, open DM policies, exec without sandbox, path traversal, missing authentication, hardcoded credentials, and more.
 
 ```bash
-oktsec rules                     # List all 255 rules
+oktsec rules                     # List all 268 rules
 oktsec rules --explain CE-004    # Explain a container escape rule
 oktsec rules --explain IAP-001   # Explain a specific rule
 oktsec rules --explain TC-001    # Explain a tool-call rule
@@ -1099,6 +1113,44 @@ Oktsec is aligned with the [OWASP Top 10 for Agentic Applications](https://genai
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and pull request process.
 
 For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
+## How it compares
+
+Oktsec lives at the **runtime execution layer** — the tool calls and messages agents emit *while* they run. Adjacent projects attack different slices of the stack.
+
+| Capability | Oktsec | Lakera Guard | Protect AI | Glasswing | WAFs (Cloudflare/AWS) |
+|---|---|---|---|---|---|
+| Agent-to-agent message control | ✅ | ❌ | ❌ | ❌ | ❌ |
+| MCP tool-call interception (10-stage pipeline) | ✅ | ❌ | ❌ | partial | ❌ |
+| Deterministic detection (zero LLM on hot path) | ✅ | LLM-based | hybrid | LLM-based | regex |
+| Ed25519 identity + tamper-evident audit chain | ✅ | ❌ | ❌ | ❌ | ❌ |
+| On-prem single binary (Apache 2.0) | ✅ | SaaS | SaaS | SaaS | SaaS |
+| Distributed rate limiting (Redis-backed) | ✅ | SaaS | SaaS | SaaS | ✅ |
+| OpenTelemetry tracing + CRL export | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 268 detection rules (prompt injection, creds, MCP attacks, PII, supply chain) | ✅ | ~100 | ~50 | ~80 | generic |
+
+**Different layer, complementary.** A typical deployment runs a WAF at the edge, a prompt-injection classifier (Lakera, PromptArmor) at the LLM boundary, and **Oktsec at the agent-to-tool boundary** where actual actions happen.
+
+## Try it
+
+```bash
+# Install
+curl -fsSL https://raw.githubusercontent.com/oktsec/oktsec/main/install.sh | bash
+
+# Run everything (auto-discovers MCP clients, generates config, starts dashboard)
+oktsec run
+
+# Open http://localhost:8082/dashboard — access code printed in the terminal
+```
+
+Everything runs locally. No telemetry, no account, no egress.
+
+## Get in touch
+
+- **Star this repo** if agent security matters to your team.
+- **Production deployment / enterprise questions**: gus@oktsec.com
+- **Security disclosure**: see [SECURITY.md](SECURITY.md)
+- **Issues & feature requests**: [GitHub Issues](https://github.com/oktsec/oktsec/issues)
 
 ## License
 

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -3299,7 +3299,13 @@ func (s *Server) handleSaveLLM(w http.ResponseWriter, r *http.Request) {
 
 	s.cfg.LLM.Model = r.FormValue("model")
 	s.cfg.LLM.BaseURL = r.FormValue("base_url")
-	s.cfg.LLM.APIKey = r.FormValue("api_key")
+	// API key is write-only from the UI: an empty field means "keep what
+	// you already have". The form never ships the real key to the browser
+	// (template renders value="" with a masked placeholder), so the only
+	// way api_key arrives non-empty is if the operator typed a new one.
+	if newKey := r.FormValue("api_key"); newKey != "" {
+		s.cfg.LLM.APIKey = newKey
+	}
 	s.cfg.LLM.APIKeyEnv = r.FormValue("api_key_env")
 	if v := r.FormValue("timeout"); v != "" {
 		s.cfg.LLM.Timeout = v

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -9,24 +9,84 @@ import (
 	"time"
 )
 
-// snakeToTitle converts snake_case to Title Case.
+// categoryOverrides pins the canonical casing for acronym-heavy category
+// names that a generic title-caser mangles. "Mcp" / "Openclaw" look
+// unprofessional on customer-facing pages, and these names show up in the
+// Rules catalog and in the Settings drawer where VCs see them first.
+var categoryOverrides = map[string]string{
+	"mcp":             "MCP",
+	"mcp_attack":      "MCP Attack",
+	"mcp_config":      "MCP Config",
+	"openclaw":        "OpenClaw",
+	"openclaw_config": "OpenClaw Config",
+	"inter_agent":     "Inter-Agent",
+	"ipi":             "IPI",
+	"iap":             "IAP",
+	"oclaw":           "OCLAW",
+	"ce":              "CE",
+	"tc":              "TC",
+	"pii":             "PII",
+	"api":             "API",
+	"llm":             "LLM",
+	"rce":             "RCE",
+	"ssrf":            "SSRF",
+	"xss":             "XSS",
+	"sql":             "SQL",
+	"jwt":             "JWT",
+	"oauth":           "OAuth",
+	"cors":            "CORS",
+	"tls":             "TLS",
+	"csrf":            "CSRF",
+	"acl":             "ACL",
+	"ai":              "AI",
+}
+
+// normalizedKey lets categoryOverrides match regardless of whether the
+// caller hands us snake_case ("inter_agent"), kebab-case ("inter-agent"),
+// or just the raw word. Without this the same category ID reaches the UI
+// formatted differently depending on the source.
+func normalizedKey(s string) string {
+	return strings.ReplaceAll(strings.ToLower(s), "-", "_")
+}
+
+// snakeToTitle converts snake_case to Title Case, preserving canonical
+// capitalization for well-known acronyms (MCP, OpenClaw, IPI, …). Without
+// this, the UI ships strings like "Mcp Attack" and "Openclaw Config" which
+// read as unpolished to a security buyer.
 func snakeToTitle(s string) string {
+	if v, ok := categoryOverrides[normalizedKey(s)]; ok {
+		return v
+	}
 	words := strings.Split(s, "_")
 	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		if len(w) == 0 {
+			continue
 		}
+		if v, ok := categoryOverrides[normalizedKey(w)]; ok {
+			words[i] = v
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
 	}
 	return strings.Join(words, " ")
 }
 
-// kebabToTitle converts kebab-case to Title Case.
+// kebabToTitle converts kebab-case to Title Case with the same acronym
+// overrides as snakeToTitle.
 func kebabToTitle(s string) string {
+	if v, ok := categoryOverrides[normalizedKey(s)]; ok {
+		return v
+	}
 	words := strings.FieldsFunc(s, func(r rune) bool { return r == '-' || r == '_' })
 	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		if len(w) == 0 {
+			continue
 		}
+		if v, ok := categoryOverrides[normalizedKey(w)]; ok {
+			words[i] = v
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
 	}
 	return strings.Join(words, " ")
 }
@@ -2640,9 +2700,11 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
     <div class="ed-slbl">Rules triggered ({{len .Rules}})</div>
     {{range .Rules}}
     <div style="display:flex;align-items:center;gap:var(--sp-2);padding:var(--sp-2) 0;font-size:var(--text-sm);border-bottom:1px solid var(--border-subtle)">
-      {{if eq .Severity "CRITICAL"}}<span class="sev-critical">critical</span>
-      {{else if eq .Severity "HIGH"}}<span class="sev-high">high</span>
-      {{else if eq .Severity "MEDIUM"}}<span class="sev-medium">medium</span>
+      {{$s := lower .Severity}}
+      {{if eq $s "critical"}}<span class="sev-critical">critical</span>
+      {{else if eq $s "high"}}<span class="sev-high">high</span>
+      {{else if eq $s "medium"}}<span class="sev-medium">medium</span>
+      {{else if eq $s "low"}}<span class="sev-low">low</span>
       {{else}}<span class="sev-low">{{.Severity}}</span>{{end}}
       <span style="font-family:var(--mono);font-weight:600;color:var(--text);font-size:var(--text-sm)">{{.RuleID}}</span>
       <span style="color:var(--text3);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:var(--text-sm)">{{.Name}}</span>
@@ -3923,9 +3985,9 @@ tqApply();
     <div class="form-group" style="margin-bottom:8px" id="cfg-key-group">
       <label id="cfg-key-label">API Key</label>
       <div style="position:relative">
-        <input type="password" name="api_key" id="cfg-key" value="{{.Cfg.APIKey}}" autocomplete="off" style="padding-right:40px" placeholder="sk-...">
-        <button type="button" aria-label="Toggle API key visibility" onclick="var k=document.getElementById('cfg-key');k.type=k.type==='password'?'text':'password'" style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--text3);cursor:pointer;padding:4px;font-size:0.75rem" title="Show/hide">&#x1f441;</button>
+        <input type="password" name="api_key" id="cfg-key" value="" autocomplete="off" style="padding-right:40px" placeholder="{{if .Cfg.APIKey}}•••• (stored — leave blank to keep){{else}}sk-...{{end}}">
       </div>
+      {{if .Cfg.APIKey}}<div style="font-size:0.7rem;color:var(--text3);margin-top:4px">API key is stored (masked). Type a new one to replace it, or leave blank to keep the current key.</div>{{end}}
     </div>
     <div class="form-group" style="margin-bottom:0" id="cfg-keyenv-group">
       <label>API Key Env Variable</label>
@@ -5825,9 +5887,11 @@ var ruleDetailPageTmpl = template.Must(template.New("rule-detail-page").Funcs(tm
   </span>
 </div>
 <div class="rd-meta">
-  {{if eq .Detail.Severity "critical"}}<span class="sev-critical">critical</span>
-  {{else if eq .Detail.Severity "high"}}<span class="sev-high">high</span>
-  {{else if eq .Detail.Severity "medium"}}<span class="sev-medium">medium</span>
+  {{$sev := lower .Detail.Severity}}
+  {{if eq $sev "critical"}}<span class="sev-critical">critical</span>
+  {{else if eq $sev "high"}}<span class="sev-high">high</span>
+  {{else if eq $sev "medium"}}<span class="sev-medium">medium</span>
+  {{else if eq $sev "low"}}<span class="sev-low">low</span>
   {{else}}<span class="sev-low">{{.Detail.Severity}}</span>{{end}}
   <span style="color:var(--text3);font-size:0.78rem">{{.Detail.Name}}</span>
 </div>

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -95,7 +95,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 }
 </style>
 
-<p class="page-desc">Security posture across {{.TotalChecks}} checks. {{if gt .FixableCount 0}}{{.FixableCount}} can be auto-fixed.{{end}}</p>
+<p class="page-desc">Security posture: <strong>{{.TotalChecks}} finding{{if ne .TotalChecks 1}}s{{end}}</strong> to review.{{if gt .FixableCount 0}} <strong>{{.FixableCount}}</strong> can be auto-fixed.{{end}}</p>
 
 {{if .Sandbox}}
 <div style="display:flex;align-items:center;gap:8px;padding:10px 16px;border:1px solid var(--border);border-radius:10px;margin-bottom:20px;font-size:0.8125rem;color:var(--text3)">


### PR DESCRIPTION
## Summary

Four narrow dashboard fixes and a README rewrite for clarity and customer-facing polish. Each change is scoped so reviewing the diff stays easy.

## Changes

### Dashboard: write-only API key field
LLM settings rendered \`Cfg.APIKey\` as \`value="..."\` inside a password input. Masked visually but lived in the DOM and could be read with any show-password toggle or DevTools. The template now renders \`value=""\` with a placeholder indicating a key is stored, and the save handler preserves the existing key when the form field is empty — typing a new one replaces it, leaving it blank keeps the current key.

### Dashboard: category capitalization
\`snakeToTitle\` / \`kebabToTitle\` produced "Mcp Attack", "Openclaw Config" and "Inter Agent" from the raw YAML category IDs. Added a \`categoryOverrides\` map so well-known acronyms (MCP, OpenClaw, IPI, IAP, JWT, OAuth, SSRF, CSRF, …) and multi-word compounds (Inter-Agent, MCP Attack, OpenClaw Config) render with canonical casing. Lookup is normalized across snake_case and kebab-case so the same category reaches the UI consistently regardless of source.

### Dashboard: severity color mapping
Rule detail + event drawer compared Severity literally against \`"critical"\` / \`"high"\` / \`"medium"\` / \`"low"\`. When the scanner emitted the uppercase variant (e.g. \`"MEDIUM"\`) the else branch kicked in and MEDIUM rendered with \`sev-low\` styling (gray instead of amber). Normalized with the existing \`lower\` template function and added an explicit \`low\` branch so the final else is a true unknown-severity fallback.

### Dashboard: audit posture copy
\"Security posture across 2 checks\" conflated findings with checks run. New copy separates the two: \"Security posture: N findings to review. M can be auto-fixed.\" — no implicit claim about the total number of checks.

### README
- Leads with the problem (agents don't just chat; every tool call is a production action with no default oversight) and the product positioning, instead of the tagline + feature wall.
- New \"What's new (v0.15)\" section covering chain v2, Redis-backed rate limiter, key rotation with version pinning, OpenTelemetry tracing, gateway per-agent caps, tool classification.
- New \"How it compares\" section placing oktsec at the agent-to-tool boundary, complementary to WAFs and prompt-injection classifiers.
- Explicit \"Try it\" + \"Get in touch\" sections instead of trailing off after the license block.
- Rule count reconciled across the file (255 → 268, the actual scanner-reported number) and install-script version pin bumped (v0.11.0 → v0.15.0).

## Test plan
- [x] \`make build\` — green
- [x] \`make test\` (race, 23 packages) — all pass
- [x] \`make lint\` — 0 issues
- [x] \`make vet\` — clean
- [x] HTML render check post-fix: no \`sk-or-v1-...\` substring in settings HTML, category labels render \`MCP Attack\` / \`OpenClaw\` / \`Inter-Agent\`, uppercase severities color correctly.
- [x] \`oktsec audit verify-chain\` — chain VALID on a freshly-written trail.