### PR TITLE
Add coverage matrix to dashboard Overview

### DIFF
--- a/internal/audit/iface.go
+++ b/internal/audit/iface.go
@@ -56,6 +56,11 @@ type AuditQuerier interface {
 	QueryAgentRisk(since string) ([]AgentRisk, error)
 	QueryEdgeStats(since string) ([]EdgeStat, error)
 	QueryToolStats(since string) ([]ToolStat, error)
+	// LastSeenByPrincipalSurface returns the most recent timestamp
+	// (RFC3339) for events attributable to (principalID, surface).
+	// Anonymous rows do not count even if from_agent matches; see the
+	// store implementation for the surface→auth_method mapping.
+	LastSeenByPrincipalSurface(principalID, surface string) (string, error)
 	CountRulePrefix(prefix string) (int, error)
 	CountByPolicyDecision(decision string) (int, error)
 }

--- a/internal/audit/last_seen_test.go
+++ b/internal/audit/last_seen_test.go
@@ -1,0 +1,157 @@
+package audit
+
+import (
+	"testing"
+	"time"
+)
+
+// logRows seeds the store with a slice of entries and waits for them to
+// hit the SQLite file. Tests insert via the public Log+Flush path so the
+// query under test sees rows the same way it would in production.
+func logRows(t *testing.T, store *Store, rows ...Entry) {
+	t.Helper()
+	for _, r := range rows {
+		store.Log(r)
+	}
+	store.Flush()
+}
+
+// 1. A bearer-token gateway row attributes LastSeen to mcp_http for the
+// principal that owns it. The egress and hooks surfaces stay empty.
+func TestLastSeenByPrincipalSurface_Gateway(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		Entry{
+			ID: "gw-1", Timestamp: "2026-04-26T10:00:00Z",
+			FromAgent: "local-codex", ToAgent: "local-codex",
+			Status: StatusDelivered, PolicyDecision: "ok",
+			AuthMethod: "bearer_token",
+		},
+	)
+	got, err := store.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got != "2026-04-26T10:00:00Z" {
+		t.Errorf("mcp_http last seen = %q; want 2026-04-26T10:00:00Z", got)
+	}
+	if got, _ := store.LastSeenByPrincipalSurface("local-codex", "http_egress_proxy"); got != "" {
+		t.Errorf("egress should be empty when only gateway activity exists; got %q", got)
+	}
+	if got, _ := store.LastSeenByPrincipalSurface("local-codex", "hooks"); got != "" {
+		t.Errorf("hooks should be empty when only gateway activity exists; got %q", got)
+	}
+}
+
+// 2. A proxy_token row attributes LastSeen to http_egress_proxy. Same
+// principal can have both gateway and egress rows; each surface returns
+// its own MAX(timestamp).
+func TestLastSeenByPrincipalSurface_Egress(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		Entry{
+			ID: "eg-1", Timestamp: "2026-04-26T11:00:00Z",
+			FromAgent: "local-codex", ToAgent: "api.example.com",
+			Status: StatusDelivered, PolicyDecision: "proxy_allowed",
+			AuthMethod: "proxy_token",
+		},
+	)
+	got, err := store.LastSeenByPrincipalSurface("local-codex", "http_egress_proxy")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got != "2026-04-26T11:00:00Z" {
+		t.Errorf("egress last seen = %q; want 2026-04-26T11:00:00Z", got)
+	}
+}
+
+// 3. A hook_token row attributes LastSeen to hooks. Important: a row
+// with auth_method="" (anonymous hook) must NOT count for a configured
+// principal even if from_agent matches — that protects the matrix from
+// claiming coverage on the basis of an unauthenticated event.
+func TestLastSeenByPrincipalSurface_HooksAuthOnly(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		// Authenticated hook: counts.
+		Entry{
+			ID: "hk-1", Timestamp: "2026-04-26T12:00:00Z",
+			FromAgent: "local-codex", ToAgent: "local-codex",
+			ToolName: "Read", Status: StatusDelivered, PolicyDecision: "ok",
+			AuthMethod: "hook_token",
+		},
+		// Anonymous hook with the same from_agent name: must NOT count.
+		Entry{
+			ID: "hk-2", Timestamp: "2026-04-26T13:00:00Z",
+			FromAgent: "local-codex", ToAgent: "local-codex",
+			ToolName: "Read", Status: StatusDelivered, PolicyDecision: "ok",
+			AuthMethod: "", // anonymous
+		},
+	)
+	got, err := store.LastSeenByPrincipalSurface("local-codex", "hooks")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got != "2026-04-26T12:00:00Z" {
+		t.Errorf("hooks last seen = %q; want 2026-04-26T12:00:00Z (anonymous row must not count)", got)
+	}
+}
+
+// 4. MAX(timestamp) returns the latest authenticated event for the
+// surface even when older events with the same auth_method exist.
+func TestLastSeenByPrincipalSurface_ReturnsMostRecent(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		Entry{ID: "1", Timestamp: "2026-04-25T10:00:00Z", FromAgent: "local-codex", Status: StatusDelivered, PolicyDecision: "ok", AuthMethod: "bearer_token"},
+		Entry{ID: "2", Timestamp: "2026-04-26T10:00:00Z", FromAgent: "local-codex", Status: StatusDelivered, PolicyDecision: "ok", AuthMethod: "bearer_token"},
+		Entry{ID: "3", Timestamp: "2026-04-24T10:00:00Z", FromAgent: "local-codex", Status: StatusDelivered, PolicyDecision: "ok", AuthMethod: "bearer_token"},
+	)
+	got, _ := store.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if got != "2026-04-26T10:00:00Z" {
+		t.Errorf("most recent timestamp = %q; want 2026-04-26T10:00:00Z", got)
+	}
+}
+
+// 5. trusted_loopback rows count for both the gateway and the egress
+// surfaces — that is how the legacy header gets attributed in local
+// profile when no token is configured. Hooks is intentionally stricter:
+// it only counts authenticated hook_token rows.
+func TestLastSeenByPrincipalSurface_TrustedLoopbackCountsForLegacySurfaces(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		Entry{ID: "1", Timestamp: "2026-04-26T09:00:00Z", FromAgent: "claude-code", Status: StatusDelivered, PolicyDecision: "ok", AuthMethod: "trusted_loopback"},
+	)
+	if got, _ := store.LastSeenByPrincipalSurface("claude-code", "mcp_http"); got != "2026-04-26T09:00:00Z" {
+		t.Errorf("mcp_http should accept trusted_loopback; got %q", got)
+	}
+	if got, _ := store.LastSeenByPrincipalSurface("claude-code", "http_egress_proxy"); got != "2026-04-26T09:00:00Z" {
+		t.Errorf("http_egress_proxy should accept trusted_loopback; got %q", got)
+	}
+	if got, _ := store.LastSeenByPrincipalSurface("claude-code", "hooks"); got != "" {
+		t.Errorf("hooks should not attribute trusted_loopback rows to a principal; got %q", got)
+	}
+}
+
+// 6. Unknown surface returns empty without error so callers iterating
+// over a hardcoded surface list never crash on a typo.
+func TestLastSeenByPrincipalSurface_UnknownSurfaceEmpty(t *testing.T) {
+	store := newTestStore(t)
+	logRows(t, store,
+		Entry{ID: "1", Timestamp: time.Now().UTC().Format(time.RFC3339), FromAgent: "local-codex", Status: StatusDelivered, PolicyDecision: "ok", AuthMethod: "bearer_token"},
+	)
+	got, err := store.LastSeenByPrincipalSurface("local-codex", "not-a-surface")
+	if err != nil {
+		t.Errorf("unknown surface should not error; got %v", err)
+	}
+	if got != "" {
+		t.Errorf("unknown surface should return empty; got %q", got)
+	}
+}
+
+// 7. Empty principal returns empty without error.
+func TestLastSeenByPrincipalSurface_EmptyPrincipal(t *testing.T) {
+	store := newTestStore(t)
+	got, err := store.LastSeenByPrincipalSurface("", "mcp_http")
+	if err != nil || got != "" {
+		t.Errorf("empty principal should be empty/no-error; got %q, %v", got, err)
+	}
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -1861,6 +1861,58 @@ func (s *Store) QueryReasoningByAuditID(auditEntryID string) (*ReasoningEntry, e
 	return &r, nil
 }
 
+// surfaceAuthMethods is the conservative mapping the coverage matrix
+// uses to attribute audit rows to a surface. Anonymous (auth_method="")
+// rows are deliberately NOT mapped to any surface — attributing them
+// would risk crediting a configured principal with activity from an
+// unauthenticated client that just happened to share a name in its
+// payload.
+var surfaceAuthMethods = map[string][]string{
+	"mcp_http":          {"bearer_token", "trusted_loopback"},
+	"http_egress_proxy": {"proxy_token", "trusted_loopback"},
+	"hooks":             {"hook_token"},
+}
+
+// LastSeenByPrincipalSurface returns the most recent timestamp (RFC3339)
+// for audit rows attributable to the given principal on the given
+// surface. Returns "" without an error when there is no matching row.
+//
+// Attribution requires both:
+//   - from_agent equals principalID, and
+//   - auth_method is one of the surface's recognized authenticated paths.
+//
+// Anonymous rows (auth_method="") never count even if from_agent matches,
+// because that would let a stray unauthenticated event credit a
+// configured principal in the coverage matrix.
+func (s *Store) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	methods, ok := surfaceAuthMethods[surface]
+	if !ok || principalID == "" {
+		return "", nil
+	}
+	// Build the IN (?, ?) placeholder list with the dialect's syntax so
+	// the same query works on SQLite and Postgres.
+	placeholders := make([]string, len(methods))
+	args := make([]any, 0, len(methods)+1)
+	args = append(args, principalID)
+	for i, m := range methods {
+		placeholders[i] = s.dialect.Placeholder(i + 2)
+		args = append(args, m)
+	}
+	q := fmt.Sprintf(
+		"SELECT MAX(timestamp) FROM audit_log WHERE from_agent = %s AND auth_method IN (%s)",
+		s.dialect.Placeholder(1),
+		strings.Join(placeholders, ","),
+	)
+	var ts sql.NullString
+	if err := s.db.QueryRow(q, args...).Scan(&ts); err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("querying last seen for %s on %s: %w", principalID, surface, err)
+	}
+	return ts.String, nil
+}
+
 // expiryLoop periodically expires old quarantine items and purges old audit entries.
 func (s *Store) expiryLoop() {
 	ticker := time.NewTicker(60 * time.Second)

--- a/internal/coverage/compute.go
+++ b/internal/coverage/compute.go
@@ -1,0 +1,230 @@
+package coverage
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// Compute folds the current configuration and audit observations into a
+// per-principal, per-surface coverage matrix. Output is sorted by
+// principal id then surface so dashboard rendering is deterministic.
+//
+// The function is intentionally pure: it does not query the audit store
+// directly (callers pass a narrow AuditReader) and does not mutate cfg.
+// Tests can drive it with a fake AuditReader and any *config.Config.
+func Compute(cfg *config.Config, ar AuditReader) []CoverageCell {
+	if cfg == nil {
+		return nil
+	}
+	now := time.Now()
+
+	var cells []CoverageCell
+	for _, p := range cfg.Identity.Principals {
+		tokensByType := activeTokenTypes(p, now)
+		connector := inferConnectorIDFromActive(tokensByType)
+		for _, surface := range AllSurfaces {
+			cell := computeCell(cfg, p, connector, surface, tokensByType)
+			if ar != nil {
+				if ts, err := ar.LastSeenByPrincipalSurface(p.ID, string(surface)); err == nil {
+					cell.LastSeen = ts
+				}
+			}
+			cells = append(cells, cell)
+		}
+	}
+	sort.Slice(cells, func(i, j int) bool {
+		if cells[i].PrincipalID != cells[j].PrincipalID {
+			return cells[i].PrincipalID < cells[j].PrincipalID
+		}
+		return cells[i].Surface < cells[j].Surface
+	})
+	return cells
+}
+
+// activeTokenTypes returns the set of TokenTypes the principal currently
+// holds in active form. Inactive entries (revoked or past expires_at)
+// are skipped so a stale revoked gateway token does not look like
+// "protected MCP" in the matrix.
+func activeTokenTypes(p config.PrincipalConfig, now time.Time) map[string]bool {
+	out := make(map[string]bool, len(p.Tokens))
+	for _, t := range p.Tokens {
+		if t.RevokedAt != "" {
+			continue
+		}
+		if t.ExpiresAt != "" {
+			exp, err := time.Parse(time.RFC3339, t.ExpiresAt)
+			if err != nil || !now.Before(exp) {
+				continue
+			}
+		}
+		out[t.Type] = true
+	}
+	return out
+}
+
+// computeCell decides the (Coverage, AuthMethod, TrustLevel, Limitation)
+// for one (principal, surface) pair. The decision uses three inputs:
+//   1. Whether the surface is enabled at all.
+//   2. Whether the principal holds a token of the matching type.
+//   3. The surface's local/enterprise auth posture (loopback header on,
+//      require_auth, etc.).
+func computeCell(cfg *config.Config, p config.PrincipalConfig, connector string, surface Surface, tokens map[string]bool) CoverageCell {
+	cell := CoverageCell{
+		PrincipalID: p.ID,
+		ConnectorID: connector,
+		Surface:     string(surface),
+	}
+
+	switch surface {
+	case SurfaceMCPHTTP:
+		fillMCPHTTP(&cell, cfg, tokens)
+	case SurfaceHTTPEgress:
+		fillEgress(&cell, cfg, tokens)
+	case SurfaceHooks:
+		fillHooks(&cell, cfg, tokens)
+	}
+	return cell
+}
+
+func fillMCPHTTP(c *CoverageCell, cfg *config.Config, tokens map[string]bool) {
+	if !cfg.Gateway.Enabled {
+		c.Coverage = CoverageBlind
+		c.Limitation = "gateway not enabled"
+		return
+	}
+	if tokens["gateway_bearer"] {
+		c.Coverage = CoverageProtected
+		c.AuthMethod = "bearer_token"
+		c.TrustLevel = "authenticated"
+		return
+	}
+	// No token but loopback header may still grant trusted_local in
+	// local profile when the operator has not flipped to enterprise.
+	if isLocalLoopbackHeaderActive(cfg, cfg.Gateway.SurfaceAuthConfig) {
+		c.Coverage = CoverageObserved
+		c.AuthMethod = "trusted_loopback"
+		c.TrustLevel = "trusted_local"
+		c.Limitation = "loopback header only — issue a gateway_bearer token for stronger auth"
+		return
+	}
+	c.Coverage = CoverageBlind
+	c.Limitation = "no gateway_bearer token configured"
+}
+
+func fillEgress(c *CoverageCell, cfg *config.Config, tokens map[string]bool) {
+	if !cfg.ForwardProxy.Enabled {
+		c.Coverage = CoverageBlind
+		c.Limitation = "forward proxy not enabled"
+		return
+	}
+	if tokens["proxy_basic"] {
+		c.Coverage = CoverageProtected
+		c.AuthMethod = "proxy_token"
+		c.TrustLevel = "authenticated"
+		// Egress is special: we can block before the action only when the
+		// payload is visible (plain HTTP or explicit HTTPS inspection).
+		// CONNECT tunnels are domain-only by default. Surface that as a
+		// limitation, not as a downgrade.
+		c.Limitation = egressProtectionDetail(cfg)
+		return
+	}
+	if isLocalLoopbackHeaderActive(cfg, cfg.ForwardProxy.SurfaceAuthConfig) {
+		c.Coverage = CoverageObserved
+		c.AuthMethod = "trusted_loopback"
+		c.TrustLevel = "trusted_local"
+		c.Limitation = "loopback header only — issue a proxy_basic token for stronger auth"
+		return
+	}
+	c.Coverage = CoverageBlind
+	c.Limitation = "no proxy_basic token configured"
+}
+
+func fillHooks(c *CoverageCell, cfg *config.Config, tokens map[string]bool) {
+	// The hooks endpoint is mounted on the gateway's HTTP mux at
+	// /hooks/event (see gateway.Start). When the gateway is disabled
+	// the surface is not exposed at all — every principal is blind
+	// regardless of token configuration.
+	if !cfg.Gateway.Enabled {
+		c.Coverage = CoverageBlind
+		c.Limitation = "hooks endpoint not exposed (gateway disabled)"
+		return
+	}
+	if tokens["hook_bearer"] {
+		c.Coverage = CoverageProtected
+		c.AuthMethod = "hook_token"
+		c.TrustLevel = "authenticated"
+		c.Limitation = "pre-action hooks block when client honors the decision; post-action hooks are observed only"
+		return
+	}
+	// Hooks accept unauthenticated POSTs as observed telemetry in local
+	// profile. Enterprise / require_auth flips this to blind for the
+	// principal because the surface refuses anonymous events.
+	if hooksAcceptsUnauth(cfg) {
+		c.Coverage = CoverageObserved
+		c.AuthMethod = ""
+		c.TrustLevel = "anonymous"
+		c.Limitation = "no hook_bearer token; events accepted as observed telemetry only"
+		return
+	}
+	c.Coverage = CoverageBlind
+	c.Limitation = "no hook_bearer token; surface requires authenticated identity"
+}
+
+// isLocalLoopbackHeaderActive mirrors the resolver's local-profile logic:
+// loopback header authentication is on either when the surface explicitly
+// enabled it or when the operator has not customized auth_methods at all
+// in local profile.
+func isLocalLoopbackHeaderActive(cfg *config.Config, sa config.SurfaceAuthConfig) bool {
+	if !strings.EqualFold(strings.TrimSpace(cfg.Deployment.Profile), "local") &&
+		strings.TrimSpace(cfg.Deployment.Profile) != "" {
+		return false
+	}
+	if sa.TrustedLoopbackHeaders {
+		return true
+	}
+	if len(sa.AuthMethods) == 0 {
+		return true
+	}
+	for _, m := range sa.AuthMethods {
+		if strings.EqualFold(strings.TrimSpace(m), "trusted_loopback_header") {
+			return true
+		}
+	}
+	return false
+}
+
+// hooksAcceptsUnauth mirrors what the hook handler does at request
+// time: when require_auth is off and the deployment is not enterprise,
+// unauthenticated POSTs are recorded as observed telemetry rather than
+// rejected.
+func hooksAcceptsUnauth(cfg *config.Config) bool {
+	if strings.EqualFold(strings.TrimSpace(cfg.Deployment.Profile), "enterprise") {
+		return false
+	}
+	if cfg.Deployment.RequireSurfaceAuth {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Hooks.RequireAuth)) {
+	case "true", "yes", "1":
+		return false
+	}
+	return true
+}
+
+// egressProtectionDetail picks the right one-sentence caveat for a
+// principal that is technically authenticated to the egress proxy but
+// whose effective coverage depends on whether HTTPS bodies are being
+// inspected. Defaults to the conservative "domain-only" framing because
+// HTTPS inspection is opt-in and not configured today.
+func egressProtectionDetail(cfg *config.Config) string {
+	if cfg.ForwardProxy.ScanResponses && cfg.ForwardProxy.ScanRequests {
+		return "plain HTTP bodies inspected; HTTPS CONNECT is domain-only unless inspection is enabled"
+	}
+	if cfg.ForwardProxy.ScanRequests {
+		return "request bodies inspected on plain HTTP; HTTPS CONNECT is domain-only"
+	}
+	return "domain-only (HTTPS CONNECT and disabled body scanning)"
+}

