### PR TITLE
Add activity event foundation (Phase 2B.1 PR1)

### DIFF
--- a/internal/activity/migrate.go
+++ b/internal/activity/migrate.go
@@ -1,0 +1,166 @@
+package activity
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// schemaSQLite is the CREATE TABLE used when the activity store runs on
+// SQLite. The table sits beside audit_log in the same database file so
+// migrations and DSN are shared with the audit store; activity is a
+// peer table, not a peer database.
+//
+// Indexes mirror the queries the dashboard runs:
+//   - timestamp        for time-window scans
+//   - principal+surface+timestamp  for last-seen and drill-down
+//   - connector+timestamp          for per-connector views
+//   - workspace+timestamp          for workspace activity pages (Phase 2B+)
+//   - session+timestamp            for trace timelines
+//   - resource_hash+timestamp      for "who else touched this resource"
+const schemaSQLite = `
+CREATE TABLE IF NOT EXISTS activity_events (
+    id TEXT PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    org_id TEXT DEFAULT '',
+    host_id TEXT DEFAULT '',
+    workspace_id TEXT DEFAULT '',
+
+    principal_id TEXT NOT NULL,
+    reported_actor TEXT DEFAULT '',
+    auth_method TEXT DEFAULT '',
+    principal_trust_level TEXT DEFAULT '',
+
+    connector_id TEXT DEFAULT '',
+    client_id TEXT DEFAULT '',
+    surface TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    evidence_type TEXT NOT NULL,
+
+    session_id TEXT DEFAULT '',
+    request_id TEXT DEFAULT '',
+    audit_entry_id TEXT DEFAULT '',
+    decision_trace_id TEXT DEFAULT '',
+
+    status TEXT DEFAULT '',
+    policy_decision TEXT DEFAULT '',
+    coverage_mode TEXT NOT NULL,
+    confidence INTEGER DEFAULT 0,
+
+    resource_type TEXT DEFAULT '',
+    resource_id TEXT DEFAULT '',
+    resource_hash TEXT DEFAULT '',
+    resource_label TEXT DEFAULT '',
+
+    evidence_json TEXT DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_events_time
+    ON activity_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_principal_surface_time
+    ON activity_events(principal_id, surface, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_connector_time
+    ON activity_events(connector_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_workspace_time
+    ON activity_events(workspace_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_session_time
+    ON activity_events(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_resource_time
+    ON activity_events(resource_hash, timestamp);
+`
+
+// schemaPostgres mirrors schemaSQLite using TEXT/INTEGER (Postgres
+// accepts both with the same semantics we use here). DEFAULT is set on
+// every nullable column so older code paths can omit fields without
+// breaking the insert.
+const schemaPostgres = `
+CREATE TABLE IF NOT EXISTS activity_events (
+    id TEXT PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    org_id TEXT DEFAULT '',
+    host_id TEXT DEFAULT '',
+    workspace_id TEXT DEFAULT '',
+
+    principal_id TEXT NOT NULL,
+    reported_actor TEXT DEFAULT '',
+    auth_method TEXT DEFAULT '',
+    principal_trust_level TEXT DEFAULT '',
+
+    connector_id TEXT DEFAULT '',
+    client_id TEXT DEFAULT '',
+    surface TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    evidence_type TEXT NOT NULL,
+
+    session_id TEXT DEFAULT '',
+    request_id TEXT DEFAULT '',
+    audit_entry_id TEXT DEFAULT '',
+    decision_trace_id TEXT DEFAULT '',
+
+    status TEXT DEFAULT '',
+    policy_decision TEXT DEFAULT '',
+    coverage_mode TEXT NOT NULL,
+    confidence INTEGER DEFAULT 0,
+
+    resource_type TEXT DEFAULT '',
+    resource_id TEXT DEFAULT '',
+    resource_hash TEXT DEFAULT '',
+    resource_label TEXT DEFAULT '',
+
+    evidence_json TEXT DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_events_time
+    ON activity_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_principal_surface_time
+    ON activity_events(principal_id, surface, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_connector_time
+    ON activity_events(connector_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_workspace_time
+    ON activity_events(workspace_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_session_time
+    ON activity_events(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_activity_events_resource_time
+    ON activity_events(resource_hash, timestamp);
+`
+
+// Dialect names the SQL flavor the Store should target. Surface adapters
+// in PR2+ will pass the same dialect their audit store uses, so audit
+// and activity tables live in one DB file with consistent placeholder
+// syntax.
+type Dialect string
+
+const (
+	DialectSQLite   Dialect = "sqlite"
+	DialectPostgres Dialect = "postgres"
+)
+
+// Migrate creates the activity_events table and its indexes. Safe to
+// call repeatedly: every CREATE uses IF NOT EXISTS so a process restart
+// or a parallel migration never errors.
+func Migrate(db *sql.DB, d Dialect) error {
+	var schema string
+	switch d {
+	case DialectPostgres:
+		schema = schemaPostgres
+	case DialectSQLite, "":
+		schema = schemaSQLite
+	default:
+		return fmt.Errorf("activity: unknown dialect %q", d)
+	}
+	if _, err := db.Exec(schema); err != nil {
+		return fmt.Errorf("activity: migrate: %w", err)
+	}
+	return nil
+}
+
+// placeholder returns the right SQL placeholder for the dialect at
+// position n (1-based). SQLite accepts both "?" and "$N"; we use "?"
+// for SQLite and "$N" for Postgres to match the audit store's style.
+func placeholder(d Dialect, n int) string {
+	if d == DialectPostgres {
+		return fmt.Sprintf("$%d", n)
+	}
+	return "?"
+}

