### PR TITLE
fix: P1 dashboard clarity sprint

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -6,7 +6,9 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 )
 
@@ -739,5 +741,54 @@ func TestServer_BuildInfoInSidebar(t *testing.T) {
 	}
 	if !strings.Contains(body, "abc1234") {
 		t.Error("sidebar missing commit hash")
+	}
+}
+
+func TestServer_SessionsAvgDuration(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	now := time.Now().UTC()
+	// Session 1: 2 events spanning 5 minutes
+	srv.audit.Log(audit.Entry{
+		ID: "s1-e1", Timestamp: now.Add(-10 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-a", ToAgent: "agent-b", SessionID: "sess-1",
+		Status: "delivered", LatencyMs: 2,
+	})
+	srv.audit.Log(audit.Entry{
+		ID: "s1-e2", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-a", ToAgent: "agent-b", SessionID: "sess-1",
+		Status: "delivered", LatencyMs: 3,
+	})
+	// Session 2: 2 events spanning 3 minutes
+	srv.audit.Log(audit.Entry{
+		ID: "s2-e1", Timestamp: now.Add(-8 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-c", ToAgent: "agent-d", SessionID: "sess-2",
+		Status: "delivered", LatencyMs: 1,
+	})
+	srv.audit.Log(audit.Entry{
+		ID: "s2-e2", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-c", ToAgent: "agent-d", SessionID: "sess-2",
+		Status: "delivered", LatencyMs: 1,
+	})
+	srv.audit.Flush()
+
+	req := httptest.NewRequest("GET", "/dashboard/sessions?range=24h", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("sessions page returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// Avg of 5m and 3m = 4m. Should NOT be "0s".
+	if strings.Contains(body, "Avg duration: 0s") || strings.Contains(body, "Avg duration: -") {
+		t.Error("avg duration should not be 0s or - with real sessions")
+	}
+	if !strings.Contains(body, "4m") {
+		t.Errorf("expected avg duration ~4m in body, got page without it")
 	}
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1743,24 +1743,28 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	// Compute summary stats
 	totalEvents := 0
 	threatSessions := 0
-	var totalDurationMs int64
+	var totalDuration time.Duration
 	durCount := 0
 	for _, ss := range sessions {
 		totalEvents += ss.EventCount
 		if ss.Blocks > 0 || ss.Quarantines > 0 {
 			threatSessions++
 		}
-		totalDurationMs += ss.TotalLatencyMs
 		if ss.Duration != "" {
-			durCount++
+			if d, err := time.ParseDuration(ss.Duration); err == nil && d > 0 {
+				totalDuration += d
+				durCount++
+			}
 		}
 	}
 
 	avgDuration := "-"
 	if durCount > 0 {
-		avgMs := totalDurationMs / int64(durCount)
-		if avgMs > 0 {
-			avgDuration = (time.Duration(avgMs) * time.Millisecond).Round(time.Second).String()
+		avg := totalDuration / time.Duration(durCount)
+		if avg >= time.Second {
+			avgDuration = avg.Round(time.Second).String()
+		} else if avg > 0 {
+			avgDuration = avg.Round(time.Millisecond).String()
 		}
 	}
 

--- a/internal/dashboard/static/dashboard.css
+++ b/internal/dashboard/static/dashboard.css
@@ -19,7 +19,7 @@
   /* Colors — GitHub-inspired dark with oktsec violet accent */
   --bg:#0d1117;--surface:#161b22;--surface2:#1c2128;--surface-hover:#21262d;
   --border:#30363d;--border-hover:#484f58;--border-subtle:#21262d;
-  --text:#e6edf3;--text2:#8b949e;--text3:#6e7681;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;
   --accent:#58a6ff;--accent-light:#58a6ff;--accent-dim:#1f6feb;
   --accent-glow:rgba(56,139,253,0.08);--accent-glow-md:rgba(56,139,253,0.15);--accent-border:rgba(56,139,253,0.25);
   --danger:#f85149;--success:#3fb950;--warn:#d29922;
@@ -106,11 +106,11 @@ a{color:inherit;text-decoration:none}
 .sidebar .brand{padding:var(--sp-5) var(--sp-5) var(--sp-6);font-family:var(--mono);font-size:1.35rem;font-weight:700;letter-spacing:-0.3px;text-decoration:none;display:block;background:linear-gradient(135deg,#ededed 0%,var(--accent-light) 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
 .sidebar-section{padding:0 var(--sp-3);margin-bottom:var(--sp-4)}
 .sidebar-section+.sidebar-section{border-top:1px solid var(--border);padding-top:var(--sp-2)}
-.sidebar-section-label{font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#6e7681;font-weight:500;padding:var(--sp-2) var(--sp-3) 6px;user-select:none}
-.sidebar-item{display:flex;align-items:center;gap:10px;padding:var(--sp-2) var(--sp-3);border-radius:var(--radius-md);color:#8b949e;font-size:var(--text-sm);font-weight:500;text-decoration:none;letter-spacing:var(--ls-tight);transition:background var(--ease-default),color var(--ease-default),border-color var(--ease-default);border-left:2px solid transparent;margin-bottom:1px}
+.sidebar-section-label{font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:var(--text3);font-weight:500;padding:var(--sp-2) var(--sp-3) 6px;user-select:none}
+.sidebar-item{display:flex;align-items:center;gap:10px;padding:var(--sp-2) var(--sp-3);border-radius:var(--radius-md);color:var(--text2);font-size:var(--text-sm);font-weight:500;text-decoration:none;letter-spacing:var(--ls-tight);transition:background var(--ease-default),color var(--ease-default),border-color var(--ease-default);border-left:2px solid transparent;margin-bottom:1px}
 .sidebar-item:hover{background:rgba(139,148,158,0.08);color:#e6edf3}
 .sidebar-item.active{color:#e6edf3;background:rgba(56,139,253,0.15);border-left-color:#58a6ff;font-weight:600}
-.sidebar-item svg{width:18px;height:18px;flex-shrink:0;color:#8b949e}
+.sidebar-item svg{width:18px;height:18px;flex-shrink:0;color:var(--text2)}
 .sidebar-item.active svg{color:#e6edf3}
 
 /* ==========================================================================

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -417,7 +417,7 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
   /* Canvas & Surfaces */
   --bg:#0d1117;--surface:#161b22;--surface2:#21262d;--border:#30363d;--border-muted:#21262d;
   /* Text - WCAG AA validated */
-  --text:#e6edf3;--text2:#8b949e;--text3:#6e7681;--text-on-emphasis:#ffffff;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;--text-on-emphasis:#ffffff;
   /* Accent / Info */
   --accent:#58a6ff;--accent-light:#58a6ff;--accent-dim:#1f6feb;--accent-muted:rgba(56,139,253,0.15);--accent-border:rgba(56,139,253,0.30);
   /* Semantic */
@@ -466,7 +466,7 @@ button:active{transform:scale(0.98)}
   <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><rect x="9" y="11" width="6" height="5" rx="1"/><path d="M12 11V9a2 2 0 0 0-4 0"/></svg></div>
   <div class="logo">oktsec</div>
   <div class="subtitle">Dashboard Access</div>
-  <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec run</code> to get a code.<br><small style="color:#8b949e">Code changes each time the server restarts.</small></p>
+  <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec run</code> to get a code.<br><small style="color:#9ca3af">Code changes each time the server restarts.</small></p>
   <form method="POST" action="/dashboard/login" autocomplete="off">
     <label for="login-code" class="sr-only">Access code</label>
     <input type="text" id="login-code" name="code" placeholder="00000000" maxlength="8" pattern="\d{8}" inputmode="numeric" autofocus required>
@@ -490,7 +490,7 @@ var SplashTmpl = template.Must(template.New("splash").Parse(`<!DOCTYPE html>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
   --bg:#0d1117;--surface:#161b22;--border:#30363d;
-  --text:#e6edf3;--text2:#8b949e;--text3:#6e7681;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;
   --accent:#58a6ff;--accent-light:#58a6ff;--accent-dim:#1f6feb;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;
   --sans:'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans',Helvetica,Arial,sans-serif;
@@ -543,7 +543,7 @@ var notFoundTmpl = template.Must(template.New("notfound").Parse(`<!DOCTYPE html>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
   --bg:#0d1117;--surface:#161b22;--surface2:#1c2128;--border:#30363d;
-  --text:#e6edf3;--text2:#8b949e;--text3:#6e7681;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;
   --accent:#58a6ff;--accent-light:#58a6ff;--accent-dim:#1f6feb;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;
   --sans:'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans',Helvetica,Arial,sans-serif;

--- a/internal/dashboard/tmpl_llm.go
+++ b/internal/dashboard/tmpl_llm.go
@@ -585,7 +585,7 @@ var llmDetailTmpl = template.Must(template.New("llm-detail").Funcs(tmplFuncs).Pa
     <span style="display:inline-block;min-width:48px;padding:6px 12px;border-radius:6px;font-family:var(--mono);font-weight:800;font-size:1.4rem;text-align:center;{{if ge .RiskScore 80.0}}background:rgba(239,68,68,0.15);color:var(--danger){{else if ge .RiskScore 50.0}}background:rgba(210,153,34,0.15);color:var(--warn){{else if gt .RiskScore 0.0}}background:rgba(34,197,94,0.1);color:var(--success){{else}}background:var(--surface2);color:var(--text3){{end}}">{{printf "%.0f" .RiskScore}}</span>
     <div>
       <div style="font-weight:600;margin-bottom:2px">Risk Score</div>
-      <div style="color:var(--text3);font-size:0.78rem">Confidence: {{printf "%.0f" .Confidence}}%</div>
+      <div style="color:var(--text3);font-size:0.78rem">Confidence: {{printf "%.0f" .Confidence}}%{{if lt .Confidence 30.0}} <span title="Risk score comes from deterministic rule matches. Low confidence means the LLM had limited session context." style="cursor:help;color:var(--warn)">&#9432;</span>{{end}}</div>
     </div>
     <span style="margin-left:auto;padding:4px 12px;border-radius:4px;font-size:0.78rem;font-weight:500;{{if eq .RecommendedAction "block"}}background:rgba(239,68,68,0.15);color:var(--danger){{else if eq .RecommendedAction "investigate"}}background:rgba(210,153,34,0.15);color:var(--warn){{else if eq .RecommendedAction "quarantine"}}background:var(--danger-muted);color:var(--danger){{else}}background:var(--surface2);color:var(--text3){{end}}">{{.RecommendedAction}}</span>
   </div>
@@ -733,7 +733,7 @@ var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(
     <div class="l">{{if ge .RiskScore 76.0}}CRITICAL{{else if ge .RiskScore 51.0}}HIGH{{else if ge .RiskScore 31.0}}MEDIUM{{else if gt .RiskScore 10.0}}LOW{{else}}BENIGN{{end}}</div>
   </div>
   <div class="cs-banner-body">
-    <h2 class="cs-banner-title">{{firstThreatSummary .ThreatsJSON .RiskScore}}{{if and (gt .Confidence 0.0) (lt .Confidence 30.0)}} <span style="font-size:var(--text-xs);color:var(--warn);font-weight:500">&#9888; Low confidence</span>{{end}}</h2>
+    <h2 class="cs-banner-title">{{firstThreatSummary .ThreatsJSON .RiskScore}}{{if and (gt .Confidence 0.0) (lt .Confidence 30.0)}} <span title="The LLM had limited context for this analysis. Risk score is based on deterministic rule matches, not LLM certainty." style="font-size:var(--text-xs);color:var(--warn);font-weight:500;cursor:help">&#9888; Low confidence (limited context)</span>{{end}}</h2>
     <div class="cs-banner-meta">
       {{if .FromAgent}}<a href="/dashboard/agents/{{.FromAgent}}" style="color:var(--accent-light);text-decoration:none;font-weight:500">{{.FromAgent}}</a> <span style="opacity:0.5">&rarr;</span> <a href="/dashboard/agents/{{.ToAgent}}" style="color:var(--text2);text-decoration:none">{{.ToAgent}}</a><span class="sep">&middot;</span>{{end}}
       <span>{{relativeTime .Timestamp}}</span>
@@ -858,6 +858,7 @@ var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(
           <span class="v">{{printf "%.0f" .Confidence}}%</span>
         </div>
         <div class="cs-conf-bar"><div class="cs-conf-fill" style="width:{{printf "%.0f" .Confidence}}%;background:{{if ge .Confidence 80.0}}#3fb950{{else if ge .Confidence 50.0}}#d29922{{else}}#f85149{{end}}"></div></div>
+        {{if lt .Confidence 30.0}}<div style="font-size:0.68rem;color:var(--text3);margin-top:4px">Risk score is from rule matches. Low confidence means the LLM had limited context.</div>{{end}}
         <div class="cs-row" style="margin-top:6px"><span class="k">Latency</span><span class="v">{{latencySec .LatencyMs}}s</span></div>
         <div class="cs-row"><span class="k">Model</span><span class="v" style="font-size:0.68rem">{{.Model}}</span></div>
         <div class="cs-row"><span class="k">Tokens</span><span class="v">{{.TokensUsed}}</span></div>

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -86,6 +86,9 @@ a.ov-metric:hover{background:var(--surface2)}
 {{else}}
 
 <!-- Hero: the 4 numbers that tell the story -->
+<div style="display:flex;align-items:baseline;gap:var(--sp-2);margin-bottom:var(--sp-2)">
+  <span style="font-size:var(--text-xs);color:var(--text3);text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">All time</span>
+</div>
 <div class="hero-stats" id="hero-stats">
   <a href="/dashboard/events" class="hero-stat">
     <div class="num success" id="stat-total">{{formatNum .Stats.TotalMessages}}</div>

--- a/internal/dashboard/tmpl_report.go
+++ b/internal/dashboard/tmpl_report.go
@@ -13,7 +13,7 @@ var reportTmpl = template.Must(template.New("report").Funcs(tmplFuncs).Parse(`<!
 :root{
   --bg:#0d1117;--surface:#161b22;--surface2:#1c2128;
   --border:#30363d;--border-subtle:#21262d;
-  --text:#e6edf3;--text2:#8b949e;--text3:#6e7681;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;
   --accent:#58a6ff;--accent-light:#58a6ff;
   --danger:#f85149;--success:#3fb950;--warn:#d29922;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace;


### PR DESCRIPTION
## Summary

Addresses all P1 findings from the Codex deep UI/UX review. Clarity over features.

- **Avg duration: 0s bug** — Sessions page showed 0s because the handler summed per-event pipeline latency (`TotalLatencyMs`, typically 1-5ms) instead of the actual session wall-clock duration. Now parses `ss.Duration` (e.g., "5m0s") and averages that. A session spanning 5 minutes now correctly shows ~5m, not 0s.
- **Low contrast** — Raised `--text2` from `#8b949e` → `#9ca3af` and `--text3` from `#6e7681` → `#848d97` across all CSS roots (dashboard.css, templates.go, tmpl_report.go). Replaced 3 hardcoded color values with CSS variable references. Affects all secondary and tertiary text across Settings, Rules, Gateway, Agents.
- **KPI temporal window** — Added "All time" label above overview hero stats. Users now immediately see that "5,231 Messages Protected" is cumulative, not a 24h window.
- **AI Analysis confidence clarity** — When confidence is <30% alongside a high risk score, the banner now says "Low confidence (limited context)" with a tooltip: "The LLM had limited context for this analysis. Risk score is based on deterministic rule matches, not LLM certainty." Added info icon and explanation in the detail panel sidebar.

## Test plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [x] `go test -race ./internal/dashboard/` — all pass (~10s)
- [x] New `TestServer_SessionsAvgDuration` inserts 2 sessions with known 5m/3m durations, verifies avg is ~4m not 0s
- [ ] Browser validation: overview page shows "All time" above KPIs
- [ ] Browser validation: sessions page avg duration shows real values
- [ ] Browser validation: text contrast improvement visible across all pages
- [ ] Browser validation: AI Analysis low-confidence tooltip displays on hover