### PR TITLE
Tighten CoverageFromHookEvent: only pre_tool_use can claim Protected

### DIFF
--- a/internal/activity/coverage_from_auth.go
+++ b/internal/activity/coverage_from_auth.go
@@ -40,29 +40,52 @@ func ConfidenceFromAuthMethod(method string) int {
 	return 0
 }
 
-// HookEventPostToolUse is the normalized stage name for hooks that
-// fire after the tool ran. Kept as a constant so the coverage helper
-// and any future hook-stage logic agree on the wire value.
-const HookEventPostToolUse = "post_tool_use"
+// Hook stage names. The hooks handler normalizes incoming wire
+// values (e.g., Claude Code's "PreToolUse") into these snake_case
+// forms before emitting activity, so the coverage helper compares
+// against a single canonical vocabulary.
+const (
+	HookEventPreToolUse  = "pre_tool_use"
+	HookEventPostToolUse = "post_tool_use"
+)
 
 // CoverageFromHookEvent returns the coverage label and confidence the
-// dashboard should attribute to a single hook event. It accounts for
-// the hook stage, which CoverageFromAuthMethod alone cannot:
+// dashboard should attribute to a single hook event. It is
+// stage-driven on purpose: only pre_tool_use can claim Protected
+// because it is the only stage where oktsec can block before the
+// action runs. Every other stage is evidence after-the-fact at best,
+// regardless of how trustworthy the auth method is.
 //
-//   - pre_tool_use is the only stage where oktsec can block before the
-//     action ran; with token auth it is genuinely Protected/100.
-//   - post_tool_use is evidence after the fact. Even when carried by a
-//     valid hook_token the surface cannot block, so it is Observed
-//     with confidence 60 per the Phase 2B.1 spec ladder.
+//   - pre_tool_use inherits the auth-method base — token auth is
+//     Protected/100, trusted_loopback is Observed/80, etc.
+//   - post_tool_use with a token-authenticated source is Observed/60
+//     per the Phase 2B.1 spec ladder. Unauthenticated falls through
+//     to the auth-method base.
+//   - Any other explicit stage (notification, session lifecycle
+//     events, future stages) and any unrecognized stage value cannot
+//     be Protected. With a token-authenticated source we record
+//     Observed/40 — the source is trustworthy but we cannot say which
+//     lifecycle moment this evidence represents. Without a token we
+//     fall through to the auth-method base.
 //
-// Unauthenticated hooks (any stage) inherit the auth-method-only
-// mapping — they were already Observed with low confidence and the
-// stage does not change that.
+// The conservative default for unknown stages is the point of this
+// helper: a future hook stage added to a client must not silently
+// inflate the coverage matrix.
 func CoverageFromHookEvent(authMethod, hookEvent string) (CoverageMode, int) {
 	base := CoverageFromAuthMethod(authMethod)
 	conf := ConfidenceFromAuthMethod(authMethod)
-	if hookEvent == HookEventPostToolUse && base == CoverageProtected {
-		return CoverageObserved, 60
+	switch hookEvent {
+	case HookEventPreToolUse:
+		return base, conf
+	case HookEventPostToolUse:
+		if base == CoverageProtected {
+			return CoverageObserved, 60
+		}
+		return base, conf
+	default:
+		if base == CoverageProtected {
+			return CoverageObserved, 40
+		}
+		return base, conf
 	}
-	return base, conf
 }

--- a/internal/activity/coverage_from_auth_test.go
+++ b/internal/activity/coverage_from_auth_test.go
@@ -56,6 +56,50 @@ func TestCoverageFromHookEvent(t *testing.T) {
 			wantCov:    CoverageObserved,
 			wantConf:   80,
 		},
+		{
+			// Claude Code emits Notification/Stop/SessionStart hooks
+			// in addition to PreToolUse/PostToolUse. None of them
+			// run before the action, so token auth must not promote
+			// them to Protected.
+			name:       "notification with hook_token is observed/40 (cannot block, unknown stage)",
+			authMethod: "hook_token",
+			hookEvent:  "notification",
+			wantCov:    CoverageObserved,
+			wantConf:   40,
+		},
+		{
+			name:       "stop with hook_token is observed/40 (session lifecycle, cannot block)",
+			authMethod: "hook_token",
+			hookEvent:  "stop",
+			wantCov:    CoverageObserved,
+			wantConf:   40,
+		},
+		{
+			// Defensive: a future client could send a stage name we
+			// have not seen. The conservative default protects the
+			// matrix from silent inflation.
+			name:       "unknown stage with hook_token is observed/40",
+			authMethod: "hook_token",
+			hookEvent:  "future_stage_we_dont_know",
+			wantCov:    CoverageObserved,
+			wantConf:   40,
+		},
+		{
+			// Defensive: empty stage should never happen post-normalization,
+			// but if it does the helper must not over-claim.
+			name:       "empty stage with hook_token is observed/40 (defensive)",
+			authMethod: "hook_token",
+			hookEvent:  "",
+			wantCov:    CoverageObserved,
+			wantConf:   40,
+		},
+		{
+			name:       "notification unauthenticated stays observed/0 (no inflation)",
+			authMethod: "",
+			hookEvent:  "notification",
+			wantCov:    CoverageObserved,
+			wantConf:   0,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to PR #139. The `post_tool_use` downgrade landed correctly, but the helper still inherited the auth-method base for any other explicit hook stage. So a `hook_token`-authenticated `notification`, `stop`, `session_start`, or any future stage a client invents would silently be classified as `Protected/100` — exactly the overclaim Phase 2B.1 is trying to eliminate.

## What changes

`activity.CoverageFromHookEvent` switches explicitly by stage. Only `pre_tool_use` can claim `Protected` because it is the only stage where oktsec can block before the action runs:

- `pre_tool_use` -> auth-method base (token => `Protected/100`)
- `post_tool_use` -> token => `Observed/60`, else auth base
- any other or unknown stage -> token => `Observed/40`, else auth base

`Observed/40` for token-authenticated unknown stages records "trustworthy source, unknown lifecycle moment" — the source is real, but we cannot say which part of the action this evidence represents.

Unauthenticated events fall through to the auth-method base in every branch so the no-token paths stay unchanged.

## Tests

Extends the existing `TestCoverageFromHookEvent` table with five new rows:
- `notification` + `hook_token` -> `Observed/40`
- `stop` + `hook_token` -> `Observed/40`
- unknown stage + `hook_token` -> `Observed/40`
- empty stage + `hook_token` -> `Observed/40` (defensive — should never happen post-normalization)
- `notification` + unauth -> `Observed/0` (no inflation either way)

A future hook stage added to a client now requires a test update before it can affect the coverage matrix.

## Test plan

- [x] `make test` (race) green
- [x] `make lint` 0 issues
- [x] `make vet` clean
- [ ] Manual smoke: emit a `notification` hook with a valid `hook_token`; confirm `coverage_mode=observed`, `confidence=40` in `activity_events`.