### PR TITLE
fix: P1 security audit findings (wildcard egress, SDK auth, Go toolchain)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/documentation/guides/openclaw.md
+++ b/documentation/guides/openclaw.md
@@ -1,6 +1,6 @@
 # Securing OpenClaw with Oktsec
 
-OpenClaw agents call MCP tools, relay instructions between agents, and make autonomous decisions. Oktsec intercepts every tool call and agent message, scanning for prompt injection, credential leaks, data exfiltration, and 226 other threat patterns.
+OpenClaw agents call MCP tools, relay instructions between agents, and make autonomous decisions. Oktsec intercepts every tool call and agent message, scanning through 268 detection rules across 19 categories -- prompt injection, credential leaks, data exfiltration, supply chain attacks, MCP exploits, and more.
 
 This guide gets you from zero to secured in under 5 minutes.
 
@@ -107,7 +107,7 @@ agents:
 ### 3. Start oktsec
 
 ```bash
-oktsec serve
+oktsec run
 ```
 
 You'll see:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/oktsec/oktsec
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -131,6 +131,17 @@ func (e *EgressEvaluator) resolveScope(scope string) []string {
 	return domains
 }
 
+// domainMatch checks if hostname matches pattern, supporting wildcards.
+// Pattern "*.example.com" matches "sub.example.com" and "a.b.example.com".
+// Pattern "example.com" matches only "example.com" (case-insensitive).
+func domainMatch(hostname, pattern string) bool {
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:] // ".example.com"
+		return strings.HasSuffix(strings.ToLower(hostname), strings.ToLower(suffix))
+	}
+	return strings.EqualFold(hostname, pattern)
+}
+
 // DomainAllowed checks a host against the resolved policy.
 // Global blocked_domains always win (cannot be overridden per-agent).
 func (p *ResolvedEgressPolicy) DomainAllowed(host string) bool {
@@ -140,14 +151,14 @@ func (p *ResolvedEgressPolicy) DomainAllowed(host string) bool {
 	}
 
 	for _, d := range p.BlockedDomains {
-		if strings.EqualFold(hostname, d) {
+		if domainMatch(hostname, d) {
 			return false
 		}
 	}
 
 	if len(p.AllowedDomains) > 0 {
 		for _, d := range p.AllowedDomains {
-			if strings.EqualFold(hostname, d) {
+			if domainMatch(hostname, d) {
 				return true
 			}
 		}
@@ -182,13 +193,13 @@ func (p *ResolvedEgressPolicy) ToolDomainAllowed(toolName, host string) bool {
 
 	// Check blocked first (global blocked always wins)
 	for _, d := range p.BlockedDomains {
-		if strings.EqualFold(hostname, d) {
+		if domainMatch(hostname, d) {
 			return false
 		}
 	}
 
 	for _, d := range domains {
-		if strings.EqualFold(hostname, d) {
+		if domainMatch(hostname, d) {
 			return true
 		}
 	}

--- a/internal/proxy/egress_test.go
+++ b/internal/proxy/egress_test.go
@@ -195,6 +195,56 @@ func TestResolvedPolicy_DomainAllowed(t *testing.T) {
 	}
 }
 
+func TestDomainMatch(t *testing.T) {
+	tests := []struct {
+		hostname, pattern string
+		want              bool
+	}{
+		{"example.com", "example.com", true},
+		{"Example.COM", "example.com", true},
+		{"sub.example.com", "*.example.com", true},
+		{"a.b.example.com", "*.example.com", true},
+		{"example.com", "*.example.com", false},
+		{"notexample.com", "*.example.com", false},
+		{"evil-example.com", "*.example.com", false},
+		{"api.supabase.co", "*.supabase.co", true},
+		{"db.supabase.co", "*.supabase.co", true},
+		{"supabase.co", "*.supabase.co", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.hostname+"_"+tt.pattern, func(t *testing.T) {
+			assert.Equal(t, tt.want, domainMatch(tt.hostname, tt.pattern))
+		})
+	}
+}
+
+func TestDomainAllowed_Wildcard(t *testing.T) {
+	p := ResolvedEgressPolicy{
+		AllowedDomains: []string{"*.supabase.co", "exact.com"},
+		BlockedDomains: []string{"*.evil.org"},
+	}
+
+	assert.True(t, p.DomainAllowed("api.supabase.co"))
+	assert.True(t, p.DomainAllowed("db.supabase.co"))
+	assert.True(t, p.DomainAllowed("exact.com"))
+	assert.False(t, p.DomainAllowed("other.com"))
+	assert.False(t, p.DomainAllowed("sub.evil.org"))
+	assert.False(t, p.DomainAllowed("deep.sub.evil.org"))
+}
+
+func TestToolDomainAllowed_Wildcard(t *testing.T) {
+	p := ResolvedEgressPolicy{
+		BlockedDomains: []string{"*.blocked.io"},
+		ToolRestrictions: map[string][]string{
+			"db_query": {"*.supabase.co"},
+		},
+	}
+
+	assert.True(t, p.ToolDomainAllowed("db_query", "api.supabase.co"))
+	assert.False(t, p.ToolDomainAllowed("db_query", "other.com"))
+	assert.False(t, p.ToolDomainAllowed("db_query", "sub.blocked.io"))
+}
+
 func TestMergeUnique(t *testing.T) {
 	result := mergeUnique([]string{"a", "b"}, []string{"B", "c"})
 	assert.Len(t, result, 3)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -10,6 +10,10 @@
 //	kp, _ := sdk.LoadKeypair("./keys", "my-agent")
 //	c := sdk.NewClient("http://localhost:8080", "my-agent", kp.PrivateKey)
 //	resp, err := c.SendMessage(ctx, "recipient", "hello")
+//
+// With API key authentication:
+//
+//	c := sdk.NewClient("http://localhost:8080", "my-agent", nil, sdk.WithAPIKey("your-key"))
 package sdk
 
 import (
@@ -76,18 +80,31 @@ type Client struct {
 	baseURL    string
 	agentName  string
 	privateKey ed25519.PrivateKey // nil = unsigned
+	apiKey     string             // sent as Bearer token when set
 	httpClient *http.Client
+}
+
+// ClientOption configures optional Client settings.
+type ClientOption func(*Client)
+
+// WithAPIKey sets the API key sent as Authorization: Bearer on every request.
+func WithAPIKey(key string) ClientOption {
+	return func(c *Client) { c.apiKey = key }
 }
 
 // NewClient creates a client for the oktsec proxy.
 // Pass nil for privateKey to send unsigned messages.
-func NewClient(baseURL, agentName string, privateKey ed25519.PrivateKey) *Client {
-	return &Client{
+func NewClient(baseURL, agentName string, privateKey ed25519.PrivateKey, opts ...ClientOption) *Client {
+	c := &Client{
 		baseURL:    baseURL,
 		agentName:  agentName,
 		privateKey: privateKey,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
 }
 
 // SendMessage sends a message to another agent through the proxy.
@@ -123,6 +140,9 @@ func (c *Client) SendMessageWithMetadata(ctx context.Context, to, content string
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -148,6 +168,9 @@ func (c *Client) Health(ctx context.Context) (*HealthResponse, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
 	if err != nil {
 		return nil, err
+	}
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 
 	httpResp, err := c.httpClient.Do(httpReq)

--- a/sdk/python/src/oktsec/client.py
+++ b/sdk/python/src/oktsec/client.py
@@ -41,11 +41,16 @@ class Client:
         agent_name: str,
         keypair: Keypair | None = None,
         timeout: float = 30.0,
+        api_key: str | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.agent_name = agent_name
         self.keypair = keypair
-        self._client = httpx.Client(timeout=timeout)
+        self._api_key = api_key
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.Client(timeout=timeout, headers=headers)
 
     def send_message(
         self,
@@ -136,11 +141,16 @@ class AsyncClient:
         agent_name: str,
         keypair: Keypair | None = None,
         timeout: float = 30.0,
+        api_key: str | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.agent_name = agent_name
         self.keypair = keypair
-        self._client = httpx.AsyncClient(timeout=timeout)
+        self._api_key = api_key
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.AsyncClient(timeout=timeout, headers=headers)
 
     async def send_message(
         self,


### PR DESCRIPTION
## Summary

Addresses 3 P1 findings from the external security audit (continuation of P0 fixes in #106).

### 1. Wildcard egress matching (internal/proxy/egress.go)

**Problem:** `DomainAllowed()` and `ToolDomainAllowed()` used `strings.EqualFold` for exact-match comparison only. Integration presets in `config/presets.go` define wildcard domains like `*.supabase.co`, `*.atlassian.net`, `*.firebaseio.com`, `*.hf.co` — none of these ever matched because `strings.EqualFold("api.supabase.co", "*.supabase.co")` returns false.

**Fix:** Added `domainMatch()` helper that handles both exact matches and `*.suffix` wildcard patterns using `strings.HasSuffix`. Applied to all 4 comparison sites across `DomainAllowed()` and `ToolDomainAllowed()` (both allowed and blocked domain lists). Wildcard `*.example.com` matches `sub.example.com` and `a.b.example.com` but not `example.com` itself (subdomain-only).

**Tests:** 3 new test functions covering 10 domainMatch cases, wildcard allow/block in DomainAllowed, and wildcard tool restrictions in ToolDomainAllowed.

### 2. SDK API key authentication (sdk/client.go, sdk/python/src/oktsec/client.py)

**Problem:** Both Go and Python SDKs had no way to send API key authentication headers. When `oktsec run` generates an `OKTSEC_API_KEY` and enables the `requireAPIKey` middleware, SDK clients get 401 Unauthorized on every request.

**Fix:**
- **Go SDK:** Added `ClientOption` functional options pattern with `WithAPIKey(key)`. Sends `Authorization: Bearer <key>` on all HTTP requests (SendMessage, Health). Backwards compatible — existing callers without options continue to work.
- **Python SDK:** Added `api_key` parameter to both `Client` and `AsyncClient` constructors. Sets the header on the underlying httpx client at construction time.

### 3. Go toolchain bump (go.mod, CI/release workflows)

**Problem:** Go 1.26.1 has 5 known stdlib CVEs (crypto/x509 parsing, crypto/tls DoS, html/template XSS) fixed in Go 1.26.2. go.mod specified `go 1.25.0` with no toolchain directive. CI and release workflows pinned to `go-version: "1.25"`.

**Fix:**
- go.mod: `go 1.25.0` → `go 1.26.0` + `toolchain go1.26.2`
- CI workflow: `go-version: "1.25"` → `"1.26"`
- Release workflow: `go-version: "1.25"` → `"1.26"`

Also includes a stale doc fix for `documentation/guides/openclaw.md` (268 detection rules, `oktsec run` command).

## Test plan

- [x] `make build` — compiles clean
- [x] `make test` — all tests pass (race detector enabled)
- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] New egress wildcard tests cover: exact match, subdomain match, multi-level subdomain, non-match, evil-prefix non-match, wildcard blocked domains, tool-level wildcards
- [ ] CI validates Go 1.26 builds and runs all tests