### PR TITLE
Align graph rendering with audit truth and generalize across MCP clients

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -3982,14 +3982,35 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 	}
 
 	// Collapse gateway/tool edges: "agent → gateway/X" becomes "agent → gateway".
-	// Skip forward proxy entries (IPs with ports, hostnames with dots).
 	// Multiple tool calls from the same agent are merged into one edge.
+	// Routes that graph v1 cannot model as agent↔agent edges (forward-proxy
+	// domains, IP:port pairs, endpoints not in agentSet) are captured in
+	// `unrepresented` rather than dropped silently — see UnrepresentedRoute.
 	type edgeKey struct{ from, to string }
 	merged := make(map[edgeKey]*graph.EdgeInput)
+	type unrepKey struct{ from, to, reason string }
+	unrepMerged := make(map[unrepKey]*graph.UnrepresentedRoute)
+	captureUnrep := func(from, to, reason string, es audit.EdgeStat) {
+		k := unrepKey{from, to, reason}
+		if u, ok := unrepMerged[k]; ok {
+			u.Total += es.Total
+			u.Blocked += es.Blocked
+			u.Quarantined += es.Quarantined
+			return
+		}
+		unrepMerged[k] = &graph.UnrepresentedRoute{
+			From: from, To: to, Total: es.Total,
+			Blocked: es.Blocked, Quarantined: es.Quarantined, Reason: reason,
+		}
+	}
+	isForwardProxyEndpoint := func(s string) bool {
+		return strings.Contains(s, ":") || strings.Count(s, ".") >= 2
+	}
 	for _, es := range edgeStats {
-		// Skip forward proxy traffic (IP:port sources and domain destinations)
-		if strings.Contains(es.From, ":") || strings.Count(es.From, ".") >= 2 ||
-			strings.Contains(es.To, ":") || strings.Count(es.To, ".") >= 2 {
+		// Forward proxy traffic (IP:port sources and domain destinations) cannot
+		// be drawn as an agent↔agent edge today. Surface it instead of dropping it.
+		if isForwardProxyEndpoint(es.From) || isForwardProxyEndpoint(es.To) {
+			captureUnrep(es.From, es.To, "forward_proxy_endpoint", es)
 			continue
 		}
 		to := es.To
@@ -4023,37 +4044,42 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 		}
 	}
 
-	// Rewrite orchestrator → agent edges as gateway → agent so the visual
-	// flow correctly shows: orchestrator → gateway → agents.
-	// The audit trail records these as claude-code → agent because the
-	// gateway is transparent, but visually all traffic routes through it.
-	hasGateway := false
-	for k := range merged {
-		if k.to == "gateway" || k.from == "gateway" {
-			hasGateway = true
-			break
-		}
-	}
-
+	// No edge rewriting. The audit trail is the source of truth — if it records
+	// `clientA → agentB`, render that, even if visually less tidy. Synthesizing
+	// `gateway → agentB` based on a hardcoded client name lied about coverage and
+	// hid which client actually originated the traffic. (See client-agnostic
+	// activity layer spec, Phase 0.)
 	edges := make([]graph.EdgeInput, 0, len(merged))
 	for _, e := range merged {
 		if e.From == e.To {
 			continue
 		}
-		if _, ok := agentSet[e.From]; !ok {
+		_, fromInSet := agentSet[e.From]
+		_, toInSet := agentSet[e.To]
+		if !fromInSet || !toInSet {
+			// Endpoint that is not a known agent — capture so the dashboard can
+			// surface it instead of pretending it didn't happen.
+			captureUnrep(e.From, e.To, "non_agent_endpoint", audit.EdgeStat{
+				From: e.From, To: e.To, Total: e.Total,
+				Blocked: e.Blocked, Quarantined: e.Quarantined,
+			})
 			continue
-		}
-		if _, ok := agentSet[e.To]; !ok {
-			continue
-		}
-		// Reroute: claude-code → agent becomes gateway → agent
-		if hasGateway && e.From == "claude-code" && e.To != "gateway" {
-			e.From = "gateway"
 		}
 		edges = append(edges, *e)
 	}
 
 	g := graph.Build(agents, edges)
+	// Attach unrepresented routes (sorted for stable rendering / tests).
+	for _, u := range unrepMerged {
+		g.UnrepresentedRoutes = append(g.UnrepresentedRoutes, *u)
+	}
+	sort.Slice(g.UnrepresentedRoutes, func(i, j int) bool {
+		if g.UnrepresentedRoutes[i].Total != g.UnrepresentedRoutes[j].Total {
+			return g.UnrepresentedRoutes[i].Total > g.UnrepresentedRoutes[j].Total
+		}
+		return g.UnrepresentedRoutes[i].From+g.UnrepresentedRoutes[i].To <
+			g.UnrepresentedRoutes[j].From+g.UnrepresentedRoutes[j].To
+	})
 
 	// Add tool usage edges from audit data.
 	// Strip gateway namespace prefixes and merge duplicates.
@@ -4075,7 +4101,10 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 		toolTotals[tool] += ts.Total
 	}
 
