### PR TITLE
fix: P0 security audit findings

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -559,6 +559,7 @@ func startServer(configPath string, opts runOpts) error {
 	// would show different events.
 	var gw *gateway.Gateway
 	auditStore := srv.AuditStore()
+	srv.Dashboard().SetGatewayManaged()
 	if cfg.Gateway.Enabled {
 		var gwErr error
 		gw, gwErr = gateway.NewGateway(cfg, logger, auditStore)

--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -82,30 +82,32 @@ func RedactEntries(entries []Entry, level RedactionLevel) []RedactedEntry {
 }
 
 // RedactRuleFindings strips matched content from rule findings JSON while
-// preserving rule IDs, names, and severities. This is a simple string-level
-// redaction that removes "matched" fields.
+// preserving rule IDs, names, and severities. Handles both "matched" (Aguara
+// raw findings) and "match" (scanner FindingSummary) field names.
 func RedactRuleFindings(rulesJSON string) string {
 	if rulesJSON == "" || rulesJSON == "[]" {
 		return rulesJSON
 	}
 
-	const needle = `"matched":"`
-	const placeholder = `"matched":"[REDACTED]"`
-	var b strings.Builder
-	b.Grow(len(rulesJSON))
+	rulesJSON = redactJSONField(rulesJSON, `"matched":"`, `"matched":"[REDACTED]"`)
+	rulesJSON = redactJSONField(rulesJSON, `"match":"`, `"match":"[REDACTED]"`)
+	return rulesJSON
+}
 
-	remaining := rulesJSON
+func redactJSONField(s, needle, placeholder string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	remaining := s
 	for {
 		idx := strings.Index(remaining, needle)
 		if idx == -1 {
 			b.WriteString(remaining)
 			break
 		}
-		// Write everything before the match key + the placeholder
 		b.WriteString(remaining[:idx])
 		b.WriteString(placeholder)
 
-		// Skip past the original value: find closing quote after the key
 		valStart := idx + len(needle)
 		end := valStart
 		for end < len(remaining) {
@@ -114,7 +116,7 @@ func RedactRuleFindings(rulesJSON string) string {
 				continue
 			}
 			if remaining[end] == '"' {
-				end++ // consume closing quote
+				end++
 				break
 			}
 			end++

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -35,9 +35,10 @@ type Server struct {
 	logger  *slog.Logger
 	mux     *http.ServeMux
 
-	gwMu     sync.Mutex
-	gwCmd    *exec.Cmd
-	llmQueue *llm.Queue
+	gwMu      sync.Mutex
+	gwCmd     *exec.Cmd
+	gwManaged bool // true when an in-process gateway is managed by the caller
+	llmQueue  *llm.Queue
 	ruleGen  *llm.RuleGenerator
 
 	// Gateway tool classification callback (set when gateway runs in-process)
@@ -80,8 +81,10 @@ func NewServer(cfg *config.Config, cfgPath string, auditStore audit.AuditStore, 
 		go scanner.ListRules()
 	}
 
-	// Auto-start gateway if enabled in config and backends exist
-	if cfg.Gateway.Enabled && len(cfg.MCPServers) > 0 {
+	// Auto-start gateway only when no in-process gateway is managed by the
+	// caller (e.g. run command). Without this guard, both the dashboard child
+	// process and the embedded gateway would compete for the same port.
+	if cfg.Gateway.Enabled && len(cfg.MCPServers) > 0 && !s.gwManaged {
 		s.gwMu.Lock()
 		s.startGateway()
 		s.gwMu.Unlock()
@@ -97,6 +100,12 @@ func NewServer(cfg *config.Config, cfgPath string, auditStore audit.AuditStore, 
 	}()
 
 	return s
+}
+
+// SetGatewayManaged marks that an in-process gateway is already running.
+// When set, the dashboard will not spawn a child gateway process.
+func (s *Server) SetGatewayManaged() {
+	s.gwManaged = true
 }
 
 // SetLLMQueue attaches the LLM queue for budget status display.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -418,25 +418,12 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 1a. Extract sub-agent identity from tool arguments.
-		// The HTTP header (agent) is the authoritative identity for all
-		// security decisions (ACL, policy, suspension checks). The
-		// _oktsec_agent parameter is logged as metadata but cannot
-		// override policy — this prevents agent spoofing.
-		headerAgent := agent
+		// policyAgent is the immutable principal for ALL security
+		// decisions. _oktsec_agent is metadata for audit logs only.
+		policyAgent := agent
 		subAgent := extractAndStripAgentParam(req)
 		if subAgent != "" {
-			// Validate: only trust sub-agent if the header agent is
-			// configured and not suspended.
-			if agentCfg, ok := g.cfg.Agents[headerAgent]; ok && !agentCfg.Suspended {
-				agent = subAgent
-				g.autoRegisterAgent(agent)
-			} else {
-				g.logger.Warn("ignoring _oktsec_agent: header agent not configured or suspended",
-					"header_agent", headerAgent,
-					"claimed_agent", subAgent,
-				)
-				// Keep using headerAgent for all checks
-			}
+			g.autoRegisterAgent(subAgent)
 		}
 
 		// 1b. Extract tool arguments summary for audit (after stripping _oktsec_agent)
@@ -457,7 +444,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 				// Enforce per-agent delegation depth cap. Crossing this line
 				// is how a rogue agent tries to fan out into a sub-tree of
 				// delegated children; we stop it at the gateway.
-				if maxDepth := resolveDelegationDepth(g.cfg, agent); maxDepth > 0 && chainResult.Depth > maxDepth {
+				if maxDepth := resolveDelegationDepth(g.cfg, policyAgent); maxDepth > 0 && chainResult.Depth > maxDepth {
 					g.logger.Warn("delegation depth exceeded",
 						"agent", agent, "depth", chainResult.Depth, "max", maxDepth)
 					g.logAudit(msgID, agent, m.OriginalName, audit.StatusBlocked, audit.DecisionDelegationDepthExceeded, "[]", toolArgs, sessionID, start)
@@ -479,14 +466,14 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 2. Rate limit check
-		if !g.rateLimiter.Allow(agent) {
+		if !g.rateLimiter.Allow(policyAgent) {
 			g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionRateLimited, "[]", toolArgs, sessionID, start)
 			return toolError("rate limit exceeded"), nil
 		}
 
 		// 2b. Per-agent concurrency slot. Held through scan + backend call so
 		// a single agent can't open N parallel sockets against the same tool.
-		release, err := g.concurrency.acquire(ctx, agent)
+		release, err := g.concurrency.acquire(ctx, policyAgent)
 		if err != nil {
 			g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionConcurrencyExceeded, "[]", toolArgs, sessionID, start)
 			return toolError("concurrency limit exceeded"), nil
@@ -494,7 +481,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		defer release()
 
 		// 3. Tool allowlist check
-		if agentCfg, ok := g.cfg.Agents[agent]; ok {
+		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok {
 			if agentCfg.Suspended {
 				g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionAgentSuspended, "[]", toolArgs, sessionID, start)
 				return toolError("agent suspended"), nil
@@ -515,10 +502,10 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 3b. Tool policy enforcement (spending limits, rate limits, approval thresholds)
-		if agentCfg, ok := g.cfg.Agents[agent]; ok && agentCfg.ToolPolicies != nil {
+		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok && agentCfg.ToolPolicies != nil {
 			if policy, hasPolicy := agentCfg.ToolPolicies[m.OriginalName]; hasPolicy {
 				amount := ExtractAmount(mcputil.GetArguments(req.Params.Arguments))
-				result := g.policyEnforcer.Check(agent, m.OriginalName, amount, policy)
+				result := g.policyEnforcer.Check(policyAgent, m.OriginalName, amount, policy)
 				if !result.Allowed {
 					status := audit.StatusBlocked
 					if result.Decision == "quarantine_approval" {
@@ -538,7 +525,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 					params[k] = s
 				}
 			}
-			result := g.constraintChecker.CheckToolCall(agent, m.OriginalName, params)
+			result := g.constraintChecker.CheckToolCall(policyAgent, m.OriginalName, params)
 			if !result.Allowed {
 				g.logAudit(msgID, agent, m.OriginalName, audit.StatusBlocked, audit.DecisionConstraintViolated, "[]", toolArgs, sessionID, start)
 				return toolError(fmt.Sprintf("constraint: %s", result.Reason)), nil
@@ -567,7 +554,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		verdict.ApplyToolScopedOverridesPostAguara(g.cfg.Rules, outcome, m.OriginalName)
 
 		// 6b. Apply agent scan profile if explicitly configured.
-		if agentCfg, ok := g.cfg.Agents[agent]; ok && agentCfg.ScanProfile != "" {
+		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok && agentCfg.ScanProfile != "" {
 			verdict.ApplyScanProfile(agentCfg.ScanProfile, outcome, m.OriginalName)
 		}
 
@@ -577,12 +564,12 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 7. Apply blocked content
-		if agentCfg, ok := g.cfg.Agents[agent]; ok {
+		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok {
 			verdict.ApplyBlockedContent(agentCfg, outcome)
 		}
 
 		// 7b. LLM-driven agent escalation (async feedback loop)
-		if g.escalationTracker != nil && g.escalationTracker.IsEscalated(agent) {
+		if g.escalationTracker != nil && g.escalationTracker.IsEscalated(policyAgent) {
 			outcome.Verdict = verdict.EscalateOneLevel(outcome.Verdict)
 		}
 
@@ -664,10 +651,10 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 
 		// 12b. Record successful call for tool policy tracking
-		if agentCfg, ok := g.cfg.Agents[agent]; ok && agentCfg.ToolPolicies != nil {
+		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok && agentCfg.ToolPolicies != nil {
 			if _, hasPolicy := agentCfg.ToolPolicies[m.OriginalName]; hasPolicy {
 				amount := ExtractAmount(mcputil.GetArguments(req.Params.Arguments))
-				g.policyEnforcer.Record(agent, m.OriginalName, amount)
+				g.policyEnforcer.Record(policyAgent, m.OriginalName, amount)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Three P0 fixes from external security audit (Codex agent):

### 1. Agent identity spoofing via `_oktsec_agent` parameter
The `_oktsec_agent` tool argument was changing the effective principal for ALL policy checks (allowlist, tool policies, constraints, blocked content, suspension). A restricted agent could declare a sub-agent name and bypass its own policies.

**Fix:** Introduced `policyAgent` as immutable principal derived from the HTTP header. `_oktsec_agent` is now metadata for audit logs only. All 11 policy check sites updated.

### 2. Dual gateway on `oktsec run`
`dashboard.NewServer()` auto-started a child gateway process via `exec.Command`. When called from `run` (which also starts an embedded gateway), two gateways would compete for the same port with separate audit stores.

**Fix:** Added `SetGatewayManaged()` flag. When set by `run`, the dashboard skips child process spawn.

### 3. Audit redaction field name mismatch
`RedactRuleFindings` searched for `"matched":"` but the scanner's `FindingSummary` serializes as `json:"match"`. Sensitive content in the `match` field was not redacted in analyst exports.

**Fix:** Redaction now handles both `"matched"` and `"match"` field names.

## Test plan

- [x] `make build`
- [x] `make test` (all pass, race detector enabled)
- [x] `make lint` (0 issues)
- [ ] Manual: verify `_oktsec_agent` in tool args no longer changes policy principal
- [ ] Manual: verify single gateway process when running `oktsec run`
- [ ] Manual: verify exported findings redact both `match` and `matched` fields