### PR TITLE
Extend identity resolver to forward proxy and hooks

### DIFF
--- a/documentation/guides/egress.md
+++ b/documentation/guides/egress.md
@@ -8,19 +8,48 @@ The forward proxy scans all outbound HTTP traffic. With per-agent egress control
 
 ## Agent identification
 
-Agents identify themselves via the `X-Oktsec-Agent` header on proxy requests:
+Agents identify themselves to the forward proxy through one of two paths.
+
+### Recommended: proxy bearer token
+
+Issue a `proxy_basic` token via the CLI:
 
 ```bash
-curl -x http://localhost:8081 \
-  -H "X-Oktsec-Agent: researcher" \
-  http://api.google.com/test
+oktsec tokens create --principal researcher --type proxy_basic --expires 30d
 ```
+
+The CLI prints the raw token once. Use it as the username in the proxy URL with an empty password — the standard `Proxy-Authorization: Basic` mechanism every HTTP client supports natively:
+
+```bash
+HTTP_PROXY=http://okt_proxy_<raw>:@127.0.0.1:8083
+HTTPS_PROXY=http://okt_proxy_<raw>:@127.0.0.1:8083
+```
+
+Or with curl:
+
+```bash
+curl -x http://okt_proxy_<raw>:@127.0.0.1:8083 https://api.example.com/test
+```
+
+Oktsec strips the `Proxy-Authorization` header before forwarding so the token never reaches the upstream destination. The raw value is stored only as a salted SHA-256 hash. See the [bearer-token guide](mcp-http-bearer-client.md) for the full token model (principal vs reported actor, local vs enterprise, rotation).
+
+### Legacy local: X-Oktsec-Agent header
+
+For backwards compatibility, the `X-Oktsec-Agent` header still works in local profile when the request originates from loopback:
+
+```bash
+curl -x http://localhost:8083 \
+  -H "X-Oktsec-Agent: researcher" \
+  http://api.example.com/test
+```
+
+This path is rejected in enterprise profile and when `forward_proxy.require_auth=true`. Use the bearer-token path for any setup beyond a single-developer laptop.
 
 The header is:
 
-- Read by the forward proxy before policy evaluation
+- Read by the forward proxy as a `trusted_local` principal source
 - **Stripped before forwarding upstream** (never leaked to destination)
-- Optional — requests without it fall back to global rules
+- Optional — requests without it fall back to global rules in local profile
 
 ## Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	ForwardProxy   ForwardProxyConfig             `yaml:"forward_proxy,omitempty"`
 	Alerting       AlertingConfig                 `yaml:"alerting,omitempty"`
 	Gateway        GatewayConfig                  `yaml:"gateway,omitempty"`
+	Hooks          HooksConfig                    `yaml:"hooks,omitempty"`
 	MCPServers     map[string]MCPServerConfig     `yaml:"mcp_servers,omitempty"`
 	LLM            LLMConfig                      `yaml:"llm,omitempty"`
 	Telemetry      TelemetryConfig                `yaml:"telemetry,omitempty"`
@@ -430,9 +431,48 @@ type ForwardProxyConfig struct {
 	ScanRequests   bool     `yaml:"scan_requests"`              // Scan outbound HTTP bodies (default: true)
 	ScanResponses  bool     `yaml:"scan_responses"`             // Scan inbound HTTP bodies (default: false)
 	MaxBodySize    int64    `yaml:"max_body_size,omitempty"`    // Max body to scan in bytes (default: 1MB)
+
+	// Per-surface auth (proxy_basic tokens). Reads forward_proxy.require_auth,
+	// forward_proxy.auth_methods, forward_proxy.trusted_loopback_headers in YAML.
+	SurfaceAuthConfig `yaml:",inline"`
+}
+
+// HooksConfig configures the hook ingestion endpoint that surfaces use to
+// emit pre/post-tool telemetry. Auth is opt-in: in local profile an
+// unauthenticated hook is recorded as observed coverage; in enterprise
+// profile (or when require_auth=true) the request is rejected.
+type HooksConfig struct {
+	// Per-surface auth (hook_bearer tokens). Reads hooks.require_auth, etc.
+	SurfaceAuthConfig `yaml:",inline"`
 }
 
 // GatewayConfig configures the MCP gateway mode.
