### PR TITLE
Add bearer-token identity for MCP HTTP gateway

### DIFF
--- a/documentation/guides/mcp-http-bearer-client.md
+++ b/documentation/guides/mcp-http-bearer-client.md
@@ -1,0 +1,193 @@
+# Generic MCP HTTP Client with Bearer Token
+
+This guide shows how to connect any MCP HTTP client to the Oktsec gateway using a bearer token, without relying on the legacy `X-Oktsec-Agent` header. The bearer token is the recommended path for new integrations and the only path supported in enterprise deployments.
+
+## When to use this
+
+- Your client cannot set arbitrary HTTP headers (so the legacy `X-Oktsec-Agent` path is not an option).
+- You are deploying Oktsec in enterprise mode and need authenticated identity on every request.
+- You want one identity contract that works the same for any MCP HTTP client (Claude Code, Codex, Cursor, custom agents, internal services).
+
+## Concepts
+
+### Principal vs. reported actor
+
+Oktsec separates **principal** (the authenticated identity used for every policy decision) from **reported actor** (display-only metadata supplied by the client, payload, or hook):
+
+- `Principal` drives ACL, rate limit, suspension, tool allowlist, delegation, and every blocking decision.
+- `ReportedActor` is shown in the dashboard alongside the principal so an analyst can see, for example, that the principal `local-codex` was acting on behalf of a sub-agent named `review-subagent`.
+
+A reported actor never overrides the principal. A spoofed `X-Oktsec-Agent: admin` header cannot grant admin policy when a bearer token says the request belongs to `local-codex`.
+
+### Local vs. enterprise
+
+Oktsec ships two deployment profiles. Each surface (gateway, hooks, forward proxy) honors them the same way:
+
+| Profile | Default behavior | Use when |
+|---|---|---|
+| `local` | Auth optional. The legacy `X-Oktsec-Agent` header from `127.0.0.1` is accepted as `trusted_local` identity for backwards compatibility. | Single-developer setup on a laptop. |
+| `enterprise` | Auth required. The loopback header is **never** accepted as principal — only as reported-actor metadata. | Anything exposed beyond loopback, fleet/team rollouts, regulated workloads. |
+
+Local mode stays permissive on purpose: existing setups using `X-Oktsec-Agent` keep working without config changes. Enterprise mode fails closed: missing or invalid identity returns `401 Unauthorized` before any policy code runs.
+
+You can force fail-closed behavior on a local laptop with:
+
+```yaml
+deployment:
+  require_surface_auth: true
+```
+
+This lets you test the enterprise contract end-to-end without flipping the whole profile.
+
+### `X-Oktsec-Agent` is legacy
+
+The `X-Oktsec-Agent` header is supported as a backwards-compatibility path for local profile only:
+
+- Accepted as principal **only** when (1) profile is `local`, (2) the request originates from the loopback interface, and (3) `gateway.trusted_loopback_headers` is on (default in local profile when no `auth_methods` override is set).
+- In enterprise mode the header is downgraded to a low-confidence reported actor and never grants policy authority.
+- Bearer tokens always win: if both a valid `Authorization: Bearer …` and `X-Oktsec-Agent` are present, the token's principal is used and the header surfaces as a reported actor only.
+
+For new integrations and enterprise deployments, use a bearer token.
+
+## Configure a principal and a token
+
+A principal is an identity Oktsec recognizes. Tokens are bound to one principal and stored as salted SHA-256 hashes — the raw secret is never persisted.
+
+> **Coming next**: `oktsec tokens create` will generate the raw token, hash it, and append the principal to your config in one command. Until that lands, generate the hash manually as shown below.
+
+### 1. Generate a raw token and hash
+
+Pick a 32-byte random secret with the `okt_gw_` prefix and produce the storage hash. Any tool that produces SHA-256 with a salt works; the format is `sha256:<hex_salt>:<hex_digest>`.
+
+For a one-off, paste this into a Python REPL:
+
+```python
+import secrets, hashlib
+
+raw  = "okt_gw_" + secrets.token_hex(32)
+salt = secrets.token_bytes(16)
+hash_ = "sha256:" + salt.hex() + ":" + hashlib.sha256(salt + raw.encode()).hexdigest()
+
+print("RAW (show once, then discard):", raw)
+print("HASH (paste into config):", hash_)
+```
+
+Save the raw value somewhere safe and paste **only the hash** into config.
+
+### 2. Add the principal to `oktsec.yaml`
+
+```yaml
+identity:
+  principals:
+    - id: local-codex
+      display_name: Codex local agent
+      kind: agent
+      allowed_surfaces:
+        - mcp_http
+      tokens:
+        - id: gw-local-codex
+          type: gateway_bearer
+          hash: "sha256:<paste_hex_salt>:<paste_hex_digest>"
+          created_at: "2026-04-26T00:00:00Z"
+          # Optional fields:
+          # expires_at: "2027-04-26T00:00:00Z"
+          # revoked_at: "2026-05-15T00:00:00Z"
+```
+
+Token types:
+
+- `gateway_bearer` — used for the MCP HTTP gateway (this guide).
+- `proxy_basic` — used for the HTTP forward proxy (separate surface, separate token).
+- `hook_bearer` — used by authenticated hook adapters.
+
+A leaked `gateway_bearer` token cannot authenticate to the forward proxy, and vice versa.
+
+### 3. Decide auth strictness
+
+For local development, the defaults are fine — bearer tokens authenticate as principal, the legacy header still works for any client that hasn't migrated.
+
+For enterprise:
+
+```yaml
+deployment:
+  profile: enterprise
+
+gateway:
+  bind: "0.0.0.0"
+  require_auth: true
+  auth_methods:
+    - bearer_token
+    # - mtls       # reserved for a future release
+  trusted_loopback_headers: false  # never trust the header in enterprise
+```
+
+`require_auth` is a per-surface override (`auto` | `true` | `false`). `auto` (or unset) follows the deployment profile. Explicit `true`/`false` always wins.
+
+## Use the bearer token from a client
+
+The MCP client makes its `tools/call` requests against the gateway endpoint with the standard `Authorization: Bearer …` header:
+
+```bash
+curl -X POST http://127.0.0.1:9090/mcp \
+  -H "Authorization: Bearer okt_gw_<your_raw_token_here>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}'
+```
+
+For an MCP client SDK that supports bearer auth (the official `@modelcontextprotocol/sdk` does), pass the token as the `headers.Authorization` value when constructing the transport. The gateway treats the request the same regardless of which SDK or runtime sent it — that is the point of being surface-agnostic.
+
+### Optional: declare the reported actor
+
+If your client wants the dashboard to show a sub-agent name (e.g. `review-subagent`) alongside the principal, set the reported-actor header. It is display-only and never affects policy:
+
+```bash
+curl ... \
+  -H "Authorization: Bearer okt_gw_..." \
+  -H "X-Oktsec-Reported-Actor: review-subagent" \
+  ...
+```
+
+Or include `_oktsec_agent` in the tool arguments — the gateway strips it from the upstream payload and stores it as the reported actor.
+
+## Verify it worked
+
+A successful call returns the tool's result. The audit row carries the resolved identity provenance:
+
+```sql
+SELECT from_agent, auth_method, principal_trust_level, reported_actor
+FROM audit_log
+ORDER BY timestamp DESC
+LIMIT 1;
+```
+
+Expected:
+
+| from_agent | auth_method | principal_trust_level | reported_actor |
+|---|---|---|---|
+| `local-codex` | `bearer_token` | `authenticated` | `review-subagent` (or empty) |
+
+A 401 response means either the token did not match any active principal, the token was revoked or expired, or `require_auth` is on and no `Authorization` header was sent. The response includes a `WWW-Authenticate: Bearer realm="oktsec gateway"` hint.
+
+## Token rotation and revocation
+
+Until the CLI lands, rotate by appending a new token to the principal's `tokens:` list, distributing the new raw value to the client, then setting `revoked_at` on the old entry. Revoked tokens stop authenticating immediately on the next request — the resolver revalidates each token's active state on every lookup, not just at config load time.
+
+```yaml
+tokens:
+  - id: gw-local-codex
+    type: gateway_bearer
+    hash: "sha256:..."
+    created_at: "2026-04-26T00:00:00Z"
+    revoked_at: "2026-05-15T00:00:00Z"   # this token no longer works
+  - id: gw-local-codex-2
+    type: gateway_bearer
+    hash: "sha256:..."                    # new hash, new raw value to the client
+    created_at: "2026-05-15T00:00:00Z"
+```
+
+Reload the gateway (SIGHUP) for the rebuild to pick up the changes.
+
+## Related
+
+- [MCP Gateway](gateway.md) — gateway configuration, backends, and tool routing.
+- [Egress](egress.md) — HTTP forward proxy with proxy-token auth (separate surface, same identity contract).

--- a/internal/audit/dialect.go
+++ b/internal/audit/dialect.go
@@ -69,6 +69,12 @@ func (SQLiteDialect) MigrateStatements() []string {
 		"ALTER TABLE audit_log ADD COLUMN tool_name TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN delegation_chain_hash TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN delegation_chain TEXT DEFAULT ''",
+		// Identity provenance — populated when a surface adapter resolves
+		// the request through internal/identity/resolve. Older rows leave
+		// these blank, which read as "unknown" by the dashboard.
+		"ALTER TABLE audit_log ADD COLUMN auth_method TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN principal_trust_level TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN reported_actor TEXT DEFAULT ''",
 		"CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id)",
 	}
 }
@@ -118,6 +124,10 @@ func (PostgresDialect) MigrateStatements() []string {
 		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS tool_name TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS delegation_chain_hash TEXT DEFAULT ''",
 		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS delegation_chain TEXT DEFAULT ''",
+		// Identity provenance — see SQLiteDialect.MigrateStatements.
+		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS auth_method TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS principal_trust_level TEXT DEFAULT ''",
+		"ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS reported_actor TEXT DEFAULT ''",
 		"CREATE INDEX IF NOT EXISTS idx_audit_session ON audit_log(session_id)",
 	}
 }
@@ -146,7 +156,10 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	entry_hash TEXT DEFAULT '',
 	proxy_signature TEXT DEFAULT '',
 	delegation_chain_hash TEXT DEFAULT '',
-	delegation_chain TEXT DEFAULT ''
+	delegation_chain TEXT DEFAULT '',
+	auth_method TEXT DEFAULT '',
+	principal_trust_level TEXT DEFAULT '',
+	reported_actor TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);

--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -27,6 +27,18 @@ type Entry struct {
 	AgentInstanceID     string `json:"agent_instance_id,omitempty"`     // unique sub-agent instance ID from client
 	RootAgent           string `json:"root_agent,omitempty"`            // original initiator of the chain
 	AgentDepth          int    `json:"agent_depth,omitempty"`           // 0=root, 1=sub-agent, 2=sub-sub-agent
+
+	// Identity provenance — populated by surface adapters that route the
+	// request through internal/identity/resolve. Older entries (and
+	// entries from adapters that have not migrated yet) leave these blank,
+	// which read as "unknown" by callers and dashboards.
+	//
+	// FromAgent always equals the policy Principal; these fields tell the
+	// reader HOW that Principal was established and what display-only
+	// actor name (subagent, model role, hook payload) accompanied it.
+	AuthMethod        string `json:"auth_method,omitempty"`         // bearer_token | trusted_loopback | proxy_token | hook_token | ed25519 | mtls | ""
+	PrincipalTrustLevel string `json:"principal_trust_level,omitempty"` // authenticated | trusted_local | observed | inferred | anonymous
+	ReportedActor     string `json:"reported_actor,omitempty"`      // display-only actor (subagent name, etc.); never used for policy
 }
 
 // HierarchyEntry tracks parent-child agent relationships within a session.

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -58,7 +58,10 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	parent_agent TEXT DEFAULT '',
 	agent_instance_id TEXT DEFAULT '',
 	root_agent TEXT DEFAULT '',
-	agent_depth INTEGER DEFAULT 0
+	agent_depth INTEGER DEFAULT 0,
+	auth_method TEXT DEFAULT '',
+	principal_trust_level TEXT DEFAULT '',
+	reported_actor TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status);
@@ -560,7 +563,11 @@ func (s *Store) Log(entry Entry) {
 
 // auditSelectCols is the shared SELECT column list for audit queries.
 // Update this constant (and the corresponding Scan calls) when adding columns.
-const auditSelectCols = "id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,''), COALESCE(parent_agent,''), COALESCE(agent_instance_id,''), COALESCE(root_agent,''), COALESCE(agent_depth,0)"
+//
+// COALESCE on identity provenance fields is required for backward
+// compatibility: rows written before the migration ran will have NULLs in
+// those columns until they age out, and Scan into string would fail.
+const auditSelectCols = "id, timestamp, from_agent, to_agent, COALESCE(tool_name,''), content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, COALESCE(intent,''), COALESCE(session_id,''), COALESCE(entry_hash,''), COALESCE(delegation_chain_hash,''), COALESCE(delegation_chain,''), COALESCE(parent_agent,''), COALESCE(agent_instance_id,''), COALESCE(root_agent,''), COALESCE(agent_depth,0), COALESCE(auth_method,''), COALESCE(principal_trust_level,''), COALESCE(reported_actor,'')"
 
 // Query returns audit entries matching the given filters.
 func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
@@ -629,7 +636,7 @@ func (s *Store) Query(opts QueryOpts) ([]Entry, error) {
 		var fp, rules sql.NullString
 		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 			&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth); err != nil {
+			&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth, &e.AuthMethod, &e.PrincipalTrustLevel, &e.ReportedActor); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		e.PubkeyFingerprint = fp.String
@@ -712,7 +719,7 @@ func (s *Store) QueryByID(id string) (*Entry, error) {
 	var fp, rules sql.NullString
 	if err := row.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent, &e.ToolName, &e.ContentHash,
 		&e.SignatureVerified, &fp, &e.Status, &rules, &e.PolicyDecision, &e.LatencyMs,
-		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth); err != nil {
+		&e.Intent, &e.SessionID, &e.EntryHash, &e.DelegationChainHash, &e.DelegationChain, &e.ParentAgent, &e.AgentInstanceID, &e.RootAgent, &e.AgentDepth, &e.AuthMethod, &e.PrincipalTrustLevel, &e.ReportedActor); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -876,7 +883,7 @@ func (s *Store) writeLoop() {
 			continue
 		}
 
-		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash, delegation_chain, parent_agent, agent_instance_id, root_agent, agent_depth) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		stmt, err := tx.Prepare(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, tool_name, content_hash, signature_verified, pubkey_fingerprint, status, rules_triggered, policy_decision, latency_ms, intent, session_id, prev_hash, entry_hash, proxy_signature, delegation_chain_hash, delegation_chain, parent_agent, agent_instance_id, root_agent, agent_depth, auth_method, principal_trust_level, reported_actor) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			s.logger.Error("audit batch prepare failed", "error", err)
 			_ = tx.Rollback()
