### PR TITLE
Wire gateway dual-write to activity store (Phase 2B.1 PR2)

### DIFF
--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -180,6 +180,21 @@ type Store struct {
 // DB returns the underlying *sql.DB for direct access (benchmarking/migrations).
 func (s *Store) DB() *sql.DB { return s.db }
 
+// DialectName returns "sqlite" or "postgres" so a peer table (e.g. the
+// activity event store added in Phase 2B.1) can run its own migrations
+// against the same DB handle without re-deriving the dialect from
+// cfg.DBBackend. Empty when the dialect is not one of the two known
+// values, which keeps callers honest about the unknown case.
+func (s *Store) DialectName() string {
+	switch s.dialect.(type) {
+	case SQLiteDialect:
+		return "sqlite"
+	case PostgresDialect:
+		return "postgres"
+	}
+	return ""
+}
+
 // NewStoreReadOnly opens the SQLite audit database in a mode that refuses to
 // auto-repair or rebuild chain hashes. The underlying sqlite connection is
 // additionally put under `PRAGMA query_only=ON` after init so any subsequent

--- a/internal/gateway/activity_test.go
+++ b/internal/gateway/activity_test.go
@@ -1,0 +1,262 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/oktsec/oktsec/internal/activity"
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+)
+
+// recordingActivityWriter is a test double for activityWriter that
+// captures every Insert call. The mu makes it safe to read from the
+// test goroutine while the gateway's emit goroutine writes.
+type recordingActivityWriter struct {
+	mu     sync.Mutex
+	events []activity.Event
+	err    error // when set, every Insert returns this error
+}
+
+func (r *recordingActivityWriter) Insert(_ context.Context, e activity.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.events = append(r.events, e)
+	return nil
+}
+
+func (r *recordingActivityWriter) snapshot() []activity.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]activity.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// waitForActivity polls the recorder until it has at least n events or
+// the deadline elapses. The gateway emits activity in a goroutine so a
+// blocking wait is the fairest way to assert against it without sleep
+// races.
+func waitForActivity(t *testing.T, r *recordingActivityWriter, n int) []activity.Event {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := r.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("activity recorder: wanted %d events, got %d", n, len(r.snapshot()))
+	return nil
+}
+
+// 1. Bearer-authenticated tool call writes a Protected activity event
+// with bearer_token / authenticated identity. Confidence is 100. The
+// audit row id is preserved as AuditEntryID for correlation.
+func TestGatewayActivity_BearerToolCallProtected(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	rec := &recordingActivityWriter{}
+	gw.SetActivityStore(rec)
+
+	ctx := ctxWithIdentity("local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated), "")
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	if _, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"})); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	events := waitForActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex", ev.PrincipalID)
+	}
+	if ev.AuthMethod != string(resolve.AuthMethodBearerToken) {
+		t.Errorf("auth_method = %q; want bearer_token", ev.AuthMethod)
+	}
+	if ev.CoverageMode != activity.CoverageProtected {
+		t.Errorf("coverage = %q; want protected", ev.CoverageMode)
+	}
+	if ev.Confidence != 100 {
+		t.Errorf("confidence = %d; want 100", ev.Confidence)
+	}
+	if ev.Surface != activity.SurfaceMCPHTTP || ev.EventType != activity.EventMCPToolCall {
+		t.Errorf("surface/event = %q/%q; want mcp_http/mcp.tool_call", ev.Surface, ev.EventType)
+	}
+	if ev.AuditEntryID == "" {
+		t.Error("audit_entry_id should be populated for correlation")
+	}
+}
+
+// 2. Reported actor (e.g. spoofed X-Oktsec-Agent or _oktsec_agent
+// payload param) is preserved as ReportedActor on the activity event
+// but never replaces the bearer-token principal.
+func TestGatewayActivity_ReportedActorDoesNotReplacePrincipal(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	rec := &recordingActivityWriter{}
+	gw.SetActivityStore(rec)
+
+	ctx := ctxWithIdentity("local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated),
+		"admin") // spoofed reported actor
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	if _, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"})); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	events := waitForActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex (spoof must not replace)", ev.PrincipalID)
+	}
+	if ev.ReportedActor != "admin" {
+		t.Errorf("reported_actor = %q; want admin", ev.ReportedActor)
+	}
+}
+
+// 3. Trusted_loopback identity (legacy local header path) writes an
+// Observed activity event, not Protected. Confidence is 80. This is
+// the contract that prevents the dashboard from claiming protection
+// for the loopback header.
+func TestGatewayActivity_TrustedLoopbackIsObserved(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["claude-code"] = config.Agent{}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	rec := &recordingActivityWriter{}
+	gw.SetActivityStore(rec)
+
+	ctx := ctxWithIdentity("claude-code",
+		string(resolve.AuthMethodTrustedLoopback),
+		string(resolve.TrustLocal), "")
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	if _, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"})); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	events := waitForActivity(t, rec, 1)
+	ev := events[0]
+	if ev.CoverageMode != activity.CoverageObserved {
+		t.Errorf("coverage = %q; want observed (loopback header is not protected)", ev.CoverageMode)
+	}
+	if ev.Confidence != 80 {
+		t.Errorf("confidence = %d; want 80", ev.Confidence)
+	}
+	if ev.AuthMethod != string(resolve.AuthMethodTrustedLoopback) {
+		t.Errorf("auth_method = %q; want trusted_loopback", ev.AuthMethod)
+	}
+}
+
+// 4. When the gateway's activity field is nil (no audit DB handle, or
+// pre-PR2 setups), the handler still writes audit and returns success.
+// Activity emission is best-effort; it must never gate the request.
+func TestGatewayActivity_NilStoreDoesNotBreakHandler(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	gw.SetActivityStore(nil) // explicitly disable
+
+	ctx := ctxWithIdentity("local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated), "")
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	res, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"}))
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handler returned MCP error: %+v", res)
+	}
+	// Audit row should still be present.
+	gw.audit.Flush()
+	if _, err := gw.audit.Query(audit.QueryOpts{Agent: "local-codex", Limit: 1}); err != nil {
+		t.Errorf("audit query: %v", err)
+	}
+}
+
+// 5. An Insert error from the activity store is logged but does NOT
+// affect the handler's success or the audit row. Activity is a
+// secondary write; failures must not be visible to the client.
+func TestGatewayActivity_InsertErrorDoesNotAffectRequest(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	rec := &recordingActivityWriter{err: errors.New("simulated db down")}
+	gw.SetActivityStore(rec)
+
+	ctx := ctxWithIdentity("local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated), "")
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	res, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"}))
+	if err != nil {
+		t.Fatalf("handler must succeed even when activity insert fails; got %v", err)
+	}
+	if res.IsError {
+		t.Errorf("handler returned MCP error on activity failure: %+v", res)
+	}
+	// Audit row is the compliance trail and must still land.
+	gw.audit.Flush()
+	entries, err := gw.audit.Query(audit.QueryOpts{Agent: "local-codex", Limit: 1})
+	if err != nil || len(entries) == 0 {
+		t.Errorf("audit row missing after activity failure (entries=%d, err=%v)", len(entries), err)
+	}
+	// Give the goroutine time to attempt and fail; recorder should still
+	// have zero events because Insert returned an error.
+	time.Sleep(50 * time.Millisecond)
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Errorf("recorder should hold zero events on Insert error; got %d", len(got))
+	}
+}
+
+// 6. Early-return blocked paths (rate limit, allowlist, etc.) emit
+// activity events too. The contract is "every audit row has a paired
+// activity event", and this test guards the most important class —
+// security-blocked requests — from silently bypassing dual-write.
+func TestGatewayActivity_BlockedRequestStillEmitsActivity(t *testing.T) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{
+		AllowedTools: []string{"only-this-tool"}, // echo is NOT in the allowlist
+	}
+	// Map test-agent so the allowlist check matches our principal.
+	cfg.Agents["local-codex"] = config.Agent{
+		AllowedTools: []string{"only-this-tool"},
+	}
+	gw := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	rec := &recordingActivityWriter{}
+	gw.SetActivityStore(rec)
+
+	ctx := ctxWithIdentity("local-codex",
+		string(resolve.AuthMethodBearerToken),
+		string(resolve.TrustAuthenticated), "")
+	handler := gw.makeHandler(gw.toolMap["echo"])
+	// Allowlist mismatch produces an MCP error result with status=blocked.
+	if _, err := handler(ctx, makeHandlerRequest("echo", map[string]any{"text": "hi"})); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	events := waitForActivity(t, rec, 1)
+	ev := events[0]
+	if ev.Status != audit.StatusBlocked {
+		t.Errorf("status = %q; want %q (blocked path must surface in activity)", ev.Status, audit.StatusBlocked)
+	}
+	if ev.PolicyDecision == "" {
+		t.Errorf("policy_decision should explain why request was blocked; got empty")
+	}
+	if ev.Surface != activity.SurfaceMCPHTTP {
+		t.Errorf("surface = %q; want mcp_http", ev.Surface)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -16,6 +16,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 
+	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
@@ -27,6 +28,14 @@ import (
 	"github.com/oktsec/oktsec/internal/proxy"
 	"github.com/oktsec/oktsec/internal/verdict"
 )
+
+// activityWriter is the narrow projection of activity.Store the gateway
+// uses. Defined locally so tests can inject a stub without depending on
+// the full Store interface (Query, ListByCoverageCell, etc.). Production
+// passes an *activity.SQLStore; tests pass a recorder.
+type activityWriter interface {
+	Insert(ctx context.Context, e activity.Event) error
+}
 
 // Version is set from the CLI at startup (via ldflags).
 var Version = "dev"
@@ -125,6 +134,14 @@ type Gateway struct {
 	resolver       resolve.Resolver
 	resolverConfig resolve.Config
 	requireAuth    bool // derived from cfg.Gateway.RequireAuth + deployment profile
+
+	// activity emits one normalized activity event per audit row so the
+	// dashboard coverage matrix can show real evidence behind each cell.
+	// May be nil when the audit store does not expose a *sql.DB (e.g.,
+	// some test scaffolds) or when activity migration failed at startup —
+	// in either case the gateway logs only audit and the dashboard falls
+	// back to its audit-backed last-seen reader.
+	activity activityWriter
 }
 
 // authMiddleware runs the identity resolver for every gateway request,
@@ -220,6 +237,82 @@ func buildResolver(cfg *config.Config) resolve.Resolver {
 	return resolve.NewDefaultResolver(store, nil)
 }
 
+// buildGatewayActivity constructs the activity store the gateway uses
+// for dual-write. Lives in NewGateway (and newGatewayForTest) so the
+// gateway is wired exactly the same whether oktsec runs standalone
+// (`oktsec gateway`) or as part of `oktsec serve`. Returns nil when the
+// audit store does not expose a *sql.DB or migration fails: callers
+// continue with audit-only logging and the coverage matrix falls back
+// to its audit-backed reader.
+func buildGatewayActivity(auditStore *audit.Store, logger *slog.Logger) activityWriter {
+	if auditStore == nil {
+		return nil
+	}
+	db := auditStore.DB()
+	if db == nil {
+		return nil
+	}
+	dialect := activity.Dialect(auditStore.DialectName())
+	if dialect == "" {
+		// Unknown dialect; do not invent a default. Coverage will fall
+		// back to the audit-backed last-seen reader.
+		logger.Warn("activity store skipped: audit store reports unknown dialect")
+		return nil
+	}
+	if err := activity.Migrate(db, dialect); err != nil {
+		logger.Warn("activity store skipped: migrate failed", "error", err)
+		return nil
+	}
+	return activity.NewSQLStore(db, dialect)
+}
+
+// coverageFromAuth maps an auth method id to the coverage label the
+// dashboard should attribute to a single observed event. trusted_local
+// is observed (not protected) because the loopback header path cannot
+// guarantee the policy principal — it is convenience identity for
+// local-mode back-compat.
+func coverageFromAuth(method string) activity.CoverageMode {
+	switch method {
+	case "bearer_token", "proxy_token", "hook_token":
+		return activity.CoverageProtected
+	case "trusted_loopback":
+		return activity.CoverageObserved
+	}
+	return activity.CoverageObserved
+}
+
+// confidenceFromAuth maps an auth method id to the dashboard confidence
+// hint. Numbers come from the spec; 0 for unknown so the dashboard can
+// surface diagnostic-quality rows separately.
+func confidenceFromAuth(method string) int {
+	switch method {
+	case "bearer_token", "proxy_token":
+		return 100
+	case "hook_token":
+		return 100
+	case "trusted_loopback":
+		return 80
+	}
+	return 0
+}
+
+// principalIDOrUnknown enforces activity.Event's PrincipalID-required
+// invariant for surfaces that allow anonymous local telemetry (hooks).
+// The gateway never produces an empty principal in normal flow but
+// handlers run during startup edge cases where the field can be empty.
+func principalIDOrUnknown(id string) string {
+	if id == "" {
+		return "unknown"
+	}
+	return id
+}
+
+// activityInsertTimeout bounds the dual-write so a stalled DB cannot
+// pin a goroutine indefinitely. 2s is generous for a single insert on
+// SQLite WAL and short enough that a misbehaving Postgres does not fan
+// out goroutines forever.
+const activityInsertTimeout = 2 * time.Second
+
 // NewGateway creates a gateway from the given configuration.
 // Callers must call Start to begin serving and Shutdown to stop.
 // If sharedStore is non-nil, the gateway uses it instead of creating its own.
@@ -262,6 +355,7 @@ func NewGateway(cfg *config.Config, logger *slog.Logger, sharedStore *audit.Stor
 		resolver:          buildResolver(cfg),
 		resolverConfig:    policy.ResolverConfig,
 		requireAuth:       policy.RequireAuth,
+		activity:          buildGatewayActivity(auditStore, logger),
 	}, nil
 }
 