--- a/internal/coverage/compute_test.go
+++ b/internal/coverage/compute_test.go
@@ -1,0 +1,321 @@
+package coverage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// fakeAuditReader returns canned timestamps. The narrow AuditReader
+// interface is the whole point: Compute can be exercised without a
+// real audit store, and tests own exactly what they want LastSeen to
+// look like for each (principal, surface).
+type fakeAuditReader struct{ stamps map[string]string }
+
+func (f fakeAuditReader) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	return f.stamps[principalID+"|"+surface], nil
+}
+
+// pickCell returns the cell for a (principal, surface) pair so tests can
+// assert per-cell instead of indexing into the slice.
+func pickCell(t *testing.T, cells []CoverageCell, principalID string, surface Surface) CoverageCell {
+	t.Helper()
+	for _, c := range cells {
+		if c.PrincipalID == principalID && c.Surface == string(surface) {
+			return c
+		}
+	}
+	t.Fatalf("no cell for principal=%q surface=%q (have %d cells)", principalID, surface, len(cells))
+	return CoverageCell{}
+}
+
+func principalWith(id string, tokenTypes ...string) config.PrincipalConfig {
+	p := config.PrincipalConfig{ID: id, DisplayName: id, Kind: "agent"}
+	for i, tt := range tokenTypes {
+		p.Tokens = append(p.Tokens, config.PrincipalTokenConfig{
+			ID:        id + "-tok-" + tt,
+			Type:      tt,
+			Hash:      "sha256:dummy",
+			CreatedAt: time.Now().Add(-time.Duration(i+1) * time.Hour).UTC().Format(time.RFC3339),
+		})
+	}
+	return p
+}
+
+// 1. A principal with a gateway_bearer token, on an enabled gateway,
+// reports MCP HTTP as protected with bearer-token identity. The other
+// surfaces are blind because the principal does not own their tokens.
+func TestCompute_BearerGatewayProtected(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "gateway_bearer"),
+		}},
+		Gateway: config.GatewayConfig{Enabled: true},
+	}
+	cells := Compute(cfg, nil)
+
+	mcp := pickCell(t, cells, "local-codex", SurfaceMCPHTTP)
+	if mcp.Coverage != CoverageProtected || mcp.AuthMethod != "bearer_token" {
+		t.Errorf("MCP cell = %+v; want protected/bearer_token", mcp)
+	}
+	if mcp.TrustLevel != "authenticated" {
+		t.Errorf("MCP trust level = %q; want authenticated", mcp.TrustLevel)
+	}
+	if mcp.ConnectorID != ConnectorGenericMCPHTTP {
+		t.Errorf("connector = %q; want %s", mcp.ConnectorID, ConnectorGenericMCPHTTP)
+	}
+}
+
+// 2. A principal with a proxy_basic token, on an enabled forward proxy,
+// is protected at the egress surface. The Limitation field carries the
+// HTTPS-CONNECT caveat so dashboards do not over-claim content visibility.
+func TestCompute_ProxyTokenProtectedEgress(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "proxy_basic"),
+		}},
+		ForwardProxy: config.ForwardProxyConfig{Enabled: true, ScanRequests: true},
+	}
+	cells := Compute(cfg, nil)
+
+	eg := pickCell(t, cells, "local-codex", SurfaceHTTPEgress)
+	if eg.Coverage != CoverageProtected {
+		t.Errorf("egress coverage = %q; want protected", eg.Coverage)
+	}
+	if eg.AuthMethod != "proxy_token" {
+		t.Errorf("egress auth = %q; want proxy_token", eg.AuthMethod)
+	}
+	if eg.Limitation == "" {
+		t.Error("egress protected cell must carry a Limitation explaining CONNECT visibility")
+	}
+}
+
+// 3. A principal with a hook_bearer token is protected at the hooks
+// surface and the cell explains the pre/post asymmetry instead of
+// claiming "fully blocked".
+func TestCompute_HookBearerProtected(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "hook_bearer"),
+		}},
+		// Hooks are mounted on the gateway's HTTP mux, so they are only
+		// exposed when the gateway is enabled. Tests that exercise hooks
+		// must enable the gateway even when MCP HTTP is not the focus.
+		Gateway: config.GatewayConfig{Enabled: true},
+	}
+	cells := Compute(cfg, nil)
+
+	hk := pickCell(t, cells, "local-codex", SurfaceHooks)
+	if hk.Coverage != CoverageProtected || hk.AuthMethod != "hook_token" {
+		t.Errorf("hooks cell = %+v; want protected/hook_token", hk)
+	}
+	if hk.Limitation == "" {
+		t.Error("hooks protected cell should explain pre vs post action behavior in Limitation")
+	}
+}
+
+// 4. A principal with no tokens, in default local profile, falls back to
+// the legacy X-Oktsec-Agent loopback path: trusted_local identity but
+// only observed coverage. The matrix must not paint this as protected.
+func TestCompute_LegacyLoopbackHeaderObservedNotProtected(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("claude-code"),
+		}},
+		Gateway: config.GatewayConfig{Enabled: true}, // local profile, no AuthMethods override
+	}
+	cells := Compute(cfg, nil)
+
+	mcp := pickCell(t, cells, "claude-code", SurfaceMCPHTTP)
+	if mcp.Coverage == CoverageProtected {
+		t.Errorf("MCP cell = %+v; loopback header must not be reported as protected", mcp)
+	}
+	if mcp.TrustLevel != "trusted_local" {
+		t.Errorf("MCP trust level = %q; want trusted_local", mcp.TrustLevel)
+	}
+	if mcp.ConnectorID != ConnectorLegacyLocalHeader {
+		t.Errorf("connector = %q; want %s", mcp.ConnectorID, ConnectorLegacyLocalHeader)
+	}
+}
+
+// 5. A surface that is not enabled is reported as blind for every
+// principal, with a Limitation that names the missing piece. This is
+// the structural antidote to the dashboard inflating coverage.
+func TestCompute_DisabledSurfaceIsBlind(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "gateway_bearer"),
+		}},
+		Gateway:      config.GatewayConfig{Enabled: false},      // off
+		ForwardProxy: config.ForwardProxyConfig{Enabled: false}, // off
+	}
+	cells := Compute(cfg, nil)
+
+	mcp := pickCell(t, cells, "local-codex", SurfaceMCPHTTP)
+	if mcp.Coverage != CoverageBlind {
+		t.Errorf("MCP cell = %+v; disabled gateway must be blind", mcp)
+	}
+	eg := pickCell(t, cells, "local-codex", SurfaceHTTPEgress)
+	if eg.Coverage != CoverageBlind {
+		t.Errorf("egress cell = %+v; disabled forward proxy must be blind", eg)
+	}
+}
+
+// 6. Hooks unauthenticated path: in local profile without require_auth,
+// a principal with no hook_bearer token is observed (not blind) because
+// the surface accepts anonymous events as telemetry. Enterprise flips
+// the same scenario to blind because the surface refuses anonymous.
+func TestCompute_HooksUnauthLocalObservedEnterpriseBlind(t *testing.T) {
+	base := func(profile string) *config.Config {
+		return &config.Config{
+			Deployment: config.DeploymentConfig{Profile: profile},
+			Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+				principalWith("local-codex"), // no tokens
+			}},
+			Gateway: config.GatewayConfig{Enabled: true}, // hooks live on gateway mux
+		}
+	}
+
+	local := Compute(base("local"), nil)
+	hk := pickCell(t, local, "local-codex", SurfaceHooks)
+	if hk.Coverage != CoverageObserved {
+		t.Errorf("local hooks coverage = %q; want observed", hk.Coverage)
+	}
+
+	ent := Compute(base("enterprise"), nil)
+	hk = pickCell(t, ent, "local-codex", SurfaceHooks)
+	if hk.Coverage != CoverageBlind {
+		t.Errorf("enterprise hooks coverage = %q; want blind", hk.Coverage)
+	}
+}
+
+// 7. Multi-surface principal is reported with the custom-client
+// connector. The matrix shows protected for every surface where a
+// matching token exists.
+func TestCompute_MultiSurfacePrincipalIsCustomClient(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "gateway_bearer", "proxy_basic", "hook_bearer"),
+		}},
+		Gateway:      config.GatewayConfig{Enabled: true},
+		ForwardProxy: config.ForwardProxyConfig{Enabled: true},
+	}
+	cells := Compute(cfg, nil)
+
+	for _, surface := range AllSurfaces {
+		c := pickCell(t, cells, "local-codex", surface)
+		if c.Coverage != CoverageProtected {
+			t.Errorf("surface %q coverage = %q; want protected", surface, c.Coverage)
+		}
+		if c.ConnectorID != ConnectorCustomClient {
+			t.Errorf("surface %q connector = %q; want %s", surface, c.ConnectorID, ConnectorCustomClient)
+		}
+	}
+}
+
+// 8. Revoked tokens do not contribute to coverage. A principal whose
+// only gateway_bearer token has revoked_at set is reported as blind
+// for MCP HTTP, even though the token row still exists.
+func TestCompute_RevokedTokenDoesNotProtect(t *testing.T) {
+	p := principalWith("local-codex", "gateway_bearer")
+	p.Tokens[0].RevokedAt = time.Now().UTC().Format(time.RFC3339)
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{p}},
+		Gateway:  config.GatewayConfig{Enabled: true},
+		Deployment: config.DeploymentConfig{Profile: "enterprise"}, // turn off loopback fallback
+	}
+	cells := Compute(cfg, nil)
+
+	mcp := pickCell(t, cells, "local-codex", SurfaceMCPHTTP)
+	if mcp.Coverage == CoverageProtected {
+		t.Errorf("MCP cell = %+v; a revoked gateway_bearer must not protect", mcp)
+	}
+}
+
+// 9b. An expired-only gateway_bearer token must NOT label the principal
+// as generic-mcp-http. inferConnectorIDFromActive uses the same active
+// set Compute uses for coverage, so an expired token is invisible to
+// both. Without this guard, the matrix would advertise a connector the
+// principal cannot actually use.
+func TestCompute_ExpiredTokenDoesNotInferConnector(t *testing.T) {
+	p := principalWith("local-codex", "gateway_bearer")
+	p.Tokens[0].ExpiresAt = "2026-01-02T00:00:00Z" // already in the past
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{p}},
+		Gateway:  config.GatewayConfig{Enabled: true},
+		Deployment: config.DeploymentConfig{Profile: "enterprise"},
+	}
+	cells := Compute(cfg, nil)
+
+	mcp := pickCell(t, cells, "local-codex", SurfaceMCPHTTP)
+	if mcp.ConnectorID != ConnectorLegacyLocalHeader {
+		t.Errorf("connector = %q; want %s when the only token is expired",
+			mcp.ConnectorID, ConnectorLegacyLocalHeader)
+	}
+	if mcp.Coverage == CoverageProtected {
+		t.Errorf("MCP cell = %+v; an expired gateway_bearer must not protect", mcp)
+	}
+}
+
+// 10. LastSeen flows from the AuditReader into the right surface cell
+// for every supported surface. The fake reader keys (principal+surface)
+// match what Compute requests, so a regression in either side surfaces
+// here as a missing or misplaced timestamp.
+func TestCompute_LastSeenPerSurfaceAllThree(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "gateway_bearer", "proxy_basic", "hook_bearer"),
+		}},
+		Gateway:      config.GatewayConfig{Enabled: true},
+		ForwardProxy: config.ForwardProxyConfig{Enabled: true},
+	}
+	stamps := map[string]string{
+		"local-codex|mcp_http":          "2026-04-26T10:00:00Z",
+		"local-codex|http_egress_proxy": "2026-04-26T11:00:00Z",
+		"local-codex|hooks":             "2026-04-26T12:00:00Z",
+	}
+	cells := Compute(cfg, fakeAuditReader{stamps: stamps})
+
+	for _, tc := range []struct {
+		surface Surface
+		want    string
+	}{
+		{SurfaceMCPHTTP, "2026-04-26T10:00:00Z"},
+		{SurfaceHTTPEgress, "2026-04-26T11:00:00Z"},
+		{SurfaceHooks, "2026-04-26T12:00:00Z"},
+	} {
+		if got := pickCell(t, cells, "local-codex", tc.surface).LastSeen; got != tc.want {
+			t.Errorf("surface %q last_seen = %q; want %q", tc.surface, got, tc.want)
+		}
+	}
+}
+
+// 9. LastSeen is populated from the AuditReader and threaded onto each
+// cell independently. A principal active on MCP HTTP yesterday and on
+// hooks 2 minutes ago must show both timestamps in the right cells.
+func TestCompute_LastSeenPerSurface(t *testing.T) {
+	cfg := &config.Config{
+		Identity: config.IdentityConfig{Principals: []config.PrincipalConfig{
+			principalWith("local-codex", "gateway_bearer", "hook_bearer"),
+		}},
+		Gateway: config.GatewayConfig{Enabled: true},
+	}
+	stamps := map[string]string{
+		"local-codex|mcp_http": "2026-04-25T10:00:00Z",
+		"local-codex|hooks":    "2026-04-26T13:58:00Z",
+	}
+	cells := Compute(cfg, fakeAuditReader{stamps: stamps})
+
+	if got := pickCell(t, cells, "local-codex", SurfaceMCPHTTP).LastSeen; got != "2026-04-25T10:00:00Z" {
+		t.Errorf("MCP last seen = %q; want 2026-04-25T10:00:00Z", got)
+	}
+	if got := pickCell(t, cells, "local-codex", SurfaceHooks).LastSeen; got != "2026-04-26T13:58:00Z" {
+		t.Errorf("hooks last seen = %q; want 2026-04-26T13:58:00Z", got)
+	}
+	// A surface with no recorded activity stays empty rather than
+	// inheriting another surface's timestamp.
+	if got := pickCell(t, cells, "local-codex", SurfaceHTTPEgress).LastSeen; got != "" {
+		t.Errorf("egress last seen = %q; want empty", got)
+	}
+}