@@ -892,6 +899,7 @@ func (s *Store) writeLoop() {
 				batch[i].PolicyDecision, batch[i].LatencyMs, batch[i].Intent, batch[i].SessionID,
 				batch[i].PrevHash, batch[i].EntryHash, batch[i].ProxySignature, batch[i].DelegationChainHash, batch[i].DelegationChain,
 				batch[i].ParentAgent, batch[i].AgentInstanceID, batch[i].RootAgent, batch[i].AgentDepth,
+				batch[i].AuthMethod, batch[i].PrincipalTrustLevel, batch[i].ReportedActor,
 			)
 			if err != nil {
 				s.logger.Error("audit write failed", "id", batch[i].ID, "error", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type TrustBoundaries struct {
 // Config is the top-level oktsec configuration.
 type Config struct {
 	Version          string                         `yaml:"version"`
+	Deployment       DeploymentConfig               `yaml:"deployment,omitempty"`
 	Server           ServerConfig                   `yaml:"server"`
 	Identity         IdentityConfig                 `yaml:"identity"`
 	TrustBoundaries  TrustBoundaries                `yaml:"trust_boundaries,omitempty"`
@@ -180,10 +181,54 @@ type ServerConfig struct {
 
 // IdentityConfig configures agent identity verification.
 type IdentityConfig struct {
-	KeysDir            string          `yaml:"keys_dir"`
-	RequireSignature   bool            `yaml:"require_signature"`
-	RequireDelegation  bool            `yaml:"require_delegation,omitempty"`
-	Ephemeral          EphemeralConfig `yaml:"ephemeral,omitempty"`
+	KeysDir            string             `yaml:"keys_dir"`
+	RequireSignature   bool               `yaml:"require_signature"`
+	RequireDelegation  bool               `yaml:"require_delegation,omitempty"`
+	Ephemeral          EphemeralConfig    `yaml:"ephemeral,omitempty"`
+
+	// Principals declares authenticated identities (agents, services) that
+	// surface adapters can resolve from bearer/proxy/hook tokens, mTLS
+	// certificates, or Ed25519 signatures. Tokens are stored as salted
+	// SHA-256 hashes; raw secrets must be shown to the operator exactly
+	// once at creation and never logged.
+	Principals []PrincipalConfig `yaml:"principals,omitempty"`
+}
+
+// PrincipalConfig is the on-disk shape of a Principal that surface
+// adapters use for policy decisions. The shape mirrors
+// resolve.PrincipalRecord; the resolve package converts between them at
+// resolver-build time so the resolver does not depend on the config
+// package.
+type PrincipalConfig struct {
+	ID              string                 `yaml:"id"`
+	DisplayName     string                 `yaml:"display_name,omitempty"`
+	Kind            string                 `yaml:"kind,omitempty"` // agent, user, service, workspace
+	WorkspaceID     string                 `yaml:"workspace_id,omitempty"`
+	AllowedSurfaces []string               `yaml:"allowed_surfaces,omitempty"` // e.g. ["mcp_http", "http_egress_proxy"]
+	Tokens          []PrincipalTokenConfig `yaml:"tokens,omitempty"`
+}
+
+// PrincipalTokenConfig is one token bound to a Principal. The Hash field
+// is the salted SHA-256 of the raw secret in the format
+// `sha256:<hex_salt>:<hex_digest>`. The raw token is never persisted.
+type PrincipalTokenConfig struct {
+	ID         string `yaml:"id"`
+	Type       string `yaml:"type"`              // gateway_bearer, proxy_basic, hook_bearer
+	Hash       string `yaml:"hash"`              // sha256:<salt>:<hex>
+	CreatedAt  string `yaml:"created_at,omitempty"`
+	ExpiresAt  string `yaml:"expires_at,omitempty"`
+	RevokedAt  string `yaml:"revoked_at,omitempty"`
+	LastUsedAt string `yaml:"last_used_at,omitempty"`
+}
+
+// DeploymentConfig declares how this oktsec instance is deployed. Profile
+// changes the default fail-closed behavior of surface adapters: local
+// allows trusted-loopback fallbacks for friction-light onboarding;
+// enterprise requires authenticated identity on every protected path.
+type DeploymentConfig struct {
+	Profile            string `yaml:"profile,omitempty"`              // local | enterprise (default: local)
+	OrgID              string `yaml:"org_id,omitempty"`               // tenant id, enterprise
+	RequireSurfaceAuth bool   `yaml:"require_surface_auth,omitempty"` // forces fail-closed on every surface
 }
 
 // EphemeralConfig controls task-scoped ephemeral key issuance.
@@ -402,6 +447,26 @@ type GatewayConfig struct {
 	// permissive defaults. Set true in production / stricter deployments
 	// where every agent should be reviewed before it can execute tools.
 	DisableAutoRegister bool `yaml:"disable_auto_register,omitempty"`
+
+	// RequireAuth controls whether the gateway rejects requests that the
+	// identity resolver cannot authenticate. Values:
+	//   "auto"  — derive from deployment profile (enterprise => true)
+	//   "true"  — always require an authenticated principal
+	//   "false" — accept anonymous requests (local-only setups)
+	// Empty defaults to "auto".
+	RequireAuth string `yaml:"require_auth,omitempty"`
+
+	// AuthMethods restricts which identity methods the gateway accepts.
+	// Allowed values: "bearer_token", "mtls", "trusted_loopback_header".
+	// Empty defaults to ["bearer_token", "trusted_loopback_header"] in
+	// local profile and ["bearer_token", "mtls"] in enterprise.
+	AuthMethods []string `yaml:"auth_methods,omitempty"`
+
+	// TrustedLoopbackHeaders lets the legacy X-Oktsec-Agent header act as
+	// a Principal (TrustLocal) when the request originates from loopback.
+	// Honored only in local profile; enterprise always treats the header
+	// as reported-actor metadata.
+	TrustedLoopbackHeaders bool `yaml:"trusted_loopback_headers,omitempty"`
 }
 
 // MCPServerConfig defines a backend MCP server to proxy through the gateway.

--- a/internal/gateway/audit_identity_test.go
+++ b/internal/gateway/audit_identity_test.go
@@ -1,0 +1,160 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// echoBackends is the single-server backend map used by the audit
+// identity tests. The echo server is defined in gateway_test.go and
+// exposes one tool ("echo") with a permissive schema.
+func echoBackends() map[string]*mcp.Server {
+	return map[string]*mcp.Server{"echo": echoServer()}
+}
+
+// ctxWithIdentity builds a request context shaped exactly like the auth
+// middleware leaves it after a successful Resolve. Tests use this to
+// drive makeHandler() without spinning up the full HTTP path — the
+// middleware contract is already covered in identity_test.go.
+func ctxWithIdentity(principal, authMethod, trustLevel, reportedActor string) context.Context {
+	ctx := context.Background()
+	if principal != "" {
+		ctx = context.WithValue(ctx, agentContextKey, principal)
+	}
+	if authMethod != "" {
+		ctx = context.WithValue(ctx, authMethodContextKey, authMethod)
+	}
+	if trustLevel != "" {
+		ctx = context.WithValue(ctx, trustLevelContextKey, trustLevel)
+	}
+	if reportedActor != "" {
+		ctx = context.WithValue(ctx, reportedActorContextKey, reportedActor)
+	}
+	return ctx
+}
+
+// lastAuditEntry returns the most recently inserted entry for a given
+// principal id. Tests call gw.audit.Flush() first to drain the batch
+// writer.
+func lastAuditEntry(t *testing.T, gw *Gateway, principal string) audit.Entry {
+	t.Helper()
+	gw.audit.Flush()
+	entries, err := gw.audit.Query(audit.QueryOpts{Agent: principal, Limit: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "no audit entry for principal %q", principal)
+	return entries[0]
+}
+
+// 1. Bearer principal + spoofed reported actor: audit row stores
+// FromAgent=principal (the bearer-token owner) while ReportedActor
+// carries the spoofed display name. AuthMethod records bearer_token so
+// downstream readers can tell HOW it was authenticated.
+func TestAudit_BearerPrincipalSeparatesReportedActor(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["local-codex"] = config.Agent{}
+	gw := newTestGateway(t, cfg, echoBackends())
+
+	ctx := ctxWithIdentity(
+		"local-codex",                            // principal
+		string(resolve.AuthMethodBearerToken),    // auth method
+		string(resolve.TrustAuthenticated),       // trust level
+		"admin",                                  // spoofed reported actor
+	)
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	_, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"}))
+	require.NoError(t, err)
+
+	e := lastAuditEntry(t, gw, "local-codex")
+	assert.Equal(t, "local-codex", e.FromAgent, "policy principal must be from bearer, not spoofed actor")
+	assert.Equal(t, string(resolve.AuthMethodBearerToken), e.AuthMethod)
+	assert.Equal(t, string(resolve.TrustAuthenticated), e.PrincipalTrustLevel)
+	assert.Equal(t, "admin", e.ReportedActor, "reported actor preserved for display")
+}
+
+// 2. Local legacy loopback header: principal name comes from the header,
+// auth method records trusted_loopback so readers can distinguish it
+// from token-authenticated rows. ReportedActor stays empty when no
+// surface header / payload supplied one.
+func TestAudit_LocalLegacyLoopbackHeader(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["claude-code"] = config.Agent{}
+	gw := newTestGateway(t, cfg, echoBackends())
+
+	ctx := ctxWithIdentity(
+		"claude-code",
+		string(resolve.AuthMethodTrustedLoopback),
+		string(resolve.TrustLocal),
+		"", // no reported actor
+	)
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	_, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"}))
+	require.NoError(t, err)
+
+	e := lastAuditEntry(t, gw, "claude-code")
+	assert.Equal(t, "claude-code", e.FromAgent)
+	assert.Equal(t, string(resolve.AuthMethodTrustedLoopback), e.AuthMethod)
+	assert.Equal(t, string(resolve.TrustLocal), e.PrincipalTrustLevel)
+	assert.Empty(t, e.ReportedActor, "no reported actor source means empty field")
+}
+
+// 3. The _oktsec_agent payload param surfaces as ReportedActor but never
+// becomes the policy Principal. This is the structural invariant: the
+// payload supplies display metadata, the bearer token / loopback header
+// supplies authority.
+func TestAudit_OktsecAgentPayloadDoesNotChangeFromAgent(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["local-codex"] = config.Agent{}
+	gw := newTestGateway(t, cfg, echoBackends())
+
+	ctx := ctxWithIdentity(
+		"local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated),
+		"", // no header reported actor
+	)
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	_, err := handler(ctx, makeHandlerRequest("echo", map[string]any{
+		"text":          "hi",
+		"_oktsec_agent": "review-subagent", // payload sub-agent
+	}))
+	require.NoError(t, err)
+
+	e := lastAuditEntry(t, gw, "local-codex")
+	assert.Equal(t, "local-codex", e.FromAgent, "principal must come from auth, not payload")
+	assert.Equal(t, "review-subagent", e.ReportedActor, "payload sub-agent surfaces as reported actor")
+	assert.Equal(t, string(resolve.AuthMethodBearerToken), e.AuthMethod)
+}
+
+// 4. Backward compatibility: an Entry written without identity provenance
+// fields persists and reads back as empty strings. This guards the
+// migration: existing audit rows from before #61 must keep working.
+func TestAudit_BackwardCompatEmptyIdentityFields(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	gw := newTestGateway(t, cfg, echoBackends())
+
+	// Old-style entry with no identity provenance.
+	gw.audit.Log(audit.Entry{
+		ID:             "legacy-1",
+		Timestamp:      "2026-04-01T00:00:00Z",
+		FromAgent:      "legacy-agent",
+		ToAgent:        "legacy-agent",
+		Status:         audit.StatusDelivered,
+		PolicyDecision: "ok",
+	})
+	gw.audit.Flush()
+
+	e, err := gw.audit.QueryByID("legacy-1")
+	require.NoError(t, err)
+	require.NotNil(t, e, "legacy entry should be retrievable")
+	assert.Equal(t, "legacy-agent", e.FromAgent)
+	assert.Empty(t, e.AuthMethod, "old rows have no auth_method")
+	assert.Empty(t, e.PrincipalTrustLevel, "old rows have no trust_level")
+	assert.Empty(t, e.ReportedActor, "old rows have no reported_actor")
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/identity"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
 	"github.com/oktsec/oktsec/internal/llm"
 	"github.com/oktsec/oktsec/internal/mcputil"
 	"github.com/oktsec/oktsec/internal/netutil"
@@ -35,6 +36,46 @@ type contextKey string
 const agentContextKey contextKey = "oktsec-agent"
 const sessionContextKey contextKey = "oktsec-session"
 const delegationContextKey contextKey = "oktsec-delegation"
+const reportedActorContextKey contextKey = "oktsec-reported-actor"
+const authMethodContextKey contextKey = "oktsec-auth-method"
+const trustLevelContextKey contextKey = "oktsec-trust-level"
+
+// requestIdentity is the identity bundle the gateway carries from the
+// auth middleware down to logAudit. Built once per request via
+// identityFromContext so handlers do not have to reach into context for
+// each field — and so audit calls cannot accidentally pass the wrong
+// principal to the security pipeline.
+//
+// PrincipalID is the only identity policy code may use. AuthMethod and
+// TrustLevel record HOW it was established; ReportedActor is the
+// display-only actor the surface saw alongside it (subagent name,
+// payload field, hook body) and never affects policy.
+type requestIdentity struct {
+	PrincipalID   string
+	AuthMethod    string
+	TrustLevel    string
+	ReportedActor string
+}
+
+// identityFromContext lifts the values the auth middleware put into ctx
+// into a single struct. Empty fields are returned as "" — handlers and
+// logAudit treat that as "no information" rather than failing.
+func identityFromContext(ctx context.Context) requestIdentity {
+	var id requestIdentity
+	if v, ok := ctx.Value(agentContextKey).(string); ok {
+		id.PrincipalID = v
+	}
+	if v, ok := ctx.Value(authMethodContextKey).(string); ok {
+		id.AuthMethod = v
+	}
+	if v, ok := ctx.Value(trustLevelContextKey).(string); ok {
+		id.TrustLevel = v
+	}
+	if v, ok := ctx.Value(reportedActorContextKey).(string); ok {
+		id.ReportedActor = v
+	}
+	return id
+}
 
 // toolMapping maps a frontend tool name to its backend.
 type toolMapping struct {
@@ -76,6 +117,107 @@ type Gateway struct {
 	registeredAgents  map[string]bool
 	registeredMu      sync.Mutex
 	cfgPath           string
+
+	// resolver and resolverConfig together decide which Principal a
+	// request belongs to. The resolver is always non-nil — even when no
+	// principals are configured the store is empty rather than nil so the
+	// adapter never has to nil-check before each Resolve.
+	resolver       resolve.Resolver
+	resolverConfig resolve.Config
+	requireAuth    bool // derived from cfg.Gateway.RequireAuth + deployment profile
+}
+
+// authMiddleware runs the identity resolver for every gateway request,
+// fails closed when require_auth is on, and exposes the resolved Principal
+// (plus reported actor and auth method) to downstream handlers via the
+// request context. Extracted for testability so identity contracts can be
+// exercised without spinning up the full MCP backend stack.
+func (g *Gateway) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		evidence := resolve.Evidence{
+			Surface:     resolve.SurfaceMCPHTTP,
+			Header:      r.Header,
+			RemoteAddr:  r.RemoteAddr,
+			ConfigAgent: r.Header.Get("X-Oktsec-Agent"),
+		}
+		result, err := g.resolver.Resolve(r.Context(), g.resolverConfig, evidence)
+		if err != nil {
+			// Resolver should not error on well-formed paths today, but
+			// any transport-style failure fails closed rather than
+			// continuing with no identity.
+			http.Error(w, "identity resolver error", http.StatusInternalServerError)
+			return
+		}
+		if g.requireAuth {
+			if trustErr := result.RequireMinimumTrust(resolve.TrustAuthenticated); trustErr != nil {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="oktsec gateway"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		ctx := context.WithValue(r.Context(), agentContextKey, result.Principal.ID)
+		ctx = context.WithValue(ctx, authMethodContextKey, string(result.Principal.AuthMethod))
+		ctx = context.WithValue(ctx, trustLevelContextKey, string(result.Principal.TrustLevel))
+		if result.ReportedActor.ID != "" {
+			ctx = context.WithValue(ctx, reportedActorContextKey, result.ReportedActor.ID)
+		}
+		if sid := r.Header.Get("Mcp-Session-Id"); sid != "" {
+			ctx = context.WithValue(ctx, sessionContextKey, sid)
+		}
+		if del := r.Header.Get("X-Oktsec-Delegation"); del != "" {
+			ctx = context.WithValue(ctx, delegationContextKey, del)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// gatewaySurfacePolicy derives the per-surface identity contract for the
+// MCP gateway. Same helper (resolve.DerivePolicy) will be used by hooks
+// and the forward proxy when those surfaces migrate; the gateway just
+// fills in its own AuthMethods / TrustedLoopbackHeaders / RequireAuth
+// from cfg.Gateway.
+func gatewaySurfacePolicy(cfg *config.Config) resolve.SurfacePolicy {
+	return resolve.DerivePolicy(resolve.SurfaceAuthInput{
+		Surface:                 resolve.SurfaceMCPHTTP,
+		Profile:                 resolve.ProfileFromString(cfg.Deployment.Profile),
+		RequireSurfaceAuth:      cfg.Deployment.RequireSurfaceAuth,
+		RequireAuthOverride:     cfg.Gateway.RequireAuth,
+		AuthMethods:             cfg.Gateway.AuthMethods,
+		TrustedLoopbackHeaders:  cfg.Gateway.TrustedLoopbackHeaders,
+		ReportedActorHeaderName: "X-Oktsec-Reported-Actor",
+		AllowedTokenTypes:       []resolve.TokenType{resolve.TokenTypeGatewayBearer},
+	})
+}
+
+// configPrincipalsFor projects cfg.Identity.Principals into the
+// resolve-package shape so the resolver does not import config.
+func configPrincipalsFor(cfg *config.Config) []resolve.ConfigPrincipal {
+	out := make([]resolve.ConfigPrincipal, 0, len(cfg.Identity.Principals))
+	for _, p := range cfg.Identity.Principals {
+		toks := make([]resolve.ConfigToken, 0, len(p.Tokens))
+		for _, t := range p.Tokens {
+			toks = append(toks, resolve.ConfigToken{
+				ID: t.ID, Type: t.Type, Hash: t.Hash,
+				CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt, RevokedAt: t.RevokedAt,
+			})
+		}
+		out = append(out, resolve.ConfigPrincipal{
+			ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
+			WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
+			Tokens: toks,
+		})
+	}
+	return out
+}
+
+// buildResolver constructs the resolver/store the gateway uses for every
+// request. The store is always non-nil — even when no principals are
+// configured the bucket is empty and Lookup just returns ErrNoToken — so
+// the request path never has to nil-check before resolving.
+func buildResolver(cfg *config.Config) resolve.Resolver {
+	principals := resolve.PrincipalsFromConfig(configPrincipalsFor(cfg))
+	store := resolve.NewMemoryTokenStoreWithClock(principals, nil)
+	return resolve.NewDefaultResolver(store, nil)
 }
 
 // NewGateway creates a gateway from the given configuration.
@@ -103,6 +245,7 @@ func NewGateway(cfg *config.Config, logger *slog.Logger, sharedStore *audit.Stor
 
 	agentConstraints, agentChainRules := buildConstraintMaps(cfg)
 
+	policy := gatewaySurfacePolicy(cfg)
 	return &Gateway{
 		cfg:               cfg,
 		backends:          make(map[string]*Backend),
@@ -116,12 +259,16 @@ func NewGateway(cfg *config.Config, logger *slog.Logger, sharedStore *audit.Stor
 		constraintChecker: NewConstraintChecker(agentConstraints, agentChainRules),
 		logger:            logger,
 		registeredAgents:  make(map[string]bool),
+		resolver:          buildResolver(cfg),
+		resolverConfig:    policy.ResolverConfig,
+		requireAuth:       policy.RequireAuth,
 	}, nil
 }
 
 // newGatewayForTest creates a gateway with injected dependencies (no real scanner/audit).
 func newGatewayForTest(cfg *config.Config, scanner *engine.Scanner, auditStore *audit.Store, logger *slog.Logger) *Gateway {
 	agentConstraints, agentChainRules := buildConstraintMaps(cfg)
+	policy := gatewaySurfacePolicy(cfg)
 	return &Gateway{
 		cfg:               cfg,
 		backends:          make(map[string]*Backend),
@@ -134,6 +281,10 @@ func newGatewayForTest(cfg *config.Config, scanner *engine.Scanner, auditStore *
 		policyEnforcer:    NewToolPolicyEnforcer(),
 		constraintChecker: NewConstraintChecker(agentConstraints, agentChainRules),
 		logger:            logger,
+		registeredAgents:  make(map[string]bool),
+		resolver:          buildResolver(cfg),
+		resolverConfig:    policy.ResolverConfig,
+		requireAuth:       policy.RequireAuth,
 	}
 }
 
@@ -223,21 +374,7 @@ func (g *Gateway) Start(ctx context.Context) error {
 		nil,
 	)
 
-	// Wrap with middleware for agent header and session ID injection
-	agentMiddleware := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		agent := r.Header.Get("X-Oktsec-Agent")
-		if agent == "" {
-			agent = "unknown"
-		}
-		ctx := context.WithValue(r.Context(), agentContextKey, agent)
-		if sid := r.Header.Get("Mcp-Session-Id"); sid != "" {
-			ctx = context.WithValue(ctx, sessionContextKey, sid)
-		}
-		if del := r.Header.Get("X-Oktsec-Delegation"); del != "" {
-			ctx = context.WithValue(ctx, delegationContextKey, del)
-		}
-		streamable.ServeHTTP(w, r.WithContext(ctx))
-	})
+	agentMiddleware := g.authMiddleware(streamable)
 
 	// Bind with auto-port
 	bind := g.cfg.Gateway.Bind
@@ -411,19 +548,27 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		start := time.Now()
 		msgID := uuid.New().String()
 
-		// 1. Extract agent name from context (parent identity from HTTP header)
-		agent, _ := ctx.Value(agentContextKey).(string)
-		if agent == "" {
-			agent = "unknown"
+		// 1. Lift the resolved Principal + provenance the auth middleware
+		// stored on ctx into a single struct. Every audit row written for
+		// this request will carry the same identity bundle, so the policy
+		// principal cannot drift from what the audit reader sees.
+		id := identityFromContext(ctx)
+		if id.PrincipalID == "" {
+			id.PrincipalID = "unknown"
 		}
+		agent := id.PrincipalID
 
-		// 1a. Extract sub-agent identity from tool arguments.
-		// policyAgent is the immutable principal for ALL security
-		// decisions. _oktsec_agent is metadata for audit logs only.
+		// 1a. Extract sub-agent identity from tool arguments. The
+		// _oktsec_agent param is metadata for audit only — it never
+		// becomes the policy principal regardless of value. If the
+		// payload supplied a sub-agent it is the most specific reported
+		// actor we have, so it overrides whatever the surface header
+		// declared.
 		policyAgent := agent
 		subAgent := extractAndStripAgentParam(req)
 		if subAgent != "" {
 			g.autoRegisterAgent(subAgent)
+			id.ReportedActor = subAgent
 		}
 
 		// 1b. Extract tool arguments summary for audit (after stripping _oktsec_agent)
@@ -447,7 +592,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 				if maxDepth := resolveDelegationDepth(g.cfg, policyAgent); maxDepth > 0 && chainResult.Depth > maxDepth {
 					g.logger.Warn("delegation depth exceeded",
 						"agent", agent, "depth", chainResult.Depth, "max", maxDepth)
-					g.logAudit(msgID, agent, m.OriginalName, audit.StatusBlocked, audit.DecisionDelegationDepthExceeded, "[]", toolArgs, sessionID, start)
+					g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionDelegationDepthExceeded, "[]", toolArgs, sessionID, start)
 					return toolError(fmt.Sprintf("delegation depth %d exceeds max %d", chainResult.Depth, maxDepth)), nil
 				}
 				delegationChainHash = chainResult.ChainHash
@@ -467,7 +612,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 
 		// 2. Rate limit check
 		if !g.rateLimiter.Allow(policyAgent) {
-			g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionRateLimited, "[]", toolArgs, sessionID, start)
+			g.logAudit(msgID, id, m.OriginalName, audit.StatusRejected, audit.DecisionRateLimited, "[]", toolArgs, sessionID, start)
 			return toolError("rate limit exceeded"), nil
 		}
 
@@ -475,7 +620,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		// a single agent can't open N parallel sockets against the same tool.
 		release, err := g.concurrency.acquire(ctx, policyAgent)
 		if err != nil {
-			g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionConcurrencyExceeded, "[]", toolArgs, sessionID, start)
+			g.logAudit(msgID, id, m.OriginalName, audit.StatusRejected, audit.DecisionConcurrencyExceeded, "[]", toolArgs, sessionID, start)
 			return toolError("concurrency limit exceeded"), nil
 		}
 		defer release()
@@ -483,7 +628,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		// 3. Tool allowlist check
 		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok {
 			if agentCfg.Suspended {
-				g.logAudit(msgID, agent, m.OriginalName, audit.StatusRejected, audit.DecisionAgentSuspended, "[]", toolArgs, sessionID, start)
+				g.logAudit(msgID, id, m.OriginalName, audit.StatusRejected, audit.DecisionAgentSuspended, "[]", toolArgs, sessionID, start)
 				return toolError("agent suspended"), nil
 			}
 			if len(agentCfg.AllowedTools) > 0 {
@@ -495,7 +640,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 					}
 				}
 				if !allowed {
-					g.logAudit(msgID, agent, m.OriginalName, audit.StatusBlocked, audit.DecisionToolNotAllowed, "[]", toolArgs, sessionID, start)
+					g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionToolNotAllowed, "[]", toolArgs, sessionID, start)
 					return toolError(fmt.Sprintf("tool %q not allowed for agent %q", m.OriginalName, agent)), nil
 				}
 			}
@@ -511,7 +656,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 					if result.Decision == "quarantine_approval" {
 						status = audit.StatusQuarantined
 					}
-					g.logAudit(msgID, agent, m.OriginalName, status, result.Decision, "[]", toolArgs, sessionID, start)
+					g.logAudit(msgID, id, m.OriginalName, status, result.Decision, "[]", toolArgs, sessionID, start)
 					return toolError(fmt.Sprintf("tool policy: %s", result.Reason)), nil
 				}
 			}
@@ -527,7 +672,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			}
 			result := g.constraintChecker.CheckToolCall(policyAgent, m.OriginalName, params)
 			if !result.Allowed {
-				g.logAudit(msgID, agent, m.OriginalName, audit.StatusBlocked, audit.DecisionConstraintViolated, "[]", toolArgs, sessionID, start)
+				g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionConstraintViolated, "[]", toolArgs, sessionID, start)
 				return toolError(fmt.Sprintf("constraint: %s", result.Reason)), nil
 			}
 		}
@@ -541,7 +686,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		outcome, err := g.scanner.ScanContentWithTool(scanCtx, content, m.OriginalName)
 		if err != nil {
 			g.logger.Error("scan failed", "error", err, "tool", m.OriginalName)
-			g.logAudit(msgID, agent, m.OriginalName, audit.StatusDelivered, audit.DecisionScanError, "[]", toolArgs, sessionID, start)
+			g.logAudit(msgID, id, m.OriginalName, audit.StatusDelivered, audit.DecisionScanError, "[]", toolArgs, sessionID, start)
 			// Forward on scan error — fail open
 		}
 
@@ -578,7 +723,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		status, decision := verdictToGateway(outcome.Verdict)
 
 		// 9. Audit log (with delegation chain if verified)
-		g.logAudit(msgID, agent, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start, delegationChainHash, delegationChainSummary)
+		g.logAudit(msgID, id, m.OriginalName, status, decision, findingsJSON, toolArgs, sessionID, start, delegationChainHash, delegationChainSummary)
 
 		// 9a. Enqueue quarantined items for human review
 		if outcome.Verdict == engine.VerdictQuarantine {
@@ -679,7 +824,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 			if violation := checkResponseScope(result, delegationAllowedTools); violation != "" {
 				g.logger.Warn("subagent response outside delegated scope",
 					"agent", agent, "tool", m.OriginalName, "violation", violation)
-				g.logAudit(msgID, agent, m.OriginalName, audit.StatusDelivered,
+				g.logAudit(msgID, id, m.OriginalName, audit.StatusDelivered,
 					audit.DecisionDelegationScopeViolation, "[]", toolArgs, sessionID, start,
 					delegationChainHash, delegationChainSummary)
 			}
@@ -795,7 +940,16 @@ func (g *Gateway) autoRegisterAgent(name string) {
 
 // logAudit writes an audit entry for a gateway tool call.
 // Optional extra strings: first is delegation_chain_hash.
-func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time, extra ...string) {
+// logAudit writes one audit entry. The caller passes the resolved
+// requestIdentity so the audit row carries the same Principal that
+// drove the policy decision, plus the AuthMethod / TrustLevel /
+// ReportedActor provenance the resolver established.
+//
+// FromAgent and ToAgent both equal id.PrincipalID — historical: the
+// gateway logs every tool call as a self-edge from the principal. Other
+// surfaces (agent message API) populate ToAgent differently and call
+// audit.Log directly.
+func (g *Gateway) logAudit(msgID string, id requestIdentity, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time, extra ...string) {
 	var delHash, delChain string
 	if len(extra) > 0 {
 		delHash = extra[0]
@@ -806,8 +960,8 @@ func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, t
 	g.audit.Log(audit.Entry{
 		ID:                  msgID,
 		Timestamp:           time.Now().UTC().Format(time.RFC3339),
-		FromAgent:           agent,
-		ToAgent:             agent,
+		FromAgent:           id.PrincipalID,
+		ToAgent:             id.PrincipalID,
 		ToolName:            tool,
 		ContentHash:         "",
 		Status:              status,
@@ -818,6 +972,9 @@ func (g *Gateway) logAudit(msgID, agent, tool, status, decision, findingsJSON, t
 		SessionID:           sessionID,
 		DelegationChainHash: delHash,
 		DelegationChain:     delChain,
+		AuthMethod:          id.AuthMethod,
+		PrincipalTrustLevel: id.TrustLevel,
+		ReportedActor:       id.ReportedActor,
 	})
 }
 

--- a/internal/gateway/identity_test.go
+++ b/internal/gateway/identity_test.go
@@ -1,0 +1,305 @@
+package gateway
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+)
+
+// identityProbe is the downstream handler used by these tests. It captures
+// what authMiddleware put into the request context so the assertions can
+// verify Principal/ReportedActor/AuthMethod independently of the MCP path.
+type identityProbe struct {
+	called        bool
+	principal     string
+	reportedActor string
+	authMethod    string
+	status        int
+}
+
+func (p *identityProbe) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.called = true
+		if v, ok := r.Context().Value(agentContextKey).(string); ok {
+			p.principal = v
+		}
+		if v, ok := r.Context().Value(reportedActorContextKey).(string); ok {
+			p.reportedActor = v
+		}
+		if v, ok := r.Context().Value(authMethodContextKey).(string); ok {
+			p.authMethod = v
+		}
+		p.status = http.StatusOK
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// gatewayWithPrincipal builds a test gateway with one principal whose
+// gateway-bearer token is returned as `raw`. The deployment profile and
+// gateway-auth knobs come from the supplied builder so each test can
+// declare its own scenario without smuggling globals.
+func gatewayWithPrincipal(t *testing.T, principalID string, build func(*config.Config)) (*Gateway, string) {
+	t.Helper()
+	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{
+			Principals: []config.PrincipalConfig{{
+				ID:          principalID,
+				DisplayName: principalID,
+				Kind:        "agent",
+				Tokens: []config.PrincipalTokenConfig{{
+					ID:        principalID + "-tok",
+					Type:      "gateway_bearer",
+					Hash:      hash,
+					CreatedAt: "2026-04-26T00:00:00Z",
+				}},
+			}},
+		},
+		Gateway: config.GatewayConfig{Enabled: true},
+		Agents:  map[string]config.Agent{},
+	}
+	if build != nil {
+		build(cfg)
+	}
+	g := newGatewayForTest(cfg, nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return g, raw
+}
+
+// 1. A valid bearer token wins over a spoofed X-Oktsec-Agent header. The
+// header is allowed to surface as a low-confidence reported actor, but
+// the Principal must be the token owner.
+func TestGatewayAuth_BearerWinsOverSpoofedAgentHeader(t *testing.T) {
+	g, raw := gatewayWithPrincipal(t, "local-codex", func(c *config.Config) {
+		// Local profile + loopback headers on is the strictest test:
+		// even when the legacy header path is enabled, the bearer wins.
+		c.Gateway.TrustedLoopbackHeaders = true
+	})
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("X-Oktsec-Agent", "admin") // attacker spoof
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if !probe.called {
+		t.Fatal("middleware short-circuited but should have allowed the request")
+	}
+	if probe.principal != "local-codex" {
+		t.Errorf("principal = %q, want local-codex (bearer must win)", probe.principal)
+	}
+	if probe.authMethod != string(resolve.AuthMethodBearerToken) {
+		t.Errorf("auth method = %q, want bearer_token", probe.authMethod)
+	}
+	if probe.reportedActor != "admin" {
+		t.Errorf("reported actor = %q, want admin (header surfaces as reported only)", probe.reportedActor)
+	}
+}
+
+// 2. Enterprise profile rejects the loopback header path: even when the
+// remote really is loopback and YAML says trusted_loopback_headers=true,
+// enterprise treats the header as reported metadata only. With
+// require_auth implied by enterprise, the request is 401.
+func TestGatewayAuth_EnterpriseRejectsLoopbackHeader(t *testing.T) {
+	g, _ := gatewayWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Deployment.Profile = "enterprise"
+		c.Gateway.TrustedLoopbackHeaders = true // honored only in local
+	})
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Oktsec-Agent", "admin")
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (enterprise must fail closed)", rr.Code)
+	}
+	if probe.called {
+		t.Error("downstream handler should not run on 401")
+	}
+	if got := rr.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("401 response missing WWW-Authenticate hint")
+	}
+}
+
+// 3. Local profile with require_auth=true rejects requests that lack an
+// authenticated principal. Confirms the explicit override beats the
+// permissive local default.
+func TestGatewayAuth_RequireAuthRejectsAnonymous(t *testing.T) {
+	g, _ := gatewayWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Gateway.RequireAuth = "true"
+	})
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if probe.called {
+		t.Error("downstream handler should not run on 401")
+	}
+}
+
+// 4. Local profile keeps the legacy loopback header working out of the
+// box (no token, no auth_methods override). This is what every existing
+// X-Oktsec-Agent caller relies on; backwards-compat must not break.
+func TestGatewayAuth_LocalLegacyLoopbackHeaderStillWorks(t *testing.T) {
+	g, _ := gatewayWithPrincipal(t, "local-codex", nil) // local default
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Oktsec-Agent", "claude-code")
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if !probe.called {
+		t.Fatal("middleware short-circuited; local loopback header should authenticate")
+	}
+	if probe.principal != "claude-code" {
+		t.Errorf("principal = %q, want claude-code", probe.principal)
+	}
+	if probe.authMethod != string(resolve.AuthMethodTrustedLoopback) {
+		t.Errorf("auth method = %q, want trusted_loopback", probe.authMethod)
+	}
+}
+
+// 5. An expired token is rejected even when its raw secret is valid and
+// the hash matches. Lookup-time revalidation contract from the resolver.
+func TestGatewayAuth_ExpiredTokenRejected(t *testing.T) {
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{Enabled: true, RequireAuth: "true"},
+		Agents:  map[string]config.Agent{},
+	}
+	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	cfg.Identity = config.IdentityConfig{
+		Principals: []config.PrincipalConfig{{
+			ID: "local-codex",
+			Tokens: []config.PrincipalTokenConfig{{
+				ID:        "tok-1",
+				Type:      "gateway_bearer",
+				Hash:      hash,
+				CreatedAt: "2026-01-01T00:00:00Z",
+				ExpiresAt: "2026-01-02T00:00:00Z", // already in the past
+			}},
+		}},
+	}
+	g := newGatewayForTest(cfg, nil, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for expired token", rr.Code)
+	}
+}
+
+// 6. The reported-actor surface header (X-Oktsec-Reported-Actor) does NOT
+// become Principal. This is the structural invariant that lets dashboards
+// safely render a sub-agent name without the resolver upgrading it to
+// authority. The Principal stays whatever the bearer token said.
+func TestGatewayAuth_ReportedActorHeaderDoesNotAffectPrincipal(t *testing.T) {
+	g, raw := gatewayWithPrincipal(t, "local-codex", nil)
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("X-Oktsec-Reported-Actor", "review-subagent")
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if probe.principal != "local-codex" {
+		t.Errorf("principal = %q, want local-codex", probe.principal)
+	}
+	if probe.reportedActor != "review-subagent" {
+		t.Errorf("reported actor = %q, want review-subagent", probe.reportedActor)
+	}
+}
+
+// 7. deployment.require_surface_auth=true forces fail-closed even in
+// local profile, regardless of gateway.require_auth being unset. Lets a
+// developer test the enterprise contract on a laptop without flipping
+// the whole profile.
+func TestGatewayAuth_DeploymentRequireSurfaceAuthForcesFailClosed(t *testing.T) {
+	g, _ := gatewayWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Deployment.RequireSurfaceAuth = true // local profile, but require auth
+	})
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Oktsec-Agent", "claude-code") // legacy header
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (deployment.require_surface_auth must force fail-closed)", rr.Code)
+	}
+	if probe.called {
+		t.Error("downstream handler should not run on 401")
+	}
+}
+
+// 8. Enterprise profile + an explicit auth_methods list that mentions
+// trusted_loopback_header still does NOT accept the loopback header as
+// Principal. The enterprise floor is non-negotiable: header identity is
+// always reported-actor-only when profile is enterprise.
+func TestGatewayAuth_EnterpriseOverridesLoopbackHeaderAuthMethod(t *testing.T) {
+	g, _ := gatewayWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Deployment.Profile = "enterprise"
+		c.Gateway.AuthMethods = []string{"bearer_token", "trusted_loopback_header"}
+	})
+	probe := &identityProbe{}
+	mw := g.authMiddleware(probe.handler())
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("X-Oktsec-Agent", "admin")
+	req.RemoteAddr = "127.0.0.1:55001"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (enterprise must reject loopback header even when auth_methods lists it)", rr.Code)
+	}
+	if probe.called {
+		t.Error("downstream handler should not run on 401")
+	}
+}