-	// Limit to top 8 tools by total invocations.
+	// Top tools by total invocations. No client-name skips: a tool literally
+	// named "Agent" used to be filtered as "redundant with orchestration",
+	// which baked in an assumption about one specific client. If a tool is
+	// actually called, the user should see it.
 	type toolRank struct {
 		name  string
 		total int
@@ -4090,64 +4119,18 @@ func (s *Server) buildGraph(since string) *graph.AgentGraph {
 		if len(topTools) >= 5 {
 			break
 		}
-		// Skip "Agent" — orchestration is already shown by agent edges.
-		if r.name == "Agent" {
-			continue
-		}
 		topTools[r.name] = true
 		g.ToolNodes = append(g.ToolNodes, graph.ToolNode{Name: r.name, Total: r.total})
 	}
 
-	// Build tool edges. If all tool calls come from a single agent (e.g.
-	// orchestrator via hooks), distribute them across subagents for a
-	// realistic graph — agents use multiple tools and tools are shared.
-	var subagents []string
-	for _, e := range edges {
-		if (e.From == "claude-code" || e.From == "gateway") && e.To != "gateway" && e.To != "claude-code" {
-			if _, inCfg := s.cfg.Agents[e.To]; inCfg || len(e.To) <= 25 {
-				subagents = append(subagents, e.To)
-			}
-		}
-	}
-	sort.Strings(subagents)
-
-	// Check if tool data is single-source (all from one agent).
-	sourceAgents := make(map[string]bool)
-	for k := range toolEdgeMerged {
+	// Tool edges: only what the audit actually saw. We used to detect a
+	// single-source tool fan-in (typically: all hook events report the
+	// orchestrator as caller) and synthesize fake edges to subagents with
+	// invented per-edge counts so the graph "looked balanced". That fabricated
+	// data and presented it as real; removed in Phase 0.
+	for k, total := range toolEdgeMerged {
 		if topTools[k.tool] {
-			sourceAgents[k.agent] = true
-		}
-	}
-
-	if len(sourceAgents) <= 1 && len(subagents) > 0 {
-		// Distribute: each tool connects to 2-3 agents, round-robin offset.
-		toolList := make([]string, 0, len(topTools))
-		for _, r := range ranked {
-			if topTools[r.name] {
-				toolList = append(toolList, r.name)
-			}
-		}
-		for ti, tool := range toolList {
-			total := toolTotals[tool]
-			// Each tool connects to 2 or 3 subagents starting at offset.
-			fanout := 2
-			if len(subagents) >= 4 && ti%2 == 0 {
-				fanout = 3
-			}
-			for fi := 0; fi < fanout && fi < len(subagents); fi++ {
-				sa := subagents[(ti+fi)%len(subagents)]
-				share := total / fanout
-				if fi == 0 {
-					share = total - share*(fanout-1)
-				}
-				g.ToolEdges = append(g.ToolEdges, graph.ToolEdge{Agent: sa, Tool: tool, Total: share})
-			}
-		}
-	} else {
-		for k, total := range toolEdgeMerged {
-			if topTools[k.tool] {
-				g.ToolEdges = append(g.ToolEdges, graph.ToolEdge{Agent: k.agent, Tool: k.tool, Total: total})
-			}
+			g.ToolEdges = append(g.ToolEdges, graph.ToolEdge{Agent: k.agent, Tool: k.tool, Total: total})
 		}
 	}
 

--- a/internal/dashboard/regression_test.go
+++ b/internal/dashboard/regression_test.go
@@ -3,11 +3,16 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 )
+
+var osReadFile = os.ReadFile
 
 // TestRegression_AllPagesLoad is a smoke test that hits every dashboard page
 // and confirms it returns 200 and renders the global skip link. If a template
@@ -199,29 +204,28 @@ func TestRegression_CSPHeader(t *testing.T) {
 	}
 }
 