--- a/internal/coverage/connector.go
+++ b/internal/coverage/connector.go
@@ -1,0 +1,44 @@
+package coverage
+
+// Connector identifiers reported in CoverageCell.ConnectorID. Phase 2A
+// infers these from the principal's token mix; later phases will move
+// to an explicit `connector:` field in PrincipalConfig.
+const (
+	ConnectorGenericMCPHTTP    = "generic-mcp-http"
+	ConnectorGenericEgressProxy = "generic-egress-proxy"
+	ConnectorGenericHooks      = "generic-hooks"
+	ConnectorCustomClient      = "custom-client"     // multi-surface principal
+	ConnectorLegacyLocalHeader = "legacy-local-header"
+)
+
+// inferConnectorIDFromActive picks a connector label from the set of
+// active token types the principal currently holds. Callers compute the
+// active set once with activeTokenTypes (which already filters revoked
+// and expired entries) and pass it in here, so an expired-only
+// gateway_bearer never ends up labeling the principal as
+// generic-mcp-http while Compute correctly marks every surface blind.
+func inferConnectorIDFromActive(active map[string]bool) string {
+	hasGW := active["gateway_bearer"]
+	hasProxy := active["proxy_basic"]
+	hasHook := active["hook_bearer"]
+
+	count := 0
+	for _, b := range []bool{hasGW, hasProxy, hasHook} {
+		if b {
+			count++
+		}
+	}
+	switch {
+	case count >= 2:
+		return ConnectorCustomClient
+	case hasGW:
+		return ConnectorGenericMCPHTTP
+	case hasProxy:
+		return ConnectorGenericEgressProxy
+	case hasHook:
+		return ConnectorGenericHooks
+	}
+	// No active tokens: the principal exists in config but only relies
+	// on the legacy X-Oktsec-Agent header for identity.
+	return ConnectorLegacyLocalHeader
+}