+// SurfaceAuthConfig is the per-surface auth knob shared by gateway,
+// forward proxy, and hooks. Each surface embeds this in its own config
+// section so the operator sees the same three fields with consistent
+// semantics. The surface adapter passes them through resolve.DerivePolicy.
+type SurfaceAuthConfig struct {
+	// RequireAuth controls whether the surface rejects requests that the
+	// identity resolver cannot authenticate. Values:
+	//   "auto"  — derive from deployment profile (enterprise => true)
+	//   "true"  — always require an authenticated principal
+	//   "false" — accept anonymous requests (local-only setups)
+	// Empty defaults to "auto".
+	RequireAuth string `yaml:"require_auth,omitempty"`
+
+	// AuthMethods restricts which identity methods the surface accepts.
+	// Values: "bearer_token", "proxy_basic_token", "hook_token", "mtls",
+	// "trusted_loopback_header". Empty defaults to the surface's natural
+	// token type plus the loopback header in local profile.
+	AuthMethods []string `yaml:"auth_methods,omitempty"`
+
+	// TrustedLoopbackHeaders lets the legacy X-Oktsec-Agent header act as
+	// a Principal (TrustLocal) when the request originates from loopback.
+	// Honored only in local profile; enterprise always treats the header
+	// as reported-actor metadata.
+	TrustedLoopbackHeaders bool `yaml:"trusted_loopback_headers,omitempty"`
+}
+
 type GatewayConfig struct {
 	Enabled                bool   `yaml:"enabled"`
 	Port                   int    `yaml:"port"`                      // default 9090
@@ -448,25 +488,10 @@ type GatewayConfig struct {
 	// where every agent should be reviewed before it can execute tools.
 	DisableAutoRegister bool `yaml:"disable_auto_register,omitempty"`
 
-	// RequireAuth controls whether the gateway rejects requests that the
-	// identity resolver cannot authenticate. Values:
-	//   "auto"  — derive from deployment profile (enterprise => true)
-	//   "true"  — always require an authenticated principal
-	//   "false" — accept anonymous requests (local-only setups)
-	// Empty defaults to "auto".
-	RequireAuth string `yaml:"require_auth,omitempty"`
-
-	// AuthMethods restricts which identity methods the gateway accepts.
-	// Allowed values: "bearer_token", "mtls", "trusted_loopback_header".
-	// Empty defaults to ["bearer_token", "trusted_loopback_header"] in
-	// local profile and ["bearer_token", "mtls"] in enterprise.
-	AuthMethods []string `yaml:"auth_methods,omitempty"`
-
-	// TrustedLoopbackHeaders lets the legacy X-Oktsec-Agent header act as
-	// a Principal (TrustLocal) when the request originates from loopback.
-	// Honored only in local profile; enterprise always treats the header
-	// as reported-actor metadata.
-	TrustedLoopbackHeaders bool `yaml:"trusted_loopback_headers,omitempty"`
+	// SurfaceAuthConfig is embedded inline so cfg.Gateway.RequireAuth /
+	// AuthMethods / TrustedLoopbackHeaders read directly from
+	// gateway.require_auth, gateway.auth_methods, etc. in YAML.
+	SurfaceAuthConfig `yaml:",inline"`
 }
 
 // MCPServerConfig defines a backend MCP server to proxy through the gateway.

--- a/internal/gateway/identity_test.go
+++ b/internal/gateway/identity_test.go
@@ -191,7 +191,10 @@ func TestGatewayAuth_LocalLegacyLoopbackHeaderStillWorks(t *testing.T) {
 // the hash matches. Lookup-time revalidation contract from the resolver.
 func TestGatewayAuth_ExpiredTokenRejected(t *testing.T) {
 	cfg := &config.Config{
-		Gateway: config.GatewayConfig{Enabled: true, RequireAuth: "true"},
+		Gateway: config.GatewayConfig{
+			Enabled:           true,
+			SurfaceAuthConfig: config.SurfaceAuthConfig{RequireAuth: "true"},
+		},
 		Agents:  map[string]config.Agent{},
 	}
 	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeGatewayBearer)

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -19,9 +19,55 @@ import (
 	"github.com/google/uuid"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
 	"github.com/oktsec/oktsec/internal/verdict"
 	"github.com/oktsec/oktsec/internal/config"
 )
+
+// buildHooksIdentity wires the hooks endpoint into the same identity
+// contract gateway and forward proxy use. cfg may be nil (test paths
+// that build a minimal handler); in that case the resolver runs against
+// an empty principal store and the surface stays in observed-coverage
+// mode, matching the historic behavior.
+func buildHooksIdentity(cfg *config.Config) (resolve.Resolver, resolve.Config, bool) {
+	var principals []resolve.ConfigPrincipal
+	var deployProfile string
+	var requireSurface bool
+	var hooksCfg config.HooksConfig
+	if cfg != nil {
+		deployProfile = cfg.Deployment.Profile
+		requireSurface = cfg.Deployment.RequireSurfaceAuth
+		hooksCfg = cfg.Hooks
+		for _, p := range cfg.Identity.Principals {
+			toks := make([]resolve.ConfigToken, 0, len(p.Tokens))
+			for _, t := range p.Tokens {
+				toks = append(toks, resolve.ConfigToken{
+					ID: t.ID, Type: t.Type, Hash: t.Hash,
+					CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt, RevokedAt: t.RevokedAt,
+				})
+			}
+			principals = append(principals, resolve.ConfigPrincipal{
+				ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
+				WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
+				Tokens: toks,
+			})
+		}
+	}
+	store := resolve.NewMemoryTokenStoreWithClock(resolve.PrincipalsFromConfig(principals), nil)
+	resolver := resolve.NewDefaultResolver(store, nil)
+
+	policy := resolve.DerivePolicy(resolve.SurfaceAuthInput{
+		Surface:                  resolve.SurfaceHooks,
+		Profile:                  resolve.ProfileFromString(deployProfile),
+		RequireSurfaceAuth:       requireSurface,
+		RequireAuthOverride:      hooksCfg.RequireAuth,
+		AuthMethods:              hooksCfg.AuthMethods,
+		TrustedLoopbackHeaders:   hooksCfg.TrustedLoopbackHeaders,
+		AllowedTokenTypes:        []resolve.TokenType{resolve.TokenTypeHookBearer},
+		ReportedActorPayloadKeys: []string{"agent_type", "agent_id"},
+	})
+	return resolver, policy.ResolverConfig, policy.RequireAuth
+}
 
 // ToolEvent is the client-agnostic payload for a tool call event.
 // Clients normalize their native format into these fields, or send them
@@ -141,15 +187,27 @@ type Handler struct {
 	cfg      *config.Config
 	logger   *slog.Logger
 	sessions sync.Map // session_id -> *sessionState
+
+	// Identity stack: same shape as gateway and forward proxy. The
+	// resolver is always non-nil so the hot path never has to nil-check.
+	// In local profile, hooks without a token continue to be accepted as
+	// observed coverage; require_auth flips that to fail-closed.
+	resolver       resolve.Resolver
+	resolverConfig resolve.Config
+	requireAuth    bool
 }
 
 // NewHandler creates a hooks handler wired to the security pipeline.
 func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, logger *slog.Logger) *Handler {
+	resolver, resolverCfg, requireAuth := buildHooksIdentity(cfg)
 	h := &Handler{
-		scanner: scanner,
-		store:   store,
-		cfg:     cfg,
-		logger:  logger,
+		scanner:        scanner,
+		store:          store,
+		cfg:            cfg,
+		logger:         logger,
+		resolver:       resolver,
+		resolverConfig: resolverCfg,
+		requireAuth:    requireAuth,
 	}
 	// Periodic cleanup of old session states to prevent memory leaks.
 	go func() {
@@ -237,6 +295,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Identity resolution runs before the body parse so unauthenticated
+	// requests in fail-closed mode return 401 without paying the scan
+	// cost. The Result is reused below to seed Principal / ReportedActor
+	// on the audit row.
+	authResult, _ := h.resolver.Resolve(r.Context(), h.resolverConfig, resolve.Evidence{
+		Surface:     resolve.SurfaceHooks,
+		Header:      r.Header,
+		RemoteAddr:  r.RemoteAddr,
+		ConfigAgent: r.Header.Get("X-Oktsec-Agent"),
+	})
+	if h.requireAuth {
+		if err := authResult.RequireMinimumTrust(resolve.TrustAuthenticated); err != nil {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="oktsec hooks"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxBody))
 	if err != nil {
 		http.Error(w, "read error", http.StatusBadRequest)
@@ -249,6 +325,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ev.normalize(r)
+
+	// When the resolver established a Principal (token-authenticated or
+	// trusted_local loopback header), it overrides the payload-supplied
+	// agent name. The original ev.Agent value is preserved by normalize()
+	// and remains visible to operators via the audit reported_actor
+	// column further down — not because it grants any authority, but
+	// because it is useful display metadata.
+	if authResult.Principal.ID != "" && authResult.Principal.ID != "unknown" {
+		ev.Agent = authResult.Principal.ID
+	}
 
 	start := time.Now()
 

--- a/internal/hooks/identity_test.go
+++ b/internal/hooks/identity_test.go
@@ -1,0 +1,149 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+)
+
+// hooksHandlerWithPrincipal builds a hooks Handler whose identity stack
+// knows about one principal owning a hook_bearer token. The build
+// callback can adjust deployment / hooks auth knobs per test.
+func hooksHandlerWithPrincipal(t *testing.T, principalID string, build func(*config.Config)) (*Handler, string, func()) {
+	t.Helper()
+	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeHookBearer)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.Identity.Principals = append(cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          principalID,
+		DisplayName: principalID,
+		Kind:        "agent",
+		Tokens: []config.PrincipalTokenConfig{{
+			ID:        principalID + "-hook",
+			Type:      "hook_bearer",
+			Hash:      hash,
+			CreatedAt: "2026-04-26T00:00:00Z",
+		}},
+	})
+	if build != nil {
+		build(cfg)
+	}
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store := mustCreateAuditStore(t, dir+"/audit.db", logger)
+	scanner := engine.NewScanner("")
+	h := NewHandler(scanner, store, cfg, logger)
+	return h, raw, func() {
+		scanner.Close()
+		_ = store.Close()
+	}
+}
+
+// 1. A valid hook_bearer token wins over a payload-supplied agent name.
+// The resolver-established Principal becomes ev.Agent for the audit
+// path; the payload value is preserved for display via the resolver's
+// reported-actor channel.
+func TestHooksAuth_TokenWinsOverPayloadAgent(t *testing.T) {
+	h, raw, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "admin",        // attacker spoof
+		AgentType: "review-subagent",
+		SessionID: "sess-1",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	// (Direct audit-row inspection is covered by gateway tests; the
+	// invariant exercised here is the request flow: token authenticates,
+	// payload spoof does not block or escalate.)
+}
+
+// 2. Enterprise profile rejects unauthenticated hooks. No payload is
+// even parsed; the handler short-circuits with 401.
+func TestHooksAuth_EnterpriseRejectsUnauth(t *testing.T) {
+	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Deployment.Profile = "enterprise"
+	})
+	defer cleanup()
+
+	body, _ := json.Marshal(ToolEvent{ToolName: "Read"})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if rec.Header().Get("WWW-Authenticate") == "" {
+		t.Error("401 response missing WWW-Authenticate hint")
+	}
+}
+
+// 3. Local profile keeps unauthenticated hooks working as observed
+// telemetry. This is the back-compat path: every existing client that
+// posts to /hooks/event with no Authorization header keeps working.
+func TestHooksAuth_LocalUnauthenticatedAccepted(t *testing.T) {
+	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "claude-code",
+		SessionID: "sess-2",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// 4. require_auth=true on local profile flips fail-closed without
+// changing the deployment profile. Same contract as the gateway and the
+// forward proxy.
+func TestHooksAuth_RequireAuthRejectsAnonymous(t *testing.T) {
+	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Hooks.RequireAuth = "true"
+	})
+	defer cleanup()
+
+	body, _ := json.Marshal(ToolEvent{ToolName: "Read"})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
 	"github.com/oktsec/oktsec/internal/verdict"
 )
 