-// TestRegression_OnsubmitConfirmInterceptor guards against the P1 bug Codex caught
-// after the dashboard clarity sprint: window.confirm is overridden to always return
-// false, so any form that uses onsubmit="return confirm(...)" silently never submits
-// unless a global submit listener intercepts it and re-submits after the modal.
+// TestRegression_OnsubmitConfirmInterceptor enforces the contract for the
+// global submit interceptor. window.confirm is overridden so the custom modal
+// can take over; the layout JS must include a submit listener that mirrors the
+// click interceptor, drop the onsubmit attribute before re-submitting, and use
+// requestSubmit() so the originating button is honored.
 func TestRegression_OnsubmitConfirmInterceptor(t *testing.T) {
 	body := authedGet(t, "/dashboard").Body.String()
-	// The submit-listener block must exist in the layout JS.
 	if !strings.Contains(body, `addEventListener('submit'`) {
-		t.Error("layout missing global submit listener — onsubmit confirm forms will never submit (window.confirm is overridden to false)")
+		t.Error("layout JS must include a global submit listener for forms using onsubmit confirm")
 	}
 	if !strings.Contains(body, `removeAttribute('onsubmit')`) {
-		t.Error("submit interceptor must drop the onsubmit attribute before re-submitting; otherwise the confirm runs again and recurses")
+		t.Error("submit interceptor must drop the onsubmit attribute before re-submitting (otherwise the confirm path recurses)")
 	}
 	if !strings.Contains(body, `requestSubmit`) {
 		t.Error("submit interceptor should prefer form.requestSubmit() so the originating button is honored")
 	}
 }
 
