### PR TITLE
Wire forward proxy and hooks dual-write to activity store (Phase 2B.1 PR3)

### DIFF
--- a/internal/activity/coverage_from_auth.go
+++ b/internal/activity/coverage_from_auth.go
@@ -39,3 +39,30 @@ func ConfidenceFromAuthMethod(method string) int {
 	}
 	return 0
 }
+
+// HookEventPostToolUse is the normalized stage name for hooks that
+// fire after the tool ran. Kept as a constant so the coverage helper
+// and any future hook-stage logic agree on the wire value.
+const HookEventPostToolUse = "post_tool_use"
+
+// CoverageFromHookEvent returns the coverage label and confidence the
+// dashboard should attribute to a single hook event. It accounts for
+// the hook stage, which CoverageFromAuthMethod alone cannot:
+//
+//   - pre_tool_use is the only stage where oktsec can block before the
+//     action ran; with token auth it is genuinely Protected/100.
+//   - post_tool_use is evidence after the fact. Even when carried by a
+//     valid hook_token the surface cannot block, so it is Observed
+//     with confidence 60 per the Phase 2B.1 spec ladder.
+//
+// Unauthenticated hooks (any stage) inherit the auth-method-only
+// mapping — they were already Observed with low confidence and the
+// stage does not change that.
+func CoverageFromHookEvent(authMethod, hookEvent string) (CoverageMode, int) {
+	base := CoverageFromAuthMethod(authMethod)
+	conf := ConfidenceFromAuthMethod(authMethod)
+	if hookEvent == HookEventPostToolUse && base == CoverageProtected {
+		return CoverageObserved, 60
+	}
+	return base, conf
+}

--- a/internal/activity/coverage_from_auth.go
+++ b/internal/activity/coverage_from_auth.go
@@ -1,0 +1,41 @@
+package activity
+
+// CoverageFromAuthMethod maps an auth method id (the string form of
+// resolve.AuthMethod) to the dashboard coverage label a single observed
+// event should carry. Token-based and cryptographic auth produce
+// Protected. Trusted local (loopback header), unauthenticated
+// telemetry, or anything unrecognized produce Observed — under-claim
+// rather than over-claim.
+//
+// Surface adapters (gateway, forward proxy, hooks) all call this so the
+// dashboard cannot drift from a per-surface fork of the same logic.
+func CoverageFromAuthMethod(method string) CoverageMode {
+	switch method {
+	case "bearer_token", "proxy_token", "hook_token",
+		"ed25519", "mtls", "wrapper":
+		return CoverageProtected
+	case "trusted_loopback":
+		return CoverageObserved
+	}
+	return CoverageObserved
+}
+
+// ConfidenceFromAuthMethod maps an auth method id to the dashboard
+// confidence hint. Numbers come from the Phase 2B.1 spec:
+//
+//	100  token-authenticated direct surface evidence (bearer / proxy /
+//	     hook tokens, ed25519, mTLS, wrapper-signed)
+//	 80  trusted local loopback evidence
+//	  0  unknown or anonymous; surfaced separately as diagnostic-quality
+//
+// Confidence is a hint for the dashboard, not a policy input.
+func ConfidenceFromAuthMethod(method string) int {
+	switch method {
+	case "bearer_token", "proxy_token", "hook_token",
+		"ed25519", "mtls", "wrapper":
+		return 100
+	case "trusted_loopback":
+		return 80
+	}
+	return 0
+}

--- a/internal/activity/coverage_from_auth_test.go
+++ b/internal/activity/coverage_from_auth_test.go
@@ -1,0 +1,71 @@
+package activity
+
+import "testing"
+
+// CoverageFromHookEvent encodes the Phase 2B.1 invariant that
+// "Protected means oktsec can block before the action ran." A failing
+// row here means the dashboard would over-claim coverage on at least
+// one cell, so the table is exhaustive on purpose.
+func TestCoverageFromHookEvent(t *testing.T) {
+	cases := []struct {
+		name       string
+		authMethod string
+		hookEvent  string
+		wantCov    CoverageMode
+		wantConf   int
+	}{
+		{
+			name:       "pre_tool_use with hook_token is protected",
+			authMethod: "hook_token",
+			hookEvent:  "pre_tool_use",
+			wantCov:    CoverageProtected,
+			wantConf:   100,
+		},
+		{
+			name:       "post_tool_use with hook_token downgrades to observed/60",
+			authMethod: "hook_token",
+			hookEvent:  "post_tool_use",
+			wantCov:    CoverageObserved,
+			wantConf:   60,
+		},
+		{
+			name:       "post_tool_use with bearer_token also downgrades (any token-protected auth)",
+			authMethod: "bearer_token",
+			hookEvent:  "post_tool_use",
+			wantCov:    CoverageObserved,
+			wantConf:   60,
+		},
+		{
+			name:       "pre_tool_use unauthenticated stays observed/0",
+			authMethod: "",
+			hookEvent:  "pre_tool_use",
+			wantCov:    CoverageObserved,
+			wantConf:   0,
+		},
+		{
+			name:       "post_tool_use unauthenticated stays observed/0 (no inflation either way)",
+			authMethod: "",
+			hookEvent:  "post_tool_use",
+			wantCov:    CoverageObserved,
+			wantConf:   0,
+		},
+		{
+			name:       "trusted_loopback is unaffected by stage (cannot block; already observed)",
+			authMethod: "trusted_loopback",
+			hookEvent:  "post_tool_use",
+			wantCov:    CoverageObserved,
+			wantConf:   80,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCov, gotConf := CoverageFromHookEvent(tc.authMethod, tc.hookEvent)
+			if gotCov != tc.wantCov {
+				t.Errorf("coverage = %q; want %q", gotCov, tc.wantCov)
+			}
+			if gotConf != tc.wantConf {
+				t.Errorf("confidence = %d; want %d", gotConf, tc.wantConf)
+			}
+		})
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -266,36 +266,6 @@ func buildGatewayActivity(auditStore *audit.Store, logger *slog.Logger) activity
 	return activity.NewSQLStore(db, dialect)
 }
 