@@ -32,10 +33,23 @@ type ForwardProxy struct {
 	logger          *slog.Logger
 	transport       *http.Transport
 	upstreamProxy   bool // true when HTTP_PROXY/HTTPS_PROXY is set
+
+	// Identity stack: same shape as the gateway. The resolver is always
+	// non-nil (empty principal store when nothing is configured) so the
+	// hot path never has to nil-check.
+	resolver       resolve.Resolver
+	resolverConfig resolve.Config
+	requireAuth    bool
 }
 
 // NewForwardProxy creates a forward proxy with scanning and audit capabilities.
-func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, auditStore *audit.Store, rateLimiter RateStore, agents map[string]config.Agent, logger *slog.Logger, tb *config.TrustBoundaries) *ForwardProxy {
+//
+// fullCfg carries the deployment profile and identity.principals the
+// resolver needs. ForwardProxyConfig stays as the per-surface knob so
+// existing call sites that build cfg.ForwardProxy by hand continue to
+// work — they just lose surface auth, which is the correct fail-soft
+// behavior (no principal store ⇒ no tokens accepted).
+func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, auditStore *audit.Store, rateLimiter RateStore, agents map[string]config.Agent, logger *slog.Logger, tb *config.TrustBoundaries, fullCfg *config.Config) *ForwardProxy {
 	// When an upstream proxy is configured (e.g., inside Docker Sandbox),
 	// the transport dials the proxy, not the target. Use standard dialer
 	// for proxy connections; SSRF checks are applied at handler level.
@@ -65,6 +79,7 @@ func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, au
 			IdleConnTimeout:       90 * time.Second,
 		},
 	}