-// TestRegression_OnsubmitConfirmFormsStillUseAttribute ensures the suspend agent
-// and add-server-to-gateway forms still rely on the global interceptor. If a future
-// edit converts these to onclick or removes onsubmit, this test does not fail —
-// but if it converts the attribute to a form-level handler that is NOT confirm(),
-// the assumption breaks. Keeps the contract visible.
+// TestRegression_OnsubmitConfirmForms verifies that templates using
+// onsubmit="return confirm(...)" remain compatible with the global submit
+// interceptor in the layout. If a template switches to a non-confirm onsubmit
+// handler, the contract breaks — this guard keeps that visible.
 func TestRegression_OnsubmitConfirmForms(t *testing.T) {
 	srv := newTestServer(t)
 	srv.cfg.Agents = map[string]config.Agent{"test-agent": {}}
@@ -234,29 +238,214 @@ func TestRegression_OnsubmitConfirmForms(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	body := rr.Body.String()
 	if strings.Contains(body, `onsubmit="return confirm(`) {
-		// Good: this template still uses onsubmit; verify the interceptor in layout will catch it.
 		layoutBody := authedGet(t, "/dashboard").Body.String()
 		if !strings.Contains(layoutBody, `addEventListener('submit'`) {
-			t.Error("agent suspend form uses onsubmit confirm but layout has no submit interceptor")
+			t.Error("template uses onsubmit confirm but layout JS has no submit listener to handle it")
 		}
 	}
 }
 
-// TestRegression_SettingsToggleNoStaleSavedOnRedirect guards the second P1 from
-// Codex: stToggleSave used to treat r.redirected as success. A session-expired
-// redirect to /dashboard/login also has r.redirected === true, so the user saw
-// a green "Saved" toast for a save that never happened.
+// TestRegression_SettingsToggleNoStaleSavedOnRedirect enforces that
+// stToggleSave uses redirect:'manual' and explicitly handles opaqueredirect
+// so a session-expired POST is surfaced to the user instead of being
+// indistinguishable from a successful save.
 func TestRegression_SettingsToggleNoStaleSavedOnRedirect(t *testing.T) {
 	body := authedGet(t, "/dashboard/settings").Body.String()
 	if !strings.Contains(body, `redirect: 'manual'`) && !strings.Contains(body, `redirect:'manual'`) {
-		t.Error("stToggleSave must use redirect:'manual' so a session-expired redirect to /login does not surface as a successful save")
+		t.Error("stToggleSave must use redirect:'manual' so a session-expired redirect is observable")
 	}
 	if strings.Contains(body, `r.ok || r.redirected`) {
-		t.Error("stToggleSave should not treat r.redirected as success — that lies about saves when the session expired")
+		t.Error("stToggleSave must distinguish a redirected response from a successful save")
 	}
 	if !strings.Contains(body, `opaqueredirect`) {
 		t.Error("stToggleSave should detect opaqueredirect responses and surface session-expired feedback")
 	}
+}
+
+// ── Phase 0: Graph rendering invariants (client-agnostic activity layer) ──
+//
+// These tests lock in the contract for graph rendering:
+//   1. The graph code generalizes across MCP clients (no hardcoded display names).
+//   2. Edge originators in the graph match the audit trail.
+//   3. Tool edges are derived only from observed audit evidence.
+//   4. Forward-proxy traffic and edges to non-agent endpoints surface in
+//      UnrepresentedRoutes rather than being aggregated out.
+//
+// These guards stay in place until the activity layer (Phase 1+) ships an
+// explicit role/client model that supersedes them.
+
+// TestRegression_GraphCodeIsClientAgnostic fails if a specific client display
+// name appears as a literal in the graph builder or template. Replace with a
+// capability lookup once the activity layer ships.
+func TestRegression_GraphCodeIsClientAgnostic(t *testing.T) {
+	files := []string{
+		"handlers.go",
+		"tmpl_graph.go",
+	}
+	for _, f := range files {
+		t.Run(f, func(t *testing.T) {
+			// Test runs with CWD = package dir under `go test`, so relative paths
+			// resolve to the package source files. Works in CI without hardcoding.
+			data, err := readFileForTest(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			// A specific client name as a literal in graph code paths would
+			// re-introduce a single-client assumption. Comments are fine; code is not.
+			lines := strings.Split(data, "\n")
+			for i, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+					continue
+				}
+				if strings.Contains(line, `"claude-code"`) || strings.Contains(line, `'claude-code'`) {
+					t.Errorf("%s:%d hardcodes 'claude-code' in non-comment code: %s",
+						f, i+1, strings.TrimSpace(line))
+				}
+			}
+		})
+	}
+}
+
+// TestRegression_ToolEdgesAreEvidenceBased exercises buildGraph through the
+// public dashboard route with a fixture where one agent calls one tool. The
+// graph must emit exactly one tool edge: from the agent that actually called
+// the tool. No other agent may appear as caller.
+func TestRegression_ToolEdgesAreEvidenceBased(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents = map[string]config.Agent{
+		"agent-a": {CanMessage: []string{"agent-b"}},
+		"agent-b": {},
+	}
+	// One tool call from agent-a; nothing from agent-b.
+	srv.audit.Log(audit.Entry{
+		ID:        "tool-evidence-1",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		FromAgent: "agent-a",
+		ToAgent:   "agent-b",
+		Status:    "delivered",
+		ToolName:  "read_file",
+	})
+	srv.audit.Flush()
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest("GET", "/dashboard/api/graph?range=24h", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if strings.Contains(body, `"agent":"agent-b","tool":"read_file"`) {
+		t.Error("tool edge for read_file must only appear under agent-a; agent-b never called it")
+	}
+}
+
+// TestRegression_EdgeOriginatorPreserved feeds the audit a node→node edge and
+// verifies the graph renders it with the originator the audit recorded, not a
+// substituted node.
+func TestRegression_EdgeOriginatorPreserved(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents = map[string]config.Agent{
+		"clientX": {CanMessage: []string{"agent-y"}},
+		"agent-y": {},
+		"gateway": {},
+	}
+	srv.audit.Log(audit.Entry{
+		ID:        "origin-1",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		FromAgent: "clientX",
+		ToAgent:   "agent-y",
+		Status:    "delivered",
+	})
+	srv.audit.Flush()
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest("GET", "/dashboard/api/graph?range=24h", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, `"from":"clientX"`) {
+		t.Errorf("edge originator must match audit (clientX → agent-y); got %s", body)
+	}
+}
+
+// TestRegression_UnrepresentedRoutesSurfaced verifies that traffic the graph
+// model cannot render as a node-to-node edge (forward-proxy endpoints,
+// hostnames, IP:port pairs) is captured in UnrepresentedRoutes so it remains
+// visible in the dashboard.
+func TestRegression_UnrepresentedRoutesSurfaced(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents = map[string]config.Agent{
+		"agent-a": {},
+	}
+	// Forward-proxy style: agent makes a request to an external host.
+	srv.audit.Log(audit.Entry{
+		ID:        "fp-1",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		FromAgent: "agent-a",
+		ToAgent:   "api.example.com",
+		Status:    "delivered",
+	})
+	srv.audit.Flush()
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest("GET", "/dashboard/api/graph?range=24h", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "unrepresented_routes") {
+		t.Error("graph JSON missing unrepresented_routes — forward-proxy traffic must remain visible")
+	}
+	if !strings.Contains(body, "api.example.com") {
+		t.Error("forward-proxy endpoint api.example.com must appear in unrepresented_routes")
+	}
+}
+
+// TestRegression_GraphCopyScopedToInstrumentedSurfaces enforces that the graph
+// page-desc names the instrumented surfaces (MCP gateway, hooks, stdio
+// wrappers) so the page does not generalize beyond what the system observes.
+func TestRegression_GraphCopyScopedToInstrumentedSurfaces(t *testing.T) {
+	body := authedGet(t, "/dashboard/graph").Body.String()
+	pageDescStart := strings.Index(body, `class="page-desc"`)
+	if pageDescStart < 0 {
+		t.Fatal("graph page missing page-desc paragraph")
+	}
+	pageDescEnd := strings.Index(body[pageDescStart:], "</p>")
+	if pageDescEnd < 0 {
+		t.Fatal("graph page page-desc not closed")
+	}
+	desc := body[pageDescStart : pageDescStart+pageDescEnd]
+	if !strings.Contains(strings.ToLower(desc), "mcp") &&
+		!strings.Contains(strings.ToLower(desc), "gateway") &&
+		!strings.Contains(strings.ToLower(desc), "hook") {
+		t.Errorf("graph page-desc must reference instrumented surfaces (MCP / gateway / hooks); got: %s", desc)
+	}
+	for _, banned := range []string{
+		"Visual map of how your AI agents communicate",
+		"all your AI agents",
+		"all agents",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("graph page-desc contains overly broad copy %q — must scope to instrumented surfaces", banned)
+		}
+	}
+}
+
+// readFileForTest is a tiny os.ReadFile shim so the assertions above stay
+// readable. Kept local to this file so it does not leak into production paths.
+func readFileForTest(path string) (string, error) {
+	b, err := osReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // TestRegression_NoExternalScriptTags confirms no <script src="https://..."> tags

--- a/internal/dashboard/tmpl_graph.go
+++ b/internal/dashboard/tmpl_graph.go
@@ -3,7 +3,7 @@ package dashboard
 import "html/template"
 
 var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layoutHead + `
-<p class="page-desc">Visual map of how your AI agents communicate and which tools they use. Red nodes indicate high risk. Dashed lines are unmonitored routes.</p>
+<p class="page-desc">Agent communication and tool usage observed across the MCP gateway, hooks, and stdio wrappers.</p>
 
 <div style="display:flex;gap:8px;margin-bottom:16px">
   {{range $v := .Ranges}}<a href="/dashboard/graph?range={{$v}}" class="btn btn-sm{{if eq $v $.Range}} active{{end}}" style="{{if eq $v $.Range}}background:#1F6FEB;color:#fff;border:none{{else}}background:transparent;color:#8B949E;border:1px solid #30363D{{end}}">{{$v}}</a>{{end}}
@@ -112,7 +112,7 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
     {{if .Graph.Edges}}
     <table>
       <thead><tr><th>From</th><th>To</th><th data-tooltip="Ratio of delivered messages to total — lower scores indicate more blocked or quarantined traffic">Health</th></tr></thead>
-      <tbody>
+      <tbody id="ch-tbody">
       {{range .Graph.Edges}}
       <tr class="clickable ch-row" data-health="{{printf "%.0f" .HealthScore}}" data-blocked="{{.Blocked}}" data-quarantined="{{.Quarantined}}" hx-get="/dashboard/api/graph/edge?from={{.From}}&amp;to={{.To}}&amp;range={{$.Range}}" hx-target="#panel-content" hx-swap="innerHTML">
         <td>{{.From}}</td>
@@ -129,6 +129,9 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
       {{end}}
       </tbody>
     </table>
+    {{if gt (len .Graph.Edges) 10}}
+    <button id="ch-toggle" onclick="toggleTablePagination('ch')" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .Graph.Edges}})</button>
+    {{end}}
     {{else}}<p class="empty">No traffic in this time range</p>{{end}}
   </div>
 </div>
@@ -161,8 +164,25 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
     </tbody>
   </table>
   {{if gt (len .Graph.UnusedACL) 10}}
-  <button id="acl-toggle" onclick="(function(){var rows=document.querySelectorAll('.acl-row');var btn=document.getElementById('acl-toggle');if(btn.dataset.open==='1'){rows.forEach(function(r,i){r.style.display=i>=10?'none':''});btn.textContent='Show all ('+rows.length+')';btn.dataset.open='0'}else{rows.forEach(function(r){r.style.display=''});btn.textContent='Show less';btn.dataset.open='1'}})()" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .Graph.UnusedACL}})</button>
-  <script>document.querySelectorAll('.acl-row').forEach(function(r,i){if(i>=10)r.style.display='none'});</script>
+  <button id="acl-toggle" onclick="toggleTablePagination('acl')" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .Graph.UnusedACL}})</button>
+  {{end}}
+</div>
+{{end}}
+
+{{if .Graph.UnrepresentedRoutes}}
+<div class="card" id="unrepresented-routes-section">
+  <h2>Routes seen but not represented in graph v1</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:12px">Forward-proxy domains, hostnames, and endpoints that the current agent-graph cannot model as node-to-node edges. Listed here so they are not silently dropped from coverage.</p>
+  <table>
+    <thead><tr><th>From</th><th>To</th><th>Total</th><th>Blocked</th><th>Quarantined</th><th>Reason</th></tr></thead>
+    <tbody id="ur-tbody">
+    {{range .Graph.UnrepresentedRoutes}}
+    <tr class="ur-row"><td style="font-family:var(--mono);font-size:0.8rem">{{.From}}</td><td style="font-family:var(--mono);font-size:0.8rem">{{.To}}</td><td>{{.Total}}</td><td>{{.Blocked}}</td><td>{{.Quarantined}}</td><td style="color:var(--text3);font-size:0.75rem">{{.Reason}}</td></tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{if gt (len .Graph.UnrepresentedRoutes) 10}}
+  <button id="ur-toggle" onclick="toggleTablePagination('ur')" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .Graph.UnrepresentedRoutes}})</button>
   {{end}}
 </div>
 {{end}}
@@ -170,6 +190,10 @@ var graphTmpl = template.Must(template.New("graph").Funcs(tmplFuncs).Parse(layou
 
 <script>
 var _graphFilter='all';
+// Persist expanded/collapsed state across the 15s poll swaps. The poll
+// replaces #graph-tables.innerHTML, which wipes inline DOM state, so we
+// keep the user's pagination preference here.
+var _tableExpanded={ch:false,ur:false,acl:false};
 function gfApply(f){
   _graphFilter=f;
   document.querySelectorAll('[id^="gf-"]').forEach(function(btn){
@@ -192,7 +216,29 @@ function _applyGraphFilter(){
   });
   var unm=document.getElementById('unmonitored-section');
   if(unm) unm.style.display=(_graphFilter==='blocked'||_graphFilter==='risky')?'none':'';
+  // Pagination only makes sense when no filter is narrowing the rows.
+  if(_graphFilter==='all') _applyTablePagination();
 }
+function _applyTablePagination(){
+  [['ch-tbody','ch-row','ch-toggle','ch'],['ur-tbody','ur-row','ur-toggle','ur'],['acl-tbody','acl-row','acl-toggle','acl']].forEach(function(spec){
+    var rows=document.querySelectorAll('#'+spec[0]+' .'+spec[1]);
+    if(rows.length<=10) return;
+    var btn=document.getElementById(spec[2]);
+    if(_tableExpanded[spec[3]]){
+      rows.forEach(function(r){r.style.display='';});
+      if(btn){btn.dataset.open='1';btn.textContent='Show less';}
+    } else {
+      rows.forEach(function(r,i){r.style.display=i>=10?'none':'';});
+      if(btn){btn.dataset.open='0';btn.textContent='Show all ('+rows.length+')';}
+    }
+  });
+}
+function toggleTablePagination(key){
+  _tableExpanded[key]=!_tableExpanded[key];
+  _applyTablePagination();
+}
+// Initial render: poll has not fired yet, so apply pagination once on load.
+_applyTablePagination();
 </script>
 <script>
 function toggleGraphSidebar() {
@@ -253,8 +299,13 @@ function toggleGraphSidebar() {
     });
 
     // ── Build node + link arrays ──
+    // No client-name hardcode: the orchestrator hex render used to fire only
+    // when n.name === 'claude-code'. That made one specific client look like
+    // "the orchestrator" while every other client rendered as a peer agent.
+    // Until the activity layer ships an explicit role field, every non-tool
+    // node is rendered the same way.
     var nodes = data.nodes.map(function(n) {
-      return {name:n.name, isTool:false, isOrch:n.name==='claude-code', threat:n.threat_score, sent:n.total_sent||0, recv:n.total_recv||0, betweenness:n.betweenness!=null?n.betweenness:-1, x:cx, y:cy, _g:null};
+      return {name:n.name, isTool:false, isOrch:false, threat:n.threat_score, sent:n.total_sent||0, recv:n.total_recv||0, betweenness:n.betweenness!=null?n.betweenness:-1, x:cx, y:cy, _g:null};
     });
     var nodeIdx = {};
     nodes.forEach(function(n,i){ nodeIdx[n.name]=i; });
@@ -284,11 +335,8 @@ function toggleGraphSidebar() {
       agentNodes.push(i);
     });
 
-    // Position orchestrator (column 1)
-    if(nodeIdx['claude-code']!==undefined){
-      nodes[nodeIdx['claude-code']].x=COL1;
-      nodes[nodeIdx['claude-code']].y=H*0.50;
-    }
+    // (Removed: positioning a hardcoded 'claude-code' node into a SOURCE
+    // column. The graph no longer assumes which client is the orchestrator.)
     // Position gateway checkpoint (between col 1 and col 2)
     if(gwIdx>=0){
       nodes[gwIdx].x=COL_GW;
@@ -358,13 +406,17 @@ function toggleGraphSidebar() {
 
     // Column headers
     var headerFont='font-size:9px;fill:#52525b;font-family:ui-monospace,SFMono-Regular,monospace;letter-spacing:0.08em';
-    ['SOURCE','AGENTS','TOOLS'].forEach(function(label,ci){
-      var hx=[COL1,COL2,COL3][ci];
+    // Two column headers (AGENTS, TOOLS). The leftmost zone used to be
+    // labeled SOURCE/CLIENTS for a hardcoded orchestrator node — until the
+    // activity layer ships an explicit client model, leaving it labeled is
+    // dishonest (it would imply Oktsec identifies clients today, which it
+    // does not).
+    [{label:'AGENTS', x:COL2}, {label:'TOOLS', x:COL3}].forEach(function(h){
       var ht=document.createElementNS(NS,'text');
-      ht.setAttribute('x',hx); ht.setAttribute('y',24);
+      ht.setAttribute('x',h.x); ht.setAttribute('y',24);
       ht.setAttribute('text-anchor','middle');
       ht.setAttribute('style',headerFont);
-      ht.textContent=label;
+      ht.textContent=h.label;
       svg.appendChild(ht);
     });
 

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -442,7 +442,7 @@ var graphTablesTmpl = template.Must(template.New("graph-tables").Funcs(tmplFuncs
     {{if .Edges}}
     <table>
       <thead><tr><th>From</th><th>To</th><th>Health</th></tr></thead>
-      <tbody>
+      <tbody id="ch-tbody">
       {{range .Edges}}
       <tr class="ch-row" data-health="{{printf "%.0f" .HealthScore}}" data-blocked="{{.Blocked}}" data-quarantined="{{.Quarantined}}">
         <td>{{.From}}</td>
@@ -452,6 +452,9 @@ var graphTablesTmpl = template.Must(template.New("graph-tables").Funcs(tmplFuncs
       {{end}}
       </tbody>
     </table>
+    {{if gt (len .Edges) 10}}
+    <button id="ch-toggle" onclick="toggleTablePagination('ch')" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .Edges}})</button>
+    {{end}}
     {{else}}<p class="empty">No traffic in this time range</p>{{end}}
   </div>
 </div>
@@ -463,6 +466,19 @@ var graphTablesTmpl = template.Must(template.New("graph-tables").Funcs(tmplFuncs
     <thead><tr><th>From</th><th>To</th><th>Messages</th><th></th></tr></thead>
     <tbody>{{range .ShadowEdges}}<tr><td>{{.From}}</td><td>{{.To}}</td><td>{{.Total}}</td><td style="text-align:right"><a href="/dashboard/agents" style="color:var(--accent-light);font-size:0.75rem;text-decoration:none">Add rule &rarr;</a></td></tr>{{end}}</tbody>
   </table>
+</div>
+{{end}}
+{{if .UnrepresentedRoutes}}
+<div class="card" id="unrepresented-routes-section">
+  <h2>Routes seen but not represented in graph v1</h2>
+  <p style="color:var(--text2);font-size:0.82rem;margin-bottom:12px">Forward-proxy domains, hostnames, and endpoints that the current agent-graph cannot model as node-to-node edges. Listed here so they are not silently dropped from coverage.</p>
+  <table>
+    <thead><tr><th>From</th><th>To</th><th>Total</th><th>Blocked</th><th>Quarantined</th><th>Reason</th></tr></thead>
+    <tbody id="ur-tbody">{{range .UnrepresentedRoutes}}<tr class="ur-row"><td style="font-family:var(--mono);font-size:0.8rem">{{.From}}</td><td style="font-family:var(--mono);font-size:0.8rem">{{.To}}</td><td>{{.Total}}</td><td>{{.Blocked}}</td><td>{{.Quarantined}}</td><td style="color:var(--text3);font-size:0.75rem">{{.Reason}}</td></tr>{{end}}</tbody>
+  </table>
+  {{if gt (len .UnrepresentedRoutes) 10}}
+  <button id="ur-toggle" onclick="toggleTablePagination('ur')" data-open="0" style="margin-top:8px;background:none;border:1px solid var(--border);color:var(--accent-light);padding:6px 16px;border-radius:6px;cursor:pointer;font-size:0.78rem">Show all ({{len .UnrepresentedRoutes}})</button>
+  {{end}}
 </div>
 {{end}}`))
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -84,17 +84,32 @@ type ToolEdge struct {
 	Total int    `json:"total"`
 }
 
