### PR TITLE
fix: P0/P1 dashboard audit findings (webhook masking, graph render, modal a11y)

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
 )
 
 func authedGet(t *testing.T, path string) *httptest.ResponseRecorder {
@@ -584,5 +586,86 @@ func TestServer_ExportSARIF(t *testing.T) {
 	}
 	if !strings.Contains(body, `"name": "oktsec"`) {
 		t.Error("SARIF output missing tool name")
+	}
+}
+
+func TestMaskWebhookURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantHost  string
+		forbidden []string
+	}{
+		{
+			name:      "slack-like webhook",
+			input:     "https://hooks.example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			wantHost:  "hooks.example.com",
+			forbidden: []string{"/services/T00000000", "B00000000", "XXXXXXXXXXXXXXXXXXXX"},
+		},
+		{
+			name:      "discord webhook",
+			input:     "https://discord.com/api/webhooks/123456789/abcdefghijklmnop",
+			wantHost:  "discord.com",
+			forbidden: []string{"/api/webhooks/123456789/abcdefghijklmno"},
+		},
+		{
+			name:      "no path returns unchanged",
+			input:     "https://example.com",
+			wantHost:  "example.com",
+			forbidden: nil,
+		},
+		{
+			name:      "no scheme long string",
+			input:     "not-a-url-but-long-enough",
+			wantHost:  "",
+			forbidden: []string{"not-a-url-but-long-enough"},
+		},
+		{
+			name:      "no scheme short string",
+			input:     "short",
+			wantHost:  "",
+			forbidden: []string{"short"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskWebhookURL(tt.input)
+			if tt.wantHost != "" && !strings.Contains(got, tt.wantHost) {
+				t.Errorf("maskWebhookURL(%q) = %q, missing host %q", tt.input, got, tt.wantHost)
+			}
+			for _, f := range tt.forbidden {
+				if strings.Contains(got, f) {
+					t.Errorf("maskWebhookURL(%q) = %q, must not contain secret segment %q", tt.input, got, f)
+				}
+			}
+			if got == tt.input && tt.forbidden != nil {
+				t.Errorf("maskWebhookURL(%q) returned input unchanged, secret is exposed", tt.input)
+			}
+		})
+	}
+}
+
+func TestServer_AlertsPageMasksWebhookURLs(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Webhooks = []config.Webhook{
+		{Name: "slack-sec", URL: "https://hooks.example.com/services/T1234/B5678/xyzSECRETtokenABCD"},
+	}
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/alerts", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("alerts status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "/services/T1234/B5678/xyzSECRETtokenABCD") {
+		t.Error("alerts page exposes full webhook URL in DOM")
+	}
+	if !strings.Contains(body, "hooks.example.com") {
+		t.Error("alerts page should show webhook host")
 	}
 }