+	fp.resolver, fp.resolverConfig, fp.requireAuth = buildForwardProxyIdentity(cfg, fullCfg)
 
 	// Pre-create per-agent rate limiters
 	for name, agent := range agents {
@@ -96,11 +111,63 @@ func (fp *ForwardProxy) Wrap(mux http.Handler) http.Handler {
 	})
 }
 
-// extractAgent reads and strips the X-Oktsec-Agent header.
-func extractAgent(r *http.Request) string {
-	agent := r.Header.Get("X-Oktsec-Agent")
-	r.Header.Del("X-Oktsec-Agent")
-	return strings.TrimSpace(agent)
+// buildForwardProxyIdentity wires the forward proxy into the same
+// identity contract the gateway uses. fullCfg may be nil (legacy callers
+// that constructed only ForwardProxyConfig); in that case the resolver
+// runs against an empty principal store and the surface stays in
+// loopback-header mode for backwards compatibility.
+func buildForwardProxyIdentity(cfg *config.ForwardProxyConfig, fullCfg *config.Config) (resolve.Resolver, resolve.Config, bool) {
+	var principals []resolve.ConfigPrincipal
+	var deployProfile string
+	var requireSurface bool
+	if fullCfg != nil {
+		deployProfile = fullCfg.Deployment.Profile
+		requireSurface = fullCfg.Deployment.RequireSurfaceAuth
+		for _, p := range fullCfg.Identity.Principals {
+			toks := make([]resolve.ConfigToken, 0, len(p.Tokens))
+			for _, t := range p.Tokens {
+				toks = append(toks, resolve.ConfigToken{
+					ID: t.ID, Type: t.Type, Hash: t.Hash,
+					CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt, RevokedAt: t.RevokedAt,
+				})
+			}
+			principals = append(principals, resolve.ConfigPrincipal{
+				ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
+				WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
+				Tokens: toks,
+			})
+		}
+	}
+	store := resolve.NewMemoryTokenStoreWithClock(resolve.PrincipalsFromConfig(principals), nil)
+	resolver := resolve.NewDefaultResolver(store, nil)
+
+	policy := resolve.DerivePolicy(resolve.SurfaceAuthInput{
+		Surface:                resolve.SurfaceHTTPEgress,
+		Profile:                resolve.ProfileFromString(deployProfile),
+		RequireSurfaceAuth:     requireSurface,
+		RequireAuthOverride:    cfg.RequireAuth,
+		AuthMethods:            cfg.AuthMethods,
+		TrustedLoopbackHeaders: cfg.TrustedLoopbackHeaders,
+		AllowedTokenTypes:      []resolve.TokenType{resolve.TokenTypeProxyBasic},
+	})
+	return resolver, policy.ResolverConfig, policy.RequireAuth
+}
+
+// resolveIdentity runs the identity resolver against an incoming request
+// and returns the full Result. Callers use Result.Principal for policy,
+// Result.ReportedActor for display/audit, and Result.RequireMinimumTrust
+// to fail closed when require_auth is on. The legacy X-Oktsec-Agent
+// header is consumed via Evidence.ConfigAgent (loopback header path);
+// callers strip it from the request so it never reaches the upstream
+// destination. Proxy-Authorization is also stripped at the call site.
+func (fp *ForwardProxy) resolveIdentity(r *http.Request) resolve.Result {
+	res, _ := fp.resolver.Resolve(r.Context(), fp.resolverConfig, resolve.Evidence{
+		Surface:     resolve.SurfaceHTTPEgress,
+		Header:      r.Header,
+		RemoteAddr:  r.RemoteAddr,
+		ConfigAgent: r.Header.Get("X-Oktsec-Agent"),
+	})
+	return res
 }
 
 // extractSession reads and strips the X-Oktsec-Session header.
@@ -114,7 +181,20 @@ func extractSession(r *http.Request) string {
 func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	host := r.Host
-	agent := extractAgent(r)
+	res := fp.resolveIdentity(r)
+	r.Header.Del("X-Oktsec-Agent")
+	r.Header.Del("Proxy-Authorization")
+	if fp.requireAuth {
+		if err := res.RequireMinimumTrust(resolve.TrustAuthenticated); err != nil {
+			w.Header().Set("Proxy-Authenticate", `Basic realm="oktsec forward proxy"`)
+			http.Error(w, "Proxy Authentication Required", http.StatusProxyAuthRequired)
+			return
+		}
+	}
+	agent := res.Principal.ID
+	if agent == "unknown" {
+		agent = ""
+	}
 	session := extractSession(r)
 
 	policy := fp.resolvePolicy(agent)
@@ -198,7 +278,20 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if host == "" {
 		host = r.Host
 	}
-	agent := extractAgent(r)
+	res := fp.resolveIdentity(r)
+	r.Header.Del("X-Oktsec-Agent")
+	r.Header.Del("Proxy-Authorization")
+	if fp.requireAuth {
+		if err := res.RequireMinimumTrust(resolve.TrustAuthenticated); err != nil {
+			w.Header().Set("Proxy-Authenticate", `Basic realm="oktsec forward proxy"`)
+			http.Error(w, "Proxy Authentication Required", http.StatusProxyAuthRequired)
+			return
+		}
+	}
+	agent := res.Principal.ID
+	if agent == "unknown" {
+		agent = ""
+	}
 	session := extractSession(r)
 	logAgent := fp.logAgent(agent, r.RemoteAddr)
 

--- a/internal/proxy/forward_identity_test.go
+++ b/internal/proxy/forward_identity_test.go
@@ -1,0 +1,218 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+)
+
+// fpWithPrincipal builds a forward proxy whose identity stack knows
+// about one principal owning a proxy_basic token. The build callback
+// can adjust deployment / surface auth knobs per test.
+func fpWithPrincipal(t *testing.T, principalID string, build func(*config.Config)) (*ForwardProxy, string) {
+	t.Helper()
+	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeProxyBasic)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{
+			Principals: []config.PrincipalConfig{{
+				ID:          principalID,
+				DisplayName: principalID,
+				Kind:        "agent",
+				Tokens: []config.PrincipalTokenConfig{{
+					ID:        principalID + "-tok",
+					Type:      "proxy_basic",
+					Hash:      hash,
+					CreatedAt: "2026-04-26T00:00:00Z",
+				}},
+			}},
+		},
+		ForwardProxy: config.ForwardProxyConfig{Enabled: true},
+		Agents:       map[string]config.Agent{principalID: {}},
+	}
+	if build != nil {
+		build(cfg)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scanner := engine.NewScanner("")
+	t.Cleanup(func() { scanner.Close() })
+	store, err := audit.NewStore(t.TempDir()+"/audit.db", logger)
+	if err != nil {
+		t.Fatalf("audit store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	rl := NewRateLimiter(0, 60)
+	fp := NewForwardProxy(&cfg.ForwardProxy, scanner, store, rl, cfg.Agents, logger, nil, cfg)
+	fp.transport = &http.Transport{}
+	return fp, raw
+}
+
+// proxyBasicHeader builds the Proxy-Authorization Basic value the
+// forward proxy expects when a client uses an HTTP_PROXY URL with the
+// proxy token as username (and empty password).
+func proxyBasicHeader(token string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(token+":"))
+}
+
+// 1. proxy_basic token wins over a spoofed X-Oktsec-Agent header. The
+// header value still appears as a low-confidence reported actor on the
+// audit row, but the policy principal comes from the token.
+func TestForwardProxyAuth_TokenWinsOverSpoofedAgentHeader(t *testing.T) {
+	fp, raw := fpWithPrincipal(t, "local-codex", nil)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", target.URL+"/get", nil)
+	req.Header.Set("Proxy-Authorization", proxyBasicHeader(raw))
+	req.Header.Set("X-Oktsec-Agent", "admin") // spoof attempt
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (token must authenticate)", rec.Code)
+	}
+}
+
+// 2. Enterprise profile rejects the loopback header path: an
+// unauthenticated request returns 407 Proxy Authentication Required.
+func TestForwardProxyAuth_EnterpriseRejectsLoopbackHeader(t *testing.T) {
+	fp, _ := fpWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.Deployment.Profile = "enterprise"
+		c.ForwardProxy.TrustedLoopbackHeaders = true // honored only in local
+	})
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", "http://example.com/get", nil)
+	req.Header.Set("X-Oktsec-Agent", "admin")
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("status = %d, want 407 (enterprise must fail closed)", rec.Code)
+	}
+	if got := rec.Header().Get("Proxy-Authenticate"); got == "" {
+		t.Error("407 response missing Proxy-Authenticate hint")
+	}
+}
+
+// 3. require_auth=true on local profile rejects requests with no token
+// regardless of the legacy header path.
+func TestForwardProxyAuth_RequireAuthRejectsAnonymous(t *testing.T) {
+	fp, _ := fpWithPrincipal(t, "local-codex", func(c *config.Config) {
+		c.ForwardProxy.RequireAuth = "true"
+	})
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", "http://example.com/get", nil)
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("status = %d, want 407", rec.Code)
+	}
+}
+
+// 4. Local profile keeps the legacy X-Oktsec-Agent header working when
+// the request originates from loopback. Required for back-compat with
+// every existing forward-proxy caller.
+func TestForwardProxyAuth_LocalLegacyLoopbackHeaderStillWorks(t *testing.T) {
+	fp, _ := fpWithPrincipal(t, "local-codex", nil)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", target.URL+"/get", nil)
+	req.Header.Set("X-Oktsec-Agent", "claude-code")
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (local loopback header should authenticate)", rec.Code)
+	}
+}
+
+// 5. Expired tokens are rejected at lookup time, not at store-build
+// time. Same contract as the gateway.
+func TestForwardProxyAuth_ExpiredTokenRejected(t *testing.T) {
+	cfg := &config.Config{
+		ForwardProxy: config.ForwardProxyConfig{Enabled: true,
+			SurfaceAuthConfig: config.SurfaceAuthConfig{RequireAuth: "true"},
+		},
+		Agents: map[string]config.Agent{},
+	}
+	raw, hash, err := resolve.GenerateRawToken(resolve.TokenTypeProxyBasic)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	cfg.Identity = config.IdentityConfig{
+		Principals: []config.PrincipalConfig{{
+			ID: "local-codex",
+			Tokens: []config.PrincipalTokenConfig{{
+				ID:        "tok-1",
+				Type:      "proxy_basic",
+				Hash:      hash,
+				CreatedAt: "2026-01-01T00:00:00Z",
+				ExpiresAt: "2026-01-02T00:00:00Z",
+			}},
+		}},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scanner := engine.NewScanner("")
+	t.Cleanup(func() { scanner.Close() })
+	store, _ := audit.NewStore(t.TempDir()+"/audit.db", logger)
+	t.Cleanup(func() { _ = store.Close() })
+	fp := NewForwardProxy(&cfg.ForwardProxy, scanner, store, NewRateLimiter(0, 60), cfg.Agents, logger, nil, cfg)
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", "http://example.com/get", nil)
+	req.Header.Set("Proxy-Authorization", proxyBasicHeader(raw))
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("status = %d, want 407 for expired token", rec.Code)
+	}
+}
+
+// 6. Proxy-Authorization is stripped from the request before any
+// upstream forwarding. Even a hand-rolled forwarder that bypasses
+// copyHeaders cannot leak the token to the destination.
+func TestForwardProxyAuth_ProxyAuthorizationStrippedBeforeUpstream(t *testing.T) {
+	leaked := make(chan string, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked <- r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	fp, raw := fpWithPrincipal(t, "local-codex", nil)
+	handler := fp.Wrap(http.NewServeMux())
+
+	req := httptest.NewRequest("GET", target.URL+"/get", nil)
+	req.Header.Set("Proxy-Authorization", proxyBasicHeader(raw))
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := <-leaked
+	if got != "" {
+		t.Errorf("upstream received Proxy-Authorization header: %q (must be stripped)", got)
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -28,7 +28,7 @@ func newTestForwardProxyWithAgents(t *testing.T, cfg *config.ForwardProxyConfig,
 	scanner := engine.NewScanner("")
 	t.Cleanup(func() { scanner.Close() })
 	rl := NewRateLimiter(0, 60)
-	fp := NewForwardProxy(cfg, scanner, store, rl, agents, logger, nil)
+	fp := NewForwardProxy(cfg, scanner, store, rl, agents, logger, nil, nil)
 	// Override transport to allow localhost connections in tests
 	// (safeDialContext blocks loopback IPs by design)
 	fp.transport = &http.Transport{}
@@ -284,6 +284,7 @@ func TestForwardProxy_PerAgent_AllowedDomain(t *testing.T) {
 	// With agent header: 127.0.0.1 in merged allowlist → allowed
 	req = httptest.NewRequest("GET", target.URL+"/get", nil)
 	req.Header.Set("X-Oktsec-Agent", "researcher")
+	req.RemoteAddr = "127.0.0.1:1" // resolver requires loopback for header-as-principal
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -320,6 +321,7 @@ func TestForwardProxy_PerAgent_BlockedDomain(t *testing.T) {
 	// With agent header: 127.0.0.1 in agent blocklist → blocked
 	req = httptest.NewRequest("GET", target.URL+"/get", nil)
 	req.Header.Set("X-Oktsec-Agent", "restricted")
+	req.RemoteAddr = "127.0.0.1:1" // resolver requires loopback for header-as-principal
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -366,6 +368,7 @@ func TestForwardProxy_PerAgent_CONNECT_Blocked(t *testing.T) {
 	req := httptest.NewRequest("CONNECT", "evil.com:443", nil)
 	req.Host = "evil.com:443"
 	req.Header.Set("X-Oktsec-Agent", "locked")
+	req.RemoteAddr = "127.0.0.1:1" // resolver requires loopback for header-as-principal
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -360,7 +360,7 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	// Forward proxy on dedicated port (separate from dashboard/API)
 	if cfg.ForwardProxy.Enabled {
 		fp := NewForwardProxy(&cfg.ForwardProxy, scanner, auditStore,
-			NewRateLimiter(cfg.RateLimit.PerAgent, cfg.RateLimit.WindowS), cfg.Agents, logger, &cfg.TrustBoundaries)
+			NewRateLimiter(cfg.RateLimit.PerAgent, cfg.RateLimit.WindowS), cfg.Agents, logger, &cfg.TrustBoundaries, cfg)
 
 		fwdBind := cfg.ForwardProxy.Bind
 		if fwdBind == "" {


### PR DESCRIPTION
## Summary

The MCP HTTP gateway, the HTTP forward proxy, and the hooks endpoint now share one identity contract. A token issued by `oktsec tokens create` authenticates against the surface that matches its type; the same `auto` / `true` / `false` `require_auth` flag and the same local-vs-enterprise behavior apply across all three.

This closes Phase 1 of the surface-agnostic runtime architecture. The relevant talking point goes from *"any MCP HTTP client connects with a bearer token"* to *"Oktsec has one identity model across MCP gateway, egress proxy, and hooks"*.

## What this enables

- A client that cannot send `X-Oktsec-Agent` (any HTTP-aware tool, any MCP client, any agent that uses `HTTP_PROXY`) authenticates uniformly through token-based identity.
- `oktsec tokens create --type proxy_basic` and `--type hook_bearer` now activate real surfaces; the CLI was already minting both types in the previous release.
- Operators flip enterprise fail-closed once via `deployment.profile: enterprise` (or `deployment.require_surface_auth: true`) and every surface honors it.

## What changed

### Forward proxy (`internal/proxy`)

- `proxy_basic` tokens consumed via `Proxy-Authorization: Basic <token>:` — the standard mechanism every HTTP client supports through `HTTP_PROXY=http://<token>:@host:port`.
- `Proxy-Authorization` is stripped from the request before upstream forwarding so the token cannot leak to the destination.
- `407 Proxy Authentication Required` with `Proxy-Authenticate: Basic` when `require_auth` or enterprise mode rejects an unauthenticated request.
- Legacy `X-Oktsec-Agent` still works in local profile from loopback for backwards compatibility.

### Hooks (`internal/hooks`)

- `hook_bearer` tokens consumed via `Authorization: Bearer`.
- Local profile keeps unauthenticated hooks working as observed telemetry; enterprise or `hooks.require_auth=true` flips to fail-closed (`401` with `WWW-Authenticate`).
- When the resolver establishes a Principal, it overrides the payload-supplied agent name. The original payload value remains available as the reported actor.

### Configuration (`internal/config`)

- New embedded `SurfaceAuthConfig` (`require_auth`, `auth_methods`, `trusted_loopback_headers`) that `gateway`, `forward_proxy`, and `hooks` all expose with identical semantics.
- New top-level `hooks:` section.

### Documentation

- `documentation/guides/egress.md` updated with the `proxy_basic` token flow and a link to the bearer-token guide for the full token model.

## Tests

10 new tests (proxy and hooks). Highlights:

- Token wins over a spoofed `X-Oktsec-Agent` header (proxy and hooks).
- Enterprise profile rejects the loopback header even when `auth_methods` lists it.
- `require_auth=true` flips fail-closed in local profile.
- Expired tokens fail at lookup time.
- `Proxy-Authorization` is stripped from the upstream request — verified with a real httptest upstream that records every received header.

End-to-end smoke against a running gateway with `require_auth: true`:

| Scenario | Result |
|---|---|
| Gateway POST `/mcp` with `Authorization: Bearer <gateway_bearer>` | `200 OK` |
| Gateway POST `/mcp` with no auth | `401 Unauthorized` |
| Hooks POST `/hooks/event` with `Authorization: Bearer <hook_bearer>` | `200 OK` |
| Hooks POST `/hooks/event` with no auth | `401 Unauthorized` |

Forward proxy verified by 6 httptest end-to-end tests, including the upstream-leak check. Suite, lint, vet stay green.

## Not included

- mTLS gateway authentication. The config field is reserved.
- Activity model and connector registry (Phase 2).
- Coverage matrix UI and graph v2 (later phases).