--- a/internal/coverage/display.go
+++ b/internal/coverage/display.go
@@ -1,0 +1,97 @@
+package coverage
+
+import "strings"
+
+// ConnectorDisplayName turns a machine connector id into the label the
+// dashboard renders. Returns the id verbatim when it is not in the
+// catalog, so adding a new connector cannot crash the table.
+func ConnectorDisplayName(id string) string {
+	switch id {
+	case ConnectorGenericMCPHTTP:
+		return "Generic MCP HTTP"
+	case ConnectorGenericEgressProxy:
+		return "Generic egress proxy"
+	case ConnectorGenericHooks:
+		return "Generic hooks"
+	case ConnectorCustomClient:
+		return "Custom client"
+	case ConnectorLegacyLocalHeader:
+		return "Legacy loopback header"
+	}
+	return id
+}
+
+// AuthMethodDisplayName humanizes one auth method id for the Identity
+// column. Joining is the caller's job; this only formats one token.
+func AuthMethodDisplayName(method string) string {
+	switch method {
+	case "bearer_token":
+		return "Bearer token"
+	case "proxy_token":
+		return "Proxy token"
+	case "hook_token":
+		return "Hook token"
+	case "trusted_loopback":
+		return "Loopback header"
+	case "":
+		return ""
+	}
+	return method
+}
+
+// CoverageDisplayName is the title-case label for the badge. Observed
+// gets an explicit "only" suffix so the badge color cannot read as
+// stronger than it is.
+func CoverageDisplayName(c CoverageMode) string {
+	switch c {
+	case CoverageProtected:
+		return "Protected"
+	case CoverageObserved:
+		return "Observed only"
+	case CoverageBlind:
+		return "Blind"
+	}
+	return string(c)
+}
+
+// LimitationShortLabel reduces the full Limitation sentence to a small
+// inline tag the cell can show under the badge without bloating the
+// row. The full text remains available as a tooltip; this is just a
+// summary that keeps the matrix scannable.
+//
+// Returns empty when the cell has no caveat (clean Protected, or a
+// Blind cell whose Limitation is already self-explanatory).
+func LimitationShortLabel(c CoverageCell) string {
+	if c.Limitation == "" {
+		return ""
+	}
+	lim := strings.ToLower(c.Limitation)
+	switch {
+	case strings.Contains(lim, "gateway not enabled"),
+		strings.Contains(lim, "forward proxy not enabled"),
+		strings.Contains(lim, "gateway disabled"):
+		return "Surface off"
+	case strings.Contains(lim, "loopback header only"):
+		return "Loopback only"
+	case strings.Contains(lim, "no gateway_bearer token"),
+		strings.Contains(lim, "no proxy_basic token"),
+		strings.Contains(lim, "no hook_bearer token; surface requires"):
+		return "No token"
+	case strings.Contains(lim, "no hook_bearer token; events accepted"):
+		return "Telemetry only"
+	case strings.Contains(lim, "pre-action hooks block"):
+		return "Pre-action only"
+	case strings.Contains(lim, "domain-only"):
+		return "Domain only"
+	case strings.Contains(lim, "request bodies inspected"):
+		return "Request bodies inspected"
+	case strings.Contains(lim, "plain http bodies inspected"):
+		return "HTTP bodies inspected"
+	}
+	// Unknown limitation: take the first clause so something inline
+	// still appears; the tooltip carries the full detail.
+	if i := strings.IndexAny(lim, ".—;"); i > 0 {
+		return strings.TrimSpace(c.Limitation[:i])
+	}
+	return c.Limitation
+}