+// UnrepresentedRoute is observed traffic that the current agent-graph model
+// (graph v1) cannot render as a node→node edge: forward-proxy domains, raw
+// hostnames, IP:port pairs. We surface them in the dashboard as a list so the
+// user knows the data was seen — silently dropping it would let the dashboard
+// look more covered than it actually is.
+type UnrepresentedRoute struct {
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Total       int    `json:"total"`
+	Blocked     int    `json:"blocked"`
+	Quarantined int    `json:"quarantined"`
+	Reason      string `json:"reason"` // forward_proxy_endpoint, non_agent_endpoint, etc.
+}
+
 // AgentGraph is the complete computed interaction graph.
 type AgentGraph struct {
-	Nodes       []Node       `json:"nodes"`
-	Edges       []Edge       `json:"edges"`
-	ToolNodes   []ToolNode   `json:"tool_nodes,omitempty"`
-	ToolEdges   []ToolEdge   `json:"tool_edges,omitempty"`
-	ACLEdges    []ACLEdge    `json:"acl_edges"`
-	ShadowEdges []ShadowEdge `json:"shadow_edges"`
-	UnusedACL   []ACLEdge    `json:"unused_acl"`
-	TotalNodes  int          `json:"total_nodes"`
-	TotalEdges  int          `json:"total_edges"`
+	Nodes               []Node               `json:"nodes"`
+	Edges               []Edge               `json:"edges"`
+	ToolNodes           []ToolNode           `json:"tool_nodes,omitempty"`
+	ToolEdges           []ToolEdge           `json:"tool_edges,omitempty"`
+	ACLEdges            []ACLEdge            `json:"acl_edges"`
+	ShadowEdges         []ShadowEdge         `json:"shadow_edges"`
+	UnusedACL           []ACLEdge            `json:"unused_acl"`
+	UnrepresentedRoutes []UnrepresentedRoute `json:"unrepresented_routes,omitempty"`
+	TotalNodes          int                  `json:"total_nodes"`
+	TotalEdges          int                  `json:"total_edges"`
 }
 
 // Build constructs the full agent interaction graph from config agents and observed edges.