--- a/internal/identity/resolve/configbridge.go
+++ b/internal/identity/resolve/configbridge.go
@@ -1,0 +1,83 @@
+package resolve
+
+import (
+	"strings"
+)
+
+// ConfigPrincipal is the minimal projection of internal/config that the
+// resolver needs. The config package builds these values from the YAML
+// PrincipalConfig and passes them in; resolve does not import config to
+// avoid a cycle. See PrincipalsFromConfig for the canonical bridge.
+type ConfigPrincipal struct {
+	ID              string
+	DisplayName     string
+	Kind            string
+	WorkspaceID     string
+	AllowedSurfaces []string
+	Tokens          []ConfigToken
+}
+
+// ConfigToken mirrors config.PrincipalTokenConfig but stays free of YAML
+// tags so resolve can be imported in tests without pulling config.
+type ConfigToken struct {
+	ID        string
+	Type      string // "gateway_bearer" | "proxy_basic" | "hook_bearer"
+	Hash      string
+	CreatedAt string
+	ExpiresAt string
+	RevokedAt string
+}
+
+// PrincipalsFromConfig converts the on-disk shape into PrincipalRecords.
+// Tokens with an unknown Type are dropped with no error so a typo in the
+// YAML cannot accidentally become an authenticatable secret.
+func PrincipalsFromConfig(in []ConfigPrincipal) []PrincipalRecord {
+	out := make([]PrincipalRecord, 0, len(in))
+	for _, p := range in {
+		surfaces := make([]Surface, 0, len(p.AllowedSurfaces))
+		for _, s := range p.AllowedSurfaces {
+			surfaces = append(surfaces, Surface(s))
+		}
+		tokens := make([]TokenRecord, 0, len(p.Tokens))
+		for _, t := range p.Tokens {
+			tt, ok := tokenTypeFromString(t.Type)
+			if !ok {
+				continue
+			}
+			tokens = append(tokens, TokenRecord{
+				ID:          t.ID,
+				Type:        tt,
+				PrincipalID: p.ID,
+				Hash:        t.Hash,
+				CreatedAt:   t.CreatedAt,
+				ExpiresAt:   t.ExpiresAt,
+				RevokedAt:   t.RevokedAt,
+			})
+		}
+		kind := PrincipalKind(strings.TrimSpace(p.Kind))
+		if kind == "" {
+			kind = PrincipalKindAgent
+		}
+		out = append(out, PrincipalRecord{
+			ID:              p.ID,
+			DisplayName:     p.DisplayName,
+			Kind:            kind,
+			WorkspaceID:     p.WorkspaceID,
+			AllowedSurfaces: surfaces,
+			Tokens:          tokens,
+		})
+	}
+	return out
+}
+
+func tokenTypeFromString(s string) (TokenType, bool) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "gateway_bearer":
+		return TokenTypeGatewayBearer, true
+	case "proxy_basic":
+		return TokenTypeProxyBasic, true
+	case "hook_bearer":
+		return TokenTypeHookBearer, true
+	}
+	return "", false
+}