@@ -285,7 +379,16 @@ func newGatewayForTest(cfg *config.Config, scanner *engine.Scanner, auditStore *
 		resolver:          buildResolver(cfg),
 		resolverConfig:    policy.ResolverConfig,
 		requireAuth:       policy.RequireAuth,
+		activity:          buildGatewayActivity(auditStore, logger),
 	}
+}
+
+// SetActivityStore lets callers inject a custom activityWriter (e.g., a
+// recorder in tests, or a future shared store wired by `oktsec serve`).
+// Pass nil to disable activity dual-write entirely. Safe to call before
+// the gateway starts serving; not safe to swap mid-flight.
+func (g *Gateway) SetActivityStore(w activityWriter) {
+	g.activity = w
 }
 
 // Start connects to all backends, discovers tools, and starts the HTTP server.
@@ -940,15 +1043,21 @@ func (g *Gateway) autoRegisterAgent(name string) {
 
 // logAudit writes an audit entry for a gateway tool call.
 // Optional extra strings: first is delegation_chain_hash.
-// logAudit writes one audit entry. The caller passes the resolved
-// requestIdentity so the audit row carries the same Principal that
-// drove the policy decision, plus the AuthMethod / TrustLevel /
-// ReportedActor provenance the resolver established.
+// logAudit writes one audit entry and emits the matching activity
+// event. The caller passes the resolved requestIdentity so the audit
+// row carries the same Principal that drove the policy decision, plus
+// the AuthMethod / TrustLevel / ReportedActor provenance the resolver
+// established.
 //
 // FromAgent and ToAgent both equal id.PrincipalID — historical: the
 // gateway logs every tool call as a self-edge from the principal. Other
 // surfaces (agent message API) populate ToAgent differently and call
 // audit.Log directly.
+//
+// emitGatewayActivity runs after the audit insert so every audit row
+// the gateway writes has a paired activity event. Activity emission is
+// async with a short timeout: a slow or failing activity store cannot
+// affect the request latency or the security decision.
 func (g *Gateway) logAudit(msgID string, id requestIdentity, tool, status, decision, findingsJSON, toolArgs, sessionID string, start time.Time, extra ...string) {
 	var delHash, delChain string
 	if len(extra) > 0 {
@@ -976,6 +1085,53 @@ func (g *Gateway) logAudit(msgID string, id requestIdentity, tool, status, decis
 		PrincipalTrustLevel: id.TrustLevel,
 		ReportedActor:       id.ReportedActor,
 	})
+	g.emitGatewayActivity(msgID, id, tool, status, decision, sessionID)
+}
+
+// emitGatewayActivity writes one activity event correlated to the
+// audit row just logged. Runs in a fresh background context with a
+// bounded timeout so a slow DB cannot delay the request handler.
+// Insert errors are logged at warn — they never affect the policy
+// decision or the audit row.
+//
+// The activity event uses a fresh UUID so two audit rows with the
+// same msgID (rare, but possible on certain post-decision paths) do
+// not collide on the activity primary key. Correlation back to the
+// audit row goes through AuditEntryID.
+func (g *Gateway) emitGatewayActivity(msgID string, id requestIdentity, tool, status, decision, sessionID string) {
+	if g.activity == nil {
+		return
+	}
+	ev := activity.Event{
+		ID:                  uuid.NewString(),
+		Timestamp:           time.Now().UTC(),
+		PrincipalID:         principalIDOrUnknown(id.PrincipalID),
+		ReportedActor:       id.ReportedActor,
+		AuthMethod:          id.AuthMethod,
+		PrincipalTrustLevel: id.TrustLevel,
+		Surface:             activity.SurfaceMCPHTTP,
+		EventType:           activity.EventMCPToolCall,
+		EvidenceType:        activity.EvidenceGateway,
+		SessionID:           sessionID,
+		AuditEntryID:        msgID,
+		Status:              status,
+		PolicyDecision:      decision,
+		CoverageMode:        coverageFromAuth(id.AuthMethod),
+		Confidence:          confidenceFromAuth(id.AuthMethod),
+		ResourceType:        "mcp_tool",
+		ResourceLabel:       tool,
+		ResourceID:          tool,
+	}
+	go func() {
+		// Detached context: the request context can be cancelled by the
+		// time the goroutine runs (client closed, response written), and
+		// activity should still land if the DB is reachable.
+		ctx, cancel := context.WithTimeout(context.Background(), activityInsertTimeout)
+		defer cancel()
+		if err := g.activity.Insert(ctx, ev); err != nil {
+			g.logger.Warn("activity insert failed", "error", err, "msg_id", msgID, "surface", "mcp_http")
+		}
+	}()
 }
 
 // Scanner returns the gateway's content scanner.


### PR DESCRIPTION
## Summary

Phase 2B.1 PR2 wires the MCP gateway to dual-write `activity.Event` rows beside its existing `audit.Entry` rows so the dashboard coverage matrix can later show the real evidence behind every cell. Gateway only — proxy and hooks come in PR3.

No policy decision changes. No audit row changes. No request-path latency cost: activity emission runs in a goroutine on a detached background context with a 2s timeout, and errors are warn-logged.

## What changed

- **`internal/audit/store.go`** — adds `Store.DialectName()` returning `"sqlite"` or `"postgres"` so a peer table (the activity store) can run its own migrations against the same DB without re-deriving the dialect from `cfg.DBBackend`. Empty for unknown dialects so callers stay honest about that case.
- **`internal/gateway/gateway.go`**
  - `activityWriter` narrow interface (Insert only) so tests inject a stub without dragging in the whole Store API.
  - `buildGatewayActivity(auditStore, logger)` wires the dual-write identically for `NewGateway` (standalone `oktsec gateway`) and `newGatewayForTest`. Returns `nil` and logs a warn when the audit store exposes no `*sql.DB` or migration fails — coverage falls back to its audit-backed last-seen reader.
  - `coverageFromAuth` / `confidenceFromAuth` / `principalIDOrUnknown` helpers map the resolver output to dashboard fields. `trusted_loopback` is `observed` + 80, never `protected` — the loopback header is local-mode convenience identity, not a policy guarantee.
  - `SetActivityStore(w activityWriter)` setter for tests and future shared-store wiring from `oktsec serve`.
  - **Emission lives inside `logAudit`** so every audit-writing path (rate-limit, allowlist, suspended, scan-error, blocked, quarantine, ok) gets a paired activity event. The early-return blocked path is what the test in case 6 guards.
  - Event ID is a fresh `uuid.NewString()`; `msgID` is preserved as `AuditEntryID` so correlation back to audit works without risking a PK collision when `logAudit` is called twice with the same `msgID`.
  - Goroutine + `context.WithTimeout(context.Background(), 2 * time.Second)` so a stalled DB cannot pin a goroutine indefinitely or affect handler latency.
- **`internal/gateway/activity_test.go`** — 6 new tests:
  1. Bearer-authenticated tool call → `coverage=protected`, `confidence=100`, `AuditEntryID` populated.
  2. Spoofed reported actor preserved as `ReportedActor` but never replaces the bearer principal.
  3. `trusted_loopback` → `coverage=observed`, `confidence=80`.
  4. `SetActivityStore(nil)` keeps the handler succeeding and the audit row landing.
  5. Insert error → handler still succeeds, audit row still lands, recorder stays empty.
  6. Allowlist-blocked early-return path emits activity with `status=blocked` and a populated `policy_decision`.

## Not included

- Proxy + hooks dual-write — PR3.
- Connector registry (`internal/connectors`) + hybrid coverage reader — PR4.
- Dashboard activity drill-down — PR5.
- `EvidenceJSON` with tool args — deferred until the dashboard actually shows it (and we have a redaction story for arg payloads).

## Test plan

- [x] `make test` — 0 failures, race detector clean.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] All 6 new gateway activity tests pass.
- [ ] Manual smoke: run `oktsec gateway`, hit a tool, confirm one row in `audit_log` and one row in `activity_events` with matching `audit_entry_id`.