### PR TITLE
fix: dashboard accessibility (skip link, aria-current, reduced motion)

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -1450,6 +1450,62 @@ func TestServer_GraphRiskyRoutesSidebar(t *testing.T) {
 	}
 }
 
+// ── PR 9: Visual readability, tokens and accessibility ──
+
+func TestServer_SkipLinkPresent(t *testing.T) {
+	rr := authedGet(t, "/dashboard")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("dashboard returned %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `class="skip-link"`) || !strings.Contains(body, `href="#main"`) {
+		t.Error("layout should include a skip-to-main-content link")
+	}
+	if !strings.Contains(body, `id="main"`) {
+		t.Error("<main> should have id=\"main\" as skip link target")
+	}
+}
+
+func TestServer_SidebarAriaCurrent(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		mark string
+	}{
+		{"/dashboard", `href="/dashboard" class="sidebar-item active" aria-current="page"`},
+		{"/dashboard/events", `href="/dashboard/events" class="sidebar-item active" aria-current="page"`},
+		{"/dashboard/agents", `href="/dashboard/agents" class="sidebar-item active" aria-current="page"`},
+	} {
+		rr := authedGet(t, tc.path)
+		if rr.Code != http.StatusOK {
+			t.Errorf("%s returned %d", tc.path, rr.Code)
+			continue
+		}
+		if !strings.Contains(rr.Body.String(), tc.mark) {
+			t.Errorf("%s should mark active sidebar link with aria-current=\"page\"", tc.path)
+		}
+	}
+}
+
+func TestServer_SidebarRoleNavigation(t *testing.T) {
+	rr := authedGet(t, "/dashboard")
+	body := rr.Body.String()
+	if !strings.Contains(body, `role="navigation"`) {
+		t.Error("sidebar should have role=\"navigation\" for screen readers")
+	}
+	if !strings.Contains(body, `aria-label="Primary"`) {
+		t.Error("sidebar should be labeled as primary navigation")
+	}
+}
+
+func TestServer_SidebarSVGsAriaHidden(t *testing.T) {
+	rr := authedGet(t, "/dashboard")
+	body := rr.Body.String()
+	// At least the sidebar icons should be marked decorative since the link text labels them.
+	if !strings.Contains(body, `aria-hidden="true"`) {
+		t.Error("decorative sidebar SVGs should be marked aria-hidden=\"true\"")
+	}
+}
+
 // ── PR 8: Posture remediation surface ──
 
 func TestServer_PostureFilterChips(t *testing.T) {

--- a/internal/dashboard/static/dashboard.css
+++ b/internal/dashboard/static/dashboard.css
@@ -89,6 +89,15 @@ html{scroll-behavior:smooth}
 /* --- Focus ring --- */
 :focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 
+/* --- Skip to main content (keyboard a11y) --- */
+.skip-link{position:absolute;top:-40px;left:8px;padding:8px 16px;background:var(--accent);color:#fff;border-radius:var(--radius-md);font-weight:600;font-size:var(--text-sm);z-index:1000;text-decoration:none;transition:top var(--ease-default)}
+.skip-link:focus{top:8px;outline:2px solid var(--text);outline-offset:2px}
+
+/* --- Reduced motion: disable non-essential animations --- */
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:0.01ms!important;animation-iteration-count:1!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}
+}
+
 /* --- Global input dark theme --- */
 input,select,textarea{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-md);color:var(--text);font-family:var(--sans);font-size:var(--text-sm);padding:var(--sp-2) var(--sp-3);outline:none;transition:border-color var(--ease-smooth)}
 input:focus,select:focus,textarea:focus{border-color:var(--accent)}

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -584,64 +584,65 @@ const layoutHead = `<!DOCTYPE html>
 <title>oktsec — {{.Active}}</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3Cpath d='M9 12l2 2 4-4'/%3E%3C/svg%3E">
 <script src="/dashboard/static/htmx.min.js"></script>
-<link rel="stylesheet" href="/dashboard/static/dashboard.css?v=20260320">
+<link rel="stylesheet" href="/dashboard/static/dashboard.css?v=20260425">
 </head>
 <body>
-<aside class="sidebar">
-  <a href="/dashboard" class="brand">oktsec</a>
+<a href="#main" class="skip-link">Skip to main content</a>
+<aside class="sidebar" role="navigation" aria-label="Primary">
+  <a href="/dashboard" class="brand" aria-label="oktsec home">oktsec</a>
   <div class="sidebar-section">
     <div class="sidebar-section-label">Monitor</div>
-    <a href="/dashboard" class="sidebar-item {{if eq .Active "overview"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+    <a href="/dashboard" class="sidebar-item {{if eq .Active "overview"}}active{{end}}"{{if eq .Active "overview"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
       Overview
     </a>
-    <a href="/dashboard/events" class="sidebar-item {{if eq .Active "events"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    <a href="/dashboard/events" class="sidebar-item {{if eq .Active "events"}}active{{end}}"{{if eq .Active "events"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
       Events
     </a>
-    <a href="/dashboard/sessions" class="sidebar-item {{if eq .Active "sessions"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+    <a href="/dashboard/sessions" class="sidebar-item {{if eq .Active "sessions"}}active{{end}}"{{if eq .Active "sessions"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
       Sessions
     </a>
-    <a href="/dashboard/alerts" class="sidebar-item {{if eq .Active "alerts"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+    <a href="/dashboard/alerts" class="sidebar-item {{if eq .Active "alerts"}}active{{end}}"{{if eq .Active "alerts"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
       Notifications
     </a>
   </div>
   <div class="sidebar-section">
     <div class="sidebar-section-label">Security</div>
-    <a href="/dashboard/agents" class="sidebar-item {{if eq .Active "agents"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+    <a href="/dashboard/agents" class="sidebar-item {{if eq .Active "agents"}}active{{end}}"{{if eq .Active "agents"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
       Agents
     </a>
-    <a href="/dashboard/rules" class="sidebar-item {{if eq .Active "rules"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+    <a href="/dashboard/rules" class="sidebar-item {{if eq .Active "rules"}}active{{end}}"{{if eq .Active "rules"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
       Rules
     </a>
   </div>
   <div class="sidebar-section">
     <div class="sidebar-section-label">Analyze</div>
-    <a href="/dashboard/audit" class="sidebar-item {{if eq .Active "audit"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+    <a href="/dashboard/audit" class="sidebar-item {{if eq .Active "audit"}}active{{end}}"{{if eq .Active "audit"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
       Security Posture
     </a>
-    <a href="/dashboard/llm" class="sidebar-item {{if eq .Active "llm"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4v2a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z"/><path d="M16 14H8a4 4 0 0 0-4 4v2h16v-2a4 4 0 0 0-4-4z"/><circle cx="12" cy="6" r="1"/><path d="M9 22v-2"/><path d="M15 22v-2"/></svg>
+    <a href="/dashboard/llm" class="sidebar-item {{if eq .Active "llm"}}active{{end}}"{{if eq .Active "llm"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a4 4 0 0 1 4 4v2a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z"/><path d="M16 14H8a4 4 0 0 0-4 4v2h16v-2a4 4 0 0 0-4-4z"/><circle cx="12" cy="6" r="1"/><path d="M9 22v-2"/><path d="M15 22v-2"/></svg>
       AI Analysis
     </a>
-    <a href="/dashboard/graph" class="sidebar-item {{if eq .Active "graph"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+    <a href="/dashboard/graph" class="sidebar-item {{if eq .Active "graph"}}active{{end}}"{{if eq .Active "graph"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
       Graph
     </a>
   </div>
   <div class="sidebar-section">
     <div class="sidebar-section-label">Configure</div>
-    <a href="/dashboard/gateway" class="sidebar-item {{if eq .Active "gateway"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+    <a href="/dashboard/gateway" class="sidebar-item {{if eq .Active "gateway"}}active{{end}}"{{if eq .Active "gateway"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
       Gateway
     </a>
-    <a href="/dashboard/settings" class="sidebar-item {{if eq .Active "settings"}}active{{end}}">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+    <a href="/dashboard/settings" class="sidebar-item {{if eq .Active "settings"}}active{{end}}"{{if eq .Active "settings"}} aria-current="page"{{end}}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
       Settings
     </a>
   </div>
@@ -661,7 +662,7 @@ const layoutHead = `<!DOCTYPE html>
   <a href="/dashboard/settings" class="mode-pill {{if .RequireSig}}enforce{{else}}observe{{end}}" data-tooltip="{{if .RequireSig}}Enforce mode — signatures required, unsigned messages rejected{{else}}Observe mode — signatures optional, content enforcement still active. Click to configure.{{end}}"><span class="dot"></span>{{if .RequireSig}}enforce{{else}}observe{{end}}</a>
   <form method="POST" action="/dashboard/logout" style="margin-left:10px;display:inline"><button type="submit" class="topbar-logout">Logout</button></form>
 </div>
-<main>`
+<main id="main" tabindex="-1">`
 
 const layoutFoot = `</main>
 


### PR DESCRIPTION
## Summary
- Skip-to-main-content link as the first focusable element. Hidden offscreen until focused, jumps to <main id="main"> for keyboard users
- Sidebar marked role="navigation" with aria-label="Primary"; active links carry aria-current="page" so screen readers announce the current location
- Decorative SVG icons in the sidebar marked aria-hidden="true" so screen readers don't read out icon coordinates
- Brand link gets aria-label="oktsec home"
- @media (prefers-reduced-motion: reduce) disables all non-essential animations and transitions for users with motion sensitivity (covers orchPulse, particle motion, fadeIn, etc.)
- Bumped CSS cache buster

## Test plan
- [ ] Tab into the page from the URL bar: skip link should appear and jump to content
- [ ] Run a screen reader on the sidebar: it should announce "navigation" and the active page as "current page"
- [ ] Toggle "reduce motion" in OS settings: orchestrator hex should stop pulsing, particles freeze
- [ ] 4 new tests cover skip link, aria-current, role/aria-label, aria-hidden SVGs