### PR TITLE
fix: metrics truth and state semantics across dashboard

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -792,3 +792,62 @@ func TestServer_SessionsAvgDuration(t *testing.T) {
 		t.Errorf("expected avg duration ~4m in body, got page without it")
 	}
 }
+
+func TestServer_OverviewAgentsObserved(t *testing.T) {
+	rr := authedGet(t, "/dashboard")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("overview returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "Agents Secured") {
+		t.Error("overview should use 'Agents Observed' not 'Agents Secured'")
+	}
+	if !strings.Contains(body, "Agents Observed") {
+		t.Error("overview missing 'Agents Observed' label")
+	}
+	if !strings.Contains(body, "All time") {
+		t.Error("overview missing 'All time' temporal label")
+	}
+}
+
+func TestServer_SettingsTimingLabels(t *testing.T) {
+	rr := authedGet(t, "/dashboard/settings")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("settings returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Takes effect immediately") {
+		t.Error("settings missing 'Takes effect immediately' label")
+	}
+	if !strings.Contains(body, "Requires restart") {
+		t.Error("settings missing 'Requires restart' label")
+	}
+}
+
+func TestServer_GatewayDisabledBanner(t *testing.T) {
+	rr := authedGet(t, "/dashboard/gateway")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("gateway returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "Listening on") {
+		t.Error("gateway disabled should not show 'Listening on'")
+	}
+	if !strings.Contains(body, "Configured Port") {
+		t.Error("gateway disabled should show 'Configured Port'")
+	}
+	if !strings.Contains(body, "configured but not routing") {
+		t.Error("gateway disabled should explain it's not routing traffic")
+	}
+}
+
+func TestServer_AgentsRiskLabels(t *testing.T) {
+	rr := authedGet(t, "/dashboard/agents")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("agents returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "blocked ") && strings.Contains(body, " · risk ") {
+		t.Error("agents should not use ambiguous 'blocked X% · risk N' format")
+	}
+}

