### PR TITLE
chore(deps): upgrade Aguara v0.14.4 → v0.14.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
-	github.com/garagon/aguara v0.14.4
+	github.com/garagon/aguara v0.14.5
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/modelcontextprotocol/go-sdk v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/garagon/aguara v0.14.4 h1:YBqjoGI8bZe64AKb/VZf40WNg9ewMWeqiZeg0W91ndM=
-github.com/garagon/aguara v0.14.4/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
+github.com/garagon/aguara v0.14.5 h1:UiIj9n416ae0e5M27rLDaYRafy0ktLwKRAGrXkQHNIk=
+github.com/garagon/aguara v0.14.5/go.mod h1:njU1wgwlHIKnH1mmPua7ifNbzkRERnMyNndLBmMWk4A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary

Bumps Aguara v0.14.4 → v0.14.5. Dep-only change, no oktsec code modified.

## What changed upstream (v0.14.5)

- **Credential redaction by default**: `matched_text` in credential-leak findings now shows `[REDACTED]` instead of actual secrets. No-op for oktsec because `internal/engine/scanner.go` already redacts via `RedactRuleFindings` before returning results.
- **CI environment auto-detection**: Update check auto-suppresses in GitHub Actions, GitLab CI, etc. Prevents unnecessary API calls and metadata leaks in CI.
- **Symlink traversal fix**: `--changed` scans no longer follow committed symlinks to sensitive files (`/etc/passwd`, SSH keys). Changed from `os.Stat` to `os.Lstat`.
- **Repo hygiene**: `.gitignore` entries for `.env`, `.pem`, `.key` files. Self-scanning config (`.aguara.yml`) to reduce false positives from intentional attack-pattern examples in test fixtures.
- **New library APIs**: `aguara.WithRedaction(bool)`, `types.RedactedPlaceholder`, `types.RedactCredentialFindings()`.

## Why this is safe

The only behavior change (credential redaction) is already handled by oktsec's own redaction layer in `internal/engine/scanner.go`. The symlink fix and CI detection are improvements with no breaking surface.

## Test plan

- [x] `make build`
- [x] `make test` (all pass, race detector enabled)
- [x] `make lint` (0 issues)