### PR TITLE
fix: onsubmit confirm interceptor + stale Saved on session expiry

### DIFF
--- a/internal/dashboard/regression_test.go
+++ b/internal/dashboard/regression_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
 )
 
 // TestRegression_AllPagesLoad is a smoke test that hits every dashboard page
@@ -194,6 +196,66 @@ func TestRegression_CSPHeader(t *testing.T) {
 	}
 	if strings.Contains(csp, "https://") || strings.Contains(csp, "http://") {
 		t.Errorf("CSP should not whitelist external origins, got: %s", csp)
+	}
+}
+
+// TestRegression_OnsubmitConfirmInterceptor guards against the P1 bug Codex caught
+// after the dashboard clarity sprint: window.confirm is overridden to always return
+// false, so any form that uses onsubmit="return confirm(...)" silently never submits
+// unless a global submit listener intercepts it and re-submits after the modal.
+func TestRegression_OnsubmitConfirmInterceptor(t *testing.T) {
+	body := authedGet(t, "/dashboard").Body.String()
+	// The submit-listener block must exist in the layout JS.
+	if !strings.Contains(body, `addEventListener('submit'`) {
+		t.Error("layout missing global submit listener — onsubmit confirm forms will never submit (window.confirm is overridden to false)")
+	}
+	if !strings.Contains(body, `removeAttribute('onsubmit')`) {
+		t.Error("submit interceptor must drop the onsubmit attribute before re-submitting; otherwise the confirm runs again and recurses")
+	}
+	if !strings.Contains(body, `requestSubmit`) {
+		t.Error("submit interceptor should prefer form.requestSubmit() so the originating button is honored")
+	}
+}
+
+// TestRegression_OnsubmitConfirmFormsStillUseAttribute ensures the suspend agent
+// and add-server-to-gateway forms still rely on the global interceptor. If a future
+// edit converts these to onclick or removes onsubmit, this test does not fail —
+// but if it converts the attribute to a form-level handler that is NOT confirm(),
+// the assumption breaks. Keeps the contract visible.
+func TestRegression_OnsubmitConfirmForms(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents = map[string]config.Agent{"test-agent": {}}
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/agents/test-agent", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	if strings.Contains(body, `onsubmit="return confirm(`) {
+		// Good: this template still uses onsubmit; verify the interceptor in layout will catch it.
+		layoutBody := authedGet(t, "/dashboard").Body.String()
+		if !strings.Contains(layoutBody, `addEventListener('submit'`) {
+			t.Error("agent suspend form uses onsubmit confirm but layout has no submit interceptor")
+		}
+	}
+}
+
+// TestRegression_SettingsToggleNoStaleSavedOnRedirect guards the second P1 from
+// Codex: stToggleSave used to treat r.redirected as success. A session-expired
+// redirect to /dashboard/login also has r.redirected === true, so the user saw
+// a green "Saved" toast for a save that never happened.
+func TestRegression_SettingsToggleNoStaleSavedOnRedirect(t *testing.T) {
+	body := authedGet(t, "/dashboard/settings").Body.String()
+	if !strings.Contains(body, `redirect: 'manual'`) && !strings.Contains(body, `redirect:'manual'`) {
+		t.Error("stToggleSave must use redirect:'manual' so a session-expired redirect to /login does not surface as a successful save")
+	}
+	if strings.Contains(body, `r.ok || r.redirected`) {
+		t.Error("stToggleSave should not treat r.redirected as success — that lies about saves when the session expired")
+	}
+	if !strings.Contains(body, `opaqueredirect`) {
+		t.Error("stToggleSave should detect opaqueredirect responses and surface session-expired feedback")
 	}
 }
 

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -584,7 +584,7 @@ const layoutHead = `<!DOCTYPE html>
 <title>oktsec — {{.Active}}</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236366f1' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3Cpath d='M9 12l2 2 4-4'/%3E%3C/svg%3E">
 <script src="/dashboard/static/htmx.min.js"></script>
-<link rel="stylesheet" href="/dashboard/static/dashboard.css?v=20260425">
+<link rel="stylesheet" href="/dashboard/static/dashboard.css?v=20260425b">
 </head>
 <body>
 <a href="#main" class="skip-link">Skip to main content</a>
@@ -892,11 +892,13 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
     // Instead, prevent the default form submit and re-submit after confirmation.
     return false; // block by default; the click handler below handles it
   };
+  // Match confirm('...') even when the message contains newlines (gateway add-server uses \n\n).
+  var _confirmRe=/confirm\(['"]([\s\S]+?)['"]\)/;
   // Intercept clicks on elements with onclick="return confirm(...)"
   document.addEventListener('click',function(e){
     var btn=e.target.closest('[onclick*="confirm("]');
     if(!btn)return;
-    var match=btn.getAttribute('onclick').match(/confirm\(['"](.+?)['"]\)/);
+    var match=btn.getAttribute('onclick').match(_confirmRe);
     if(!match)return;
     e.preventDefault();e.stopPropagation();
     showModal(match[1]).then(function(ok){
@@ -906,6 +908,26 @@ function agentCellHTML(name){if(!name)return'';return '<span class="agent-cell">
       btn.setAttribute('onclick','');
       btn.click();
       btn.setAttribute('onclick',orig);
+    });
+  },true);
+  // Intercept submits on forms with onsubmit="return confirm(...)" — without this,
+  // window.confirm always returns false and the form would never submit.
+  document.addEventListener('submit',function(e){
+    var form=e.target;
+    if(!form||!form.getAttribute||!form.getAttribute('onsubmit'))return;
+    var attr=form.getAttribute('onsubmit');
+    if(attr.indexOf('confirm(')<0)return;
+    var match=attr.match(_confirmRe);
+    if(!match)return;
+    e.preventDefault();e.stopPropagation();
+    showModal(match[1]).then(function(ok){
+      if(!ok)return;
+      // Drop onsubmit so the re-submit goes through. requestSubmit() respects
+      // the submit button; fall back to submit() when unavailable (older browsers).
+      form.removeAttribute('onsubmit');
+      if(typeof form.requestSubmit==='function') form.requestSubmit();
+      else form.submit();
+      form.setAttribute('onsubmit',attr);
     });
   },true);
   // HTMX confirm intercept

--- a/internal/dashboard/tmpl_settings.go
+++ b/internal/dashboard/tmpl_settings.go
@@ -345,9 +345,19 @@ function stToggleSave(cb) {
   fetch(form.action, {
     method: 'POST',
     body: new URLSearchParams(new FormData(form)),
-    headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    redirect: 'manual'
   }).then(function(r) {
-    if (r.ok || r.redirected) { stToast('Saved', 'success'); }
+    // 'manual' surfaces a server redirect as type 'opaqueredirect' (status 0).
+    // The most common cause is an expired session redirecting to /dashboard/login —
+    // so do NOT pretend the toggle saved. Roll back the checkbox and reload to login.
+    if (r.type === 'opaqueredirect' || r.status === 0) {
+      cb.checked = !cb.checked;
+      stToast('Session expired — reloading', 'error');
+      setTimeout(function() { location.reload(); }, 1200);
+      return;
+    }
+    if (r.ok) { stToast('Saved', 'success'); }
     else { cb.checked = !cb.checked; stToast('Save failed', 'error'); }
   }).catch(function() { cb.checked = !cb.checked; stToast('Save failed', 'error'); });
 }


### PR DESCRIPTION
## Summary
Two P1 interaction bugs caught in code review after the dashboard clarity sprint. Both were silent — UI looked fine, action did not happen / lied about happening.

### Bug 1: Suspend agent and Add-to-gateway forms never submitted
The layout overrides \`window.confirm\` to always return false (so the custom modal can take over), and intercepts \`onclick="return confirm(...)"\` via a global click listener. There was no equivalent for \`onsubmit="return confirm(...)"\`, which is what the suspend agent form (\`tmpl_agents.go:127\`) and the add-server-to-gateway form (\`tmpl_gateway.go:182\`) use. Result: clicking the button popped no confirm and silently did nothing.

Fix: add a global submit listener that mirrors the click interceptor — extracts the message, opens the custom modal, and on confirm strips the onsubmit attribute then \`requestSubmit()\`s the form. Also tightened the confirm regex to \`[\\s\\S]\` so multi-line messages (gateway uses \`\\n\\n\`) match.

### Bug 2: Settings toggle showed "Saved" after session expiry
\`stToggleSave\` in \`tmpl_settings.go\` treated \`r.redirected\` as success. A session-expired POST to \`/dashboard/settings/...\` redirects to \`/dashboard/login\`, fetch follows it, and \`r.redirected\` becomes true — so the user saw a green "Saved" toast for a save that never happened.

Fix: \`redirect: 'manual'\`. Detect \`r.type === 'opaqueredirect'\` (status 0), roll the checkbox back, surface "Session expired — reloading", and reload after 1.2s so the login flow can take over.

## Test plan
- [ ] Click Suspend on an agent → custom modal appears, confirm submits, agent suspended
- [ ] Click Add-to-Gateway on a discovered server → custom modal with multi-line server detail, confirm adds the server
- [ ] Let the session expire (delete the cookie), toggle a setting → toast says "Session expired", page reloads to login
- [ ] 3 new regression tests: submit interceptor presence, suspend form contract, settings redirect handling