### PR TITLE
chore(deps): upgrade Aguara v0.13.0 → v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.2] - 2026-04-24
+
+### Changed
+
+- **Upgrade Aguara v0.13.0 → v0.14.4**. Zero code changes needed — public API identical. Gains:
+  - Pattern matcher 3.7-6.4x speedup via Aho-Corasick prefilter.
+  - Two new evasion decoders (base32, C-style octal escapes) in content scanning.
+  - Tighter regexes on PROMPT_INJECTION_004/011 and UNI_001/006 (fewer FPs).
+  - Documentation-context confidence penalty (findings in `## Installation` blocks score lower).
+  - Fixed AC prefilter literal collision with `bashrc` (broken in v0.14.3, fixed in v0.14.4).
+
 ## [0.15.1] - 2026-04-16
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/garagon/aguara v0.13.0
+	github.com/garagon/aguara v0.14.4
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/modelcontextprotocol/go-sdk v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/garagon/aguara v0.13.0 h1:zSUr1TzZYGwbfuBqhE2Lz3msRAK4r0BD5sdiLsRr4Aw=
-github.com/garagon/aguara v0.13.0/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
+github.com/garagon/aguara v0.14.4 h1:YBqjoGI8bZe64AKb/VZf40WNg9ewMWeqiZeg0W91ndM=
+github.com/garagon/aguara v0.14.4/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary

- Bump Aguara from v0.13.0 to v0.14.4
- 3.7-6.4x scan speedup via Aho-Corasick prefilter
- Two new evasion decoders (base32, C-style octal escapes)
- Tighter FP regexes on PROMPT_INJECTION_004/011 and UNI_001/006
- Documentation-context confidence penalty
- AC prefilter literal collision with `bashrc` fixed (was broken in v0.14.3)
- Zero code changes needed, public API identical

## Test plan

- [x] `go test -race -count=1 ./internal/engine/` passes (scanner + all rules)
- [x] `TestMEM006_NpmPostinstallAbuse` confirms `cat payload >> ~/.bashrc` detects EXTDL_005
- [x] `go test -race -count=1 ./...` full suite passes (0 failures)
- [x] `go build ./...` compiles
- [x] `go vet ./...` clean