-// coverageFromAuth maps an auth method id to the coverage label the
-// dashboard should attribute to a single observed event. trusted_local
-// is observed (not protected) because the loopback header path cannot
-// guarantee the policy principal — it is convenience identity for
-// local-mode back-compat.
-func coverageFromAuth(method string) activity.CoverageMode {
-	switch method {
-	case "bearer_token", "proxy_token", "hook_token":
-		return activity.CoverageProtected
-	case "trusted_loopback":
-		return activity.CoverageObserved
-	}
-	return activity.CoverageObserved
-}
-
-// confidenceFromAuth maps an auth method id to the dashboard confidence
-// hint. Numbers come from the spec; 0 for unknown so the dashboard can
-// surface diagnostic-quality rows separately.
-func confidenceFromAuth(method string) int {
-	switch method {
-	case "bearer_token", "proxy_token":
-		return 100
-	case "hook_token":
-		return 100
-	case "trusted_loopback":
-		return 80
-	}
-	return 0
-}
-
 // principalIDOrUnknown enforces activity.Event's PrincipalID-required
 // invariant for surfaces that allow anonymous local telemetry (hooks).
 // The gateway never produces an empty principal in normal flow but
@@ -1116,8 +1086,8 @@ func (g *Gateway) emitGatewayActivity(msgID string, id requestIdentity, tool, st
 		AuditEntryID:        msgID,
 		Status:              status,
 		PolicyDecision:      decision,
-		CoverageMode:        coverageFromAuth(id.AuthMethod),
-		Confidence:          confidenceFromAuth(id.AuthMethod),
+		CoverageMode:        activity.CoverageFromAuthMethod(id.AuthMethod),
+		Confidence:          activity.ConfidenceFromAuthMethod(id.AuthMethod),
 		ResourceType:        "mcp_tool",
 		ResourceLabel:       tool,
 		ResourceID:          tool,

--- a/internal/hooks/activity_test.go
+++ b/internal/hooks/activity_test.go
@@ -148,7 +148,11 @@ func TestHooksActivity_ReportedActorDoesNotReplacePrincipal(t *testing.T) {
 // 3. Unauthenticated local hook (no Authorization header, local
 // profile) still emits an activity event so the dashboard sees the
 // surface as Observed rather than Blind. Empty principal collapses to
-// "unknown" so the row validates.
+// "unknown", and the payload-supplied agent is preserved as
+// reported_actor — that is the only actor signal the client gave us
+// and dropping it would lose evidence (regression guard for the
+// originalPayloadAgent != ev.Agent fallback that used to skip this
+// path).
 func TestHooksActivity_UnauthenticatedIsObserved(t *testing.T) {
 	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
 	defer cleanup()
@@ -176,6 +180,9 @@ func TestHooksActivity_UnauthenticatedIsObserved(t *testing.T) {
 	if ev.PrincipalID != "unknown" {
 		t.Errorf("principal = %q; want unknown (anonymous local hook)", ev.PrincipalID)
 	}
+	if ev.ReportedActor != "claude-code" {
+		t.Errorf("reported_actor = %q; want claude-code (payload agent must be preserved when no principal)", ev.ReportedActor)
+	}
 	if ev.CoverageMode != activity.CoverageObserved {
 		t.Errorf("coverage = %q; want observed", ev.CoverageMode)
 	}
@@ -184,6 +191,53 @@ func TestHooksActivity_UnauthenticatedIsObserved(t *testing.T) {
 	}
 	if ev.Surface != activity.SurfaceHooks {
 		t.Errorf("surface = %q; want hooks", ev.Surface)
+	}
+}
+
+// 6. Post-action hooks (post_tool_use) carrying a valid hook_token
+// are NOT Protected — the action already ran and oktsec cannot block.
+// They are Observed evidence with confidence 60 per the Phase 2B.1
+// spec ladder. The Phase 2B.1 invariant "Protected means oktsec can
+// block before action" depends on this distinction; without it, every
+// post-action hook would inflate the coverage matrix.
+func TestHooksActivity_PostToolUseIsObservedEvenWithToken(t *testing.T) {
+	h, raw, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+	rec := &recordingActivityWriter{}
+	h.SetActivityStore(rec)
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:   "Read",
+		ToolInput:  json.RawMessage(`{"file_path":"/tmp/x"}`),
+		ToolOutput: "ok",
+		Agent:      "local-codex",
+		SessionID:  "sess-post",
+		Event:      "post_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec2.Code)
+	}
+
+	events := waitForHookActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex", ev.PrincipalID)
+	}
+	if ev.AuthMethod != "hook_token" {
+		t.Errorf("auth_method = %q; want hook_token", ev.AuthMethod)
+	}
+	if ev.CoverageMode != activity.CoverageObserved {
+		t.Errorf("coverage = %q; want observed (post_tool_use cannot block, even with hook_token)", ev.CoverageMode)
+	}
+	if ev.Confidence != 60 {
+		t.Errorf("confidence = %d; want 60 (authenticated post-action evidence per Phase 2B.1 ladder)", ev.Confidence)
 	}
 }
 

--- a/internal/hooks/activity_test.go
+++ b/internal/hooks/activity_test.go
@@ -1,0 +1,252 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/activity"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+)
+
+// recordingActivityWriter is a test double for activityWriter that
+// captures every Insert call. The mu makes it safe to read from the
+// test goroutine while the hook handler's emit goroutine writes.
+type recordingActivityWriter struct {
+	mu     sync.Mutex
+	events []activity.Event
+	err    error
+}
+
+func (r *recordingActivityWriter) Insert(_ context.Context, e activity.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.events = append(r.events, e)
+	return nil
+}
+
+func (r *recordingActivityWriter) snapshot() []activity.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]activity.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func waitForHookActivity(t *testing.T, r *recordingActivityWriter, n int) []activity.Event {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := r.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("activity recorder: wanted %d events, got %d", n, len(r.snapshot()))
+	return nil
+}
+
+// 1. A token-authenticated hook event emits a Protected activity event
+// with confidence 100. The audit row id is preserved as AuditEntryID
+// for correlation.
+func TestHooksActivity_TokenAuthIsProtected(t *testing.T) {
+	h, raw, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+	rec := &recordingActivityWriter{}
+	h.SetActivityStore(rec)
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "admin", // payload spoof; resolver wins
+		SessionID: "sess-1",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec2.Code)
+	}
+
+	events := waitForHookActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex", ev.PrincipalID)
+	}
+	if ev.AuthMethod != "hook_token" {
+		t.Errorf("auth_method = %q; want hook_token", ev.AuthMethod)
+	}
+	if ev.CoverageMode != activity.CoverageProtected {
+		t.Errorf("coverage = %q; want protected", ev.CoverageMode)
+	}
+	if ev.Confidence != 100 {
+		t.Errorf("confidence = %d; want 100", ev.Confidence)
+	}
+	if ev.Surface != activity.SurfaceHooks || ev.EventType != activity.EventHookEvent {
+		t.Errorf("surface/event = %q/%q; want hooks/hook.event", ev.Surface, ev.EventType)
+	}
+	if ev.AuditEntryID == "" {
+		t.Error("audit_entry_id should be populated for correlation")
+	}
+	if ev.ResourceLabel != "Read" {
+		t.Errorf("resource_label = %q; want Read", ev.ResourceLabel)
+	}
+}
+
+// 2. Reported actor (payload-supplied agent name) is preserved as
+// ReportedActor on the activity event but never replaces the
+// resolver-established principal.
+func TestHooksActivity_ReportedActorDoesNotReplacePrincipal(t *testing.T) {
+	h, raw, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+	rec := &recordingActivityWriter{}
+	h.SetActivityStore(rec)
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "admin", // spoof
+		SessionID: "sess-1",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1"
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+
+	events := waitForHookActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex (spoof must not replace)", ev.PrincipalID)
+	}
+	if ev.ReportedActor != "admin" {
+		t.Errorf("reported_actor = %q; want admin", ev.ReportedActor)
+	}
+}
+
+// 3. Unauthenticated local hook (no Authorization header, local
+// profile) still emits an activity event so the dashboard sees the
+// surface as Observed rather than Blind. Empty principal collapses to
+// "unknown" so the row validates.
+func TestHooksActivity_UnauthenticatedIsObserved(t *testing.T) {
+	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+	rec := &recordingActivityWriter{}
+	h.SetActivityStore(rec)
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "claude-code",
+		SessionID: "sess-2",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec2.Code)
+	}
+
+	events := waitForHookActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "unknown" {
+		t.Errorf("principal = %q; want unknown (anonymous local hook)", ev.PrincipalID)
+	}
+	if ev.CoverageMode != activity.CoverageObserved {
+		t.Errorf("coverage = %q; want observed", ev.CoverageMode)
+	}
+	if ev.Confidence != 0 {
+		t.Errorf("confidence = %d; want 0", ev.Confidence)
+	}
+	if ev.Surface != activity.SurfaceHooks {
+		t.Errorf("surface = %q; want hooks", ev.Surface)
+	}
+}
+
+// 4. When the hook handler's activity field is nil, the request flow
+// is unaffected — audit row still lands and the response is 200.
+// Activity emission is best-effort.
+func TestHooksActivity_NilStoreDoesNotBreakHandler(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store := mustCreateAuditStore(t, dir+"/audit.db", logger)
+	defer func() { _ = store.Close() }()
+	scanner := engine.NewScanner("")
+	defer scanner.Close()
+	cfg := config.Defaults()
+	h := NewHandler(scanner, store, cfg, logger)
+	h.SetActivityStore(nil) // explicitly disable
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "claude-code",
+		SessionID: "sess-3",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// 5. An Insert error from the activity store is logged but does NOT
+// affect the request response. Activity is a secondary write;
+// failures must not be visible to the client.
+func TestHooksActivity_InsertErrorDoesNotAffectRequest(t *testing.T) {
+	h, _, cleanup := hooksHandlerWithPrincipal(t, "local-codex", nil)
+	defer cleanup()
+	rec := &recordingActivityWriter{err: errors.New("simulated db down")}
+	h.SetActivityStore(rec)
+
+	body, _ := json.Marshal(ToolEvent{
+		ToolName:  "Read",
+		ToolInput: json.RawMessage(`{"file_path":"/tmp/x"}`),
+		Agent:     "claude-code",
+		SessionID: "sess-4",
+		Event:     "pre_tool_use",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("hooks must succeed even when activity insert fails; status = %d", rec2.Code)
+	}
+	// Give the goroutine time to attempt and fail; recorder should
+	// still hold zero events because Insert returned an error.
+	time.Sleep(50 * time.Millisecond)
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Errorf("recorder should hold zero events on Insert error; got %d", len(got))
+	}
+}
+

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -7,6 +7,7 @@ package hooks
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/identity/resolve"
@@ -171,6 +173,30 @@ type HookStore interface {
 	UpsertHierarchy(h audit.HierarchyEntry) error
 }
 
+// activityWriter is the narrow projection of activity.Store the hooks
+// handler uses. Defined locally so tests can inject a stub without
+// depending on the full Store interface (Query, ListByCoverageCell,
+// etc.). Production passes an *activity.SQLStore; tests pass a recorder.
+type activityWriter interface {
+	Insert(ctx context.Context, e activity.Event) error
+}
+
+// dbBackedAuditStore is the optional capability the hooks handler
+// type-asserts on its HookStore at construction. *audit.Store satisfies
+// it; in-memory test mocks do not, in which case activity dual-write
+// stays disabled and the dashboard falls back to its audit-backed
+// reader. Lives here (not in audit) because the assertion is a hooks-
+// specific concern, not an audit contract.
+type dbBackedAuditStore interface {
+	DB() *sql.DB
+	DialectName() string
+}
+
+// activityInsertTimeout bounds the dual-write so a stalled DB cannot
+// pin a goroutine indefinitely. Mirrors the gateway / proxy constants
+// for behavior consistency across surfaces.
+const activityInsertTimeout = 2 * time.Second
+
 // sessionState tracks agent hierarchy within a session.
 type sessionState struct {
 	mu           sync.Mutex
@@ -195,6 +221,13 @@ type Handler struct {
 	resolver       resolve.Resolver
 	resolverConfig resolve.Config
 	requireAuth    bool
+
+	// activity emits one normalized activity event per audit row so the
+	// dashboard coverage matrix can show real evidence behind each hooks
+	// cell. Nil when the HookStore is not a *audit.Store-backed
+	// implementation (e.g., test mocks that do not expose a *sql.DB) or
+	// when activity migration failed at startup.
+	activity activityWriter
 }
 
 // NewHandler creates a hooks handler wired to the security pipeline.
@@ -208,6 +241,7 @@ func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, lo
 		resolver:       resolver,
 		resolverConfig: resolverCfg,
 		requireAuth:    requireAuth,
+		activity:       buildHooksActivity(store, logger),
 	}
 	// Periodic cleanup of old session states to prevent memory leaks.
 	go func() {
@@ -218,6 +252,102 @@ func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, lo
 		}
 	}()
 	return h