--- a/internal/identity/resolve/policy.go
+++ b/internal/identity/resolve/policy.go
@@ -1,0 +1,174 @@
+package resolve
+
+import "strings"
+
+// ProfileFromString maps the on-disk `deployment.profile` value to a
+// resolve.Profile. Empty/unrecognized values default to ProfileLocal so a
+// missing config field never accidentally enables enterprise fail-closed
+// gates without an explicit opt-in.
+func ProfileFromString(s string) Profile {
+	if strings.EqualFold(strings.TrimSpace(s), "enterprise") {
+		return ProfileEnterprise
+	}
+	return ProfileLocal
+}
+
+// SurfaceAuthInput is the minimal projection of cfg every surface adapter
+// needs to derive its identity policy. Adapters build this from their own
+// section of cfg (cfg.Gateway, cfg.ForwardProxy, cfg.Hooks, ...) so the
+// helper does not have to know about every surface struct in config.
+//
+// All fields are optional. The zero value yields a permissive local
+// policy with bearer-token auth and the legacy loopback header on.
+type SurfaceAuthInput struct {
+	// Surface identifies which boundary this policy applies to. Used when
+	// the resolver needs to disambiguate token types or carries it into
+	// activity events.
+	Surface Surface
+
+	// Profile is the deployment profile (local or enterprise). Use
+	// ProfileFromString(cfg.Deployment.Profile) at the call site.
+	Profile Profile
+
+	// RequireSurfaceAuth comes from cfg.Deployment.RequireSurfaceAuth and
+	// forces fail-closed on every surface even in local profile. Lets a
+	// developer test the enterprise contract without flipping the whole
+	// profile.
+	RequireSurfaceAuth bool
+
+	// RequireAuthOverride is the per-surface knob ("auto" | "true" |
+	// "false"). It wins over the profile/RequireSurfaceAuth defaults.
+	// Empty string is treated as "auto".
+	RequireAuthOverride string
+
+	// AuthMethods is the per-surface allow-list. Empty means "use the
+	// profile default" (bearer + loopback header in local; bearer + mTLS
+	// in enterprise). Recognized values: bearer_token, mtls,
+	// trusted_loopback_header, proxy_basic_token, hook_token.
+	AuthMethods []string
+
+	// TrustedLoopbackHeaders is the surface's opt-in for the legacy
+	// X-Oktsec-Agent path. Honored only in local profile; enterprise
+	// always treats the header as reported-actor metadata.
+	TrustedLoopbackHeaders bool
+
+	// LoopbackHeaderName overrides the default header name used for the
+	// trusted-loopback path. Empty defaults to "X-Oktsec-Agent".
+	LoopbackHeaderName string
+
+	// ReportedActorHeaderName, when non-empty, declares a header whose
+	// value populates ReportedActor (never Principal).
+	ReportedActorHeaderName string
+
+	// ReportedActorPayloadKeys lists payload field names whose values may
+	// surface as ReportedActor. First non-empty wins.
+	ReportedActorPayloadKeys []string
+
+	// AllowedTokenTypes restricts which TokenTypes the resolver tries.
+	// The gateway uses [GatewayBearer], the egress proxy [ProxyBasic],
+	// hooks [HookBearer]. Empty falls back to [GatewayBearer] which is
+	// the historically-default surface.
+	AllowedTokenTypes []TokenType
+}
+
+// SurfacePolicy is the resolved per-surface identity contract: which
+// resolver Config to pass to Resolve, and whether the surface adapter
+// must short-circuit unauthenticated requests with a fail-closed
+// response (HTTP 401, JSON-RPC error, etc.).
+type SurfacePolicy struct {
+	Profile        Profile
+	RequireAuth    bool
+	ResolverConfig Config
+}
+
+// DerivePolicy folds the inputs into a SurfacePolicy. The same function
+// serves the gateway, the forward proxy, hooks, and the agent message
+// API; surface adapters just supply their own SurfaceAuthInput.
+//
+// Precedence for RequireAuth (highest first):
+//  1. Explicit RequireAuthOverride ("true" / "false").
+//  2. RequireSurfaceAuth=true (developer test of enterprise contract).
+//  3. Enterprise profile.
+//  4. Otherwise: false (permissive local default).
+//
+// Loopback-header rules:
+//   - Enterprise profile NEVER trusts the loopback header, regardless of
+//     TrustedLoopbackHeaders or what AuthMethods lists. The header always
+//     surfaces as reported-actor metadata only.
+//   - Local profile honors TrustedLoopbackHeaders (or, when AuthMethods
+//     is empty, defaults it on so existing local setups keep working).
+func DerivePolicy(in SurfaceAuthInput) SurfacePolicy {
+	profile := in.Profile
+	if profile == "" {
+		profile = ProfileLocal
+	}
+
+	loopbackHeaders := in.TrustedLoopbackHeaders
+	// In local profile, an empty AuthMethods list keeps the legacy
+	// X-Oktsec-Agent path on so existing setups do not break silently.
+	if profile == ProfileLocal && len(in.AuthMethods) == 0 {
+		loopbackHeaders = true
+	}
+	// AuthMethods may explicitly enable the loopback header.
+	for _, m := range in.AuthMethods {
+		if strings.EqualFold(strings.TrimSpace(m), "trusted_loopback_header") {
+			loopbackHeaders = true
+		}
+	}
+	// Enterprise floor: header never authenticates.
+	if profile == ProfileEnterprise {
+		loopbackHeaders = false
+	}
+
+	allowed := in.AllowedTokenTypes
+	if len(allowed) == 0 {
+		allowed = []TokenType{TokenTypeGatewayBearer}
+	}
+	// If the surface declared an explicit AuthMethods list and bearer is
+	// missing, drop bearer support. mTLS is kept as a no-op for now (no
+	// cert resolution wired) so a future enterprise switch is purely
+	// config-driven.
+	if len(in.AuthMethods) > 0 {
+		hasBearer := false
+		for _, m := range in.AuthMethods {
+			switch strings.ToLower(strings.TrimSpace(m)) {
+			case "bearer_token", "proxy_basic_token", "hook_token":
+				hasBearer = true
+			}
+		}
+		if !hasBearer {
+			allowed = nil
+		}
+	}
+
+	loopbackName := in.LoopbackHeaderName
+	if loopbackName == "" {
+		loopbackName = "X-Oktsec-Agent"
+	}
+
+	return SurfacePolicy{
+		Profile:     profile,
+		RequireAuth: deriveRequireAuth(in, profile),
+		ResolverConfig: Config{
+			Profile:                  profile,
+			AllowedTokenTypes:        allowed,
+			TrustedLoopbackHeaders:   loopbackHeaders,
+			LoopbackHeaderName:       loopbackName,
+			ReportedActorHeaderName:  in.ReportedActorHeaderName,
+			ReportedActorPayloadKeys: in.ReportedActorPayloadKeys,
+		},
+	}
+}
+
+func deriveRequireAuth(in SurfaceAuthInput, profile Profile) bool {
+	switch strings.ToLower(strings.TrimSpace(in.RequireAuthOverride)) {
+	case "true", "yes", "1":
+		return true
+	case "false", "no", "0":
+		return false
+	}
+	if in.RequireSurfaceAuth {
+		return true
+	}
+	return profile == ProfileEnterprise
+}