--- a/internal/dashboard/tmpl_agents.go
+++ b/internal/dashboard/tmpl_agents.go
@@ -48,8 +48,8 @@ var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(lay
     <div class="ag-card-desc">{{if .Description}}{{.Description}}{{else}}No description{{end}}</div>
     <div class="ag-card-stats">
       <span><span class="num">{{formatNum .Total}}</span> msgs</span>
-      <span title="Percentage of this agent's messages that were blocked by the security pipeline">blocked <span class="num" style="{{if gt .BlockedPct 20}}color:var(--danger){{else if gt .BlockedPct 5}}color:var(--warn){{end}}">{{.BlockedPct}}%</span></span>
-      <span title="Composite threat score: blocked messages x10 + quarantined x5 + flagged">risk <span class="num" style="{{if gt .RiskScore 60.0}}color:var(--danger){{else if gt .RiskScore 30.0}}color:var(--warn){{end}}">{{printf "%.0f" .RiskScore}}</span></span>
+      <span title="Percentage of this agent's messages blocked by the security pipeline">block rate <span class="num" style="{{if gt .BlockedPct 20}}color:var(--danger){{else if gt .BlockedPct 5}}color:var(--warn){{end}}">{{.BlockedPct}}%</span></span>
+      <span title="Based on blocked (x10), quarantined (x5), and flagged messages in the last 24h">risk: <span class="num" style="{{if gt .RiskScore 60.0}}color:var(--danger){{else if gt .RiskScore 30.0}}color:var(--warn){{end}}">{{if ge .RiskScore 76.0}}critical{{else if ge .RiskScore 51.0}}high{{else if ge .RiskScore 31.0}}medium{{else if gt .RiskScore 0.0}}low{{else}}none{{end}}</span></span>
       {{if gt .LLMThreatCount 0}}<span style="color:var(--danger)">&#x26A0; {{.LLMThreatCount}} threats</span>{{end}}
       {{if .LastSeen}}<span style="margin-left:auto" data-ts="{{.LastSeen}}">{{.LastSeen}}</span>{{end}}
     </div>
@@ -140,13 +140,13 @@ var agentDetailTmpl = template.Must(template.New("agent-detail").Funcs(tmplFuncs
 <!-- Risk Score + Tool Distribution -->
 <div class="ad-grid" style="margin-bottom:20px">
   <div class="card" style="padding:16px 20px">
-    <div class="ad-slbl">Risk Score <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text3)">(last 24h)</span></div>
+    <div class="ad-slbl">Current Risk <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text3)">(last 24h)</span></div>
     <div style="display:flex;align-items:center;gap:14px">
       <span style="font-size:1.5rem;font-weight:700;font-family:var(--mono)" class="{{if gt .RiskScore 60.0}}danger{{else if gt .RiskScore 30.0}}warn{{else}}success{{end}}">{{printf "%.0f" .RiskScore}}</span>
       <div class="ad-gauge" id="risk-gauge"></div>
-      <span style="color:var(--text3);font-size:0.72rem;font-family:var(--mono)">/ 100</span>
+      <span style="color:var(--text3);font-size:0.72rem;font-weight:600">{{if ge .RiskScore 76.0}}CRITICAL{{else if ge .RiskScore 51.0}}HIGH{{else if ge .RiskScore 31.0}}MEDIUM{{else if gt .RiskScore 0.0}}LOW{{else}}NONE{{end}}</span>
     </div>
-    <div style="font-size:0.68rem;color:var(--text3);margin-top:6px">Weighted score: blocked x10 + quarantined x5 + flagged, last 24h</div>
+    <div style="font-size:0.68rem;color:var(--text3);margin-top:6px">Weighted from blocked (x10), quarantined (x5), and flagged messages. Historical block rate reflects past enforcement, not current risk.</div>
     <script>
     (function(){
       var g=document.getElementById('risk-gauge');if(!g)return;

--- a/internal/dashboard/tmpl_gateway.go
+++ b/internal/dashboard/tmpl_gateway.go
@@ -48,6 +48,9 @@ function gwTab(name){
     </div>
   </div>
   {{if eq (len .Servers) 0}}<div style="text-align:center;padding-bottom:8px"><a href="#add-server" class="btn btn-sm btn-outline" style="text-decoration:none">+ Add tool server</a></div>{{end}}
+  {{if .GatewayEnabled}}<div style="padding:10px 16px;background:rgba(63,185,80,0.06);border:1px solid rgba(63,185,80,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--success);margin-top:8px">Routing tool calls through Oktsec security pipeline.</div>
+  {{else}}<div style="padding:10px 16px;background:rgba(210,153,34,0.06);border:1px solid rgba(210,153,34,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--warn);margin-top:8px">Gateway is configured but not routing traffic. Enable it in your configuration file and restart to protect tool calls.</div>
+  {{end}}
 </div>
 
 <div class="card">

--- a/internal/dashboard/tmpl_llm.go
+++ b/internal/dashboard/tmpl_llm.go
@@ -584,8 +584,8 @@ var llmDetailTmpl = template.Must(template.New("llm-detail").Funcs(tmplFuncs).Pa
   <div style="display:flex;align-items:center;gap:12px;margin-bottom:20px">
     <span style="display:inline-block;min-width:48px;padding:6px 12px;border-radius:6px;font-family:var(--mono);font-weight:800;font-size:1.4rem;text-align:center;{{if ge .RiskScore 80.0}}background:rgba(239,68,68,0.15);color:var(--danger){{else if ge .RiskScore 50.0}}background:rgba(210,153,34,0.15);color:var(--warn){{else if gt .RiskScore 0.0}}background:rgba(34,197,94,0.1);color:var(--success){{else}}background:var(--surface2);color:var(--text3){{end}}">{{printf "%.0f" .RiskScore}}</span>
     <div>
-      <div style="font-weight:600;margin-bottom:2px">Risk Score</div>
-      <div style="color:var(--text3);font-size:0.78rem">Confidence: {{printf "%.0f" .Confidence}}%{{if lt .Confidence 30.0}} <span title="Risk score comes from deterministic rule matches. Low confidence means the LLM had limited session context." style="cursor:help;color:var(--warn)">&#9432;</span>{{end}}</div>
+      <div style="font-weight:600;margin-bottom:2px">Risk Score <span style="font-weight:400;color:var(--text3);font-size:0.72rem">(rule evidence: {{if ge .RiskScore 51.0}}strong{{else if ge .RiskScore 31.0}}moderate{{else if gt .RiskScore 0.0}}weak{{else}}none{{end}})</span></div>
+      <div style="color:var(--text3);font-size:0.78rem">Model confidence: {{printf "%.0f" .Confidence}}%{{if lt .Confidence 30.0}} <span title="Risk score comes from deterministic rule matches. Low model confidence means the LLM had limited session context." style="cursor:help;color:var(--warn)">&#9432;</span>{{end}}</div>
     </div>
     <span style="margin-left:auto;padding:4px 12px;border-radius:4px;font-size:0.78rem;font-weight:500;{{if eq .RecommendedAction "block"}}background:rgba(239,68,68,0.15);color:var(--danger){{else if eq .RecommendedAction "investigate"}}background:rgba(210,153,34,0.15);color:var(--warn){{else if eq .RecommendedAction "quarantine"}}background:var(--danger-muted);color:var(--danger){{else}}background:var(--surface2);color:var(--text3){{end}}">{{.RecommendedAction}}</span>
   </div>
@@ -738,7 +738,9 @@ var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(
       {{if .FromAgent}}<a href="/dashboard/agents/{{.FromAgent}}" style="color:var(--accent-light);text-decoration:none;font-weight:500">{{.FromAgent}}</a> <span style="opacity:0.5">&rarr;</span> <a href="/dashboard/agents/{{.ToAgent}}" style="color:var(--text2);text-decoration:none">{{.ToAgent}}</a><span class="sep">&middot;</span>{{end}}
       <span>{{relativeTime .Timestamp}}</span>
       <span class="sep">&middot;</span>
-      <span>{{printf "%.0f" .Confidence}}% confidence</span>
+      <span>Rule evidence: {{if ge .RiskScore 51.0}}strong{{else if ge .RiskScore 31.0}}moderate{{else if gt .RiskScore 0.0}}weak{{else}}none{{end}}</span>
+      <span class="sep">&middot;</span>
+      <span>Model confidence: {{printf "%.0f" .Confidence}}%</span>
     </div>
   </div>
   <div class="cs-banner-action">
@@ -752,7 +754,7 @@ var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(
     {{if eq .ReviewedStatus "false_positive"}}<span class="cs-reviewed cs-reviewed-ok">&#10003; Dismissed as false positive</span>
     {{else}}<span class="cs-reviewed cs-reviewed-bad">&#10003; Confirmed as real threat</span>{{end}}
   {{else}}
-    <button class="cs-abtn cs-abtn-danger" hx-post="/dashboard/api/llm/{{.ID}}/confirm" hx-target="closest .cs-actions" hx-swap="innerHTML" hx-confirm="Confirm this as a real threat?"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg> Confirm threat</button>
+    <button class="cs-abtn cs-abtn-danger" hx-post="/dashboard/api/llm/{{.ID}}/confirm" hx-target="closest .cs-actions" hx-swap="innerHTML" hx-confirm="Confirm this as a real threat?"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg> Confirm as real threat</button>
     <button class="cs-abtn cs-abtn-ghost" hx-post="/dashboard/api/llm/{{.ID}}/dismiss" hx-target="closest .cs-actions" hx-swap="innerHTML" hx-confirm="Dismiss as false positive?">False positive</button>
     {{if and .FromAgent (not $.AgentSuspended)}}<form method="POST" action="/dashboard/agents/{{.FromAgent}}/suspend" style="display:contents"><button type="submit" class="cs-abtn cs-abtn-ghost" style="color:#f85149;border-color:rgba(239,68,68,0.2)" onclick="return confirm('Suspend agent {{.FromAgent}}?')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg> Suspend agent</button></form>{{end}}
     {{if $.AgentSuspended}}<span class="cs-abtn" style="color:#f85149;cursor:default;border-color:rgba(239,68,68,0.2)">Agent suspended</span>{{end}}
@@ -850,15 +852,17 @@ var llmCaseTmpl = template.Must(template.New("llm-case").Funcs(tmplFuncs).Parse(
 
     <!-- Assessment card -->
     <div class="cs-card">
-      <div class="cs-card-hdr">Assessment</div>
+      <div class="cs-card-hdr">Enforcement</div>
       <div class="cs-card-body">
         <div class="cs-row"><span class="k">Risk score</span><span class="v" style="font-weight:700;font-size:0.82rem;{{if ge .RiskScore 76.0}}color:#f85149{{else if ge .RiskScore 51.0}}color:var(--danger){{else if ge .RiskScore 31.0}}color:#d29922{{else}}color:#3fb950{{end}}">{{printf "%.0f" .RiskScore}}</span></div>
+        <div class="cs-row"><span class="k">Rule evidence</span><span class="v" style="font-weight:600">{{if ge .RiskScore 51.0}}strong{{else if ge .RiskScore 31.0}}moderate{{else if gt .RiskScore 0.0}}weak{{else}}none{{end}}</span></div>
+        <div style="font-size:0.68rem;color:var(--text3);margin:4px 0 8px;border-bottom:1px solid var(--border);padding-bottom:8px">Enforcement is based on deterministic rule matches and policy.</div>
         <div class="cs-row">
-          <span class="k">Confidence</span>
+          <span class="k">Model confidence</span>
           <span class="v">{{printf "%.0f" .Confidence}}%</span>
         </div>
         <div class="cs-conf-bar"><div class="cs-conf-fill" style="width:{{printf "%.0f" .Confidence}}%;background:{{if ge .Confidence 80.0}}#3fb950{{else if ge .Confidence 50.0}}#d29922{{else}}#f85149{{end}}"></div></div>
-        {{if lt .Confidence 30.0}}<div style="font-size:0.68rem;color:var(--text3);margin-top:4px">Risk score is from rule matches. Low confidence means the LLM had limited context.</div>{{end}}
+        {{if lt .Confidence 30.0}}<div style="font-size:0.68rem;color:var(--text3);margin-top:4px">Low model confidence means the LLM had limited session context. This does not reduce the strength of rule evidence.</div>{{end}}
         <div class="cs-row" style="margin-top:6px"><span class="k">Latency</span><span class="v">{{latencySec .LatencyMs}}s</span></div>
         <div class="cs-row"><span class="k">Model</span><span class="v" style="font-size:0.68rem">{{.Model}}</span></div>
         <div class="cs-row"><span class="k">Tokens</span><span class="v">{{.TokensUsed}}</span></div>

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -61,6 +61,7 @@ a.ov-metric:hover{background:var(--surface2)}
 </style>
 
 <p class="page-desc">Real-time security overview across all agents and tools. <span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
+<noscript><div style="padding:8px 12px;background:rgba(210,153,34,0.08);border:1px solid rgba(210,153,34,0.2);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--warn);margin-bottom:var(--sp-4)">Live updates require JavaScript.</div></noscript>
 
 {{if and (eq .Stats.TotalMessages 0) (eq .AgentCount 0)}}
 <div class="empty-state">
@@ -100,7 +101,7 @@ a.ov-metric:hover{background:var(--surface2)}
   </a>
   <a href="/dashboard/agents" class="hero-stat">
     <div class="num" style="color:var(--accent-light)" id="stat-agents">{{.AgentCount}}</div>
-    <div class="lbl">Agents Secured</div>
+    <div class="lbl">Agents Observed</div>
   </a>
   <a href="/dashboard/audit" class="hero-stat">
     <div class="score-ring" id="score-ring">
@@ -311,7 +312,7 @@ a.ov-metric:hover{background:var(--surface2)}
   var evtSource = new EventSource('/dashboard/api/events');
   evtSource.onopen = function() {
     dot.classList.add('connected');
-    label.textContent = 'live';
+    label.textContent = 'live updates connected';
   };
   evtSource.onerror = function() {
     dot.classList.remove('connected');

--- a/internal/dashboard/tmpl_settings.go
+++ b/internal/dashboard/tmpl_settings.go
@@ -17,6 +17,9 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
 .st-expand.open{display:block}
 .st-row{display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end}
 .st-row .form-group{flex:1;min-width:140px}
+.st-timing{font-size:0.62rem;color:var(--text3);font-weight:500;text-transform:uppercase;letter-spacing:0.5px;margin-top:3px}
+.st-timing.immediate{color:var(--success)}
+.st-timing.restart{color:var(--warn)}
 </style>
 <p class="page-desc">System status, access control, and threat response settings.</p>
 
@@ -34,6 +37,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Security Mode</div>
       <div class="st-item-desc">{{if .RequireSig}}All messages are verified before delivery. Suspicious content is blocked.{{else}}Signatures optional; content enforcement still active according to rules.{{end}}</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="val" style="{{if .RequireSig}}color:var(--success){{else}}color:var(--warn){{end}}">{{if .RequireSig}}Protection Active{{else}}Monitor Only{{end}}</span>
@@ -44,6 +48,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">MCP Gateway</div>
       <div class="st-item-desc">{{if .GatewayEnabled}}Accepting connections on port {{.GatewayPort}}{{else}}Gateway is not running. Enable it in your configuration file.{{end}}</div>
+      <div class="st-timing restart">Requires restart</div>
     </div>
     <div class="st-item-value">
       <span class="val" style="{{if .GatewayEnabled}}color:var(--success){{else}}color:var(--text3){{end}}">{{if .GatewayEnabled}}active{{else}}inactive{{end}}</span>
@@ -59,6 +64,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Default Policy</div>
       <div class="st-item-desc">{{if eq .DefaultPolicy "deny"}}Agents can only reach explicitly approved targets.{{else}}All agents can communicate freely unless specifically denied.{{end}}</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="val" style="{{if eq .DefaultPolicy "deny"}}color:var(--success){{else}}color:var(--warn){{end}}">{{if eq .DefaultPolicy "deny"}}Block unknown{{else}}Allow all{{end}}</span>
@@ -69,6 +75,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Internal Networks</div>
       <div class="st-item-desc">Domains and networks considered inside your organization. Agents with internal scope can only reach these.</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="val">{{.TrustBoundariesCount}} defined</span>
@@ -95,6 +102,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Quarantine{{if .QPending}} <span style="color:var(--warn);font-size:0.72rem;font-weight:400">{{.QPending}} pending</span>{{end}}</div>
       <div class="st-item-desc">Hold suspicious messages for human review. Window: {{.QExpiryHours}}h, retain {{.QRetentionDays}}d</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="toggle"><input type="checkbox" name="enabled" value="true" aria-label="Toggle quarantine" {{if .QEnabled}}checked{{end}} onchange="if(confirm('{{if .QEnabled}}Disable quarantine? Suspicious messages will no longer be held for review.{{else}}Enable quarantine for suspicious messages?{{end}}')){this.form.submit()}else{this.checked={{if .QEnabled}}true{{else}}false{{end}}}"><span class="toggle-slider"></span></span>
@@ -109,6 +117,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Behavior Monitoring</div>
       <div class="st-item-desc">Automatically pause agents that show suspicious behavior patterns</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="toggle"><input type="checkbox" name="auto_suspend" value="true" aria-label="Toggle behavior monitoring" {{if .AnomalyAutoSuspend}}checked{{end}} onchange="if(confirm('{{if .AnomalyAutoSuspend}}Disable automatic agent suspension? Suspicious agents will no longer be paused.{{else}}Enable automatic suspension of agents with suspicious behavior?{{end}}')){this.form.submit()}else{this.checked={{if .AnomalyAutoSuspend}}true{{else}}false{{end}}}"><span class="toggle-slider"></span></span>
@@ -124,6 +133,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Rate Limiting</div>
       <div class="st-item-desc">Limit how many messages each agent can send per minute</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="val">{{.RateLimitPerAgent}} / min</span>
@@ -138,6 +148,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Purpose Verification</div>
       <div class="st-item-desc">Require agents to declare what they're doing. Flag mismatches between stated intent and actual content.</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="toggle"><input type="checkbox" name="require_intent" value="true" aria-label="Toggle purpose verification" {{if .RequireIntent}}checked{{end}} onchange="if(confirm('{{if .RequireIntent}}Disable intent verification? Agents will no longer need to declare purpose.{{else}}Require agents to declare intent before sending messages?{{end}}')){this.form.submit()}else{this.checked={{if .RequireIntent}}true{{else}}false{{end}}}"><span class="toggle-slider"></span></span>
@@ -150,6 +161,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Testcase Export</div>
       <div class="st-item-desc">Save blocked and quarantined content as test cases for detection rule validation. Files are stored locally in ~/.oktsec/testcases/</div>
+      <div class="st-timing immediate">Takes effect immediately</div>
     </div>
     <div class="st-item-value">
       <span class="toggle"><input type="checkbox" name="export_blocked" value="true" aria-label="Toggle testcase export" {{if .ExportBlocked}}checked{{end}} onchange="this.form.submit()"><span class="toggle-slider"></span></span>
@@ -162,6 +174,7 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Outbound Traffic</div>
       <div class="st-item-desc">Inspect and control what agents send outside your network</div>
+      <div class="st-timing restart">Requires restart</div>
     </div>
     <div class="st-item-value">
       <span class="toggle"><input type="checkbox" id="fp-toggle" name="enabled" value="true" aria-label="Toggle outbound traffic inspection" {{if .FPEnabled}}checked{{end}} onchange="if(confirm('{{if .FPEnabled}}Disable outbound traffic inspection? Agent egress will no longer be monitored.{{else}}Enable outbound traffic inspection for agent requests?{{end}}')){toggleEgressDetails();this.form.submit()}else{this.checked={{if .FPEnabled}}true{{else}}false{{end}}}"><span class="toggle-slider"></span></span>
@@ -207,14 +220,16 @@ var settingsTmpl = template.Must(template.New("settings").Funcs(tmplFuncs).Parse
     <div class="st-item-info">
       <div class="st-item-name">Server</div>
       <div class="st-item-desc">Port {{.ServerPort}} &middot; {{.ServerBind}}</div>
+      <div class="st-timing restart">Requires restart</div>
     </div>
-    <div class="st-item-value"><span style="font-size:0.68rem;color:var(--text3)">restart to change</span></div>
+    <div class="st-item-value"></div>
   </div>
 
   <div class="st-item" style="flex-wrap:wrap">
     <div class="st-item-info">
       <div class="st-item-name">Database</div>
-      <div class="st-item-desc" id="db-desc">{{if eq .DBBackend "PostgreSQL"}}Production database — requires a PostgreSQL server{{else}}Local file database — no server needed{{end}}</div>
+      <div class="st-item-desc" id="db-desc">{{if eq .DBBackend "PostgreSQL"}}Production database, requires a PostgreSQL server{{else}}Local file database, no server needed{{end}}</div>
+      <div class="st-timing restart">Requires restart</div>
     </div>
     <div class="st-item-value">
       <div style="display:flex;border:1px solid var(--border);border-radius:6px;overflow:hidden">


### PR DESCRIPTION
## Summary

First PR of the Dashboard Clarity Sprint. Eliminates contradictions in metrics, states, and wording across 5 pages. Focus: a user reading the dashboard should trust the data and understand what each number means.

**Overview**
- "Agents Secured" → "Agents Observed". The dashboard counts agents from observed traffic, not from active protection claims. Saying "secured" when in observe mode would be misleading.
- SSE indicator now shows "live updates connected" instead of just "live".

**Agents**
- Card stats changed from `blocked 22% · risk 0` to `block rate 22%` and `risk: none`. Risk now shows a human-readable level (none/low/medium/high/critical) instead of a raw number without scale.
- Detail page renamed "Risk Score" to "Current Risk" with level label and explicit formula explanation.
- Separates historical block rate from current risk with a one-line clarification.

**AI Analysis**
- Banner meta now shows `Rule evidence: strong` and `Model confidence: 12%` as separate fields, instead of a single `12% confidence` that could be read as "the system isn't sure about the block."
- Detail panel sidebar renamed from "Assessment" to "Enforcement" with a divider: "Enforcement is based on deterministic rule matches and policy."
- Low confidence explanation updated: "Low model confidence means the LLM had limited session context. This does not reduce the strength of rule evidence."
- "Confirm threat" button → "Confirm as real threat" (explicit verb).

**Gateway**
- Added state banner: disabled shows "Gateway is configured but not routing traffic. Enable it in your configuration file and restart to protect tool calls." Enabled shows "Routing tool calls through Oktsec security pipeline."

**Settings**
- Every control now has a timing label: "Takes effect immediately" (green) or "Requires restart" (amber). 8 immediate controls, 4 restart-required controls.
- Removed redundant "restart to change" text on Server item, replaced with consistent timing label.

## Test plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [x] `go test -race ./internal/dashboard/` — all pass (~10s)
- [x] No `transition: all` or `alert()` regressions
- [x] 4 new regression tests:
  - `TestServer_OverviewAgentsObserved` — verifies "Agents Observed" present, "Agents Secured" absent
  - `TestServer_SettingsTimingLabels` — verifies both timing label classes render
  - `TestServer_GatewayDisabledBanner` — verifies "Configured Port" and "configured but not routing"
  - `TestServer_AgentsRiskLabels` — verifies old ambiguous format is gone
- [x] Browser: overview shows "Agents Observed", "All time", "live updates connected"
- [x] Browser: agents show "block rate" and "risk:" labels
- [x] Browser: settings has 8 "Takes effect immediately" + 4 "Requires restart"
- [x] Browser: gateway shows disabled banner with routing explanation