### PR TITLE
fix: P2/P3 dashboard audit findings (navigation, sorting, labels)

### DIFF
--- a/internal/audit/llm.go
+++ b/internal/audit/llm.go
@@ -65,7 +65,7 @@ func (s *Store) QueryLLMAnalyses(limit int) ([]LLMAnalysis, error) {
 		limit = 50
 	}
 	rows, err := s.db.Query(`SELECT `+llmSelectFields+`
-		FROM llm_analysis ORDER BY timestamp DESC LIMIT ?`, limit)
+		FROM llm_analysis ORDER BY (COALESCE(reviewed_status,'')='') DESC, risk_score DESC, timestamp DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2688,6 +2688,7 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	w.Header().Set("HX-Redirect", "/dashboard/agents")
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -4715,6 +4716,7 @@ func (s *Server) handleDeleteMCPServer(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	w.Header().Set("HX-Redirect", "/dashboard/gateway")
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/dashboard/tmpl_agents.go
+++ b/internal/dashboard/tmpl_agents.go
@@ -125,7 +125,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
     <form method="POST" action="/dashboard/agents/{{.Name}}/keygen" style="display:inline"><button type="submit" class="btn btn-sm btn-outline success" onclick="return confirm('Generate new keypair for {{.Name}}?')">Generate Keypair</button></form>
     {{if and .KeyFP (not .KeyRevoked)}}<form method="POST" action="/dashboard/identity/revoke" style="display:inline"><input type="hidden" name="agent" value="{{.Name}}"><button type="submit" class="btn btn-sm btn-outline danger" onclick="return confirm('Revoke key for {{.Name}}? This agent will not be able to send signed messages.')">Revoke Key</button></form>{{end}}
     <form method="POST" action="/dashboard/agents/{{.Name}}/suspend" style="display:inline" onsubmit="return confirm('{{if .Suspended}}Unsuspend agent {{.Name}}? It will resume sending and receiving messages.{{else}}Suspend agent {{.Name}}? All messages to and from this agent will be blocked.{{end}}')">{{if .Suspended}}<button type="submit" class="btn btn-sm btn-outline success">Unsuspend</button>{{else}}<button type="submit" class="btn btn-sm btn-outline warn">Suspend</button>{{end}}</form>
-    <button class="btn btn-sm btn-outline danger" hx-delete="/dashboard/agents/{{.Name}}" hx-confirm="Delete agent {{.Name}}? This cannot be undone." hx-swap="none" onclick="setTimeout(function(){window.location='/dashboard/agents'},300)">Delete</button>
+    <button class="btn btn-sm btn-outline danger" hx-delete="/dashboard/agents/{{.Name}}" hx-confirm="Delete agent {{.Name}}? This cannot be undone." hx-swap="none">Delete</button>
   </div>
 </div>
 

--- a/internal/dashboard/tmpl_gateway.go
+++ b/internal/dashboard/tmpl_gateway.go
@@ -94,7 +94,7 @@ function gwTab(name){
 </div>
 
 <div class="card" id="add-server">
-  <h2>Connected Tools</h2>
+  <h2>Tool Servers</h2>
   <p class="desc">
     Add the tool servers your agents use. oktsec monitors all tool calls passing through them.
   </p>
@@ -253,7 +253,7 @@ var mcpServerDetailTmpl = template.Must(template.New("mcpServerDetail").Funcs(tm
     </div>
     <div style="display:flex;gap:8px;align-items:center">
       <button type="submit" class="btn btn-sm">Save Changes</button>
-      <button type="button" class="btn btn-sm btn-danger" hx-delete="/dashboard/gateway/servers/{{.Name}}" hx-confirm="Delete server {{.Name}}? This cannot be undone." hx-swap="none" onclick="setTimeout(function(){window.location='/dashboard/gateway'},300)">Delete Server</button>
+      <button type="button" class="btn btn-sm btn-danger" hx-delete="/dashboard/gateway/servers/{{.Name}}" hx-confirm="Delete server {{.Name}}? This cannot be undone." hx-swap="none">Delete Server</button>
     </div>
   </form>
 </div>

--- a/internal/dashboard/tmpl_graph.go
+++ b/internal/dashboard/tmpl_graph.go
@@ -69,7 +69,7 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
       <tbody>
       {{range .Graph.Nodes}}
       <tr class="clickable" onclick="location.href='/dashboard/agents/{{.Name}}'">
-        <td style="font-weight:600">{{agentCell .Name}}</td>
+        <td style="font-weight:600"><a href="/dashboard/agents/{{.Name}}" style="color:inherit;text-decoration:none">{{agentCell .Name}}</a></td>
         <td>
           <div style="display:flex;align-items:center;gap:8px">
             <div class="risk-bar" style="width:60px">

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -421,7 +421,7 @@ var graphTablesTmpl = template.Must(template.New("graph-tables").Funcs(tmplFuncs
       <tbody>
       {{range .Nodes}}
       <tr class="clickable" onclick="location.href='/dashboard/agents/{{.Name}}'">
-        <td style="font-weight:600">{{agentCell .Name}}</td>
+        <td style="font-weight:600"><a href="/dashboard/agents/{{.Name}}" style="color:inherit;text-decoration:none">{{agentCell .Name}}</a></td>
         <td><div style="display:flex;align-items:center;gap:8px"><div class="risk-bar" style="width:60px"><div class="risk-bar-fill {{if gt .ThreatScore 60.0}}risk-high{{else if gt .ThreatScore 30.0}}risk-med{{else}}risk-low{{end}}" style="width:{{printf "%.0f" .ThreatScore}}%"></div></div><span>{{printf "%.1f" .ThreatScore}}</span></div></td>
         <td>{{.TotalSent}}</td>
         <td>{{.TotalRecv}}</td>


### PR DESCRIPTION
## Context

Closes the remaining P2/P3 findings from the post-fix validation report dated April 25.

## Changes

### P2: Delete button redirects via HX-Redirect (not setTimeout)

**Problem:** Agent delete and gateway server delete buttons used `onclick="setTimeout(function(){window.location='/dashboard/agents'},300)"` to redirect after HTMX delete. This created a race condition between the JS timeout and the HTMX request, and was inaccessible (no keyboard/screen reader path).

**Fix:** Added `HX-Redirect` response header to `handleDeleteAgent` and `handleDeleteMCPServer`. HTMX follows this header natively. Removed the `onclick` timeout from both templates.

**Files:** `handlers.go`, `tmpl_agents.go`, `tmpl_gateway.go`

### P2: Accessible links on clickable table rows

**Problem:** Agent tables in overview and graph pages used `onclick="location.href=..."` on `<tr>` elements with no keyboard-accessible alternative.

**Fix:** Added `<a href>` links on the primary cell (agent name) in both tables. The `onclick` stays for convenience (click anywhere on row) but keyboard users can now Tab to the link.

**Files:** `tmpl_overview.go`, `tmpl_graph.go`

### P2: LLM analysis sort prioritizes actionable items

**Problem:** `/dashboard/llm` sorted analyses by timestamp only. A high-risk unreviewed item could be buried below 20 "No threats detected" rows.

**Fix:** Changed `ORDER BY` to `(reviewed_status='') DESC, risk_score DESC, timestamp DESC`. Unreviewed items float to top, then sorted by risk descending.

**Files:** `internal/audit/llm.go`

### P2: CSP header already exists (no change needed)

The auditor noted no CSP header in `internal/dashboard/`. The header is set in `internal/proxy/middleware.go:40-46` via the `securityHeaders` middleware, which wraps the entire mux including `/dashboard/` routes (proxy/server.go:315). No code change needed.

### P3: Gateway "Connected Tools" renamed to "Tool Servers"

**Problem:** The section header said "Connected Tools" even when gateway was disabled, implying active connections. The stat card already said "Configured Servers" (correct).

**Fix:** Renamed to "Tool Servers" which is neutral regardless of gateway state.

**Files:** `tmpl_gateway.go`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/dashboard/ ./internal/audit/` clean
- [x] `go test -race -count=1 ./internal/dashboard/` passes (9.7s)
- [x] `go test -race -count=1 ./internal/audit/` passes (3.2s)
- [ ] Visual: delete agent triggers redirect via HX-Redirect (no setTimeout)
- [ ] Visual: LLM page shows unreviewed high-risk items above clean entries