+}
+
+// SetActivityStore lets callers inject a custom activityWriter (e.g., a
+// recorder in tests). Pass nil to disable activity dual-write entirely.
+// Safe to call before the handler starts serving; not safe to swap
+// mid-flight.
+func (h *Handler) SetActivityStore(w activityWriter) {
+	h.activity = w
+}
+
+// buildHooksActivity returns an activityWriter when the underlying
+// HookStore exposes the *sql.DB needed to share the audit DB. Returns
+// nil when the store is a non-DB-backed mock or when migration fails;
+// in either case the dashboard falls back to its audit-backed reader.
+//
+// The type assertion is surface-local on purpose. The audit package
+// does not need to know that hooks dual-writes activity, and
+// hooks.HookStore stays clean for tests that do not exercise this
+// code path.
+func buildHooksActivity(store HookStore, logger *slog.Logger) activityWriter {
+	dbs, ok := store.(dbBackedAuditStore)
+	if !ok {
+		return nil
+	}
+	db := dbs.DB()
+	if db == nil {
+		return nil
+	}
+	dialect := activity.Dialect(dbs.DialectName())
+	if dialect == "" {
+		logger.Warn("activity store skipped: audit store reports unknown dialect", "surface", "hooks")
+		return nil
+	}
+	if err := activity.Migrate(db, dialect); err != nil {
+		logger.Warn("activity store skipped: migrate failed", "surface", "hooks", "error", err)
+		return nil
+	}
+	return activity.NewSQLStore(db, dialect)
+}
+
+// principalIDOrUnknown enforces activity.Event's PrincipalID-required
+// invariant. Hooks accept anonymous local telemetry by design (the
+// most common deployment path is unauthenticated localhost) so the
+// resolver can return an empty principal — emit "unknown" so the
+// activity row still validates and can be filtered out by the
+// dashboard's diagnostic-quality view.
+func principalIDOrUnknown(id string) string {
+	if id == "" {
+		return "unknown"
+	}
+	return id
+}
+
+// emitHookActivity writes one activity event correlated to the audit
+// row just logged. Runs in a fresh background context with a bounded
+// timeout so a slow DB cannot delay the request handler. Insert errors
+// are logged at warn — they never affect the policy decision or the
+// audit row.
+//
+// The activity event uses a fresh UUID for ID and stores msgID as
+// AuditEntryID for correlation. ResourceLabel carries the tool name so
+// the dashboard drill-down can show which tool the hook reported.
+func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, reportedActor string, ev *ToolEvent, status, decision string) {
+	if h.activity == nil {
+		return
+	}
+	event := activity.Event{
+		ID:                  uuid.New().String(),
+		Timestamp:           time.Now().UTC(),
+		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
+		ReportedActor:       reportedActor,
+		AuthMethod:          string(authResult.Principal.AuthMethod),
+		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
+		Surface:             activity.SurfaceHooks,
+		EventType:           activity.EventHookEvent,
+		EvidenceType:        activity.EvidenceHook,
+		SessionID:           ev.SessionID,
+		AuditEntryID:        msgID,
+		Status:              status,
+		PolicyDecision:      decision,
+		CoverageMode:        activity.CoverageFromAuthMethod(string(authResult.Principal.AuthMethod)),
+		Confidence:          activity.ConfidenceFromAuthMethod(string(authResult.Principal.AuthMethod)),
+		ResourceType:        "mcp_tool",
+		ResourceLabel:       ev.ToolName,
+		ResourceID:          ev.ToolName,
+	}
+	go func() {
+		// Detached context: the request context can be cancelled by the
+		// time the goroutine runs, and activity should still land if the
+		// DB is reachable.
+		ctx, cancel := context.WithTimeout(context.Background(), activityInsertTimeout)
+		defer cancel()
+		if err := h.activity.Insert(ctx, event); err != nil {
+			h.logger.Warn("activity insert failed", "error", err, "msg_id", msgID, "surface", "hooks")
+		}
+	}()
 }
 
 // getSessionState returns or creates the session state for tracking agent hierarchy.
