### PR TITLE
fix: P2/P3 dashboard clarity sprint

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -670,6 +670,8 @@ func (s *Server) handleRules(w http.ResponseWriter, r *http.Request) {
 		llmDisabled, _ = s.ruleGen.ListDisabled()
 	}
 
+	topRules, _ := s.audit.QueryTopRules(5, "")
+
 	data := map[string]any{
 		"Active":           "rules",
 		"Tab":              tab,
@@ -680,6 +682,7 @@ func (s *Server) handleRules(w http.ResponseWriter, r *http.Request) {
 		"LLMActiveCount":   len(llmActive),
 		"LLMTotalCount":    len(llmPending) + len(llmActive),
 		"RequireSig":       s.cfg.Identity.RequireSignature,
+		"TopRules":         topRules,
 	}
 
 	// Only build category data for detection tab
@@ -4544,6 +4547,7 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 	data := map[string]any{
 		"Active":          "gateway",
 		"Gateway":         gw,
+		"GatewayEnabled":  gw.Enabled,
 		"Servers":         servers,
 		"Discovered":      discovered,
 		"Tab":             r.URL.Query().Get("tab"),

--- a/internal/dashboard/tmpl_agents.go
+++ b/internal/dashboard/tmpl_agents.go
@@ -48,8 +48,8 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
     <div class="ag-card-desc">{{if .Description}}{{.Description}}{{else}}No description{{end}}</div>
     <div class="ag-card-stats">
       <span><span class="num">{{formatNum .Total}}</span> msgs</span>
-      <span>blocked <span class="num" style="{{if gt .BlockedPct 20}}color:var(--danger){{else if gt .BlockedPct 5}}color:var(--warn){{end}}">{{.BlockedPct}}%</span></span>
-      <span>risk <span class="num" style="{{if gt .RiskScore 60.0}}color:var(--danger){{else if gt .RiskScore 30.0}}color:var(--warn){{end}}">{{printf "%.0f" .RiskScore}}</span></span>
+      <span title="Percentage of this agent's messages that were blocked by the security pipeline">blocked <span class="num" style="{{if gt .BlockedPct 20}}color:var(--danger){{else if gt .BlockedPct 5}}color:var(--warn){{end}}">{{.BlockedPct}}%</span></span>
+      <span title="Composite threat score: blocked messages x10 + quarantined x5 + flagged">risk <span class="num" style="{{if gt .RiskScore 60.0}}color:var(--danger){{else if gt .RiskScore 30.0}}color:var(--warn){{end}}">{{printf "%.0f" .RiskScore}}</span></span>
       {{if gt .LLMThreatCount 0}}<span style="color:var(--danger)">&#x26A0; {{.LLMThreatCount}} threats</span>{{end}}
       {{if .LastSeen}}<span style="margin-left:auto" data-ts="{{.LastSeen}}">{{.LastSeen}}</span>{{end}}
     </div>
@@ -146,7 +146,7 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
       <div class="ad-gauge" id="risk-gauge"></div>
       <span style="color:var(--text3);font-size:0.72rem;font-family:var(--mono)">/ 100</span>
     </div>
-    <div style="font-size:0.68rem;color:var(--text3);margin-top:6px">Based on blocked and flagged messages in the last 24 hours</div>
+    <div style="font-size:0.68rem;color:var(--text3);margin-top:6px">Weighted score: blocked x10 + quarantined x5 + flagged, last 24h</div>
     <script>
     (function(){
       var g=document.getElementById('risk-gauge');if(!g)return;

--- a/internal/dashboard/tmpl_events.go
+++ b/internal/dashboard/tmpl_events.go
@@ -36,6 +36,15 @@ var eventDetailTmpl = template.Must(template.New("event-detail").Funcs(tmplFuncs
 </div>
 <div style="font-size:var(--text-sm);color:var(--text3);padding:var(--sp-2) var(--sp-5);border-bottom:1px solid var(--border);font-family:var(--mono)" data-ts="{{.Entry.Timestamp}}">{{.Entry.Timestamp}}</div>
 
+{{if eq .Entry.Status "quarantined"}}<div style="padding:var(--sp-3) var(--sp-5);background:rgba(210,153,34,0.08);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:var(--sp-3)">
+  <span style="font-size:var(--text-sm);color:var(--warn);font-weight:500">Awaiting human review</span>
+  <a href="/dashboard/events?tab=quarantine" class="btn btn-sm" style="margin-left:auto;font-size:var(--text-xs);background:var(--warn);color:#000;border:none">Review Queue &rarr;</a>
+</div>{{end}}
+{{if eq .Entry.Status "blocked"}}<div style="padding:var(--sp-3) var(--sp-5);background:rgba(248,81,73,0.06);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:var(--sp-3)">
+  <span style="font-size:var(--text-sm);color:var(--danger);font-weight:500">Blocked by security pipeline</span>
+  <a href="/dashboard/events/{{.Entry.ID}}" class="btn btn-sm btn-outline" style="margin-left:auto;font-size:var(--text-xs)">Full Investigation &rarr;</a>
+</div>{{end}}
+
 <!-- Tabs -->
 <div class="ed-tabs">
   <div class="ed-tab active" onclick="edSwitchTab('overview',this)">Overview</div>

--- a/internal/dashboard/tmpl_gateway.go
+++ b/internal/dashboard/tmpl_gateway.go
@@ -43,8 +43,8 @@ function gwTab(name){
       <div style="font-size:1.2rem;font-weight:700">{{len .Servers}}</div>
     </div>
     <div style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;text-align:center">
-      <div style="color:var(--text3);font-size:0.68rem;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px">Listening on</div>
-      <div style="font-size:1.2rem;font-weight:700">Port {{if .Gateway.Port}}{{.Gateway.Port}}{{else}}9090{{end}}</div>
+      <div style="color:var(--text3);font-size:0.68rem;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px">{{if .GatewayEnabled}}Listening on{{else}}Configured Port{{end}}</div>
+      <div style="font-size:1.2rem;font-weight:700;{{if not .GatewayEnabled}}color:var(--text3){{end}}">Port {{if .Gateway.Port}}{{.Gateway.Port}}{{else}}9090{{end}}</div>
     </div>
   </div>
   {{if eq (len .Servers) 0}}<div style="text-align:center;padding-bottom:8px"><a href="#add-server" class="btn btn-sm btn-outline" style="text-decoration:none">+ Add tool server</a></div>{{end}}

--- a/internal/dashboard/tmpl_graph.go
+++ b/internal/dashboard/tmpl_graph.go
@@ -23,7 +23,7 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
 {{end}}
 
 <div class="card" style="padding:0;overflow:hidden">
-  <div style="display:flex;min-height:480px;height:calc(100vh - 340px)">
+  <div style="display:flex;min-height:560px;height:calc(100vh - 300px)">
     <div style="flex:1;position:relative;overflow:hidden">
       <div id="graph-container" style="width:100%;height:100%;background:var(--bg);position:relative;overflow:hidden"></div>
       <div style="position:absolute;bottom:12px;left:16px;display:flex;gap:16px;font-size:0.7rem;color:var(--text3);align-items:center">
@@ -184,7 +184,7 @@ function toggleGraphSidebar() {
     }
 
     var W = el.clientWidth, H = el.clientHeight;
-    var NR = 18, OR = 26, TR = 10, PAD = 50;
+    var NR = 22, OR = 30, TR = 12, PAD = 50;
     var cx = W / 2, cy = H / 2;
     // 3-column layout: ORCHESTRATOR | AGENTS | TOOLS
     // Agent sub-columns expand when there are many agents
@@ -256,7 +256,7 @@ function toggleGraphSidebar() {
       var col=Math.floor(i/perCol);
       var row=i%perCol;
       var colCount=Math.min(perCol, agentNodes.length-col*perCol);
-      var spacing=Math.min(80, (H-PAD*2)/(colCount+1));
+      var spacing=Math.min(90, (H-PAD*2)/(colCount+1));
       var startY=(H-(colCount-1)*spacing)/2;
       nodes[idx].x=agentZoneStart+subColWidth*(col+0.5);
       nodes[idx].y=startY+row*spacing;
@@ -517,7 +517,7 @@ function toggleGraphSidebar() {
         toolDiv.style.cssText='width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:#bc8cff;font-family:ui-monospace,SFMono-Regular,monospace;font-size:10px;font-weight:600';
         toolDiv.textContent=n.name.charAt(0).toUpperCase();
         fo.appendChild(toolDiv);
-        labelY=n.y+TR+11; textLen=nameLen*4.5+6;
+        labelY=n.y+TR+13; textLen=nameLen*5.5+8;
 
       } else if(n.isOrch){
         shape=document.createElementNS(NS,'polygon');
@@ -539,7 +539,7 @@ function toggleGraphSidebar() {
         orchIcon.textContent='⬡';
         fo.appendChild(orchIcon);
         n._innerHex=innerHex;
-        labelY=n.y+OR+16; textLen=nameLen*5.8+10;
+        labelY=n.y+OR+18; textLen=nameLen*6.5+12;
 
       } else {
         var ringColor=n.threat>60?'#f85149':(n.threat>30?'#d29922':'#3fb950');
@@ -554,7 +554,7 @@ function toggleGraphSidebar() {
         var avDiv=document.createElement('div');
         avDiv.innerHTML=agentAvatar(n.name,NR*2);
         fo.appendChild(avDiv);
-        labelY=n.y+NR+14; textLen=nameLen*5.8+10;
+        labelY=n.y+NR+16; textLen=nameLen*6.5+12;
 
         // Status dot (small indicator at top-right of node)
         var statusDot=document.createElementNS(NS,'circle');
@@ -568,7 +568,7 @@ function toggleGraphSidebar() {
       // Label
       var labelBg=document.createElementNS(NS,'rect');
       labelBg.setAttribute('x',n.x-textLen/2); labelBg.setAttribute('y',labelY-9);
-      labelBg.setAttribute('width',textLen); labelBg.setAttribute('height',n.isOrch?26:14);
+      labelBg.setAttribute('width',textLen); labelBg.setAttribute('height',n.isOrch?28:16);
       labelBg.setAttribute('rx','3');
       labelBg.setAttribute('fill','#0d1117'); labelBg.setAttribute('fill-opacity','0.9');
 
@@ -576,10 +576,10 @@ function toggleGraphSidebar() {
       label.setAttribute('x',n.x); label.setAttribute('y',labelY);
       label.setAttribute('text-anchor','middle');
       label.setAttribute('fill',n.isTool?'#bc8cff':'#e4e4e7');
-      label.setAttribute('font-size',n.isTool?'8.5':(n.isOrch?'12':'9.5'));
+      label.setAttribute('font-size',n.isTool?'10':(n.isOrch?'13':'11'));
       label.setAttribute('font-weight',n.isOrch?'600':'500');
       label.setAttribute('font-family','ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace');
-      var maxLen=n.isOrch?22:16;
+      var maxLen=n.isOrch?24:20;
       var displayName=n.name==='gateway'?'oktsec':(n.name.length>maxLen?n.name.substring(0,maxLen-1)+'…':n.name);
       label.textContent=displayName;
 
@@ -587,10 +587,10 @@ function toggleGraphSidebar() {
       var subLabel=null;
       if(n.isOrch){
         subLabel=document.createElementNS(NS,'text');
-        subLabel.setAttribute('x',n.x); subLabel.setAttribute('y',labelY+12);
+        subLabel.setAttribute('x',n.x); subLabel.setAttribute('y',labelY+13);
         subLabel.setAttribute('text-anchor','middle');
-        subLabel.setAttribute('fill','#6e7681');
-        subLabel.setAttribute('font-size','9');
+        subLabel.setAttribute('fill','#848d97');
+        subLabel.setAttribute('font-size','10');
         subLabel.setAttribute('font-family','ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace');
         subLabel.textContent='orchestrator';
       }

--- a/internal/dashboard/tmpl_rules.go
+++ b/internal/dashboard/tmpl_rules.go
@@ -46,6 +46,15 @@ var rulesTmpl = template.Must(template.New("rules").Funcs(tmplFuncs).Parse(layou
 <!-- Detection Rules Tab -->
 {{if .Categories}}
 
+{{if .TopRules}}
+<div style="margin-bottom:20px">
+  <div style="font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:var(--sp-2)">Most triggered rules</div>
+  <div style="display:flex;gap:8px;flex-wrap:wrap">
+    {{range .TopRules}}<a href="/dashboard/rules/{{.RuleID}}" style="display:inline-flex;align-items:center;gap:6px;padding:4px 12px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--text);text-decoration:none;transition:border-color var(--ease-smooth)" title="{{.Name}}"><span style="font-family:var(--mono);font-weight:600">{{.RuleID}}</span><span style="color:var(--text3)">{{.Count}}x</span></a>{{end}}
+  </div>
+</div>
+{{end}}
+
 {{if or .LLMPendingCount .LLMActiveCount}}
 <div style="display:flex;align-items:center;gap:16px;padding:14px 20px;margin-bottom:20px;background:var(--surface);border:1px solid rgba(56,139,253,0.2);border-radius:10px">
   <div style="flex:1;min-width:0">

--- a/internal/dashboard/tmpl_settings.go
+++ b/internal/dashboard/tmpl_settings.go
@@ -20,8 +20,15 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
 </style>
 <p class="page-desc">System status, access control, and threat response settings.</p>
 
+<div style="display:flex;gap:8px;margin-bottom:var(--sp-5);flex-wrap:wrap">
+  <a href="#sec-status" class="btn btn-sm btn-outline" style="text-decoration:none;font-size:var(--text-xs)">System Status</a>
+  <a href="#sec-access" class="btn btn-sm btn-outline" style="text-decoration:none;font-size:var(--text-xs)">Access Control</a>
+  <a href="#sec-threat" class="btn btn-sm btn-outline" style="text-decoration:none;font-size:var(--text-xs)">Threat Response</a>
+  <a href="#sec-infra" class="btn btn-sm btn-outline" style="text-decoration:none;font-size:var(--text-xs)">Infrastructure</a>
+</div>
+
 <!-- Section 1: System Status -->
-<div class="st-section">
+<div class="st-section" id="sec-status">
   <div class="st-section-hdr">System Status</div>
   <div class="st-item">
     <div class="st-item-info">
@@ -46,7 +53,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
 </div>
 
 <!-- Section 2: Access Control -->
-<div class="st-section">
+<div class="st-section" id="sec-access">
   <div class="st-section-hdr">Access Control</div>
   <div class="st-item">
     <div class="st-item-info">
@@ -81,7 +88,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
 </div>
 
 <!-- Section 3: Threat Response -->
-<div class="st-section">
+<div class="st-section" id="sec-threat">
   <div class="st-section-hdr">Threat Response</div>
   <form method="POST" action="/dashboard/settings/quarantine">
   <div class="st-item">
@@ -194,7 +201,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
 </div>
 
 <!-- Section 4: Infrastructure -->
-<div class="st-section">
+<div class="st-section" id="sec-infra">
   <div class="st-section-hdr">Infrastructure</div>
   <div class="st-item">
     <div class="st-item-info">


### PR DESCRIPTION
## Summary

Addresses all P2 and P3 findings from the Codex deep UI/UX review. Focus on readability, orientation, and reducing cognitive load.

- **Graph readability** — Node radii increased (18→22 for agents, 26→30 for orchestrators, 10→12 for tools). Label fonts bumped from 9.5→11px. Container min-height 480→560px, vertical spacing 80→90px. Labels truncate at 20 chars instead of 16. Result: readable without squinting or zooming.
- **Agents: risk vs blocked clarity** — Added tooltips on both metrics in the agent card grid: "blocked %" = pipeline block rate, "risk" = composite weighted score (blocked x10 + quarantined x5 + flagged). Updated agent detail page explanation.
- **Settings: section navigation** — Added quick-nav bar with 4 anchor links (System Status, Access Control, Threat Response, Infrastructure) at the top of the page. Each section has an id for direct jump.
- **Rules: action orientation** — Added "Most triggered rules" strip above the category grid showing top 5 fired rules as clickable chips with hit counts. Helps users immediately see what's active.
- **Events: primary action clarity** — Added contextual CTA banner in the event side panel: quarantined events get "Awaiting human review" + review queue link, blocked events get "Blocked by security pipeline" + investigation link.
- **Gateway: conditional port label** — Shows "Configured Port" instead of "Listening on" when the gateway is disabled. Dimmed text color when inactive.

## Test plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [x] `go test -race ./internal/dashboard/` — all pass (~10s)
- [x] Browser: graph container uses 560px min-height, NR=22, OR=30, TR=12
- [x] Browser: agent cards show tooltips on hover over blocked/risk
- [x] Browser: settings page has 4 section nav buttons at top
- [x] Browser: gateway shows "Configured Port" (gateway disabled in test config)
- [ ] Browser: rules "Most triggered" appears with audit data
- [ ] Browser: event side panel shows quarantine/blocked CTA