--- a/internal/activity/store.go
+++ b/internal/activity/store.go
@@ -1,0 +1,288 @@
+package activity
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Store is the persistence layer for activity events. Implementations
+// must be safe for concurrent use; SQLStore is the production
+// implementation backed by the same DB handle as audit.Store.
+//
+// Insert is on the request hot path. Implementations must:
+//   - validate required fields and reject malformed events;
+//   - never block on aggregate queries;
+//   - never panic on a malformed evidence blob — bad rows return errors
+//     so the caller can log and continue without crashing the surface.
+//
+// Query and ListByCoverageCell are dashboard-side and may do bounded
+// I/O; both honor DefaultQueryLimit / MaxQueryLimit so a forgotten
+// limit cannot exhaust resources.
+type Store interface {
+	Insert(ctx context.Context, e Event) error
+	Query(ctx context.Context, q Query) ([]Event, error)
+	LastSeenByPrincipalSurface(ctx context.Context, principalID, surface string) (string, error)
+	ListByCoverageCell(ctx context.Context, principalID, surface string, limit int) ([]Event, error)
+}
+
+// ErrInvalidEvent is returned by Insert when required fields are
+// missing, EvidenceJSON is too large, or coverage_mode is unknown.
+// Callers treat this as "drop the event, log a warning" — never as
+// "fail the request".
+var ErrInvalidEvent = errors.New("activity: invalid event")
+
+// SQLStore is the database-backed Store. It accepts the same *sql.DB
+// the audit store uses so activity_events lives beside audit_log
+// without a second DSN or migration tool.
+type SQLStore struct {
+	db      *sql.DB
+	dialect Dialect
+}
+
+// NewSQLStore wraps a database handle. The caller is responsible for
+// running Migrate before issuing inserts; failing to do so will surface
+// a "no such table" error on the first Insert.
+func NewSQLStore(db *sql.DB, d Dialect) *SQLStore {
+	if d == "" {
+		d = DialectSQLite
+	}
+	return &SQLStore{db: db, dialect: d}
+}
+
+// validate enforces the invariants that callers must respect. Each
+// failure returns a wrapped ErrInvalidEvent so callers can decide
+// whether to log or alert.
+func validate(e Event) error {
+	switch {
+	case e.PrincipalID == "":
+		return fmt.Errorf("%w: principal_id required", ErrInvalidEvent)
+	case e.Surface == "":
+		return fmt.Errorf("%w: surface required", ErrInvalidEvent)
+	case e.EventType == "":
+		return fmt.Errorf("%w: event_type required", ErrInvalidEvent)
+	case e.EvidenceType == "":
+		return fmt.Errorf("%w: evidence_type required", ErrInvalidEvent)
+	case e.CoverageMode == "":
+		return fmt.Errorf("%w: coverage_mode required", ErrInvalidEvent)
+	}
+	switch e.CoverageMode {
+	case CoverageProtected, CoverageObserved, CoverageBlind:
+	default:
+		return fmt.Errorf("%w: unknown coverage_mode %q", ErrInvalidEvent, e.CoverageMode)
+	}
+	if len(e.EvidenceJSON) > MaxEvidenceJSONBytes {
+		return fmt.Errorf("%w: evidence_json exceeds %d bytes (got %d)",
+			ErrInvalidEvent, MaxEvidenceJSONBytes, len(e.EvidenceJSON))
+	}
+	return nil
+}
+
+// Insert persists one event. Required fields are validated; missing or
+// malformed events return ErrInvalidEvent without touching the DB so a
+// misbehaving adapter cannot fill the table with garbage rows.
+func (s *SQLStore) Insert(ctx context.Context, e Event) error {
+	if err := validate(e); err != nil {
+		return err
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now().UTC()
+	}
+	if e.EvidenceJSON == "" {
+		e.EvidenceJSON = "{}"
+	}
+	q := `INSERT INTO activity_events (
+        id, timestamp, org_id, host_id, workspace_id,
+        principal_id, reported_actor, auth_method, principal_trust_level,
+        connector_id, client_id, surface, event_type, evidence_type,
+        session_id, request_id, audit_entry_id, decision_trace_id,
+        status, policy_decision, coverage_mode, confidence,
+        resource_type, resource_id, resource_hash, resource_label,
+        evidence_json, created_at
+    ) VALUES (` + insertPlaceholders(s.dialect, 28) + `)`
+	_, err := s.db.ExecContext(ctx, q,
+		e.ID, e.Timestamp.UTC().Format(time.RFC3339Nano), e.OrgID, e.HostID, e.WorkspaceID,
+		e.PrincipalID, e.ReportedActor, e.AuthMethod, e.PrincipalTrustLevel,
+		e.ConnectorID, e.ClientID, string(e.Surface), string(e.EventType), string(e.EvidenceType),
+		e.SessionID, e.RequestID, e.AuditEntryID, e.DecisionTraceID,
+		e.Status, e.PolicyDecision, string(e.CoverageMode), e.Confidence,
+		e.ResourceType, e.ResourceID, e.ResourceHash, e.ResourceLabel,
+		e.EvidenceJSON, e.CreatedAt.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("activity: insert: %w", err)
+	}
+	return nil
+}
+
+// selectColumns is the canonical SELECT list. Centralized so Query and
+// ListByCoverageCell scan into the same field order.
+const selectColumns = `id, timestamp, org_id, host_id, workspace_id,
+    principal_id, reported_actor, auth_method, principal_trust_level,
+    connector_id, client_id, surface, event_type, evidence_type,
+    session_id, request_id, audit_entry_id, decision_trace_id,
+    status, policy_decision, coverage_mode, confidence,
+    resource_type, resource_id, resource_hash, resource_label,
+    evidence_json, created_at`
+
+// Query returns events matching q, applying the bounded limit policy.
+// Time bounds are inclusive when set; zero time values are ignored.
+func (s *SQLStore) Query(ctx context.Context, q Query) ([]Event, error) {
+	limit := boundLimit(q.Limit)
+	where, args := buildWhere(s.dialect, q)
+	sqlStr := "SELECT " + selectColumns + " FROM activity_events" + where +
+		" ORDER BY timestamp DESC LIMIT " + fmt.Sprintf("%d", limit)
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, fmt.Errorf("activity: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// LastSeenByPrincipalSurface returns the most recent event timestamp
+// (RFC3339) for the (principal, surface) pair. Returns "" without an
+// error when nothing matches — that maps to "No activity recorded" in
+// the dashboard rather than a noisy log line.
+func (s *SQLStore) LastSeenByPrincipalSurface(ctx context.Context, principalID, surface string) (string, error) {
+	if principalID == "" || surface == "" {
+		return "", nil
+	}
+	q := "SELECT MAX(timestamp) FROM activity_events WHERE principal_id = " +
+		placeholder(s.dialect, 1) + " AND surface = " + placeholder(s.dialect, 2)
+	var ts sql.NullString
+	if err := s.db.QueryRowContext(ctx, q, principalID, surface).Scan(&ts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("activity: last seen: %w", err)
+	}
+	return ts.String, nil
+}
+
+// ListByCoverageCell powers the dashboard drill-down: the most recent
+// `limit` events for one (principal, surface) cell, newest first.
+// Caller-supplied limit is bounded by MaxQueryLimit.
+func (s *SQLStore) ListByCoverageCell(ctx context.Context, principalID, surface string, limit int) ([]Event, error) {
+	if principalID == "" || surface == "" {
+		return nil, nil
+	}
+	limit = boundLimit(limit)
+	q := "SELECT " + selectColumns + " FROM activity_events" +
+		" WHERE principal_id = " + placeholder(s.dialect, 1) +
+		" AND surface = " + placeholder(s.dialect, 2) +
+		" ORDER BY timestamp DESC LIMIT " + fmt.Sprintf("%d", limit)
+	rows, err := s.db.QueryContext(ctx, q, principalID, surface)
+	if err != nil {
+		return nil, fmt.Errorf("activity: list by cell: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanEvents(rows)
+}
+
+// boundLimit applies the public bounds: zero/negative inputs become the
+// default; oversized inputs are capped to the maximum. No errors —
+// silently bounding is friendlier than a 500 for a typo'd limit.
+func boundLimit(n int) int {
+	if n <= 0 {
+		return DefaultQueryLimit
+	}
+	if n > MaxQueryLimit {
+		return MaxQueryLimit
+	}
+	return n
+}
+
+// buildWhere assembles the WHERE clause for Query. Returns the SQL
+// fragment (with leading " WHERE " or "" if no filters) and its
+// argument list, in placeholder-position order.
+func buildWhere(d Dialect, q Query) (string, []any) {
+	var clauses []string
+	var args []any
+	add := func(col string, val string) {
+		if val == "" {
+			return
+		}
+		clauses = append(clauses, col+" = "+placeholder(d, len(args)+1))
+		args = append(args, val)
+	}
+	add("principal_id", q.PrincipalID)
+	add("surface", q.Surface)
+	add("connector_id", q.ConnectorID)
+	add("workspace_id", q.WorkspaceID)
+	add("session_id", q.SessionID)
+	add("coverage_mode", q.Coverage)
+	if !q.Since.IsZero() {
+		clauses = append(clauses, "timestamp >= "+placeholder(d, len(args)+1))
+		args = append(args, q.Since.UTC().Format(time.RFC3339Nano))
+	}
+	if !q.Until.IsZero() {
+		clauses = append(clauses, "timestamp <= "+placeholder(d, len(args)+1))
+		args = append(args, q.Until.UTC().Format(time.RFC3339Nano))
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// insertPlaceholders builds "?, ?, ..., ?" (SQLite) or "$1, $2, ..., $N"
+// (Postgres) for an INSERT ... VALUES clause with n columns.
+func insertPlaceholders(d Dialect, n int) string {
+	parts := make([]string, n)
+	for i := 0; i < n; i++ {
+		parts[i] = placeholder(d, i+1)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// scanEvents reads a *sql.Rows into a []Event using the canonical
+// column order. Scan failures abort the whole batch rather than
+// returning partial results — partial rows are worse than none.
+func scanEvents(rows *sql.Rows) ([]Event, error) {
+	var out []Event
+	for rows.Next() {
+		var e Event
+		var ts, createdAt string
+		var surface, eventType, evidenceType, coverageMode string
+		if err := rows.Scan(
+			&e.ID, &ts, &e.OrgID, &e.HostID, &e.WorkspaceID,
+			&e.PrincipalID, &e.ReportedActor, &e.AuthMethod, &e.PrincipalTrustLevel,
+			&e.ConnectorID, &e.ClientID, &surface, &eventType, &evidenceType,
+			&e.SessionID, &e.RequestID, &e.AuditEntryID, &e.DecisionTraceID,
+			&e.Status, &e.PolicyDecision, &coverageMode, &e.Confidence,
+			&e.ResourceType, &e.ResourceID, &e.ResourceHash, &e.ResourceLabel,
+			&e.EvidenceJSON, &createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("activity: scan: %w", err)
+		}
+		// Timestamp parsing is lenient: accept both RFC3339 and the
+		// nanosecond variant we write so a row inserted by an older
+		// release can still be read.
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			e.Timestamp = t
+		} else if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			e.Timestamp = t
+		}
+		if t, err := time.Parse(time.RFC3339Nano, createdAt); err == nil {
+			e.CreatedAt = t
+		} else if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
+			e.CreatedAt = t
+		}
+		e.Surface = Surface(surface)
+		e.EventType = EventType(eventType)
+		e.EvidenceType = EvidenceType(evidenceType)
+		e.CoverageMode = CoverageMode(coverageMode)
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("activity: rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/activity/store_test.go
+++ b/internal/activity/store_test.go
@@ -1,0 +1,341 @@
+package activity
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestStore opens an isolated SQLite database under t.TempDir, runs
+// the activity migration, and returns the store. Each test gets its
+// own file so they do not contend.
+func newTestStore(t *testing.T) *SQLStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "activity.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := Migrate(db, DialectSQLite); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewSQLStore(db, DialectSQLite)
+}
+
+// validEvent returns the smallest Event that satisfies validate(). Tests
+// override fields they care about and rely on the helper for the rest
+// so a future required-field addition only updates one place.
+func validEvent(id string) Event {
+	return Event{
+		ID:           id,
+		Timestamp:    time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC),
+		PrincipalID:  "local-codex",
+		Surface:      SurfaceMCPHTTP,
+		EventType:    EventMCPToolCall,
+		EvidenceType: EvidenceGateway,
+		CoverageMode: CoverageProtected,
+		Confidence:   100,
+	}
+}
+
+// 1. Insert + Query round-trips every field. This is the basic
+// regression guard: if any column drops out of the INSERT/SELECT
+// alignment, the round-trip fails with a missing or shifted value.
+func TestSQLStore_InsertQueryRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	in := validEvent("evt-1")
+	in.OrgID = "acme"
+	in.HostID = "laptop-7"
+	in.WorkspaceID = "repo-x"
+	in.ReportedActor = "review-subagent"
+	in.AuthMethod = "bearer_token"
+	in.PrincipalTrustLevel = "authenticated"
+	in.ConnectorID = "generic-mcp-http"
+	in.ClientID = "claude-code-1"
+	in.SessionID = "s1"
+	in.RequestID = "r1"
+	in.AuditEntryID = "audit-99"
+	in.DecisionTraceID = "trace-99"
+	in.Status = "allow"
+	in.PolicyDecision = "ok"
+	in.ResourceType = "mcp_tool"
+	in.ResourceID = "files/read_file"
+	in.ResourceHash = "sha256:abc"
+	in.ResourceLabel = "filesystem.read_file"
+	in.EvidenceJSON = `{"k":"v"}`
+	in.CreatedAt = time.Date(2026, 4, 26, 10, 0, 5, 0, time.UTC)
+
+	if err := store.Insert(ctx, in); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	got, err := store.Query(ctx, Query{PrincipalID: "local-codex"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	out := got[0]
+	if out.ID != "evt-1" || out.PrincipalID != "local-codex" {
+		t.Errorf("identity round-trip wrong: %+v", out)
+	}
+	if out.Surface != SurfaceMCPHTTP || out.EventType != EventMCPToolCall ||
+		out.EvidenceType != EvidenceGateway || out.CoverageMode != CoverageProtected {
+		t.Errorf("typed columns lost in round-trip: %+v", out)
+	}
+	if out.OrgID != "acme" || out.HostID != "laptop-7" || out.WorkspaceID != "repo-x" {
+		t.Errorf("deployment context lost: %+v", out)
+	}
+	if out.ResourceLabel != "filesystem.read_file" || out.EvidenceJSON != `{"k":"v"}` {
+		t.Errorf("resource fields lost: %+v", out)
+	}
+	if !out.Timestamp.Equal(in.Timestamp) {
+		t.Errorf("timestamp lost: got %s want %s", out.Timestamp, in.Timestamp)
+	}
+}
+
+// 2. Required-field validation rejects malformed events without
+// touching the DB. A misbehaving adapter (PR2/3) cannot fill the table
+// with rows that have no principal or no surface.
+func TestSQLStore_InsertRejectsMissingRequired(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		mut   func(*Event)
+		field string
+	}{
+		{"no_principal", func(e *Event) { e.PrincipalID = "" }, "principal_id"},
+		{"no_surface", func(e *Event) { e.Surface = "" }, "surface"},
+		{"no_event_type", func(e *Event) { e.EventType = "" }, "event_type"},
+		{"no_evidence_type", func(e *Event) { e.EvidenceType = "" }, "evidence_type"},
+		{"no_coverage", func(e *Event) { e.CoverageMode = "" }, "coverage_mode"},
+		{"unknown_coverage", func(e *Event) { e.CoverageMode = "made-up" }, "unknown coverage_mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := validEvent("evt-" + tc.name)
+			tc.mut(&ev)
+			err := store.Insert(ctx, ev)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ErrInvalidEvent) {
+				t.Errorf("error = %v; want wrapped ErrInvalidEvent", err)
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error message %q should mention %q", err.Error(), tc.field)
+			}
+		})
+	}
+}
+
+// 3. EvidenceJSON is bounded at insert. A malicious or buggy adapter
+// cannot persist multi-MB blobs that would bloat the index.
+func TestSQLStore_InsertRejectsOversizedEvidence(t *testing.T) {
+	store := newTestStore(t)
+	ev := validEvent("evt-big")
+	ev.EvidenceJSON = strings.Repeat("x", MaxEvidenceJSONBytes+1)
+	err := store.Insert(context.Background(), ev)
+	if err == nil {
+		t.Fatal("oversized evidence should be rejected")
+	}
+	if !errors.Is(err, ErrInvalidEvent) {
+		t.Errorf("error = %v; want wrapped ErrInvalidEvent", err)
+	}
+}
+
+// 4. Query filters compose: principal + surface returns only the
+// matching subset, even when other surfaces share the same principal.
+func TestSQLStore_QueryFiltersComposeAcrossPrincipalAndSurface(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	a := validEvent("a")
+	a.Surface = SurfaceMCPHTTP
+	b := validEvent("b")
+	b.Surface = SurfaceHTTPEgressProxy
+	b.EventType = EventEgressRequest
+	c := validEvent("c")
+	c.PrincipalID = "researcher"
+	c.Surface = SurfaceMCPHTTP
+	for _, e := range []Event{a, b, c} {
+		if err := store.Insert(ctx, e); err != nil {
+			t.Fatalf("insert %s: %v", e.ID, err)
+		}
+	}
+
+	got, err := store.Query(ctx, Query{
+		PrincipalID: "local-codex",
+		Surface:     string(SurfaceMCPHTTP),
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Errorf("filter result = %+v; want only event a", ids(got))
+	}
+}
+
+// 5. Query Limit is bounded: zero or negative inputs default; oversized
+// inputs are capped. Forgetting to set Limit cannot accidentally page
+// through the entire table.
+func TestSQLStore_QueryLimitBounded(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert MaxQueryLimit+50 events so the cap is observable.
+	total := MaxQueryLimit + 50
+	for i := 0; i < total; i++ {
+		ev := validEvent("evt-" + intToStr(i))
+		ev.Timestamp = time.Date(2026, 4, 26, 10, 0, i, 0, time.UTC)
+		if err := store.Insert(ctx, ev); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	zero, _ := store.Query(ctx, Query{PrincipalID: "local-codex"})
+	if len(zero) != DefaultQueryLimit {
+		t.Errorf("zero limit returned %d; want default %d", len(zero), DefaultQueryLimit)
+	}
+	too, _ := store.Query(ctx, Query{PrincipalID: "local-codex", Limit: total + 1000})
+	if len(too) != MaxQueryLimit {
+		t.Errorf("oversized limit returned %d; want capped to %d", len(too), MaxQueryLimit)
+	}
+}
+
+// 6. LastSeenByPrincipalSurface returns the most recent timestamp for
+// the requested pair, and "" without an error when nothing matches.
+// Empty inputs short-circuit so callers can iterate hardcoded surface
+// lists without crashing on an unset id.
+func TestSQLStore_LastSeenByPrincipalSurface(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	older := validEvent("old")
+	older.Timestamp = time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	newer := validEvent("new")
+	newer.Timestamp = time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+	other := validEvent("other-surface")
+	other.Surface = SurfaceHTTPEgressProxy
+	other.EventType = EventEgressRequest
+	other.Timestamp = time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	for _, e := range []Event{older, newer, other} {
+		_ = store.Insert(ctx, e)
+	}
+
+	got, err := store.LastSeenByPrincipalSurface(ctx, "local-codex", string(SurfaceMCPHTTP))
+	if err != nil {
+		t.Fatalf("last seen: %v", err)
+	}
+	if !strings.HasPrefix(got, "2026-04-26T10:00:00") {
+		t.Errorf("mcp_http last seen = %q; want the newer event timestamp", got)
+	}
+
+	miss, err := store.LastSeenByPrincipalSurface(ctx, "ghost", string(SurfaceMCPHTTP))
+	if err != nil || miss != "" {
+		t.Errorf("missing principal should be empty/no-error; got %q, %v", miss, err)
+	}
+	empty, err := store.LastSeenByPrincipalSurface(ctx, "", string(SurfaceMCPHTTP))
+	if err != nil || empty != "" {
+		t.Errorf("empty principal should be empty/no-error; got %q, %v", empty, err)
+	}
+}
+
+// 7. ListByCoverageCell returns the most recent N events for a
+// (principal, surface) pair, newest first. Powers the dashboard
+// drill-down in PR5.
+func TestSQLStore_ListByCoverageCell(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		ev := validEvent("evt-" + intToStr(i))
+		ev.Timestamp = time.Date(2026, 4, 26, 10, i, 0, 0, time.UTC)
+		_ = store.Insert(ctx, ev)
+	}
+	got, err := store.ListByCoverageCell(ctx, "local-codex", string(SurfaceMCPHTTP), 3)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d; want 3", len(got))
+	}
+	// Newest first: timestamps must be strictly descending.
+	for i := 1; i < len(got); i++ {
+		if !got[i-1].Timestamp.After(got[i].Timestamp) {
+			t.Errorf("ordering broken at %d: %s vs %s", i, got[i-1].Timestamp, got[i].Timestamp)
+		}
+	}
+}
+
+// 8. Migrate is idempotent: calling it twice is a no-op and does not
+// drop or duplicate the table. Surface adapters can call it on every
+// startup without coordination.
+func TestMigrate_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "activity.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := Migrate(db, DialectSQLite); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := Migrate(db, DialectSQLite); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	store := NewSQLStore(db, DialectSQLite)
+	if err := store.Insert(context.Background(), validEvent("evt-1")); err != nil {
+		t.Errorf("insert after double-migrate failed: %v", err)
+	}
+}
+
+// 9. Unknown dialect is rejected at migrate time so a typo in
+// configuration cannot create a half-functional store.
+func TestMigrate_UnknownDialect(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "activity.db")
+	db, _ := sql.Open("sqlite", dbPath)
+	defer func() { _ = db.Close() }()
+	if err := Migrate(db, "mariadb"); err == nil {
+		t.Error("expected error for unknown dialect")
+	}
+}
+
+// helpers ---------------------------------------------------------------
+
+func ids(es []Event) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.ID
+	}
+	return out
+}
+
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}

