### PR TITLE
fix: live rule count in setup banner + correct dashboard page count

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Real-time web UI for monitoring agent activity. Protected by a GitHub-style loca
   <img src="documentation/assets/screenshots/dashboard-events.png" alt="Events - live feed of agent messages and tool calls" width="820">
 </p>
 
-**11 pages:** Overview (hero stats, pipeline health, live feed), Events (audit log with search and quarantine tab), Notifications (webhook CRUD, alert history), Agents (card grid with risk scores, agent detail with tool policies), Rules (268 rules across 19 categories, per-rule overrides, custom rules, LLM-suggested rules), Rule Detail (patterns, examples, test sandbox), Security Posture (deployment audit, health score, SARIF export), Graph (agent topology with threat scoring), AI Analysis (LLM threat cases, triage config, budget tracking), Gateway (backend CRUD, tool discovery, health checks), Settings (security mode, protection config, rate limiting), Sessions (session inventory, trace timeline, AI analysis).
+**12 pages:** Overview (hero stats, pipeline health, live feed), Events (audit log with search and quarantine tab), Notifications (webhook CRUD, alert history), Agents (card grid with risk scores, agent detail with tool policies), Rules (268 rules across 19 categories, per-rule overrides, custom rules, LLM-suggested rules), Rule Detail (patterns, examples, test sandbox), Security Posture (deployment audit, health score, SARIF export), Graph (agent topology with threat scoring), AI Analysis (LLM threat cases, triage config, budget tracking), Gateway (backend CRUD, tool discovery, health checks), Settings (security mode, protection config, rate limiting), Sessions (session inventory, trace timeline, AI analysis).
 
 ### What you see after five minutes
 

--- a/cmd/oktsec/commands/setup.go
+++ b/cmd/oktsec/commands/setup.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/oktsec/oktsec/internal/discover"
+	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/identity"
 	"gopkg.in/yaml.v3"
 
@@ -189,7 +191,7 @@ func newSetupCmd() *cobra.Command {
 			}
 			fmt.Println()
 			fmt.Printf("  Agents:  %d\n", len(agents))
-			fmt.Printf("  Rules:   175 detection rules active\n")
+			fmt.Printf("  Rules:   %d detection rules active\n", liveRuleCount())
 			fmt.Println()
 			fmt.Println("  Next steps:")
 			fmt.Println()
@@ -230,4 +232,13 @@ func newSetupCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&enforce, "enforce", false, "start in enforcement mode (block malicious requests)")
 	cmd.Flags().BoolVar(&skipWrap, "skip-wrap", false, "generate config only, don't modify client configs")
 	return cmd
+}
+
+// liveRuleCount asks the engine for the actual number of loaded rules so the
+// setup banner never drifts from reality. Returns 0 if the scanner cannot start;
+// the caller can decide whether to surface that case.
+func liveRuleCount() int {
+	s := engine.NewScanner("")
+	defer s.Close()
+	return s.RulesCount(context.Background())
 }


### PR DESCRIPTION
## Summary
Two surface-level inconsistencies caught after the dashboard clarity sprint that reduce confidence on first contact.

- \`oktsec setup\` printed \`Rules: 175 detection rules active\` from a stale literal in \`setup.go\`. README, dashboard, and \`engine.Scanner.RulesCount()\` all report 268. Replaced the literal with a call to the engine — banner now reads the live count and cannot drift again. Verified locally as 268.
- README in the "What ships in the dashboard" section said **"11 pages"** then listed 12. Updated to "12 pages" to match the list.

## Test plan
- [ ] \`./oktsec setup --skip-wrap\` shows \`Rules: 268 detection rules active\` (or whatever the live engine reports)
- [ ] Full suite + lint + vet stay green