@@ -463,6 +593,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
 		ReportedActor:       reportedActor,
 	})
+
+	// Phase 2B.1: emit the paired activity event so the dashboard
+	// coverage matrix can show real evidence behind the hooks cell.
+	// Async with a 2s timeout — never blocks the response. The
+	// reportedActor passed here is the same value the audit row
+	// carries, so the two stay in lock-step.
+	h.emitHookActivity(msgID, authResult, reportedActor, &ev, status, decision)
 
 	// Update agent hierarchy table
 	if ev.SessionID != "" {

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -318,12 +318,18 @@ func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, repo
 	if h.activity == nil {
 		return
 	}
+	authMethod := string(authResult.Principal.AuthMethod)
+	// Hook coverage is stage-aware: post_tool_use evidence cannot
+	// block (the action already ran) so even token-authenticated
+	// post-action hooks are Observed/60, not Protected/100. See
+	// activity.CoverageFromHookEvent.
+	coverage, confidence := activity.CoverageFromHookEvent(authMethod, ev.Event)
 	event := activity.Event{
 		ID:                  uuid.New().String(),
 		Timestamp:           time.Now().UTC(),
 		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
 		ReportedActor:       reportedActor,
-		AuthMethod:          string(authResult.Principal.AuthMethod),
+		AuthMethod:          authMethod,
 		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
 		Surface:             activity.SurfaceHooks,
 		EventType:           activity.EventHookEvent,
@@ -332,8 +338,8 @@ func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, repo
 		AuditEntryID:        msgID,
 		Status:              status,
 		PolicyDecision:      decision,
-		CoverageMode:        activity.CoverageFromAuthMethod(string(authResult.Principal.AuthMethod)),
-		Confidence:          activity.ConfidenceFromAuthMethod(string(authResult.Principal.AuthMethod)),
+		CoverageMode:        coverage,
+		Confidence:          confidence,
 		ResourceType:        "mcp_tool",
 		ResourceLabel:       ev.ToolName,
 		ResourceID:          ev.ToolName,
@@ -469,10 +475,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Subagent type/id (when the client is running inside a sub-agent)
 	// is more specific than the surface header, which is more specific
 	// than whatever the payload supplied as agent.
+	//
+	// The payload agent is preserved as reported_actor whenever it is
+	// not redundant with the resolved principal — covering two cases:
+	//   - resolver established a different principal and the payload
+	//     tried to claim another (forensic record of the spoof);
+	//   - no principal was established (unauthenticated local hook),
+	//     so the payload is the only actor signal we have. principal
+	//     stays unknown — reported_actor is display metadata only and
+	//     never an input to policy decisions.
 	reportedActor := authResult.ReportedActor.ID
-	if ev.AgentType != "" {
+	switch {
+	case ev.AgentType != "":
 		reportedActor = ev.AgentType
-	} else if reportedActor == "" && originalPayloadAgent != "" && originalPayloadAgent != ev.Agent {
+	case reportedActor == "" && originalPayloadAgent != "" && originalPayloadAgent != authResult.Principal.ID:
 		reportedActor = originalPayloadAgent
 	}
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -14,12 +14,27 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/identity/resolve"
 	"github.com/oktsec/oktsec/internal/verdict"
 )
+
+// activityWriter is the narrow projection of activity.Store the forward
+// proxy uses. Defined locally so tests can inject a stub without
+// depending on the full Store interface (Query, ListByCoverageCell,
+// etc.). Production passes an *activity.SQLStore; tests pass a recorder.
+type activityWriter interface {
+	Insert(ctx context.Context, e activity.Event) error
+}
+
+// activityInsertTimeout bounds the dual-write so a stalled DB cannot
+// pin a goroutine indefinitely. 2s is generous for a single insert on
+// SQLite WAL and short enough that a misbehaving Postgres does not fan
+// out goroutines forever. Mirrors the gateway constant.
+const activityInsertTimeout = 2 * time.Second
 
 // ForwardProxy implements an HTTP forward proxy that scans traffic with Aguara.
 // It handles CONNECT tunneling (HTTPS) and plain HTTP forwarding.
@@ -40,6 +55,14 @@ type ForwardProxy struct {
 	resolver       resolve.Resolver
 	resolverConfig resolve.Config
 	requireAuth    bool
+
+	// activity emits one normalized activity event per audit row so the
+	// dashboard coverage matrix can show real evidence behind each
+	// http_egress_proxy cell. May be nil when the audit store does not
+	// expose a *sql.DB or activity migration failed at startup — in
+	// either case the proxy logs only audit and the dashboard falls
+	// back to its audit-backed last-seen reader.
+	activity activityWriter
 }
 
 // NewForwardProxy creates a forward proxy with scanning and audit capabilities.
@@ -80,6 +103,7 @@ func NewForwardProxy(cfg *config.ForwardProxyConfig, scanner *engine.Scanner, au
 		},
 	}
 	fp.resolver, fp.resolverConfig, fp.requireAuth = buildForwardProxyIdentity(cfg, fullCfg)
+	fp.activity = buildForwardProxyActivity(auditStore, logger)
 
 	// Pre-create per-agent rate limiters
 	for name, agent := range agents {
@@ -462,11 +486,14 @@ func (fp *ForwardProxy) hasCategoryBlock(outcome *engine.ScanOutcome, policy *Re
 	return false
 }
 
-// proxyAuth captures the identity provenance fields the audit row needs
-// from the resolver. Built once per request after resolveIdentity and
-// passed to every logProxyEntry call so the policy principal and the
-// audit row can never drift.
+// proxyAuth captures the identity provenance fields the audit row and
+// activity event need from the resolver. Built once per request after
+// resolveIdentity and passed to every logProxyEntry call so the policy
+// principal and the audit row can never drift. PrincipalID is the
+// policy identity the resolver established for this request; activity
+// emission attributes the egress event to it.
 type proxyAuth struct {
+	PrincipalID   string
 	AuthMethod    string
 	TrustLevel    string
 	ReportedActor string
@@ -476,17 +503,23 @@ type proxyAuth struct {
 // snapshot the logProxyEntry calls expect.
 func authFromResolveResult(res resolve.Result) proxyAuth {
 	return proxyAuth{
+		PrincipalID:   res.Principal.ID,
 		AuthMethod:    string(res.Principal.AuthMethod),
 		TrustLevel:    string(res.Principal.TrustLevel),
 		ReportedActor: res.ReportedActor.ID,
 	}
 }
 
-// logProxyEntry writes an audit log entry for proxy traffic. The auth
-// snapshot threads identity provenance (auth_method,
-// principal_trust_level, reported_actor) through to the audit row so
-// downstream coverage / dashboard queries can attribute activity to the
-// egress surface without heuristics.
+// logProxyEntry writes an audit log entry for proxy traffic and emits
+// the matching activity event. The auth snapshot threads identity
+// provenance (auth_method, principal_trust_level, reported_actor)
+// through to the audit row so downstream coverage / dashboard queries
+// can attribute activity to the egress surface without heuristics.
+//
+// emitForwardProxyActivity runs after the audit insert so every audit
+// row the forward proxy writes has a paired activity event. Activity
+// emission is async with a short timeout: a slow or failing activity
+// store cannot affect the request latency or the security decision.
 func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDecision, rulesTriggered, sessionID string, bytesTransferred int64, start time.Time, auth proxyAuth) {
 	entry := audit.Entry{
 		ID:                  uuid.New().String(),
@@ -504,6 +537,99 @@ func (fp *ForwardProxy) logProxyEntry(remoteAddr, method, host, status, policyDe
 		ReportedActor:       auth.ReportedActor,
 	}
 	fp.audit.Log(entry)
+	fp.emitForwardProxyActivity(entry.ID, auth, host, method, status, policyDecision, sessionID)
+}
+
+// SetActivityStore lets callers inject a custom activityWriter (e.g., a
+// recorder in tests, or a future shared store wired by a higher-level
+// orchestrator). Pass nil to disable activity dual-write entirely. Safe
+// to call before the proxy starts serving; not safe to swap mid-flight.
+func (fp *ForwardProxy) SetActivityStore(w activityWriter) {
+	fp.activity = w
+}
+
+// emitForwardProxyActivity writes one activity event correlated to the
+// audit row just logged. Runs in a fresh background context with a
+// bounded timeout so a slow DB cannot delay the request handler.
+// Insert errors are logged at warn — they never affect the policy
+// decision or the audit row.
+//
+// The activity event uses a fresh UUID so two audit rows from the same
+// request (e.g., a CONNECT tunnel followed by a forward) do not
+// collide on the activity primary key. Correlation back to the audit
+// row goes through AuditEntryID.
+func (fp *ForwardProxy) emitForwardProxyActivity(auditID string, auth proxyAuth, host, method, status, policyDecision, sessionID string) {
+	if fp.activity == nil {
+		return
+	}
+	ev := activity.Event{
+		ID:                  uuid.New().String(),
+		Timestamp:           time.Now().UTC(),
+		PrincipalID:         principalIDOrUnknown(auth.PrincipalID),
+		ReportedActor:       auth.ReportedActor,
+		AuthMethod:          auth.AuthMethod,
+		PrincipalTrustLevel: auth.TrustLevel,
+		Surface:             activity.SurfaceHTTPEgressProxy,
+		EventType:           activity.EventEgressRequest,
+		EvidenceType:        activity.EvidenceProxy,
+		SessionID:           sessionID,
+		AuditEntryID:        auditID,
+		Status:              status,
+		PolicyDecision:      policyDecision,
+		CoverageMode:        activity.CoverageFromAuthMethod(auth.AuthMethod),
+		Confidence:          activity.ConfidenceFromAuthMethod(auth.AuthMethod),
+		ResourceType:        "http_host",
+		ResourceLabel:       host,
+		ResourceID:          method + " " + host,
+	}
+	go func() {
+		// Detached context: the request context can be cancelled by the
+		// time the goroutine runs (CONNECT tunnel torn down, response
+		// flushed), and activity should still land if the DB is reachable.
+		ctx, cancel := context.WithTimeout(context.Background(), activityInsertTimeout)
+		defer cancel()
+		if err := fp.activity.Insert(ctx, ev); err != nil {
+			fp.logger.Warn("activity insert failed", "error", err, "audit_id", auditID, "surface", "http_egress_proxy")
+		}
+	}()
+}
+
+// buildForwardProxyActivity constructs the activity store the forward
+// proxy uses for dual-write. Returns nil when the audit store is nil,
+// does not expose a *sql.DB, or migration fails: callers continue
+// audit-only and the coverage matrix falls back to its audit-backed
+// reader. Mirrors buildGatewayActivity in the gateway package; kept
+// per-package to avoid an import cycle on activityWriter.
+func buildForwardProxyActivity(auditStore *audit.Store, logger *slog.Logger) activityWriter {
+	if auditStore == nil {
+		return nil
+	}
+	db := auditStore.DB()
+	if db == nil {
+		return nil
+	}
+	dialect := activity.Dialect(auditStore.DialectName())
+	if dialect == "" {
+		logger.Warn("activity store skipped: audit store reports unknown dialect", "surface", "http_egress_proxy")
+		return nil
+	}
+	if err := activity.Migrate(db, dialect); err != nil {
+		logger.Warn("activity store skipped: migrate failed", "surface", "http_egress_proxy", "error", err)
+		return nil
+	}
+	return activity.NewSQLStore(db, dialect)
+}
+
+// principalIDOrUnknown enforces activity.Event's PrincipalID-required
+// invariant. The forward proxy can run unauthenticated in local mode,
+// in which case the resolver returns an empty principal — emit
+// "unknown" so the activity row still validates and can be filtered
+// out by the dashboard's diagnostic-quality view.
+func principalIDOrUnknown(id string) string {
+	if id == "" {
+		return "unknown"
+	}
+	return id
 }
 
 // dialTarget connects to the target host, chaining through the upstream proxy

--- a/internal/proxy/forward_activity_test.go
+++ b/internal/proxy/forward_activity_test.go
@@ -1,0 +1,230 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/activity"
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity/resolve"
+)
+
+// recordingActivityWriter is a test double for activityWriter that
+// captures every Insert call. The mu makes it safe to read from the
+// test goroutine while the proxy's emit goroutine writes.
+type recordingActivityWriter struct {
+	mu     sync.Mutex
+	events []activity.Event
+	err    error // when set, every Insert returns this error
+}
+
+func (r *recordingActivityWriter) Insert(_ context.Context, e activity.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.events = append(r.events, e)
+	return nil
+}
+
+func (r *recordingActivityWriter) snapshot() []activity.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]activity.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// waitForProxyActivity polls the recorder until it has at least n
+// events or the deadline elapses. The proxy emits activity in a
+// goroutine so a blocking wait is the fairest way to assert against
+// it without sleep races.
+func waitForProxyActivity(t *testing.T, r *recordingActivityWriter, n int) []activity.Event {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := r.snapshot()
+		if len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("activity recorder: wanted %d events, got %d", n, len(r.snapshot()))
+	return nil
+}
+
+// 1. Authenticated egress (proxy_token) emits a Protected activity
+// event with confidence 100 and the audit row id correlated through
+// AuditEntryID.
+func TestForwardProxyActivity_AuthenticatedIsProtected(t *testing.T) {
+	fp, _ := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	rec := &recordingActivityWriter{}
+	fp.SetActivityStore(rec)
+
+	auth := proxyAuth{
+		PrincipalID:   "local-codex",
+		AuthMethod:    string(resolve.AuthMethodProxyToken),
+		TrustLevel:    string(resolve.TrustAuthenticated),
+		ReportedActor: "",
+	}
+	fp.logProxyEntry("127.0.0.1", "GET", "api.example.com:443", "forwarded", "proxy_allowed", "", "sess-1", 1024, time.Now(), auth)
+
+	events := waitForProxyActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex", ev.PrincipalID)
+	}
+	if ev.AuthMethod != string(resolve.AuthMethodProxyToken) {
+		t.Errorf("auth_method = %q; want proxy_token", ev.AuthMethod)
+	}
+	if ev.CoverageMode != activity.CoverageProtected {
+		t.Errorf("coverage = %q; want protected", ev.CoverageMode)
+	}
+	if ev.Confidence != 100 {
+		t.Errorf("confidence = %d; want 100", ev.Confidence)
+	}
+	if ev.Surface != activity.SurfaceHTTPEgressProxy || ev.EventType != activity.EventEgressRequest {
+		t.Errorf("surface/event = %q/%q; want http_egress_proxy/egress.request", ev.Surface, ev.EventType)
+	}
+	if ev.AuditEntryID == "" {
+		t.Error("audit_entry_id should be populated for correlation")
+	}
+	if ev.ResourceLabel != "api.example.com:443" {
+		t.Errorf("resource_label = %q; want api.example.com:443", ev.ResourceLabel)
+	}
+}
+
+// 2. Reported actor (e.g., spoofed agent name from a header) is
+// preserved as ReportedActor on the activity event but never replaces
+// the resolver-established principal.
+func TestForwardProxyActivity_ReportedActorDoesNotReplacePrincipal(t *testing.T) {
+	fp, _ := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	rec := &recordingActivityWriter{}
+	fp.SetActivityStore(rec)
+
+	auth := proxyAuth{
+		PrincipalID:   "local-codex",
+		AuthMethod:    string(resolve.AuthMethodProxyToken),
+		TrustLevel:    string(resolve.TrustAuthenticated),
+		ReportedActor: "admin",
+	}
+	fp.logProxyEntry("127.0.0.1", "GET", "api.example.com:443", "forwarded", "proxy_allowed", "", "sess-1", 0, time.Now(), auth)
+
+	events := waitForProxyActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal = %q; want local-codex (spoof must not replace)", ev.PrincipalID)
+	}
+	if ev.ReportedActor != "admin" {
+		t.Errorf("reported_actor = %q; want admin", ev.ReportedActor)
+	}
+}
+
+// 3. Unauthenticated egress (empty auth method) still emits an
+// activity event so the dashboard sees the surface as Observed rather
+// than Blind. Empty principal id resolves to "unknown" so the row
+// validates against the activity store invariant.
+func TestForwardProxyActivity_UnauthenticatedIsObserved(t *testing.T) {
+	fp, _ := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	rec := &recordingActivityWriter{}
+	fp.SetActivityStore(rec)
+
+	auth := proxyAuth{} // no principal, no auth method
+	fp.logProxyEntry("127.0.0.1", "GET", "api.example.com:443", "forwarded", "proxy_allowed", "", "sess-1", 0, time.Now(), auth)
+
+	events := waitForProxyActivity(t, rec, 1)
+	ev := events[0]
+	if ev.PrincipalID != "unknown" {
+		t.Errorf("principal = %q; want unknown (empty principal must collapse to unknown)", ev.PrincipalID)
+	}
+	if ev.CoverageMode != activity.CoverageObserved {
+		t.Errorf("coverage = %q; want observed", ev.CoverageMode)
+	}
+	if ev.Confidence != 0 {
+		t.Errorf("confidence = %d; want 0", ev.Confidence)
+	}
+}
+
+// 4. When the proxy's activity field is nil (audit store without DB
+// or pre-PR3 setups), logProxyEntry still writes audit and returns.
+// Activity emission is best-effort; it must never gate the request.
+func TestForwardProxyActivity_NilStoreDoesNotBreakRequest(t *testing.T) {
+	fp, store := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	fp.SetActivityStore(nil) // explicitly disable
+
+	auth := proxyAuth{
+		PrincipalID: "local-codex",
+		AuthMethod:  string(resolve.AuthMethodProxyToken),
+		TrustLevel:  string(resolve.TrustAuthenticated),
+	}
+	fp.logProxyEntry("127.0.0.1", "GET", "api.example.com:443", "forwarded", "proxy_allowed", "", "sess-1", 0, time.Now(), auth)
+
+	// Audit row should still be present.
+	store.Flush()
+	if _, err := store.Query(audit.QueryOpts{Agent: "127.0.0.1", Limit: 1}); err != nil {
+		t.Errorf("audit query: %v", err)
+	}
+}
+
+// 5. An Insert error from the activity store is logged but does NOT
+// affect the audit row. Activity is a secondary write; failures must
+// not be visible to the client.
+func TestForwardProxyActivity_InsertErrorDoesNotAffectAudit(t *testing.T) {
+	fp, store := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	rec := &recordingActivityWriter{err: errors.New("simulated db down")}
+	fp.SetActivityStore(rec)
+
+	auth := proxyAuth{
+		PrincipalID: "local-codex",
+		AuthMethod:  string(resolve.AuthMethodProxyToken),
+		TrustLevel:  string(resolve.TrustAuthenticated),
+	}
+	fp.logProxyEntry("127.0.0.1", "GET", "api.example.com:443", "forwarded", "proxy_allowed", "", "sess-1", 0, time.Now(), auth)
+
+	// Audit row is the compliance trail and must still land.
+	store.Flush()
+	entries, err := store.Query(audit.QueryOpts{Agent: "127.0.0.1", Limit: 1})
+	if err != nil || len(entries) == 0 {
+		t.Errorf("audit row missing after activity failure (entries=%d, err=%v)", len(entries), err)
+	}
+	// Give the goroutine time to attempt and fail; recorder should
+	// still hold zero events because Insert returned an error.
+	time.Sleep(50 * time.Millisecond)
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Errorf("recorder should hold zero events on Insert error; got %d", len(got))
+	}
+}
+
+// 6. Blocked egress (e.g., domain blocked) emits an activity event
+// with status=blocked. The contract is "every audit row has a paired
+// activity event", and this test guards the blocked early-return
+// paths from silently bypassing dual-write.
+func TestForwardProxyActivity_BlockedRequestStillEmitsActivity(t *testing.T) {
+	fp, _ := newTestForwardProxy(t, &config.ForwardProxyConfig{Enabled: true})
+	rec := &recordingActivityWriter{}
+	fp.SetActivityStore(rec)
+
+	auth := proxyAuth{
+		PrincipalID: "local-codex",
+		AuthMethod:  string(resolve.AuthMethodProxyToken),
+		TrustLevel:  string(resolve.TrustAuthenticated),
+	}
+	fp.logProxyEntry("127.0.0.1", "CONNECT", "evil.example.com:443", audit.StatusBlocked, "proxy_blocked_domain", "", "sess-1", 0, time.Now(), auth)
+
+	events := waitForProxyActivity(t, rec, 1)
+	ev := events[0]
+	if ev.Status != audit.StatusBlocked {
+		t.Errorf("status = %q; want %q (blocked path must surface in activity)", ev.Status, audit.StatusBlocked)
+	}
+	if ev.PolicyDecision == "" {
+		t.Errorf("policy_decision should explain why request was blocked; got empty")
+	}
+	if ev.Surface != activity.SurfaceHTTPEgressProxy {
+		t.Errorf("surface = %q; want http_egress_proxy", ev.Surface)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2B.1 PR3 wires the HTTP forward proxy and the hooks endpoint to dual-write `activity.Event` rows beside their existing `audit.Entry` rows, completing the surface-adapter half of Phase 2B.1. Combined with PR2 (gateway), the dashboard coverage matrix can now show real evidence for all three surfaces.

No policy decision changes. No audit row changes. No request-path latency cost: activity emission runs in a goroutine with a 2s timeout and warn-logs failures.

## What changed

- **`internal/activity/coverage_from_auth.go`** (new) — hoists `CoverageFromAuthMethod` and `ConfidenceFromAuthMethod` out of the gateway so all three surface adapters share the same auth-method to coverage / confidence mapping. Extends the auth method coverage to `ed25519`, `mtls`, and `wrapper` (all `Protected/100`) so future surfaces don't have to relitigate the table.
- **`internal/gateway/gateway.go`** — drops the local `coverageFromAuth` / `confidenceFromAuth` helpers in favor of the exported `activity` package versions. No behavior change.
- **`internal/proxy/forward.go`**
  - `activityWriter` narrow interface (Insert only) so tests inject a stub.
  - `proxyAuth` extended with `PrincipalID` (already on the resolver `Result`).
  - `buildForwardProxyActivity(auditStore, logger)` — same nil-safe pattern as the gateway: returns nil when audit has no `*sql.DB` or migration fails.
  - `SetActivityStore(w activityWriter)` for tests / future shared-store wiring.
  - **Emission lives inside `logProxyEntry`** so all 9 call sites (CONNECT blocked, allowed, forwarded, content-blocked, response-blocked, SSRF-blocked, etc.) get a paired activity event automatically.
- **`internal/hooks/handler.go`**
  - `activityWriter` narrow interface + `dbBackedAuditStore` capability check (`DB() *sql.DB`, `DialectName() string`) on the existing `HookStore`. Production `*audit.Store` satisfies it; in-memory test mocks fall through to nil dual-write.
  - `buildHooksActivity` (same nil-safe pattern), `SetActivityStore`, `emitHookActivity`.
  - **Emission lives right after `h.store.Log(...)`** with the same `reportedActor` value the audit row carries, so the two rows stay in lock-step.
- Goroutine + `context.WithTimeout(context.Background(), 2 * time.Second)` everywhere so a stalled DB cannot pin a goroutine indefinitely or affect handler latency.

## Tests (11 new, 5+6 split)

`internal/proxy/forward_activity_test.go`:
1. Authenticated egress (`proxy_token`) → `coverage=protected`, `confidence=100`, `AuditEntryID` populated, `surface=http_egress_proxy`.
2. Spoofed reported actor preserved as `ReportedActor`, never replaces the principal.
3. Unauthenticated egress → `coverage=observed`, principal collapsed to `unknown`.
4. `SetActivityStore(nil)` keeps audit row landing.
5. Insert error → audit row still lands, recorder stays empty.
6. Blocked egress (`proxy_blocked_domain`) emits activity with `status=blocked`.

`internal/hooks/activity_test.go`:
1. `hook_token`-authenticated → `coverage=protected`, `confidence=100`, `AuditEntryID` populated, `ResourceLabel=tool name`.
2. Payload-spoofed agent preserved as `ReportedActor` (matches the audit row's derived value).
3. Unauthenticated local hook → `coverage=observed`, principal collapsed to `unknown`.
4. `SetActivityStore(nil)` keeps the response 200.
5. Insert error → 200 response, recorder stays empty.

## Not included

- Connector registry (`internal/connectors`) + hybrid coverage reader — PR4.
- Dashboard activity drill-down — PR5.
- Agent-message HTTP proxy and stdio MCP proxy — out of the current activity surface taxonomy (would need new `Surface*` constants and a coverage-matrix story).
- `EvidenceJSON` with request/tool args — deferred until the dashboard actually shows it (and we have a redaction story for arg payloads).

## Test plan

- [x] `make test` — 0 failures, race detector clean.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] All 11 new tests pass.
- [ ] Manual smoke: run a forward proxy egress and a hook event; confirm one row each in `audit_log` and `activity_events` with matching `audit_entry_id` and the expected `surface`.