--- a/internal/coverage/types.go
+++ b/internal/coverage/types.go
@@ -1,0 +1,89 @@
+// Package coverage produces the per-principal, per-surface protection
+// matrix the dashboard renders. It does not own any state itself: the
+// matrix is derived from the current config (which principals exist and
+// what tokens they hold), the per-surface auth posture, and the audit
+// trail (last observed activity).
+//
+// The output of Compute is a flat list of cells. The dashboard renderer
+// pivots them into a Principal × Surface table.
+package coverage
+
+// CoverageMode is the per-cell label the dashboard surfaces for a
+// single (principal, surface) pair. Trust level (authenticated,
+// trusted_local, etc.) is reported as a separate field so the matrix
+// does not collapse "blocking is possible" and "identity is strong"
+// into one value.
+type CoverageMode string
+
+const (
+	// CoverageProtected: Oktsec sits in the path before the action and
+	// can block it. The principal holds a token of the correct type for
+	// the surface and the surface itself is enabled.
+	CoverageProtected CoverageMode = "protected"
+
+	// CoverageObserved: Oktsec sees telemetry but cannot reliably block.
+	// Used for hooks in local profile when no hook token is configured —
+	// pre-action hooks would still record activity, but enforcement
+	// depends on the client honoring block decisions.
+	CoverageObserved CoverageMode = "observed"
+
+	// CoverageBlind: Oktsec knows the surface exists but has no signal
+	// for this principal there. Either the surface is disabled, the
+	// principal lacks a token of the matching type, or no observed
+	// activity links the two.
+	CoverageBlind CoverageMode = "blind"
+)
+
+// Surface identifies the technical boundary the coverage cell describes.
+// String values match resolve.Surface so callers can compare without
+// importing the resolver package.
+type Surface string
+
+const (
+	SurfaceMCPHTTP    Surface = "mcp_http"
+	SurfaceHTTPEgress Surface = "http_egress_proxy"
+	SurfaceHooks      Surface = "hooks"
+)
+
+// AllSurfaces is the canonical iteration order Compute uses; the
+// dashboard renders columns in the same order so the matrix reads the
+// same way every time.
+var AllSurfaces = []Surface{SurfaceMCPHTTP, SurfaceHTTPEgress, SurfaceHooks}
+
+// CoverageCell is one (principal, surface) datapoint in the matrix. The
+// dashboard pivots a slice of these into a per-principal row with one
+// column per surface.
+type CoverageCell struct {
+	PrincipalID string `json:"principal_id"`
+	ConnectorID string `json:"connector_id"` // inferred from token mix; see connector.go
+	Surface     string `json:"surface"`
+
+	// AuthMethod and TrustLevel describe HOW identity is established for
+	// this surface. They live next to Coverage instead of inside it so
+	// "trusted_local" never gets read as "protected" by accident.
+	AuthMethod string `json:"auth_method,omitempty"`
+	TrustLevel string `json:"trust_level,omitempty"`
+
+	Coverage CoverageMode `json:"coverage"`
+
+	// Limitation is the one-sentence operator-facing reason a cell is not
+	// fully protected. Examples: "no proxy_basic token configured",
+	// "domain-only (HTTPS CONNECT)", "post-action only". Empty when
+	// Coverage is protected and there is no caveat.
+	Limitation string `json:"limitation,omitempty"`
+
+	// LastSeen is the most recent audit timestamp attributing activity
+	// to this principal on this surface (RFC3339). Empty string means
+	// the pair has never been observed in the audit trail.
+	LastSeen string `json:"last_seen,omitempty"`
+}
+
+// AuditReader is the minimal projection of the audit store the coverage
+// computer needs. Keeping it narrow lets tests substitute an in-memory
+// fake without spinning up a real database.
+type AuditReader interface {
+	// LastSeenByPrincipalSurface returns the most recent timestamp
+	// (RFC3339) for events that match the given principal and surface.
+	// Returns "" without an error when there is no matching activity.
+	LastSeenByPrincipalSurface(principalID, surface string) (string, error)
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/auditcheck"
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/coverage"
 	"github.com/oktsec/oktsec/internal/discover"
 	"github.com/oktsec/oktsec/internal/graph"
 	"github.com/oktsec/oktsec/internal/identity"
@@ -223,6 +224,11 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 		ruleCount = s.scanner.RulesCount(r.Context())
 	}
 