--- a/internal/dashboard/static/dashboard.css
+++ b/internal/dashboard/static/dashboard.css
@@ -528,8 +528,8 @@ pre,pre code{background:var(--bg);border:1px solid var(--border);border-radius:v
 /* ==========================================================================
    Confirm modal (replaces browser confirm())
    ========================================================================== */
-.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:400;display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity 0.15s ease;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px)}
-.modal-overlay.open{opacity:1;pointer-events:auto}
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:400;display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;visibility:hidden;transition:opacity 0.15s ease,visibility 0.15s ease;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px)}
+.modal-overlay.open{opacity:1;pointer-events:auto;visibility:visible}
 .modal{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-xl);padding:var(--sp-6);max-width:420px;width:90%;box-shadow:var(--shadow-lg);transform:scale(0.95);transition:transform 0.15s ease}
 .modal-overlay.open .modal{transform:scale(1)}
 .modal-title{font-size:var(--text-lg);font-weight:600;color:var(--text);margin-bottom:var(--sp-2)}

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -837,21 +837,45 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
 (function(){
   var overlay=document.createElement('div');
   overlay.className='modal-overlay';
-  overlay.innerHTML='<div class="modal"><div class="modal-title">Confirm</div><div class="modal-msg" id="modal-msg"></div><div class="modal-actions"><button class="btn btn-outline" id="modal-cancel">Cancel</button><button class="btn" id="modal-ok">Confirm</button></div></div>';
+  overlay.setAttribute('aria-hidden','true');
+  overlay.hidden=true;
+  overlay.innerHTML='<div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-msg"><div class="modal-title" id="modal-title">Confirm</div><div class="modal-msg" id="modal-msg"></div><div class="modal-actions"><button class="btn btn-outline" id="modal-cancel">Cancel</button><button class="btn" id="modal-ok">Confirm</button></div></div>';
   document.body.appendChild(overlay);
-  var pendingResolve=null;
-  function closeModal(result){overlay.classList.remove('open');if(pendingResolve){pendingResolve(result);pendingResolve=null;}}
+  if('inert' in overlay)overlay.inert=true;
+  var pendingResolve=null,_modalTrigger=null;
+  function closeModal(result){
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden','true');
+    overlay.hidden=true;
+    if('inert' in overlay)overlay.inert=true;
+    if(_modalTrigger){_modalTrigger.focus();_modalTrigger=null;}
+    if(pendingResolve){pendingResolve(result);pendingResolve=null;}
+  }
   document.getElementById('modal-cancel').onclick=function(){closeModal(false)};
   overlay.onclick=function(e){if(e.target===overlay)closeModal(false)};
   document.addEventListener('keydown',function(e){if(e.key==='Escape'&&overlay.classList.contains('open'))closeModal(false)});
   document.getElementById('modal-ok').onclick=function(){closeModal(true)};
+  // Focus trap: Tab cycles within modal buttons
+  overlay.addEventListener('keydown',function(e){
+    if(e.key!=='Tab')return;
+    var focusable=overlay.querySelectorAll('button:not([disabled])');
+    if(focusable.length===0)return;
+    var first=focusable[0],last=focusable[focusable.length-1];
+    if(e.shiftKey){if(document.activeElement===first){e.preventDefault();last.focus();}}
+    else{if(document.activeElement===last){e.preventDefault();first.focus();}}
+  });
   function showModal(msg){
+    _modalTrigger=document.activeElement;
     document.getElementById('modal-msg').textContent=msg;
     var isDestructive=msg.toLowerCase().indexOf('delete')>-1||msg.toLowerCase().indexOf('suspend')>-1||msg.toLowerCase().indexOf('revoke')>-1;
     var okBtn=document.getElementById('modal-ok');
     okBtn.className=isDestructive?'btn btn-danger':'btn';
     okBtn.textContent=isDestructive?'Confirm':'OK';
+    overlay.hidden=false;
+    overlay.removeAttribute('aria-hidden');
+    if('inert' in overlay)overlay.inert=false;
     overlay.classList.add('open');
+    document.getElementById('modal-cancel').focus();
     return new Promise(function(resolve){pendingResolve=resolve});
   }
   // Override native window.confirm

--- a/internal/dashboard/tmpl_graph.go
+++ b/internal/dashboard/tmpl_graph.go
@@ -166,12 +166,19 @@ function toggleGraphSidebar() {
   var container = document.getElementById('graph-container');
   if (!container) return;
 
-  fetch('/dashboard/api/graph?range={{.Range}}')
-    .then(function(r) { return r.json(); })
-    .then(function(data) { renderGraph(container, data); });
+  fetch('/dashboard/api/graph?range={{.Range}}',{credentials:'same-origin',cache:'no-store'})
+    .then(function(r){
+      if(!r.ok) throw new Error('HTTP '+r.status);
+      return r.json();
+    })
+    .then(function(data) { renderGraph(container, data); })
+    .catch(function(err){
+      console.error('graph fetch failed:',err);
+      container.innerHTML='<p style="color:var(--text3);text-align:center;padding-top:200px">Failed to load graph data</p>';
+    });
 
   function renderGraph(el, data) {
-    if (!data.nodes || data.nodes.length === 0) {
+    if (!data || !data.nodes || data.nodes.length === 0) {
       el.innerHTML = '<p style="color:var(--text3);text-align:center;padding-top:200px">No graph data available</p>';
       return;
     }


### PR DESCRIPTION
## Context

Post-fix validation of PRs #109-#112 found 3 P0/P1 issues that affect demo/enterprise confidence. This PR addresses all three.

## P0: Webhook URL exposed in DOM

**Problem:** `maskWebhookURL` existed in code but had no test coverage. A regression could silently expose webhook secrets (Slack tokens, Discord paths) in the alerts page HTML. The auditor confirmed the live instance was still showing full URLs, likely from a stale binary.

**Fix:** Added two tests:
- `TestMaskWebhookURL`: table-driven unit test covering Slack-like, Discord, no-path, no-scheme long, and no-scheme short URLs. Each case asserts the secret path segment never appears in output.
- `TestServer_AlertsPageMasksWebhookURLs`: integration test that configures a webhook on the test server, renders `/dashboard/alerts`, and asserts the full URL path is absent from the response body while the host portion is preserved.

**Files:** `coverage_test.go` (+83 lines)

## P1: Graph page shows "No graph data available" despite API returning data

**Problem:** The initial `fetch('/dashboard/api/graph')` call was missing `credentials: 'same-origin'` and `cache: 'no-store'` (the polling fetches at the bottom of the same file already had these). It also had no `.catch()` handler and no null guard on the response data. If the fetch failed silently (e.g., stale cache, auth redirect returning HTML), the canvas stayed empty with no error feedback.

**Fix:**
- Added `{credentials:'same-origin', cache:'no-store'}` to match the polling fetches
- Added response status check (`if (!r.ok) throw`)
- Added `.catch()` with user-visible error message in the container
- Hardened the null guard: `!data || !data.nodes` instead of just `!data.nodes` (Go nil slices serialize as JSON `null`)

**Files:** `tmpl_graph.go` lines 169-182

## P1: Confirmation modal stays in accessible tree when closed

**Problem:** The modal overlay was hidden with `opacity: 0` and `pointer-events: none`, which hides it visually but leaves it in the accessibility tree. Screen readers would announce "Confirm", "Cancel" buttons on every page even when no modal was open. No `role="dialog"`, no `aria-modal`, no focus management.

**Fix (JS in templates.go):**
- Added `hidden`, `aria-hidden="true"`, and `inert` attributes when modal is closed
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-describedby` to the modal div
- On open: removes `hidden`/`aria-hidden`/`inert`, moves focus to Cancel button
- On close: restores all attributes, returns focus to the element that triggered the modal
- Added Tab focus trap: Tab/Shift+Tab cycles between modal buttons only

**Fix (CSS in dashboard.css):**
- Added `visibility: hidden` to `.modal-overlay` closed state (fallback for browsers without `inert`)
- Added `visibility: visible` to `.modal-overlay.open`

**Files:** `templates.go` lines 836-895, `dashboard.css` lines 531-532

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/dashboard/` clean  
- [x] `go test -race -count=1 ./internal/dashboard/` passes (9.0s)
- [x] `TestMaskWebhookURL` (5 cases) passes
- [x] `TestServer_AlertsPageMasksWebhookURLs` passes
- [ ] Visual: verify graph renders with data after server restart
- [ ] Visual: verify modal opens/closes correctly, focus returns to trigger
- [ ] Screen reader: verify closed modal is not announced