--- a/internal/activity/types.go
+++ b/internal/activity/types.go
@@ -1,0 +1,156 @@
+// Package activity stores normalized runtime evidence for the dashboard
+// coverage matrix and (later) the activity graph. It sits beside the
+// tamper-evident audit log: audit remains the compliance trail, activity
+// is the product/analytics substrate.
+//
+// Surface adapters (gateway, forward proxy, hooks) write one Event per
+// observed interaction after the security decision has been made and the
+// audit row exists. The Store API never appears in the policy hot path —
+// callers must treat write failures as "drop the activity row, keep the
+// security decision" so an activity outage cannot deny service.
+package activity
+
+import "time"
+
+// Surface identifies the technical boundary that produced an event.
+// String values match coverage.Surface and resolve.Surface so callers
+// can compare across packages without an import cycle.
+type Surface string
+
+const (
+	SurfaceMCPHTTP         Surface = "mcp_http"
+	SurfaceHTTPEgressProxy Surface = "http_egress_proxy"
+	SurfaceHooks           Surface = "hooks"
+)
+
+// CoverageMode is what the dashboard claims for a single observed
+// event. The aggregated per-(principal, surface) coverage cell is
+// derived from these — consistent vocabulary across the two layers.
+type CoverageMode string
+
+const (
+	CoverageProtected CoverageMode = "protected"
+	CoverageObserved  CoverageMode = "observed"
+	CoverageBlind     CoverageMode = "blind"
+)
+
+// EventType is the operation an event represents. Kept narrow on
+// purpose; new event types should be added consciously rather than
+// allowing free-form strings.
+type EventType string
+
+const (
+	EventMCPToolCall   EventType = "mcp.tool_call"
+	EventEgressRequest EventType = "egress.request"
+	EventHookEvent     EventType = "hook.event"
+)
+
+// EvidenceType records which surface adapter wrote the event. Matches
+// the surface 1:1 today but kept separate so a later release can ingest
+// observed-only telemetry from log adapters without conflating it with
+// gateway-protected evidence.
+type EvidenceType string
+
+const (
+	EvidenceGateway EvidenceType = "gateway"
+	EvidenceProxy   EvidenceType = "proxy"
+	EvidenceHook    EvidenceType = "hook"
+)
+
+// Event is one normalized activity record. Field semantics are
+// documented in the Phase 2B.1 spec; the short version:
+//
+//   - PrincipalID is the policy identity (token-authenticated, trusted
+//     local, or "unknown" only where the surface accepts unauthenticated
+//     local telemetry). Never populated from reported actor alone.
+//   - ReportedActor is display/correlation metadata; never overrides the
+//     principal for any policy or coverage decision.
+//   - Resource* describe the target (tool, domain, hook event). Labels
+//     are humanized and redacted by the writer; raw secrets and full
+//     sensitive URLs are not persisted.
+//   - EvidenceJSON is a small bounded blob for surface-specific metadata.
+//     The writer is responsible for redaction; the store enforces a size cap.
+//
+// Confidence is a hint for the dashboard, not a policy input:
+//
+//	100  token-authenticated direct surface evidence
+//	 80  trusted local loopback evidence
+//	 60  authenticated hook post-action evidence
+//	 40  unauthenticated local observed telemetry
+//	0-20 unknown or malformed evidence kept for diagnostics
+type Event struct {
+	ID        string    `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+
+	// Deployment context. Empty values are valid in local mode.
+	OrgID       string `json:"org_id,omitempty"`
+	HostID      string `json:"host_id,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+
+	// Identity provenance.
+	PrincipalID         string `json:"principal_id"`
+	ReportedActor       string `json:"reported_actor,omitempty"`
+	AuthMethod          string `json:"auth_method,omitempty"`
+	PrincipalTrustLevel string `json:"principal_trust_level,omitempty"`
+
+	// Connector and surface.
+	ConnectorID  string       `json:"connector_id,omitempty"`
+	ClientID     string       `json:"client_id,omitempty"`
+	Surface      Surface      `json:"surface"`
+	EventType    EventType    `json:"event_type"`
+	EvidenceType EvidenceType `json:"evidence_type"`
+
+	// Session / correlation.
+	SessionID       string `json:"session_id,omitempty"`
+	RequestID       string `json:"request_id,omitempty"`
+	AuditEntryID    string `json:"audit_entry_id,omitempty"`
+	DecisionTraceID string `json:"decision_trace_id,omitempty"`
+
+	// Security outcome.
+	Status         string       `json:"status,omitempty"`
+	PolicyDecision string       `json:"policy_decision,omitempty"`
+	CoverageMode   CoverageMode `json:"coverage_mode"`
+	Confidence     int          `json:"confidence"`
+
+	// Resource. ResourceLabel is humanized + redacted by the writer.
+	ResourceType  string `json:"resource_type,omitempty"`
+	ResourceID    string `json:"resource_id,omitempty"`
+	ResourceHash  string `json:"resource_hash,omitempty"`
+	ResourceLabel string `json:"resource_label,omitempty"`
+
+	// EvidenceJSON is a bounded, redacted blob the surface adapter owns.
+	// The store enforces a size cap (see store.go) but does not parse it.
+	EvidenceJSON string `json:"evidence_json,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Query filters Store.Query. Zero-valued fields are ignored.
+//
+// Limit defaults to DefaultQueryLimit and is capped at MaxQueryLimit so
+// no caller can ask for an unbounded result set — even a forgotten limit
+// will not exhaust memory or DB resources.
+type Query struct {
+	PrincipalID string
+	Surface     string
+	ConnectorID string
+	WorkspaceID string
+	SessionID   string
+	Coverage    string
+	Since       time.Time
+	Until       time.Time
+	Limit       int
+}
+
+// Bounds enforced by the Store implementation on every Query.
+const (
+	DefaultQueryLimit = 100
+	MaxQueryLimit     = 500
+
+	// MaxEvidenceJSONBytes caps EvidenceJSON at insert time. Larger
+	// payloads are rejected so a misbehaving adapter cannot fill the
+	// table with multi-MB blobs. The cap is generous enough for typical
+	// hook/gateway/proxy metadata and tight enough that one event row
+	// stays small in any normal index.
+	MaxEvidenceJSONBytes = 8 * 1024
+)


### PR DESCRIPTION
## Summary

First PR of Phase 2B.1. Adds the `internal/activity` package: a normalized runtime evidence model and a SQLite/Postgres-backed store. This is the substrate the dashboard coverage drill-down (PR5) and the activity-backed last-seen reader (PR4) build on. **No surface adapter wiring in this PR** — gateway, proxy, and hooks are unchanged.

## Stop point

The whole package is purely additive. Existing behavior is unchanged. PR2 will wire the gateway to call `Insert` after a tool call lands in audit.

## Design

### `activity.Event`

Normalized record with the fields the spec lists:

- Identity provenance: `PrincipalID`, `ReportedActor`, `AuthMethod`, `PrincipalTrustLevel`. Reported actor is display-only and never overrides the principal.
- Surface and connector context: `Surface` (`mcp_http` | `http_egress_proxy` | `hooks`), `EventType`, `EvidenceType`, `ConnectorID`, `ClientID`.
- Security outcome: `Status`, `PolicyDecision`, `CoverageMode` (`protected` | `observed` | `blind`), `Confidence`.
- Resource: `ResourceType`, `ResourceID`, `ResourceHash`, `ResourceLabel` (humanized + redacted by the writer).
- `EvidenceJSON`: bounded surface-specific metadata blob (8 KB cap).

### `activity.SQLStore`

Implements `Insert` / `Query` / `LastSeenByPrincipalSurface` / `ListByCoverageCell`. Insert validates required fields and rejects oversized `EvidenceJSON` so a misbehaving adapter cannot fill the table with garbage rows. Query default limit 100, max 500 — a forgotten cap cannot exhaust resources.

### Migrate

Creates `activity_events` with six indexes (timestamp, principal+surface+timestamp, connector+timestamp, workspace+timestamp, session+timestamp, resource_hash+timestamp). SQLite and Postgres dialects supported. Idempotent: surface adapters can call it on every startup.

### Storage decision

The store accepts an existing `*sql.DB` so `activity_events` lives **beside** `audit_log` in the same database file. No new DSN, no new migration tool, single deployment surface. If activity volume forces a separate store later, the `Store` interface stays the same.

## Tests

9 tests cover the contract:
- Insert + Query round-trip preserves every field.
- Required-field rejection for principal/surface/event_type/evidence_type/coverage_mode.
- Unknown coverage_mode rejected with wrapped `ErrInvalidEvent`.
- Oversized `EvidenceJSON` rejected before hitting the DB.
- Composite filters across principal and surface return the correct subset.
- `Limit` defaults and is capped at 500.
- `LastSeenByPrincipalSurface` returns max timestamp; empty principal/surface returns empty without error.
- `ListByCoverageCell` returns newest-first.
- `Migrate` is idempotent and rejects unknown dialects.

Suite, lint, vet stay green.

## Next

- **PR2** — Gateway dual-write: emit one activity row per MCP tool call after audit.
- **PR3** — Proxy + hooks dual-write.
- **PR4** — `internal/connectors` registry and hybrid coverage reader (activity → audit fallback).
- **PR5** — `/dashboard/api/activity` + Overview cell drill-down.

Spec: `DOCS/oktsec/engineering/specs/2026-04-26-phase-2b1-activity-foundation-spec.md` (vault).