--- a/internal/identity/resolve/policy_test.go
+++ b/internal/identity/resolve/policy_test.go
@@ -1,0 +1,135 @@
+package resolve
+
+import "testing"
+
+// 1. Local default is permissive: no auth required, legacy loopback
+// header on, bearer-token type accepted. This is what every existing
+// developer setup relies on.
+func TestDerivePolicy_LocalDefaultPermissive(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{Profile: ProfileLocal})
+	if p.RequireAuth {
+		t.Error("local default should be permissive (require_auth=false)")
+	}
+	if !p.ResolverConfig.TrustedLoopbackHeaders {
+		t.Error("local default should keep legacy X-Oktsec-Agent path on")
+	}
+	if len(p.ResolverConfig.AllowedTokenTypes) == 0 {
+		t.Error("local default should accept bearer tokens out of the box")
+	}
+}
+
+// 2. Enterprise default fails closed: auth required, header path off,
+// bearer still accepted. Equivalent to what gateway already implemented.
+func TestDerivePolicy_EnterpriseDefaultFailClosed(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{Profile: ProfileEnterprise})
+	if !p.RequireAuth {
+		t.Error("enterprise default should require auth")
+	}
+	if p.ResolverConfig.TrustedLoopbackHeaders {
+		t.Error("enterprise must never trust the loopback header")
+	}
+}
+
+// 3. RequireSurfaceAuth=true forces auth even in local profile. Lets a
+// developer test the enterprise contract on a laptop without flipping
+// the whole profile.
+func TestDerivePolicy_RequireSurfaceAuthForcesAuthInLocal(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{
+		Profile:            ProfileLocal,
+		RequireSurfaceAuth: true,
+	})
+	if !p.RequireAuth {
+		t.Error("require_surface_auth=true must force fail-closed even in local")
+	}
+}
+
+// 4. Explicit per-surface override wins over both the profile default
+// and RequireSurfaceAuth. The override is the operator's last word.
+func TestDerivePolicy_ExplicitOverrideWins(t *testing.T) {
+	cases := []struct {
+		name              string
+		profile           Profile
+		surfaceAuth       bool
+		override          string
+		wantRequireAuth   bool
+	}{
+		// "false" override beats enterprise default.
+		{"override-false-beats-enterprise", ProfileEnterprise, false, "false", false},
+		// "false" override beats RequireSurfaceAuth.
+		{"override-false-beats-require-surface", ProfileLocal, true, "false", false},
+		// "true" override forces auth on local.
+		{"override-true-on-local", ProfileLocal, false, "true", true},
+		// "auto" / unset falls through to profile default.
+		{"auto-falls-through", ProfileEnterprise, false, "auto", true},
+		{"empty-falls-through", ProfileLocal, false, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := DerivePolicy(SurfaceAuthInput{
+				Profile:             tc.profile,
+				RequireSurfaceAuth:  tc.surfaceAuth,
+				RequireAuthOverride: tc.override,
+			})
+			if p.RequireAuth != tc.wantRequireAuth {
+				t.Errorf("RequireAuth = %v, want %v", p.RequireAuth, tc.wantRequireAuth)
+			}
+		})
+	}
+}
+
+// 5. Enterprise rejects the loopback header even when AuthMethods
+// explicitly lists it. The enterprise floor is non-negotiable.
+func TestDerivePolicy_EnterpriseRejectsLoopbackHeaderEvenWhenListed(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{
+		Profile:                ProfileEnterprise,
+		TrustedLoopbackHeaders: true, // YAML opt-in
+		AuthMethods:            []string{"bearer_token", "trusted_loopback_header"},
+	})
+	if p.ResolverConfig.TrustedLoopbackHeaders {
+		t.Error("enterprise must drop loopback header even when AuthMethods lists it")
+	}
+}
+
+// 6. AuthMethods without bearer_token disables the bearer path. Lets a
+// surface restrict identity to mTLS only (in a future PR), or a custom
+// adapter that wants only proxy basic tokens.
+func TestDerivePolicy_AuthMethodsWithoutBearerDropsBearer(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{
+		Profile:     ProfileLocal,
+		AuthMethods: []string{"mtls"}, // mTLS only, no token types
+	})
+	if len(p.ResolverConfig.AllowedTokenTypes) != 0 {
+		t.Errorf("AllowedTokenTypes = %v, want empty when only mTLS is allowed",
+			p.ResolverConfig.AllowedTokenTypes)
+	}
+}
+
+// 7. AllowedTokenTypes is honored when supplied — the egress proxy will
+// pass [TokenTypeProxyBasic] and must not get gateway bearer support.
+func TestDerivePolicy_AllowedTokenTypesHonored(t *testing.T) {
+	p := DerivePolicy(SurfaceAuthInput{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeProxyBasic},
+	})
+	if len(p.ResolverConfig.AllowedTokenTypes) != 1 || p.ResolverConfig.AllowedTokenTypes[0] != TokenTypeProxyBasic {
+		t.Errorf("AllowedTokenTypes = %v, want [proxy_basic]", p.ResolverConfig.AllowedTokenTypes)
+	}
+}
+
+// 8. ProfileFromString defaults unknown values to local. Misspelled or
+// empty profile values must not silently enable enterprise gates.
+func TestProfileFromString(t *testing.T) {
+	cases := map[string]Profile{
+		"":               ProfileLocal,
+		"local":          ProfileLocal,
+		"enterprise":     ProfileEnterprise,
+		"ENTERPRISE":     ProfileEnterprise,
+		"  enterprise  ": ProfileEnterprise,
+		"prod":           ProfileLocal, // unknown -> safe default
+	}
+	for in, want := range cases {
+		if got := ProfileFromString(in); got != want {
+			t.Errorf("ProfileFromString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/identity/resolve/resolver.go
+++ b/internal/identity/resolve/resolver.go
@@ -1,0 +1,291 @@
+package resolve
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Profile selects between local-developer defaults (loose, friction-light)
+// and enterprise defaults (fail-closed, strict). The same Resolver code
+// honors both; only the policy expressed in Config differs.
+type Profile string
+
+const (
+	ProfileLocal      Profile = "local"
+	ProfileEnterprise Profile = "enterprise"
+)
+
+// Config controls Resolver behavior for one Surface. A single Resolver may
+// hold one Config per Surface so the same resolver instance can serve the
+// gateway and the egress proxy with different rules.
+type Config struct {
+	Profile Profile
+
+	// AllowedTokenTypes lists which TokenTypes the resolver will try, in
+	// priority order. The gateway should pass {GatewayBearer}, the egress
+	// proxy {ProxyBasic}, etc.
+	AllowedTokenTypes []TokenType
+
+	// TrustedLoopbackHeaders enables the legacy X-Oktsec-Agent header as a
+	// principal source — but only when the request originates from the
+	// loopback interface. In enterprise mode this should always be false.
+	TrustedLoopbackHeaders bool
+
+	// LoopbackHeaderName is the header consulted when TrustedLoopbackHeaders
+	// is true. Defaults to "X-Oktsec-Agent" when empty.
+	LoopbackHeaderName string
+
+	// ReportedActorPayloadKeys lists payload field names whose values may
+	// be surfaced as ReportedActor. The first non-empty value wins. These
+	// fields never become Principal regardless of profile.
+	ReportedActorPayloadKeys []string
+
+	// ReportedActorHeaderName, when non-empty, lets a surface declare a
+	// header that always populates ReportedActor (never Principal). Useful
+	// for hook adapters that supply a sub-agent name in headers.
+	ReportedActorHeaderName string
+}
+
+// DefaultResolver is the shared implementation. It looks up tokens in a
+// TokenStore, falls back to the loopback header in local profile when
+// allowed, and otherwise returns an anonymous Principal. A Resolver is
+// safe for concurrent use; the underlying TokenStore must be too.
+type DefaultResolver struct {
+	store TokenStore
+	now   func() time.Time // injectable for tests
+}
+
+// NewDefaultResolver returns a Resolver backed by store. If now is nil the
+// resolver uses time.Now.
+func NewDefaultResolver(store TokenStore, now func() time.Time) *DefaultResolver {
+	if now == nil {
+		now = time.Now
+	}
+	return &DefaultResolver{store: store, now: now}
+}
+
+// Resolve honors a per-surface Config. Most callers will wrap this in a
+// surface-specific helper that pre-fills the Config for that surface.
+func (r *DefaultResolver) Resolve(ctx context.Context, cfg Config, evidence Evidence) (Result, error) {
+	// 1. Try every allowed token type, in declared order, against the
+	// Authorization header. First match wins.
+	if raw, ok := bearerFromAuthorization(evidence.Header); ok {
+		for _, t := range cfg.AllowedTokenTypes {
+			if t == TokenTypeProxyBasic {
+				// Proxy basic comes from a different header; skip here.
+				continue
+			}
+			principal, tok, err := r.store.Lookup(t, raw)
+			if err == nil {
+				return r.buildResult(principal, tok, evidence, cfg), nil
+			}
+		}
+	}
+
+	// 1b. Proxy-Authorization (basic) for the egress proxy surface. The
+	// proxy surface uses Basic <user:> where the username is the raw token.
+	if user, ok := userFromProxyAuthorization(evidence.Header); ok {
+		for _, t := range cfg.AllowedTokenTypes {
+			if t != TokenTypeProxyBasic {
+				continue
+			}
+			principal, tok, err := r.store.Lookup(t, user)
+			if err == nil {
+				return r.buildResult(principal, tok, evidence, cfg), nil
+			}
+		}
+	}
+
+	// 2. Trusted loopback header is a degraded form of identity used in
+	// local profile. The remote address must actually be loopback; the
+	// header name is configurable so adapters can opt in to legacy paths
+	// (e.g. X-Oktsec-Agent for the MCP gateway).
+	if cfg.TrustedLoopbackHeaders && cfg.Profile == ProfileLocal && IsLoopback(evidence.RemoteAddr) {
+		headerName := cfg.LoopbackHeaderName
+		if headerName == "" {
+			headerName = "X-Oktsec-Agent"
+		}
+		if id := strings.TrimSpace(evidence.Header.Get(headerName)); id != "" {
+			result := Result{
+				Principal: Principal{
+					ID:          id,
+					DisplayName: id,
+					Kind:        PrincipalKindAgent,
+					AuthMethod:  AuthMethodTrustedLoopback,
+					TrustLevel:  TrustLocal,
+				},
+			}
+			result.ReportedActor = extractReportedActor(evidence, cfg)
+			// Loopback header is weaker than a token; advise the operator
+			// once the data path supports it.
+			result.Warnings = append(result.Warnings,
+				"identity established via loopback header; configure a bearer token for stronger auth")
+			return result, nil
+		}
+	}
+
+	// 3. No identity. ReportedActor may still be populated from payload or
+	// a dedicated header so the dashboard can show *something*, but it does
+	// not become Principal.
+	return Result{
+		Principal: Principal{
+			ID:          "unknown",
+			DisplayName: "unknown",
+			Kind:        PrincipalKindUnknown,
+			AuthMethod:  AuthMethodNone,
+			TrustLevel:  TrustAnonymous,
+		},
+		ReportedActor: extractReportedActor(evidence, cfg),
+	}, nil
+}
+
+func (r *DefaultResolver) buildResult(p PrincipalRecord, tok TokenRecord, evidence Evidence, cfg Config) Result {
+	res := Result{
+		Principal: Principal{
+			ID:          p.ID,
+			DisplayName: p.DisplayName,
+			Kind:        p.Kind,
+			AuthMethod:  authMethodForToken(tok.Type),
+			TrustLevel:  TrustAuthenticated,
+			TokenID:     tok.ID,
+			WorkspaceID: p.WorkspaceID,
+		},
+		ReportedActor: extractReportedActor(evidence, cfg),
+	}
+	if res.Principal.Kind == "" {
+		res.Principal.Kind = PrincipalKindAgent
+	}
+	if res.Principal.DisplayName == "" {
+		res.Principal.DisplayName = res.Principal.ID
+	}
+	return res
+}
+
+func authMethodForToken(t TokenType) AuthMethod {
+	switch t {
+	case TokenTypeGatewayBearer:
+		return AuthMethodBearerToken
+	case TokenTypeProxyBasic:
+		return AuthMethodProxyToken
+	case TokenTypeHookBearer:
+		return AuthMethodHookToken
+	}
+	return AuthMethodNone
+}
+
+// bearerFromAuthorization extracts the token portion of an `Authorization:
+// Bearer <token>` header. The check is case-insensitive on the scheme name.
+func bearerFromAuthorization(h http.Header) (string, bool) {
+	v := h.Get("Authorization")
+	if v == "" {
+		return "", false
+	}
+	const prefix = "bearer "
+	if len(v) <= len(prefix) {
+		return "", false
+	}
+	if !strings.EqualFold(v[:len(prefix)], prefix) {
+		return "", false
+	}
+	tok := strings.TrimSpace(v[len(prefix):])
+	if tok == "" {
+		return "", false
+	}
+	return tok, true
+}
+
+// userFromProxyAuthorization extracts the username portion of a Proxy
+// Basic header. The token is delivered as the username with an empty
+// password (matching `http://okt_proxy_xxx:@host:port` env-var URLs).
+func userFromProxyAuthorization(h http.Header) (string, bool) {
+	v := h.Get("Proxy-Authorization")
+	if v == "" {
+		return "", false
+	}
+	const prefix = "basic "
+	if len(v) <= len(prefix) || !strings.EqualFold(v[:len(prefix)], prefix) {
+		return "", false
+	}
+	encoded := strings.TrimSpace(v[len(prefix):])
+	dec, err := base64Decode(encoded)
+	if err != nil {
+		return "", false
+	}
+	user := dec
+	if i := strings.IndexByte(dec, ':'); i >= 0 {
+		user = dec[:i]
+	}
+	user = strings.TrimSpace(user)
+	if user == "" {
+		return "", false
+	}
+	return user, true
+}
+
+func base64Decode(s string) (string, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// extractReportedActor pulls the first non-empty payload key, then falls
+// back to the configured header. The Source/Confidence fields tell the
+// dashboard how trustworthy the value is.
+func extractReportedActor(evidence Evidence, cfg Config) ReportedActor {
+	for _, key := range cfg.ReportedActorPayloadKeys {
+		if v, ok := stringFromPayload(evidence.Payload, key); ok {
+			return ReportedActor{
+				ID:          v,
+				DisplayName: v,
+				Source:      "payload",
+				Confidence:  "medium",
+			}
+		}
+	}
+	if cfg.ReportedActorHeaderName != "" {
+		if v := strings.TrimSpace(evidence.Header.Get(cfg.ReportedActorHeaderName)); v != "" {
+			return ReportedActor{
+				ID:          v,
+				DisplayName: v,
+				Source:      "header",
+				Confidence:  "medium",
+			}
+		}
+	}
+	// Legacy ConfigAgent (set by older surfaces from X-Oktsec-Agent before
+	// the resolver existed) becomes a low-confidence reported actor when it
+	// is not the established principal.
+	if v := strings.TrimSpace(evidence.ConfigAgent); v != "" {
+		return ReportedActor{
+			ID:          v,
+			DisplayName: v,
+			Source:      "header",
+			Confidence:  "low",
+		}
+	}
+	return ReportedActor{}
+}
+
+func stringFromPayload(p map[string]any, key string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	v, ok := p[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/internal/identity/resolve/resolver_test.go
+++ b/internal/identity/resolve/resolver_test.go
@@ -1,0 +1,431 @@
+package resolve
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// helper: builds a store with one principal and one active token of the
+// given type, returning the raw token so tests can present it as a header.
+func storeWithToken(t *testing.T, principalID string, kind PrincipalKind, tokType TokenType) (*MemoryTokenStore, string) {
+	t.Helper()
+	raw, hash, err := GenerateRawToken(tokType)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	rec := PrincipalRecord{
+		ID:          principalID,
+		DisplayName: principalID,
+		Kind:        kind,
+		Tokens: []TokenRecord{{
+			ID:          principalID + "-tok-1",
+			Type:        tokType,
+			PrincipalID: principalID,
+			Hash:        hash,
+			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		}},
+	}
+	return NewMemoryTokenStore([]PrincipalRecord{rec}, time.Now()), raw
+}
+
+func TestResolver_BearerTokenPrincipal(t *testing.T) {
+	store, raw := storeWithToken(t, "local-codex", PrincipalKindAgent, TokenTypeGatewayBearer)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "203.0.113.7:54321"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.ID != "local-codex" {
+		t.Errorf("principal id = %q, want local-codex", got.Principal.ID)
+	}
+	if got.Principal.AuthMethod != AuthMethodBearerToken {
+		t.Errorf("auth method = %q, want bearer_token", got.Principal.AuthMethod)
+	}
+	if got.Principal.TrustLevel != TrustAuthenticated {
+		t.Errorf("trust level = %q, want authenticated", got.Principal.TrustLevel)
+	}
+	if got.Principal.TokenID == "" {
+		t.Error("token id should be populated for token-based auth")
+	}
+}
+
+// Bearer token always wins over a spoofed X-Oktsec-Agent header. The
+// header value can still appear as a low-confidence reported actor — but
+// it must NOT become the policy principal.
+func TestResolver_BearerTokenWinsOverSpoofedAgentHeader(t *testing.T) {
+	store, raw := storeWithToken(t, "local-codex", PrincipalKindAgent, TokenTypeGatewayBearer)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+	hdr.Set("X-Oktsec-Agent", "admin") // attacker's spoof
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:                ProfileLocal,
+		AllowedTokenTypes:      []TokenType{TokenTypeGatewayBearer},
+		TrustedLoopbackHeaders: true, // even with this on, token wins
+	}, Evidence{
+		Surface: SurfaceMCPHTTP, Header: hdr,
+		RemoteAddr:  "127.0.0.1:54321",
+		ConfigAgent: "admin", // legacy ctx value also points at admin
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.ID != "local-codex" {
+		t.Errorf("principal id = %q, want local-codex (bearer must win)", got.Principal.ID)
+	}
+	if got.ReportedActor.ID != "admin" {
+		t.Errorf("reported actor id = %q, want admin (header surfaces as reported only)", got.ReportedActor.ID)
+	}
+}
+
+// In enterprise profile the loopback-header path is disabled regardless of
+// remote address, so an unauthenticated request resolves to anonymous.
+func TestResolver_EnterpriseRejectsLoopbackHeader(t *testing.T) {
+	store, _ := storeWithToken(t, "local-codex", PrincipalKindAgent, TokenTypeGatewayBearer)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("X-Oktsec-Agent", "admin")
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:                ProfileEnterprise,
+		AllowedTokenTypes:      []TokenType{TokenTypeGatewayBearer},
+		TrustedLoopbackHeaders: true, // honored only in local
+	}, Evidence{
+		Surface:    SurfaceMCPHTTP,
+		Header:     hdr,
+		RemoteAddr: "127.0.0.1:54321",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.AuthMethod != AuthMethodNone {
+		t.Errorf("auth method = %q, want none in enterprise without token", got.Principal.AuthMethod)
+	}
+	if got.Principal.TrustLevel != TrustAnonymous {
+		t.Errorf("trust level = %q, want anonymous", got.Principal.TrustLevel)
+	}
+}
+
+// Loopback header is accepted in local profile when the remote really is
+// loopback. Carries trust_local and a warning advising token migration.
+func TestResolver_LocalLoopbackHeaderAccepted(t *testing.T) {
+	store := NewMemoryTokenStore(nil, time.Now())
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("X-Oktsec-Agent", "claude-code")
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:                ProfileLocal,
+		TrustedLoopbackHeaders: true,
+	}, Evidence{
+		Surface:    SurfaceMCPHTTP,
+		Header:     hdr,
+		RemoteAddr: "127.0.0.1:65000",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.ID != "claude-code" {
+		t.Errorf("principal id = %q, want claude-code", got.Principal.ID)
+	}
+	if got.Principal.TrustLevel != TrustLocal {
+		t.Errorf("trust level = %q, want trusted_local", got.Principal.TrustLevel)
+	}
+	if len(got.Warnings) == 0 {
+		t.Error("expected a warning when relying on loopback header identity")
+	}
+}
+
+// Loopback header is rejected when the remote is not actually loopback —
+// this prevents trusted_proxy misconfigurations from upgrading a public
+// header to principal.
+func TestResolver_LoopbackHeaderRejectedFromRemote(t *testing.T) {
+	store := NewMemoryTokenStore(nil, time.Now())
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("X-Oktsec-Agent", "admin")
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:                ProfileLocal,
+		TrustedLoopbackHeaders: true,
+	}, Evidence{
+		Surface:     SurfaceMCPHTTP,
+		Header:      hdr,
+		RemoteAddr:  "10.0.0.5:43210",
+		ConfigAgent: "admin", // gateway populates this from X-Oktsec-Agent
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.AuthMethod != AuthMethodNone {
+		t.Errorf("auth method = %q, want none for non-loopback header", got.Principal.AuthMethod)
+	}
+	// The header still surfaces as a low-confidence reported actor for UI.
+	if got.ReportedActor.ID != "admin" || got.ReportedActor.Confidence != "low" {
+		t.Errorf("reported actor = %+v, want id=admin confidence=low", got.ReportedActor)
+	}
+}
+
+// Revoked tokens never authenticate, even if the raw secret is presented.
+func TestResolver_RevokedTokenRejected(t *testing.T) {
+	raw, hash, err := GenerateRawToken(TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	rec := PrincipalRecord{
+		ID: "local-codex",
+		Tokens: []TokenRecord{{
+			ID:          "tok-1",
+			Type:        TokenTypeGatewayBearer,
+			PrincipalID: "local-codex",
+			Hash:        hash,
+			CreatedAt:   "2026-01-01T00:00:00Z",
+			RevokedAt:   "2026-04-25T00:00:00Z",
+		}},
+	}
+	store := NewMemoryTokenStore([]PrincipalRecord{rec}, time.Now())
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1234"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.ID == "local-codex" {
+		t.Error("revoked token must not authenticate")
+	}
+}
+
+// Expired tokens never authenticate.
+func TestResolver_ExpiredTokenRejected(t *testing.T) {
+	raw, hash, err := GenerateRawToken(TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	rec := PrincipalRecord{
+		ID: "local-codex",
+		Tokens: []TokenRecord{{
+			ID:          "tok-1",
+			Type:        TokenTypeGatewayBearer,
+			PrincipalID: "local-codex",
+			Hash:        hash,
+			CreatedAt:   "2026-01-01T00:00:00Z",
+			ExpiresAt:   "2026-01-02T00:00:00Z",
+		}},
+	}
+	store := NewMemoryTokenStore([]PrincipalRecord{rec}, time.Now())
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+
+	got, _ := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1234"})
+	if got.Principal.ID == "local-codex" {
+		t.Error("expired token must not authenticate")
+	}
+}
+
+// Tokens of the wrong type for this surface are rejected even when the
+// secret value is otherwise valid. Prevents a leaked egress proxy token
+// from authenticating to the gateway and vice versa.
+func TestResolver_TokenTypeMismatch(t *testing.T) {
+	store, raw := storeWithToken(t, "local-codex", PrincipalKindAgent, TokenTypeGatewayBearer)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+
+	got, _ := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeProxyBasic}, // surface only allows proxy tokens
+	}, Evidence{Surface: SurfaceHTTPEgress, Header: hdr, RemoteAddr: "127.0.0.1:1234"})
+	if got.Principal.AuthMethod == AuthMethodBearerToken {
+		t.Error("gateway bearer must not authenticate on a proxy-only surface")
+	}
+}
+
+// Proxy basic auth path: the username carries the raw token.
+func TestResolver_ProxyBasicAuth(t *testing.T) {
+	store, raw := storeWithToken(t, "local-codex", PrincipalKindAgent, TokenTypeProxyBasic)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	encoded := base64.StdEncoding.EncodeToString([]byte(raw + ":"))
+	hdr.Set("Proxy-Authorization", "Basic "+encoded)
+
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeProxyBasic},
+	}, Evidence{Surface: SurfaceHTTPEgress, Header: hdr, RemoteAddr: "127.0.0.1:1234"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Principal.AuthMethod != AuthMethodProxyToken {
+		t.Errorf("auth method = %q, want proxy_token", got.Principal.AuthMethod)
+	}
+}
+
+// Reported-actor payload key takes precedence over header fallbacks. The
+// resolver must still return Principal=unknown when no token is present.
+func TestResolver_ReportedActorFromPayload(t *testing.T) {
+	store := NewMemoryTokenStore(nil, time.Now())
+	r := NewDefaultResolver(store, nil)
+
+	got, _ := r.Resolve(context.Background(), Config{
+		Profile:                  ProfileLocal,
+		ReportedActorPayloadKeys: []string{"_oktsec_agent", "actor"},
+	}, Evidence{
+		Surface: SurfaceHooks,
+		Payload: map[string]any{"_oktsec_agent": "review-subagent"},
+	})
+	if got.Principal.AuthMethod != AuthMethodNone {
+		t.Errorf("auth method = %q, want none", got.Principal.AuthMethod)
+	}
+	if got.ReportedActor.ID != "review-subagent" {
+		t.Errorf("reported actor = %q, want review-subagent", got.ReportedActor.ID)
+	}
+	if got.ReportedActor.Source != "payload" {
+		t.Errorf("reported actor source = %q, want payload", got.ReportedActor.Source)
+	}
+}
+
+// A token that is active when the store is built but expires while the
+// store is still in memory must stop authenticating immediately. This
+// guards against the bug where Active() was checked only at index time
+// and the bucket cached a since-expired token.
+func TestStore_ExpiryRevalidatedAtLookupTime(t *testing.T) {
+	raw, hash, err := GenerateRawToken(TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	rec := PrincipalRecord{
+		ID: "local-codex",
+		Tokens: []TokenRecord{{
+			ID:          "tok-1",
+			Type:        TokenTypeGatewayBearer,
+			PrincipalID: "local-codex",
+			Hash:        hash,
+			CreatedAt:   "2026-04-26T00:00:00Z",
+			ExpiresAt:   "2026-04-26T12:00:00Z",
+		}},
+	}
+
+	// Movable clock the store reads on every Lookup.
+	now := time.Date(2026, 4, 26, 11, 59, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	store := NewMemoryTokenStoreWithClock([]PrincipalRecord{rec}, clock)
+	r := NewDefaultResolver(store, clock)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+
+	// Before expiry — must authenticate.
+	got, _ := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1"})
+	if got.Principal.ID != "local-codex" {
+		t.Fatalf("pre-expiry: principal id = %q, want local-codex", got.Principal.ID)
+	}
+
+	// Advance clock past expiry; same store, same token, must now fail.
+	now = time.Date(2026, 4, 26, 12, 0, 1, 0, time.UTC)
+	got, _ = r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1"})
+	if got.Principal.AuthMethod == AuthMethodBearerToken {
+		t.Error("post-expiry: token still authenticates; lookup-time revalidation broken")
+	}
+}
+
+// MeetsMinimumTrust orders levels: anonymous < observed < inferred <
+// trusted_local < authenticated. A higher rank also meets the lower bars.
+func TestResult_MeetsMinimumTrust(t *testing.T) {
+	cases := []struct {
+		got, min TrustLevel
+		want     bool
+	}{
+		{TrustAuthenticated, TrustAuthenticated, true},
+		{TrustAuthenticated, TrustLocal, true},
+		{TrustLocal, TrustAuthenticated, false},
+		{TrustLocal, TrustLocal, true},
+		{TrustObserved, TrustLocal, false},
+		{TrustAnonymous, TrustObserved, false},
+		{TrustLevel("garbage"), TrustObserved, false}, // unknown ranks as 0
+	}
+	for _, tc := range cases {
+		r := Result{Principal: Principal{TrustLevel: tc.got}}
+		if got := r.MeetsMinimumTrust(tc.min); got != tc.want {
+			t.Errorf("got=%s min=%s -> %v, want %v", tc.got, tc.min, got, tc.want)
+		}
+	}
+}
+
+// RequireMinimumTrust returns an InsufficientTrustError that surfaces can
+// inspect to choose the correct fail-closed response code.
+func TestResult_RequireMinimumTrust(t *testing.T) {
+	ok := Result{Principal: Principal{TrustLevel: TrustAuthenticated, AuthMethod: AuthMethodBearerToken}}
+	if err := ok.RequireMinimumTrust(TrustAuthenticated); err != nil {
+		t.Errorf("authenticated should satisfy authenticated: %v", err)
+	}
+
+	bad := Result{Principal: Principal{TrustLevel: TrustAnonymous, AuthMethod: AuthMethodNone}}
+	err := bad.RequireMinimumTrust(TrustAuthenticated)
+	if err == nil {
+		t.Fatal("anonymous must not satisfy authenticated")
+	}
+	insuf, ok2 := err.(*InsufficientTrustError)
+	if !ok2 {
+		t.Fatalf("error type = %T, want *InsufficientTrustError", err)
+	}
+	if insuf.Required != TrustAuthenticated || insuf.Got != TrustAnonymous {
+		t.Errorf("error fields = %+v", insuf)
+	}
+}
+
+// Helpful for test scaffolding: IsLoopback covers the literal cases and
+// rejects DNS-style "localhost" (which can be poisoned).
+func TestIsLoopback(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"127.0.0.1:1234", true},
+		{"127.0.0.1", true},
+		{"[::1]:1234", true},
+		{"::1", true},
+		{"localhost:1234", false},
+		{"10.0.0.5:1234", false},
+		{"203.0.113.1:1234", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsLoopback(tc.in); got != tc.want {
+			t.Errorf("IsLoopback(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/identity/resolve/tokens.go
+++ b/internal/identity/resolve/tokens.go
@@ -1,0 +1,291 @@
+package resolve
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TokenType narrows what surface a token may authenticate. A gateway bearer
+// token must not be accepted by the egress proxy, and vice versa, so each
+// is namespaced both at the type level and in the prefix of its raw value.
+type TokenType string
+
+const (
+	TokenTypeGatewayBearer TokenType = "gateway_bearer"
+	TokenTypeProxyBasic    TokenType = "proxy_basic"
+	TokenTypeHookBearer    TokenType = "hook_bearer"
+)
+
+// rawTokenPrefix returns the human-visible prefix for newly generated raw
+// tokens. The prefix lets operators tell at a glance what a leaked secret
+// would have authorized, and it lets the resolver fail fast on type
+// mismatches before doing any hash work.
+func rawTokenPrefix(t TokenType) string {
+	switch t {
+	case TokenTypeGatewayBearer:
+		return "okt_gw_"
+	case TokenTypeProxyBasic:
+		return "okt_proxy_"
+	case TokenTypeHookBearer:
+		return "okt_hook_"
+	}
+	return "okt_"
+}
+
+// TokenRecord is the on-disk shape of a token associated with a Principal.
+// The raw secret is shown to the operator exactly once at creation time;
+// only the salted SHA-256 hash is persisted.
+type TokenRecord struct {
+	ID          string    `yaml:"id" json:"id"`
+	Type        TokenType `yaml:"type" json:"type"`
+	PrincipalID string    `yaml:"principal_id" json:"principal_id"`
+	Hash        string    `yaml:"hash" json:"hash"` // sha256:<salt>:<hex>
+	CreatedAt   string    `yaml:"created_at" json:"created_at"`
+	ExpiresAt   string    `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`
+	RevokedAt   string    `yaml:"revoked_at,omitempty" json:"revoked_at,omitempty"`
+	LastUsedAt  string    `yaml:"last_used_at,omitempty" json:"last_used_at,omitempty"`
+}
+
+// Active reports whether the token may still authenticate. Expired or
+// revoked tokens are inert.
+func (r TokenRecord) Active(now time.Time) bool {
+	if r.RevokedAt != "" {
+		return false
+	}
+	if r.ExpiresAt == "" {
+		return true
+	}
+	exp, err := time.Parse(time.RFC3339, r.ExpiresAt)
+	if err != nil {
+		// Unparseable expiry is treated as expired so a malformed config
+		// fails closed instead of silently extending lifetime.
+		return false
+	}
+	return now.Before(exp)
+}
+
+// PrincipalRecord is the on-disk shape of a Principal. Tokens live inside
+// the Principal because lookups always start from a token and resolve to
+// the owning Principal.
+type PrincipalRecord struct {
+	ID              string        `yaml:"id" json:"id"`
+	DisplayName     string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Kind            PrincipalKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	WorkspaceID     string        `yaml:"workspace_id,omitempty" json:"workspace_id,omitempty"`
+	Tokens          []TokenRecord `yaml:"tokens,omitempty" json:"tokens,omitempty"`
+	AllowedSurfaces []Surface     `yaml:"allowed_surfaces,omitempty" json:"allowed_surfaces,omitempty"`
+}
+
+// TokenStore looks up tokens by ID and, given a candidate raw secret,
+// returns the owning Principal in constant time relative to the number of
+// tokens of that type. Implementations must be safe for concurrent reads.
+type TokenStore interface {
+	// Lookup attempts to authenticate `raw` as a token of the given type.
+	// On success it returns the matching PrincipalRecord and the TokenRecord
+	// that authenticated it. On failure it returns ErrNoToken.
+	Lookup(t TokenType, raw string) (PrincipalRecord, TokenRecord, error)
+
+	// PrincipalByID returns the Principal record for a known ID. Used by
+	// non-token auth methods (Ed25519, mTLS) once they have established an ID.
+	PrincipalByID(id string) (PrincipalRecord, bool)
+}
+
+// ErrNoToken is returned by TokenStore.Lookup when the candidate secret
+// does not match any active token of the requested type.
+var ErrNoToken = errors.New("identity: no matching active token")
+
+// MemoryTokenStore is the simple in-memory store used by tests and the
+// initial release. Tokens come from config; on config reload, callers
+// rebuild the store and swap it in.
+//
+// Active state (revoked/expired) is rechecked on every Lookup against the
+// store's clock — building the index does not snapshot activity, so a
+// token that expires at noon stops authenticating at noon even if the
+// store was built at 11:59.
+type MemoryTokenStore struct {
+	mu    sync.RWMutex
+	now   func() time.Time
+	byID  map[string]PrincipalRecord          // principal lookup
+	byTok map[TokenType]map[string]tokenIndex // type -> tokenID -> index entry
+}
+
+// tokenIndex caches lookup data for a token. Active state lives in the
+// authoritative TokenRecord on the PrincipalRecord; we copy expires_at and
+// revoked_at here so Lookup can fail closed without holding the principal
+// lock during hash comparison.
+type tokenIndex struct {
+	principalID string
+	hash        string // sha256:<salt>:<hex>
+	expiresAt   string // RFC3339 or "" for no expiry
+	revokedAt   string // RFC3339 or "" for active
+}
+
+// NewMemoryTokenStore builds a store from the given Principals. The store
+// uses time.Now as its clock; callers that need an injectable clock should
+// use NewMemoryTokenStoreWithClock.
+//
+// Tokens that are already expired or revoked at construction time are
+// included in the index but will fail the Active() check on Lookup. The
+// `now` argument is accepted for backwards compatibility but no longer
+// filters tokens — Lookup uses the store's clock at call time.
+func NewMemoryTokenStore(principals []PrincipalRecord, now time.Time) *MemoryTokenStore {
+	return NewMemoryTokenStoreWithClock(principals, nil)
+}
+
+// NewMemoryTokenStoreWithClock builds a store with an injectable clock.
+// When clock is nil, time.Now is used. Tests should pass a fixed clock so
+// expiry/revocation semantics are reproducible.
+func NewMemoryTokenStoreWithClock(principals []PrincipalRecord, clock func() time.Time) *MemoryTokenStore {
+	if clock == nil {
+		clock = time.Now
+	}
+	s := &MemoryTokenStore{
+		now:   clock,
+		byID:  make(map[string]PrincipalRecord, len(principals)),
+		byTok: make(map[TokenType]map[string]tokenIndex),
+	}
+	for _, p := range principals {
+		s.byID[p.ID] = p
+		for _, tok := range p.Tokens {
+			bucket, ok := s.byTok[tok.Type]
+			if !ok {
+				bucket = make(map[string]tokenIndex)
+				s.byTok[tok.Type] = bucket
+			}
+			bucket[tok.ID] = tokenIndex{
+				principalID: p.ID,
+				hash:        tok.Hash,
+				expiresAt:   tok.ExpiresAt,
+				revokedAt:   tok.RevokedAt,
+			}
+		}
+	}
+	return s
+}
+
+// Lookup walks the bucket of tokens for the given type and returns the
+// first hash match that is still active. Each hash comparison is
+// constant-time. Token candidates must start with the type-specific prefix;
+// mismatches are rejected without a hash compare to avoid timing leaks
+// across token classes. Active state is rechecked on every call against
+// the store's clock so post-build expiry takes effect immediately.
+func (s *MemoryTokenStore) Lookup(t TokenType, raw string) (PrincipalRecord, TokenRecord, error) {
+	if raw == "" || !strings.HasPrefix(raw, rawTokenPrefix(t)) {
+		return PrincipalRecord{}, TokenRecord{}, ErrNoToken
+	}
+	s.mu.RLock()
+	bucket := s.byTok[t]
+	now := s.now()
+	s.mu.RUnlock()
+	if bucket == nil {
+		return PrincipalRecord{}, TokenRecord{}, ErrNoToken
+	}
+	for tokID, idx := range bucket {
+		if !verifyHash(idx.hash, raw) {
+			continue
+		}
+		// Even if the hash matches, the token may have been revoked or
+		// passed its expiry since the index was built. Recheck both before
+		// returning a Principal.
+		if !indexActive(idx, now) {
+			return PrincipalRecord{}, TokenRecord{}, ErrNoToken
+		}
+		s.mu.RLock()
+		principal := s.byID[idx.principalID]
+		s.mu.RUnlock()
+		for _, tok := range principal.Tokens {
+			if tok.ID == tokID {
+				return principal, tok, nil
+			}
+		}
+		// Index entry without owning principal token — treat as miss.
+		return PrincipalRecord{}, TokenRecord{}, ErrNoToken
+	}
+	return PrincipalRecord{}, TokenRecord{}, ErrNoToken
+}
+
+// indexActive mirrors TokenRecord.Active using only the data cached in the
+// index, so Lookup can decide without re-walking PrincipalRecord.Tokens.
+func indexActive(idx tokenIndex, now time.Time) bool {
+	if idx.revokedAt != "" {
+		return false
+	}
+	if idx.expiresAt == "" {
+		return true
+	}
+	exp, err := time.Parse(time.RFC3339, idx.expiresAt)
+	if err != nil {
+		return false
+	}
+	return now.Before(exp)
+}
+
+// PrincipalByID returns the principal record by ID.
+func (s *MemoryTokenStore) PrincipalByID(id string) (PrincipalRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.byID[id]
+	return p, ok
+}
+
+// GenerateRawToken returns a freshly generated raw token (with type prefix)
+// and its salted hash for storage. The caller is responsible for showing the
+// raw value exactly once and persisting only the hash.
+func GenerateRawToken(t TokenType) (raw string, hash string, err error) {
+	// 32 random bytes -> 256 bits of entropy in the secret portion.
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return "", "", fmt.Errorf("identity: rand: %w", err)
+	}
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return "", "", fmt.Errorf("identity: rand: %w", err)
+	}
+	raw = rawTokenPrefix(t) + hex.EncodeToString(secret)
+	hash = formatHash(salt, raw)
+	return raw, hash, nil
+}
+
+// HashRawToken hashes a raw token with the given salt. Exposed for tests
+// and for tooling that imports an externally-issued secret.
+func HashRawToken(raw string, salt []byte) string {
+	return formatHash(salt, raw)
+}
+
+func formatHash(salt []byte, raw string) string {
+	h := sha256.New()
+	h.Write(salt)
+	h.Write([]byte(raw))
+	sum := h.Sum(nil)
+	return "sha256:" + hex.EncodeToString(salt) + ":" + hex.EncodeToString(sum)
+}
+
+// verifyHash performs a constant-time compare between a stored hash record
+// and a candidate raw token. It returns false on any parse error so a
+// malformed stored record cannot accidentally authenticate.
+func verifyHash(stored, candidate string) bool {
+	parts := strings.SplitN(stored, ":", 3)
+	if len(parts) != 3 || parts[0] != "sha256" {
+		return false
+	}
+	salt, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	expected, err := hex.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	h := sha256.New()
+	h.Write(salt)
+	h.Write([]byte(candidate))
+	got := h.Sum(nil)
+	return subtle.ConstantTimeCompare(expected, got) == 1
+}

--- a/internal/identity/resolve/types.go
+++ b/internal/identity/resolve/types.go
@@ -1,0 +1,200 @@
+// Package resolve centralizes principal/reported-actor identity resolution
+// for surface adapters (gateway, hooks, forward proxy, agent message API).
+//
+// Surface adapters do not invent principal semantics on their own. They
+// gather Evidence from the request and call a Resolver, which returns a
+// Principal (used for policy decisions) and an optional ReportedActor
+// (display/audit metadata supplied by the surface or its payload).
+//
+// The Principal is the only identity policy code may use for ACL,
+// suspension, rate limit, constraints, delegation enforcement, or blocking.
+// The ReportedActor never overrides the Principal.
+package resolve
+
+import (
+	"context"
+	"crypto/x509"
+	"net"
+	"net/http"
+)
+
+// AuthMethod names how the Principal was established.
+type AuthMethod string
+
+const (
+	AuthMethodNone            AuthMethod = ""
+	AuthMethodEd25519         AuthMethod = "ed25519"
+	AuthMethodBearerToken     AuthMethod = "bearer_token"
+	AuthMethodProxyToken      AuthMethod = "proxy_token"
+	AuthMethodMTLS            AuthMethod = "mtls"
+	AuthMethodWrapper         AuthMethod = "wrapper"
+	AuthMethodTrustedLoopback AuthMethod = "trusted_loopback"
+	AuthMethodHookToken       AuthMethod = "hook_token"
+)
+
+// TrustLevel describes how strongly the Principal is established. Policy
+// gates may require a minimum TrustLevel before allowing a class of action.
+type TrustLevel string
+
+const (
+	TrustAuthenticated TrustLevel = "authenticated" // token, signature, mTLS verified
+	TrustLocal         TrustLevel = "trusted_local" // loopback header / wrapper / config ownership in local profile
+	TrustObserved      TrustLevel = "observed"      // unauthenticated telemetry
+	TrustInferred      TrustLevel = "inferred"      // correlation only
+	TrustAnonymous     TrustLevel = "anonymous"     // no identity established
+)
+
+// trustOrder defines the ordering for MeetsMinimumTrust comparisons.
+// Higher values indicate stronger evidence; gates compare with `>=`.
+var trustOrder = map[TrustLevel]int{
+	TrustAnonymous:     0,
+	TrustObserved:      1,
+	TrustInferred:      2,
+	TrustLocal:         3,
+	TrustAuthenticated: 4,
+}
+
+// trustRank returns the comparable rank for a TrustLevel, defaulting to
+// 0 (anonymous) for unknown values so policy gates fail closed on typos.
+func trustRank(t TrustLevel) int {
+	r, ok := trustOrder[t]
+	if !ok {
+		return 0
+	}
+	return r
+}
+
+// PrincipalKind classifies the Principal entity. Useful for policy and UI.
+type PrincipalKind string
+
+const (
+	PrincipalKindAgent     PrincipalKind = "agent"
+	PrincipalKindUser      PrincipalKind = "user"
+	PrincipalKindService   PrincipalKind = "service"
+	PrincipalKindWorkspace PrincipalKind = "workspace"
+	PrincipalKindUnknown   PrincipalKind = "unknown"
+)
+
+// Surface names the technical boundary that gathered the Evidence. Each
+// surface has its own coverage and identity expectations.
+type Surface string
+
+const (
+	SurfaceMCPHTTP      Surface = "mcp_http"
+	SurfaceMCPStdio     Surface = "mcp_stdio"
+	SurfaceHTTPEgress   Surface = "http_egress_proxy"
+	SurfaceHooks        Surface = "hooks"
+	SurfaceAgentMessage Surface = "agent_message_api"
+	SurfaceFilesystem   Surface = "filesystem_guard"
+	SurfaceActivityLog  Surface = "activity_log"
+)
+
+// Evidence is everything a surface adapter has observed about a request.
+// The Resolver is responsible for combining these signals into a Principal
+// and (optionally) a ReportedActor. Adapters must not pre-decide.
+type Evidence struct {
+	Surface     Surface
+	Header      http.Header
+	RemoteAddr  string             // raw RemoteAddr; resolver decides if loopback
+	TLSPeer     *x509.Certificate  // nil unless mTLS handshake completed
+	Payload     map[string]any     // surface-supplied parsed payload (e.g. hook body, JSON-RPC params)
+	LocalSource string             // for stdio wrapper: the wrapper config that started the process
+	ConfigAgent string             // legacy: agent name from request context (e.g. X-Oktsec-Agent)
+}
+
+// Principal is the authenticated security identity used for all policy
+// decisions. It must come from one of the AuthMethods declared in config
+// for the originating Surface. Payload-supplied fields cannot create one.
+type Principal struct {
+	ID          string
+	DisplayName string
+	Kind        PrincipalKind
+	AuthMethod  AuthMethod
+	TrustLevel  TrustLevel
+	TokenID     string // empty when auth method is not token-based
+	WorkspaceID string
+}
+
+// ReportedActor is display/audit metadata supplied by the surface (header,
+// payload, hook body) or inferred by correlation. It is rendered in the UI
+// alongside the Principal, but never used for policy.
+type ReportedActor struct {
+	ID          string
+	DisplayName string
+	Source      string // header, payload, hook, log, inference
+	Confidence  string // high, medium, low
+}
+
+// Result is what the Resolver returns to a surface adapter.
+type Result struct {
+	Principal     Principal
+	ReportedActor ReportedActor
+	Warnings      []string // non-fatal advisories the surface may want to log/audit
+}
+
+// MeetsMinimumTrust reports whether the resolved Principal carries at
+// least the requested TrustLevel. Use this to gate fail-closed paths in
+// surface adapters (e.g. enterprise gateway requiring TrustAuthenticated).
+func (r Result) MeetsMinimumTrust(min TrustLevel) bool {
+	return trustRank(r.Principal.TrustLevel) >= trustRank(min)
+}
+
+// RequireMinimumTrust returns ErrInsufficientTrust when the resolved
+// Principal does not meet `min`. Surface adapters in fail-closed mode call
+// this immediately after Resolve and short-circuit the request on error.
+func (r Result) RequireMinimumTrust(min TrustLevel) error {
+	if r.MeetsMinimumTrust(min) {
+		return nil
+	}
+	return &InsufficientTrustError{
+		Required: min,
+		Got:      r.Principal.TrustLevel,
+		Method:   r.Principal.AuthMethod,
+	}
+}
+
+// InsufficientTrustError is returned by RequireMinimumTrust. Surfaces can
+// inspect Required/Got/Method to choose an appropriate failure mode (HTTP
+// 401 with WWW-Authenticate hint, JSON-RPC error, etc.).
+type InsufficientTrustError struct {
+	Required TrustLevel
+	Got      TrustLevel
+	Method   AuthMethod
+}
+
+func (e *InsufficientTrustError) Error() string {
+	return "identity: trust level " + string(e.Got) +
+		" (auth=" + string(e.Method) + ") does not meet required " + string(e.Required)
+}
+
+// Resolver turns Evidence into a (Principal, ReportedActor) for a given
+// surface configuration. Implementations must be safe for concurrent use.
+//
+// The Config argument is mandatory because identity rules differ per
+// surface: the gateway accepts gateway bearer tokens and (optionally) the
+// loopback header, the egress proxy accepts proxy basic tokens, and so on.
+// A surface adapter that does not pass its Config will get the wrong rules.
+type Resolver interface {
+	Resolve(ctx context.Context, cfg Config, evidence Evidence) (Result, error)
+}
+
+// IsLoopback reports whether a raw RemoteAddr originates from the loopback
+// interface. Only the literal IPv4/IPv6 loopback addresses are accepted;
+// the DNS name "localhost" is rejected because it can be poisoned at the
+// system level.
+func IsLoopback(remoteAddr string) bool {
+	if remoteAddr == "" {
+		return false
+	}
+	// SplitHostPort handles "ip:port", "[ipv6]:port", and rejects bare
+	// IPv6 (e.g. "::1") with an error — fall back to ParseIP for those.
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
   - Guides:
     - Dashboard: guides/dashboard.md
     - MCP Gateway: guides/gateway.md
+    - Generic MCP HTTP Client (Bearer Token): guides/mcp-http-bearer-client.md
     - OpenClaw Integration: guides/openclaw.md
     - Per-Agent Egress Control: guides/egress.md
     - Python SDK: guides/python-sdk.md


### PR DESCRIPTION
## Summary

Adds bearer-token authentication to the MCP HTTP gateway. Any MCP client that can set an `Authorization: Bearer ...` header now connects with a per-principal token, mapped to an identity Oktsec uses for every policy decision. Local setups using the `X-Oktsec-Agent` header continue to work unchanged.

## What this enables

- A generic MCP HTTP client connects to the gateway with a token, no client-specific configuration required.
- Each event in the audit log records how the principal was authenticated and what reported actor (sub-agent, payload field, request header) accompanied it.
- Deployments that need an authenticated identity on every request enable it via a single config flag and the gateway responds with `401 Unauthorized` to anything else.

## What changed

### Identity resolver — `internal/identity/resolve`

A new package centralizes how every surface adapter establishes a principal. The gateway calls it on each request; hooks and the forward proxy will adopt the same contract in later changes.

- `Resolver.Resolve` returns a `Principal` (used for policy) and a separate `ReportedActor` (display only).
- Token store keeps salted SHA-256 hashes; the raw secret is shown to the operator once at creation.
- `DerivePolicy` is the shared helper for local versus enterprise behavior, so each surface configures one struct instead of inventing its own rules.

### Configuration

```yaml
deployment:
  profile: local              # or "enterprise"
  require_surface_auth: false # set true to require auth on every surface

identity:
  principals:
    - id: local-codex
      kind: agent
      tokens:
        - id: gw-local-codex
          type: gateway_bearer
          hash: "sha256:..."

gateway:
  require_auth: auto          # auto | true | false
  trusted_loopback_headers: true
```

`require_auth: auto` follows the deployment profile. Enterprise profile defaults to fail-closed; local profile stays permissive so existing setups keep working.

### Audit log

Three optional columns added: `auth_method`, `principal_trust_level`, `reported_actor`. Older rows read back as empty values. SQLite and Postgres migrations included.

### Documentation

New guide: [Generic MCP HTTP Client (Bearer Token)](documentation/guides/mcp-http-bearer-client.md). Explains the principal and reported actor model, local versus enterprise defaults, configuration, and a curl example.

## Verification

24 new unit and integration tests. Suite, lint, and vet stay green.

End-to-end smoke against a running gateway:

| Scenario | Expected | Result |
|---|---|---|
| Valid bearer token | Request reaches the tool handler; audit row records `auth_method=bearer_token`, `principal_trust_level=authenticated` | OK |
| Bearer token plus an unrelated `X-Oktsec-Agent` header | The bearer principal drives policy; the header value is recorded as `reported_actor` only | OK |
| Missing `Authorization` header with `require_surface_auth: true` | `401 Unauthorized` with `WWW-Authenticate: Bearer` | OK |
| Revoked or unknown token | `401 Unauthorized` | OK |
| Valid bearer with `require_surface_auth: true` | Request accepted | OK |

## Not included

- A `oktsec tokens` CLI for creating, listing, rotating, and revoking tokens. The guide documents the manual hash workflow until then.
- mTLS gateway authentication. The config field is reserved.
- Hook and forward proxy integrations with the same identity model.