+	// Coverage matrix is computed once for the Overview render. Its rows
+	// are pivoted into per-principal table rows by the template; each
+	// surface column shows the corresponding cell's badge + limitation.
+	coverageRows := buildCoverageRows(coverage.Compute(s.cfg, s.audit))
+
 	data := map[string]any{
 		"Active":        "overview",
 		"Stats":         stats,
@@ -248,6 +254,7 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 		"MemPoisonCount":  memPoisonCount,
 		"GuardEnabled":    s.cfg.Guard.Enabled,
 		"GuardAlerts":     guardEventCount,
+		"CoverageRows":    coverageRows,
 	}
 
 	s.populateLLMStats(data)
@@ -4968,4 +4975,84 @@ func (s *Server) handleSaveCategoryWebhooks(w http.ResponseWriter, r *http.Reque
 	}
 
 	http.Redirect(w, r, "/dashboard/rules/"+category, http.StatusFound)
+}
+
+// handleAPICoverage returns the per-principal × per-surface coverage
+// matrix as JSON. The audit store satisfies coverage.AuditReader via
+// LastSeenByPrincipalSurface, so coverage.Compute can attribute the
+// "last seen" timestamp to each cell without extra wiring.
+func (s *Server) handleAPICoverage(w http.ResponseWriter, r *http.Request) {
+	cells := coverage.Compute(s.cfg, s.audit)
+	s.renderJSON(w, cells)
+}
+
+// coverageRow is the per-principal projection the Overview template
+// renders. Each row is one principal with one column per surface.
+// Pivoting happens here so the template stays declarative.
+//
+// The display fields (ConnectorLabel, IdentityList) are pre-formatted
+// in this layer so the template never has to reach into the coverage
+// package's internal vocabulary.
+type coverageRow struct {
+	PrincipalID    string
+	ConnectorID    string
+	ConnectorLabel string                           // humanized: "Custom client"
+	IdentityList   string                           // humanized join: "Bearer token + Hook token"
+	LastSeen       string                           // most recent across surfaces (RFC3339)
+	Cells          map[string]coverage.CoverageCell // keyed by surface
+}
+
+// buildCoverageRows turns a flat slice of CoverageCell (one per
+// principal × surface) into one row per principal with the surface
+// cells indexed for direct template lookup. Identity column collapses
+// the distinct auth methods seen across this principal into a single
+// human-readable string.
+func buildCoverageRows(cells []coverage.CoverageCell) []coverageRow {
+	byPrincipal := make(map[string]*coverageRow)
+	order := []string{}
+	for _, c := range cells {
+		row, ok := byPrincipal[c.PrincipalID]
+		if !ok {
+			row = &coverageRow{
+				PrincipalID:    c.PrincipalID,
+				ConnectorID:    c.ConnectorID,
+				ConnectorLabel: coverage.ConnectorDisplayName(c.ConnectorID),
+				Cells:          make(map[string]coverage.CoverageCell),
+			}
+			byPrincipal[c.PrincipalID] = row
+			order = append(order, c.PrincipalID)
+		}
+		row.Cells[c.Surface] = c
+		// Track most-recent LastSeen across surfaces so the row column
+		// has a single value to show. Per-cell timestamps remain
+		// available for surface-specific tooltips.
+		if c.LastSeen > row.LastSeen {
+			row.LastSeen = c.LastSeen
+		}
+	}
+	// Identity column: unique auth methods, in surface iteration order so
+	// MCP > Egress > Hooks reads stably. Each method is humanized via the
+	// coverage package's display helper so the table never shows raw ids.
+	for _, row := range byPrincipal {
+		seen := make(map[string]bool)
+		var methods []string
+		for _, surface := range coverage.AllSurfaces {
+			c, ok := row.Cells[string(surface)]
+			if !ok || c.AuthMethod == "" || seen[c.AuthMethod] {
+				continue
+			}
+			seen[c.AuthMethod] = true
+			methods = append(methods, coverage.AuthMethodDisplayName(c.AuthMethod))
+		}
+		if len(methods) == 0 {
+			row.IdentityList = "Anonymous"
+		} else {
+			row.IdentityList = strings.Join(methods, " + ")
+		}
+	}
+	out := make([]coverageRow, 0, len(order))
+	for _, id := range order {
+		out = append(out, *byPrincipal[id])
+	}
+	return out
 }

--- a/internal/dashboard/regression_test.go
+++ b/internal/dashboard/regression_test.go
@@ -449,6 +449,134 @@ func readFileForTest(path string) (string, error) {
 	return string(b), nil
 }
 