### PR DESCRIPTION
## Summary

Phase 0 of the client-agnostic activity layer. Generalizes graph rendering across MCP clients and adds first-class surfacing for forward-proxy and non-agent traffic. Sets the foundation for the broader activity model (Phases 1-4 in the internal roadmap).

### Graph rendering

- Tool edges are emitted directly from audit-trail evidence.
- Edges render with the originator the audit trail recorded.
- All non-tool nodes use a uniform render. Until the activity layer ships an explicit role/client model (Phase 1), the graph does not assume which node is the orchestrator.

### Forward-proxy and non-agent traffic

New \`UnrepresentedRoute\` type and \`Routes seen but not represented in graph v1\` table. Forward-proxy endpoints (domains, hostnames, IP:port pairs) and edges to endpoints not in the configured agent set are surfaced explicitly so coverage is visible end-to-end.

### UX

- Page copy scoped to the surfaces Oktsec instruments today: *"Agent communication and tool usage observed across the MCP gateway, hooks, and stdio wrappers."*
- Connection Health, Unrepresented Routes, and Unused ACL tables paginate to top 10 with a \`Show all (N)\` toggle. Pagination state, including a user expansion to "Show less", is preserved across the 15-second poll refresh.

### Regression coverage

Five guards in \`regression_test.go\`:

- \`TestRegression_GraphCodeIsClientAgnostic\` — graph code paths contain no client-specific literal.
- \`TestRegression_ToolEdgesAreEvidenceBased\` — tool edges trace back to audit evidence.
- \`TestRegression_EdgeOriginatorPreserved\` — edge originator matches the audit trail.
- \`TestRegression_UnrepresentedRoutesSurfaced\` — forward-proxy traffic appears in \`unrepresented_routes\`.
- \`TestRegression_GraphCopyScopedToInstrumentedSurfaces\` — page copy references MCP / gateway / hooks.

### Out of scope

This PR does not introduce the broader activity layer (separate \`client\`, \`actor\`, \`principal\`, \`coverage\` model). That is sequenced as Phases 1-4 in the internal roadmap and is paused pending design-partner input. The current PR does not change how policy decisions or audit chain integrity are computed.

### Test plan

- [ ] Graph page-desc reads "Agent communication and tool usage observed across the MCP gateway, hooks, and stdio wrappers."
- [ ] All non-tool nodes render with the same node treatment.
- [ ] Connection Health paginates to top 10 + \`Show all (N)\` toggle.
- [ ] Pagination state persists across the 15s poll refresh, including after the user clicks \`Show less\`.
- [ ] Build, lint, vet, and full test suite remain green.