+// TestRegression_OverviewRendersCoverageMatrix verifies the Coverage
+// section appears in the Overview page with one row per principal and
+// the right badges. This is the user-visible payoff of Phase 2A.
+func TestRegression_OverviewRendersCoverageMatrix(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals,
+		config.PrincipalConfig{
+			ID: "local-codex", DisplayName: "local-codex", Kind: "agent",
+			Tokens: []config.PrincipalTokenConfig{{
+				ID: "tok-1", Type: "gateway_bearer", Hash: "sha256:dummy",
+				CreatedAt: "2026-04-26T00:00:00Z",
+			}},
+		},
+		config.PrincipalConfig{
+			ID: "researcher", DisplayName: "researcher", Kind: "agent",
+			Tokens: []config.PrincipalTokenConfig{{
+				ID: "tok-2", Type: "proxy_basic", Hash: "sha256:dummy",
+				CreatedAt: "2026-04-26T00:00:00Z",
+			}},
+		},
+	)
+	srv.cfg.Gateway.Enabled = true
+	srv.cfg.ForwardProxy.Enabled = true
+	// Enterprise profile so principals without a token of the matching
+	// type fall to blind (not the legacy loopback observed path). That
+	// makes the matrix exercise both protected and blind in one go.
+	srv.cfg.Deployment.Profile = "enterprise"
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		"Coverage matrix",       // section header
+		"local-codex",           // principal #1
+		"researcher",            // principal #2
+		"Generic MCP HTTP",      // humanized connector for gateway_bearer-only
+		"Generic egress proxy",  // humanized connector for proxy_basic-only
+		"cov-badge protected",
+		"cov-badge blind",       // researcher has no gateway_bearer → mcp_http blind in enterprise
+		"Bearer token",          // humanized identity for local-codex
+		"Proxy token",           // humanized identity for researcher
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Overview missing %q in coverage matrix; first 400 chars after Coverage:\n%s",
+				want, snippetAfter(body, "Coverage", 400))
+		}
+	}
+}
+
+func snippetAfter(s, anchor string, n int) string {
+	i := strings.Index(s, anchor)
+	if i < 0 {
+		return "(anchor not found)"
+	}
+	end := i + n
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[i:end]
+}
+
+// TestRegression_OverviewCoverageEmptyState verifies the empty state
+// when no principals are configured yet — important for first-run
+// experience so a fresh install does not look broken.
+func TestRegression_OverviewCoverageEmptyState(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.Principals = nil
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	body := rr.Body.String()
+	if !strings.Contains(body, "No principals configured yet") {
+		t.Errorf("empty state missing; body fragment around Coverage:\n%s",
+			snippetAfter(body, "Coverage", 400))
+	}
+	if !strings.Contains(body, "Issue a bearer token") {
+		t.Error("empty state should link to bearer-token guide")
+	}
+}
+
+// TestRegression_CoverageAPIReturnsJSON exercises the /dashboard/api/coverage
+// endpoint added in Phase 2A. It seeds a principal with a gateway_bearer
+// token so the matrix has at least one cell with content, then asserts
+// the JSON shape contains the surface and the principal id.
+func TestRegression_CoverageAPIReturnsJSON(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID: "local-codex", DisplayName: "local-codex", Kind: "agent",
+		Tokens: []config.PrincipalTokenConfig{{
+			ID: "tok-1", Type: "gateway_bearer", Hash: "sha256:dummy",
+			CreatedAt: "2026-04-26T00:00:00Z",
+		}},
+	})
+	srv.cfg.Gateway.Enabled = true
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"principal_id":"local-codex"`) {
+		t.Errorf("response missing principal_id; body=%s", body)
+	}
+	if !strings.Contains(body, `"surface":"mcp_http"`) {
+		t.Errorf("response missing mcp_http surface; body=%s", body)
+	}
+	if !strings.Contains(body, `"coverage":"protected"`) {
+		t.Errorf("gateway_bearer + enabled gateway should produce a protected cell; body=%s", body)
+	}
+}
+
 // TestRegression_NoExternalScriptTags confirms no <script src="https://..."> tags
 // appear in any dashboard page. All assets are served from the binary.
 func TestRegression_NoExternalScriptTags(t *testing.T) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -284,6 +284,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/agents", s.handleAgents)
 
 	s.mux.HandleFunc("GET /dashboard/graph", s.handleGraph)
+	s.mux.HandleFunc("GET /dashboard/api/coverage", s.handleAPICoverage)
 	s.mux.HandleFunc("GET /dashboard/api/graph", s.handleAPIGraph)
 	s.mux.HandleFunc("GET /dashboard/api/graph/edge", s.handleEdgeDetail)
 	s.mux.HandleFunc("POST /dashboard/api/audit/clear", s.handleAuditClear)

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/oktsec/oktsec/internal/coverage"
 )
 
 // categoryOverrides pins the canonical casing for acronym-heavy category
@@ -130,6 +132,12 @@ func toFloat64(v any) float64 {
 // tmplFuncs is the shared FuncMap for all event-rendering templates.
 var tmplFuncs = template.FuncMap{
 	"humanDecision": humanReadableDecision,
+	// Coverage display helpers — let the Overview template render the
+	// matrix without reaching into the coverage package for vocabulary.
+	"covLabel": func(mode string) string {
+		return coverage.CoverageDisplayName(coverage.CoverageMode(mode))
+	},
+	"covShort": coverage.LimitationShortLabel,
 	"truncate": func(s string, n int) string {
 		if len(s) <= n {
 			return s

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -148,6 +148,84 @@ a.ov-metric:hover{background:var(--surface2)}
   </div>
 </div>
 
+<!-- Coverage matrix: per-principal, per-surface protection state. -->
+<style>
+.cov-scroll{overflow-x:auto;margin:0 -4px}
+.cov-table{width:100%;min-width:760px;border-collapse:collapse;font-size:var(--text-sm)}
+.cov-table th{text-align:left;font-weight:600;color:var(--text3);font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);padding:8px 12px;border-bottom:1px solid var(--border);white-space:nowrap}
+.cov-table td{padding:10px 12px;border-bottom:1px solid var(--border-subtle);vertical-align:top;white-space:nowrap}
+.cov-table tr:last-child td{border-bottom:none}
+.cov-principal{font-weight:600;color:var(--text);font-family:var(--mono)}
+.cov-connector{font-size:var(--text-xs);color:var(--text3)}
+.cov-badge{display:inline-block;padding:2px 8px;border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:600;letter-spacing:0.02em}
+.cov-badge.protected{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.30)}
+.cov-badge.observed{background:rgba(88,166,255,0.10);color:var(--accent);border:1px solid rgba(88,166,255,0.25)}
+.cov-badge.blind{background:transparent;color:var(--text3);border:1px solid var(--border)}
+.cov-short{display:block;font-size:var(--text-xs);color:var(--text3);margin-top:3px;line-height:1.3;cursor:help}
+.cov-identity{font-size:var(--text-xs);color:var(--text2)}
+.cov-lastseen{font-size:var(--text-xs);color:var(--text2);font-family:var(--mono)}
+.cov-empty{padding:24px;text-align:center;color:var(--text3);font-size:var(--text-sm)}
+.cov-empty a{color:var(--accent);text-decoration:none}
+.cov-empty a:hover{text-decoration:underline}
+</style>
+<div class="ov-card" style="margin-bottom:var(--sp-4)">
+  <div style="display:flex;align-items:center;gap:var(--sp-3);margin-bottom:var(--sp-3)">
+    <h3 style="margin:0">Coverage matrix</h3>
+    <span style="font-size:var(--text-xs);color:var(--text3)">Per-principal, per-surface protection state</span>
+  </div>
+  {{if .CoverageRows}}
+  <div class="cov-scroll">
+  <table class="cov-table" aria-label="Coverage matrix by principal and surface">
+    <thead>
+      <tr>
+        <th>Principal</th>
+        <th>Connector</th>
+        <th>MCP Gateway</th>
+        <th>Egress Proxy</th>
+        <th>Hooks</th>
+        <th>Identity</th>
+        <th>Last seen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .CoverageRows}}
+      <tr>
+        <td><span class="cov-principal">{{.PrincipalID}}</span></td>
+        <td><span class="cov-connector">{{.ConnectorLabel}}</span></td>
+        {{with index .Cells "mcp_http"}}
+        <td>
+          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        </td>
+        {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
+        {{with index .Cells "http_egress_proxy"}}
+        <td>
+          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        </td>
+        {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
+        {{with index .Cells "hooks"}}
+        <td>
+          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        </td>
+        {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
+        <td><span class="cov-identity">{{.IdentityList}}</span></td>
+        <td>{{if .LastSeen}}<span class="cov-lastseen" data-ts="{{.LastSeen}}">{{.LastSeen}}</span>{{else}}<span class="cov-lastseen" style="color:var(--text3)">No activity yet</span>{{end}}</td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+  </div>
+  {{else}}
+  <div class="cov-empty">
+    No principals configured yet.
+    <a href="https://oktsec.com/docs/guides/mcp-http-bearer-client/">Issue a bearer token</a>
+    to start populating the matrix.
+  </div>
+  {{end}}
+</div>
+
 <!-- Live Feed + Security Status -->
 <div class="ov-grid">
   <div class="card" style="margin-bottom:0">

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -328,12 +328,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// When the resolver established a Principal (token-authenticated or
 	// trusted_local loopback header), it overrides the payload-supplied
-	// agent name. The original ev.Agent value is preserved by normalize()
-	// and remains visible to operators via the audit reported_actor
-	// column further down — not because it grants any authority, but
-	// because it is useful display metadata.
+	// agent name. The payload value is preserved here for the audit
+	// reported_actor column further down — not because it grants any
+	// authority, but because it is useful display metadata.
+	originalPayloadAgent := ev.Agent
 	if authResult.Principal.ID != "" && authResult.Principal.ID != "unknown" {
 		ev.Agent = authResult.Principal.ID
+	}
+	// Reported actor: take the most specific display name available.
+	// Subagent type/id (when the client is running inside a sub-agent)
+	// is more specific than the surface header, which is more specific
+	// than whatever the payload supplied as agent.
+	reportedActor := authResult.ReportedActor.ID
+	if ev.AgentType != "" {
+		reportedActor = ev.AgentType
+	} else if reportedActor == "" && originalPayloadAgent != "" && originalPayloadAgent != ev.Agent {
+		reportedActor = originalPayloadAgent
 	}
 
 	start := time.Now()
@@ -445,6 +455,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AgentInstanceID:     ev.AgentID,
 		RootAgent:           rootAgent,
 		AgentDepth:          agentDepth,
+		// Identity provenance (PR coverage matrix dependency): writes
+		// the auth method / trust level / reported actor the resolver
+		// established for this hook. The coverage query upstream uses
+		// auth_method to attribute LastSeen to the hooks surface.
+		AuthMethod:          string(authResult.Principal.AuthMethod),
+		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
+		ReportedActor:       reportedActor,
 	})
 
 	// Update agent hierarchy table

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -191,6 +191,7 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	auth := authFromResolveResult(res)
 	agent := res.Principal.ID
 	if agent == "unknown" {
 		agent = ""
@@ -200,7 +201,7 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	policy := fp.resolvePolicy(agent)
 	if !policy.DomainAllowed(host) {
 		fp.logger.Warn("forward proxy: blocked CONNECT domain", "host", host, "agent", agent, "remote", r.RemoteAddr)
-		fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start)
+		fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start, auth)
 		http.Error(w, "Forbidden: domain blocked by proxy policy", http.StatusForbidden)
 		return
 	}
@@ -217,7 +218,7 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := ValidateHost(connectHost); err != nil {
 		fp.logger.Warn("forward proxy: SSRF blocked CONNECT", "host", host, "error", err)
-		fp.logProxyEntry(r.RemoteAddr, "CONNECT", host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start)
+		fp.logProxyEntry(r.RemoteAddr, "CONNECT", host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start, auth)
 		http.Error(w, "Forbidden: SSRF protection", http.StatusForbidden)
 		return
 	}
@@ -268,7 +269,7 @@ func (fp *ForwardProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Wait for either direction to finish
 	<-done
 
-	fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, "tunneled", "proxy_allowed", "", session, clientBytes+targetBytes, start)
+	fp.logProxyEntry(fp.logAgent(agent, r.RemoteAddr), "CONNECT", host, "tunneled", "proxy_allowed", "", session, clientBytes+targetBytes, start, auth)
 }
 
 // handleHTTP handles plain HTTP forward proxying with content scanning.
@@ -288,6 +289,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	auth := authFromResolveResult(res)
 	agent := res.Principal.ID
 	if agent == "unknown" {
 		agent = ""
@@ -298,7 +300,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	policy := fp.resolvePolicy(agent)
 	if !policy.DomainAllowed(host) {
 		fp.logger.Warn("forward proxy: blocked HTTP domain", "host", host, "agent", agent, "remote", r.RemoteAddr)
-		fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start)
+		fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_domain", "", session, 0, start, auth)
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "domain blocked by proxy policy"})
 		return
 	}
@@ -318,7 +320,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := ValidateHost(ssrfHost); err != nil {
 			fp.logger.Warn("forward proxy: SSRF blocked HTTP", "host", host, "error", err)
-			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_ssrf_blocked", "", session, 0, start, auth)
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": "Forbidden: SSRF protection"})
 			return
 		}
@@ -351,7 +353,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			rulesJSON := verdict.EncodeFindings(outcome.Findings)
 			fp.logger.Warn("forward proxy: blocked request content",
 				"host", host, "agent", agent, "remote", r.RemoteAddr, "findings", len(outcome.Findings))
-			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_content", rulesJSON, session, 0, start)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_content", rulesJSON, session, 0, start, auth)
 			writeJSON(w, http.StatusForbidden, map[string]string{
 				"error":  "request blocked by content scan",
 				"detail": fmt.Sprintf("%d security finding(s) detected", len(outcome.Findings)),
@@ -396,7 +398,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			rulesJSON := verdict.EncodeFindings(outcome.Findings)
 			fp.logger.Warn("forward proxy: blocked response content",
 				"host", host, "agent", agent, "remote", r.RemoteAddr, "findings", len(outcome.Findings))
-			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_response", rulesJSON, session, 0, start)
+			fp.logProxyEntry(logAgent, r.Method, host, audit.StatusBlocked, "proxy_blocked_response", rulesJSON, session, 0, start, auth)
 			writeJSON(w, http.StatusForbidden, map[string]string{
 				"error":  "response blocked by content scan",
 				"detail": fmt.Sprintf("%d security finding(s) detected", len(outcome.Findings)),
@@ -410,7 +412,7 @@ func (fp *ForwardProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(respBody)
 
-	fp.logProxyEntry(logAgent, r.Method, host, "forwarded", "proxy_allowed", "", session, int64(len(bodyBytes)+len(respBody)), start)
+	fp.logProxyEntry(logAgent, r.Method, host, "forwarded", "proxy_allowed", "", session, int64(len(bodyBytes)+len(respBody)), start, auth)
 }
 
 // resolvePolicy returns the merged egress policy for an agent.
@@ -460,19 +462,46 @@ func (fp *ForwardProxy) hasCategoryBlock(outcome *engine.ScanOutcome, policy *Re
 	return false
 }
 
-// logProxyEntry writes an audit log entry for proxy traffic.
-func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDecision, rulesTriggered, sessionID string, bytesTransferred int64, start time.Time) {
+// proxyAuth captures the identity provenance fields the audit row needs
+// from the resolver. Built once per request after resolveIdentity and
+// passed to every logProxyEntry call so the policy principal and the
+// audit row can never drift.
+type proxyAuth struct {
+	AuthMethod    string
+	TrustLevel    string
+	ReportedActor string
+}
+
+// authFromResolveResult lifts the resolver Result into the audit-friendly
+// snapshot the logProxyEntry calls expect.
+func authFromResolveResult(res resolve.Result) proxyAuth {
+	return proxyAuth{
+		AuthMethod:    string(res.Principal.AuthMethod),
+		TrustLevel:    string(res.Principal.TrustLevel),
+		ReportedActor: res.ReportedActor.ID,
+	}
+}
+
+// logProxyEntry writes an audit log entry for proxy traffic. The auth
+// snapshot threads identity provenance (auth_method,
+// principal_trust_level, reported_actor) through to the audit row so
+// downstream coverage / dashboard queries can attribute activity to the
+// egress surface without heuristics.
+func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDecision, rulesTriggered, sessionID string, bytesTransferred int64, start time.Time, auth proxyAuth) {
 	entry := audit.Entry{
-		ID:             uuid.New().String(),
-		Timestamp:      time.Now().UTC().Format(time.RFC3339),
-		FromAgent:      remoteAddr,
-		ToAgent:        host,
-		ContentHash:    fmt.Sprintf("%s:%d", method, bytesTransferred),
-		Status:         status,
-		PolicyDecision: policyDecision,
-		RulesTriggered: rulesTriggered,
-		SessionID:      sessionID,
-		LatencyMs:      time.Since(start).Milliseconds(),
+		ID:                  uuid.New().String(),
+		Timestamp:           time.Now().UTC().Format(time.RFC3339),
+		FromAgent:           remoteAddr,
+		ToAgent:             host,
+		ContentHash:         fmt.Sprintf("%s:%d", method, bytesTransferred),
+		Status:              status,
+		PolicyDecision:      policyDecision,
+		RulesTriggered:      rulesTriggered,
+		SessionID:           sessionID,
+		LatencyMs:           time.Since(start).Milliseconds(),
+		AuthMethod:          auth.AuthMethod,
+		PrincipalTrustLevel: auth.TrustLevel,
+		ReportedActor:       auth.ReportedActor,
 	}
 	fp.audit.Log(entry)
 }


### PR DESCRIPTION
## Summary

The dashboard Overview now answers the question every operator and prospective customer asks: which principals are protected, which are observed only, and which are blind across the MCP gateway, the egress proxy, and the hooks endpoint.

This is Phase 2A of the surface-agnostic runtime architecture. The matrix is derived from the identity model shipped in Phase 1 (principals, tokens, per-surface auth) plus the audit trail. No graph v2, no normalized activity model, no new dashboard pages — the matrix lives directly under Pipeline Health where it is the first thing visible after login.

## What this enables

- Operators see at a glance whether the principals they configured are reachable on each surface and how that identity was established.
- Limitations like "Loopback only", "Pre-action only", or "Domain only" appear as small tags so the table reads as truth, not as a sales claim.
- New deployments start with an empty-state CTA pointing to the bearer-token guide instead of a confusing blank.

## What changed

### `internal/coverage` (new)

- `Compute(cfg, AuditReader)` returns a flat slice of `CoverageCell` (one per principal × surface). `AuthMethod` and `TrustLevel` are separate fields from `Coverage`, so `trusted_local` is never read as "Protected".
- Connector id is inferred from active token types. Expired or revoked tokens never contribute, so a stale `gateway_bearer` cannot make a principal look multi-surface.
- `AuditReader` interface keeps `Compute` testable without a real store.
- `display.go` humanizes connector ids, auth methods, coverage labels, and folds full limitation sentences into short inline tags.

### `internal/audit`

- New `LastSeenByPrincipalSurface(principalID, surface)` on `*audit.Store`. Maps surface to authenticated `auth_method` values and returns `MAX(timestamp)`. Conservative: anonymous rows never count for a configured principal even if `from_agent` matches.
- Same method added to the `AuditQuerier` interface so the dashboard can consume it without a type assertion.

### `internal/proxy/forward.go` and `internal/hooks/handler.go`

- Both surfaces now write `auth_method`, `principal_trust_level`, and `reported_actor` on every audit row so the LastSeen attribution above has the data it needs.
- `proxyAuth` snapshot threads identity provenance through every `logProxyEntry` call site (8 in total).

### Dashboard

- `GET /dashboard/api/coverage` returns the matrix as JSON (for tooling and tests).
- Overview Coverage section under Pipeline Health: horizontal-scroll wrapper with `min-width: 760px` so Identity and Last seen never get cut off; Title-case badges (Protected, Observed only, Blind); humanized connector and identity labels; short inline limitation tags with the full text on hover; empty-state CTA with a link to the bearer-token guide.

## Tests

| Package | Count | Coverage |
|---|---|---|
| `internal/coverage` | 11 | bearer/proxy/hook protected per surface, loopback observed, disabled surface blind, hooks unauth local-vs-enterprise, multi-surface principal, revoked token, expired token does not infer connector, LastSeen per surface |
| `internal/audit` | 7 | gateway/egress/hooks attribution, anonymous rows excluded, trusted_loopback only for gateway/egress, MAX timestamp, unknown surface, empty principal |
| `internal/dashboard` | 3 | coverage API JSON shape, Overview renders matrix with right badges and humanized labels, empty-state CTA |

Suite, lint, vet stay green. Smoke verified end-to-end: `oktsec tokens create` for a principal, `oktsec serve`, dashboard Overview shows the row with the right Protected / Observed only / Blind cells and the right Identity column.

## Not included

- Activity model and connector registry as a config-driven catalog (Phase 2B).
- Graph v2 (Phase 3).
- Coverage drill-down page at `/dashboard/coverage` (Phase 2B if the demo response calls for it).