### PR TITLE
Add connector registry and hybrid coverage reader (Phase 2B.1 PR4)

### DIFF
--- a/internal/connectors/builtin.go
+++ b/internal/connectors/builtin.go
@@ -1,0 +1,132 @@
+package connectors
+
+// builtinConnectors returns a fresh map of the built-in connector
+// definitions. The returned map is the registry's authoritative state;
+// callers receive Connector values (not pointers), so they cannot
+// mutate the registered SurfaceCapability slices accidentally.
+//
+// Auth method strings reference resolve.AuthMethod; event type
+// strings reference activity.EventType. Both are duplicated here as
+// string literals (rather than imported) to keep this package free of
+// upstream dependencies — the registry is meant to be the leaf.
+func builtinConnectors() map[string]Connector {
+	return map[string]Connector{
+		IDGenericMCPHTTP: {
+			ID:          IDGenericMCPHTTP,
+			DisplayName: "Generic MCP HTTP",
+			Kind:        KindGeneric,
+			Surfaces: []SurfaceCapability{{
+				Surface:         "mcp_http",
+				TokenType:       "gateway_bearer",
+				AuthMethods:     []string{"bearer_token"},
+				EventTypes:      []string{"mcp.tool_call"},
+				CanBlock:        true,
+				DefaultCoverage: "protected",
+			}},
+		},
+		IDGenericEgressProxy: {
+			ID:          IDGenericEgressProxy,
+			DisplayName: "Generic egress proxy",
+			Kind:        KindGeneric,
+			Surfaces: []SurfaceCapability{{
+				Surface:         "http_egress_proxy",
+				TokenType:       "proxy_basic",
+				AuthMethods:     []string{"proxy_token"},
+				EventTypes:      []string{"egress.request"},
+				CanBlock:        true,
+				DefaultCoverage: "protected",
+				Caveat:          "HTTPS CONNECT is domain-only unless body inspection is enabled",
+			}},
+		},
+		IDGenericHooks: {
+			ID:          IDGenericHooks,
+			DisplayName: "Generic hooks",
+			Kind:        KindGeneric,
+			Surfaces: []SurfaceCapability{{
+				Surface:         "hooks",
+				TokenType:       "hook_bearer",
+				AuthMethods:     []string{"hook_token"},
+				EventTypes:      []string{"hook.event"},
+				CanBlock:        true, // pre-action only; coverage helper enforces stage
+				DefaultCoverage: "protected",
+				Caveat:          "post-action hooks are observed only",
+			}},
+		},
+		IDCustomClient: {
+			ID:          IDCustomClient,
+			DisplayName: "Custom client",
+			Kind:        KindCustom,
+			// The custom-client bucket spans all three surface types;
+			// the inference rule requires evidence of multiple active
+			// surface tokens, so the capability list mirrors that.
+			Surfaces: []SurfaceCapability{
+				{
+					Surface: "mcp_http", TokenType: "gateway_bearer",
+					AuthMethods: []string{"bearer_token"},
+					EventTypes:  []string{"mcp.tool_call"},
+					CanBlock:    true, DefaultCoverage: "protected",
+				},
+				{
+					Surface: "http_egress_proxy", TokenType: "proxy_basic",
+					AuthMethods: []string{"proxy_token"},
+					EventTypes:  []string{"egress.request"},
+					CanBlock:    true, DefaultCoverage: "protected",
+				},
+				{
+					Surface: "hooks", TokenType: "hook_bearer",
+					AuthMethods: []string{"hook_token"},
+					EventTypes:  []string{"hook.event"},
+					CanBlock:    true, DefaultCoverage: "protected",
+				},
+			},
+		},
+		IDLegacyLoopbackHeader: {
+			ID:          IDLegacyLoopbackHeader,
+			DisplayName: "Legacy loopback header",
+			Kind:        KindLegacy,
+			// Loopback header is only honored by the gateway and the
+			// forward proxy. Hooks accept anonymous POSTs in local
+			// profile, but that is a different code path (no
+			// trusted_loopback auth method is recorded).
+			Surfaces: []SurfaceCapability{
+				{
+					Surface: "mcp_http",
+					AuthMethods: []string{"trusted_loopback"},
+					EventTypes:  []string{"mcp.tool_call"},
+					CanBlock:    false, // header-asserted identity, no token
+					DefaultCoverage: "observed",
+					Caveat:          "loopback header only — issue a gateway_bearer token for stronger auth",
+				},
+				{
+					Surface: "http_egress_proxy",
+					AuthMethods: []string{"trusted_loopback"},
+					EventTypes:  []string{"egress.request"},
+					CanBlock:    false,
+					DefaultCoverage: "observed",
+					Caveat:          "loopback header only — issue a proxy_basic token for stronger auth",
+				},
+			},
+		},
+		IDUnknown: {
+			ID:          IDUnknown,
+			DisplayName: "Unknown source",
+			Kind:        KindUnknown,
+			Surfaces:    nil, // explicitly empty: nothing is claimed
+		},
+	}
+}
+
+// orderedIDs returns the connector IDs in the order List should
+// surface them. Generic connectors first (one per surface), then
+// custom, then legacy, then unknown — that mirrors how the dashboard
+// drill-down would group them.
+func orderedIDs() []string {
+	return []string{
+		IDGenericMCPHTTP,
+		IDGenericEgressProxy,
+		IDGenericHooks,
+		IDCustomClient,
+		IDLegacyLoopbackHeader,
+		IDUnknown,
+	}
+}

--- a/internal/connectors/registry.go
+++ b/internal/connectors/registry.go
@@ -1,0 +1,96 @@
+package connectors
+
+// BuiltinRegistry is the in-process Registry implementation backed by
+// the built-in connector table. It is safe for concurrent reads (the
+// underlying map is built once in NewBuiltinRegistry and never
+// mutated). Future operator-defined connectors would extend this type
+// or live behind a composite registry that consults the built-ins
+// first.
+type BuiltinRegistry struct {
+	items map[string]Connector
+}
+
+// NewBuiltinRegistry constructs a fresh registry with every built-in
+// connector loaded. Callers that want an isolated registry per test
+// should call this directly; the package-level Default() registry is
+// shared and safe for production use.
+func NewBuiltinRegistry() *BuiltinRegistry {
+	return &BuiltinRegistry{items: builtinConnectors()}
+}
+
+// Get returns the connector with the given ID. The bool is false when
+// the ID is not registered; callers should treat that as IDUnknown
+// rather than panicking.
+func (r *BuiltinRegistry) Get(id string) (Connector, bool) {
+	c, ok := r.items[id]
+	return c, ok
+}
+
+// List returns every registered connector in a deterministic order so
+// dashboard rendering does not flicker between requests.
+func (r *BuiltinRegistry) List() []Connector {
+	out := make([]Connector, 0, len(r.items))
+	for _, id := range orderedIDs() {
+		if c, ok := r.items[id]; ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// surfaceTokenTypes is the canonical priority order for surface tokens
+// the inference rule cares about. Defined in one place so the count /
+// last-active loop and the single-token branches always agree.
+var surfaceTokenTypes = []string{"gateway_bearer", "proxy_basic", "hook_bearer"}
+
+// Infer chooses the connector that best matches the evidence at hand.
+//
+// Rules (mirrors the Phase 2B.1 spec table):
+//
+//   - 2+ active surface tokens                  -> custom-client
+//   - exactly 1 active gateway_bearer token     -> generic-mcp-http
+//   - exactly 1 active proxy_basic token        -> generic-egress-proxy
+//   - exactly 1 active hook_bearer token        -> generic-hooks
+//   - 0 active tokens, trusted_loopback in evidence -> legacy-loopback-header
+//   - 0 active tokens, no loopback evidence     -> unknown
+//
+// Both maps may be nil; callers must not pass entries for revoked or
+// expired tokens (the coverage layer is responsible for that filter).
+// observedAuthMethods is intentionally generic so future surfaces can
+// contribute their own evidence (e.g. wrapper-signed activity) without
+// changing the signature.
+func (r *BuiltinRegistry) Infer(activeTokenTypes, observedAuthMethods map[string]bool) Connector {
+	activeCount := 0
+	var lastActive string
+	for _, t := range surfaceTokenTypes {
+		if activeTokenTypes[t] {
+			activeCount++
+			lastActive = t
+		}
+	}
+	switch {
+	case activeCount >= 2:
+		return r.items[IDCustomClient]
+	case lastActive == "gateway_bearer":
+		return r.items[IDGenericMCPHTTP]
+	case lastActive == "proxy_basic":
+		return r.items[IDGenericEgressProxy]
+	case lastActive == "hook_bearer":
+		return r.items[IDGenericHooks]
+	}
+	if observedAuthMethods["trusted_loopback"] {
+		return r.items[IDLegacyLoopbackHeader]
+	}
+	return r.items[IDUnknown]
+}
+
+// defaultRegistry is the process-wide registry used by Default(). It
+// is built once at package init and never mutated, so it is safe for
+// concurrent use.
+var defaultRegistry = NewBuiltinRegistry()
+
+// Default returns the process-wide built-in registry. Callers that
+// need to inject a different registry (e.g., tests with a custom
+// connector) should accept a Registry parameter and let the operator
+// choose; Default is the convenience for the common path.
+func Default() Registry { return defaultRegistry }

--- a/internal/connectors/registry.go
+++ b/internal/connectors/registry.go
@@ -20,19 +20,25 @@ func NewBuiltinRegistry() *BuiltinRegistry {
 
 // Get returns the connector with the given ID. The bool is false when
 // the ID is not registered; callers should treat that as IDUnknown
-// rather than panicking.
+// rather than panicking. Returned Connector is a deep copy so callers
+// cannot mutate the registry's authoritative state through the
+// returned slices.
 func (r *BuiltinRegistry) Get(id string) (Connector, bool) {
 	c, ok := r.items[id]
-	return c, ok
+	if !ok {
+		return Connector{}, false
+	}
+	return cloneConnector(c), true
 }
 
 // List returns every registered connector in a deterministic order so
-// dashboard rendering does not flicker between requests.
+// dashboard rendering does not flicker between requests. Each returned
+// Connector is a deep copy.
 func (r *BuiltinRegistry) List() []Connector {
 	out := make([]Connector, 0, len(r.items))
 	for _, id := range orderedIDs() {
 		if c, ok := r.items[id]; ok {
-			out = append(out, c)
+			out = append(out, cloneConnector(c))
 		}
 	}
 	return out
@@ -68,20 +74,45 @@ func (r *BuiltinRegistry) Infer(activeTokenTypes, observedAuthMethods map[string
 			lastActive = t
 		}
 	}
+	var picked string
 	switch {
 	case activeCount >= 2:
-		return r.items[IDCustomClient]
+		picked = IDCustomClient
 	case lastActive == "gateway_bearer":
-		return r.items[IDGenericMCPHTTP]
+		picked = IDGenericMCPHTTP
 	case lastActive == "proxy_basic":
-		return r.items[IDGenericEgressProxy]
+		picked = IDGenericEgressProxy
 	case lastActive == "hook_bearer":
-		return r.items[IDGenericHooks]
+		picked = IDGenericHooks
+	case observedAuthMethods["trusted_loopback"]:
+		picked = IDLegacyLoopbackHeader
+	default:
+		picked = IDUnknown
 	}
-	if observedAuthMethods["trusted_loopback"] {
-		return r.items[IDLegacyLoopbackHeader]
+	return cloneConnector(r.items[picked])
+}
+
+// cloneConnector returns a deep copy of c so callers cannot mutate the
+// registry's authoritative state via the returned slices. Surfaces
+// gets a fresh slice; each SurfaceCapability inside gets its own
+// AuthMethods and EventTypes copies. Strings are immutable in Go so
+// they can be assigned by value safely.
+func cloneConnector(c Connector) Connector {
+	out := c
+	if c.Surfaces != nil {
+		out.Surfaces = make([]SurfaceCapability, len(c.Surfaces))
+		for i, s := range c.Surfaces {
+			cp := s
+			if s.AuthMethods != nil {
+				cp.AuthMethods = append([]string(nil), s.AuthMethods...)
+			}
+			if s.EventTypes != nil {
+				cp.EventTypes = append([]string(nil), s.EventTypes...)
+			}
+			out.Surfaces[i] = cp
+		}
 	}
-	return r.items[IDUnknown]
+	return out
 }
 
 // defaultRegistry is the process-wide registry used by Default(). It

--- a/internal/connectors/registry_test.go
+++ b/internal/connectors/registry_test.go
@@ -1,0 +1,151 @@
+package connectors
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The Phase 2B.1 spec table is reproduced here as a single source of
+// truth: every row in the spec corresponds to one row in this table.
+// A failure here means the wire-level connector inference would drift
+// from the documented matrix.
+func TestBuiltinRegistry_Infer(t *testing.T) {
+	r := NewBuiltinRegistry()
+
+	cases := []struct {
+		name     string
+		active   map[string]bool
+		observed map[string]bool
+		wantID   string
+	}{
+		{
+			name:   "single gateway_bearer maps to generic-mcp-http",
+			active: map[string]bool{"gateway_bearer": true},
+			wantID: IDGenericMCPHTTP,
+		},
+		{
+			name:   "single proxy_basic maps to generic-egress-proxy",
+			active: map[string]bool{"proxy_basic": true},
+			wantID: IDGenericEgressProxy,
+		},
+		{
+			name:   "single hook_bearer maps to generic-hooks",
+			active: map[string]bool{"hook_bearer": true},
+			wantID: IDGenericHooks,
+		},
+		{
+			name:   "two surface tokens map to custom-client",
+			active: map[string]bool{"gateway_bearer": true, "proxy_basic": true},
+			wantID: IDCustomClient,
+		},
+		{
+			name:   "three surface tokens map to custom-client",
+			active: map[string]bool{"gateway_bearer": true, "proxy_basic": true, "hook_bearer": true},
+			wantID: IDCustomClient,
+		},
+		{
+			// The coverage layer filters revoked/expired before
+			// calling Infer, so an empty active map represents that
+			// real-world case. With loopback evidence present, the
+			// principal is labeled legacy-loopback-header.
+			name:     "no active tokens with loopback evidence maps to legacy-loopback-header",
+			active:   map[string]bool{},
+			observed: map[string]bool{"trusted_loopback": true},
+			wantID:   IDLegacyLoopbackHeader,
+		},
+		{
+			// No tokens, no loopback evidence (e.g. enterprise profile
+			// where the loopback header is rejected). The honest
+			// label is unknown — the principal exists in config but
+			// has no working auth path.
+			name:     "no active tokens and no observed evidence maps to unknown",
+			active:   map[string]bool{},
+			observed: map[string]bool{},
+			wantID:   IDUnknown,
+		},
+		{
+			name:   "nil maps are treated as empty (no panic)",
+			active: nil, observed: nil,
+			wantID: IDUnknown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.Infer(tc.active, tc.observed)
+			if got.ID != tc.wantID {
+				t.Errorf("connector = %q; want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+// Get returns the registered connector and false for unknown IDs.
+// Tests rely on this contract to avoid panicking on a typo or a
+// connector that has not been registered yet.
+func TestBuiltinRegistry_Get(t *testing.T) {
+	r := NewBuiltinRegistry()
+
+	if c, ok := r.Get(IDGenericMCPHTTP); !ok || c.DisplayName != "Generic MCP HTTP" {
+		t.Errorf("Get(generic-mcp-http) = (%+v, %v); want hit", c, ok)
+	}
+	if _, ok := r.Get("nope-this-id-does-not-exist"); ok {
+		t.Error("Get(nope) returned ok=true; want false")
+	}
+}
+
+// List returns every built-in in a deterministic order. Dashboard
+// rendering pivots on this order so flicker between requests would
+// appear as a regression in the table.
+func TestBuiltinRegistry_ListIsStable(t *testing.T) {
+	r := NewBuiltinRegistry()
+	first := r.List()
+	second := r.List()
+
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("List order is not stable across calls")
+	}
+	wantIDs := []string{
+		IDGenericMCPHTTP, IDGenericEgressProxy, IDGenericHooks,
+		IDCustomClient, IDLegacyLoopbackHeader, IDUnknown,
+	}
+	if len(first) != len(wantIDs) {
+		t.Fatalf("List length = %d; want %d", len(first), len(wantIDs))
+	}
+	for i, id := range wantIDs {
+		if first[i].ID != id {
+			t.Errorf("List[%d].ID = %q; want %q", i, first[i].ID, id)
+		}
+	}
+}
+
+// Custom-client built-in covers all three surface types. This is the
+// invariant that lets the dashboard show "Custom client" without
+// branching on a specific surface.
+func TestBuiltinRegistry_CustomClientCoversAllSurfaces(t *testing.T) {
+	r := NewBuiltinRegistry()
+	cc, ok := r.Get(IDCustomClient)
+	if !ok {
+		t.Fatal("custom-client connector not registered")
+	}
+	want := map[string]bool{"mcp_http": false, "http_egress_proxy": false, "hooks": false}
+	for _, s := range cc.Surfaces {
+		if _, expected := want[s.Surface]; expected {
+			want[s.Surface] = true
+		}
+	}
+	for surface, found := range want {
+		if !found {
+			t.Errorf("custom-client missing surface %q", surface)
+		}
+	}
+}
+
+// Default returns a non-nil registry. The tests would catch a nil
+// dereference even without this assertion; the explicit check keeps
+// the contract obvious for new readers.
+func TestDefault_NotNil(t *testing.T) {
+	if Default() == nil {
+		t.Fatal("Default registry is nil")
+	}
+}

--- a/internal/connectors/registry_test.go
+++ b/internal/connectors/registry_test.go
@@ -55,9 +55,9 @@ func TestBuiltinRegistry_Infer(t *testing.T) {
 		},
 		{
 			// No tokens, no loopback evidence (e.g. enterprise profile
-			// where the loopback header is rejected). The honest
+			// where the loopback header is rejected). The current-state
 			// label is unknown — the principal exists in config but
-			// has no working auth path.
+			// has no working auth path on any surface.
 			name:     "no active tokens and no observed evidence maps to unknown",
 			active:   map[string]bool{},
 			observed: map[string]bool{},
@@ -147,5 +147,51 @@ func TestBuiltinRegistry_CustomClientCoversAllSurfaces(t *testing.T) {
 func TestDefault_NotNil(t *testing.T) {
 	if Default() == nil {
 		t.Fatal("Default registry is nil")
+	}
+}
+
+// Mutating a connector returned from Get / List / Infer must not
+// affect later calls. The registry must hand back deep copies so a
+// caller that scribbles on Surfaces / AuthMethods / EventTypes
+// cannot poison Default() for the next dashboard request.
+func TestBuiltinRegistry_ReturnedConnectorsAreImmutable(t *testing.T) {
+	r := NewBuiltinRegistry()
+
+	first, ok := r.Get(IDGenericMCPHTTP)
+	if !ok {
+		t.Fatal("generic-mcp-http not registered")
+	}
+	if len(first.Surfaces) == 0 || len(first.Surfaces[0].AuthMethods) == 0 {
+		t.Fatal("test fixture: generic-mcp-http has no surfaces or auth methods")
+	}
+
+	// Scribble on the returned slices.
+	first.Surfaces[0].AuthMethods[0] = "POISONED"
+	first.Surfaces[0].EventTypes[0] = "POISONED"
+	first.Surfaces[0].Surface = "POISONED"
+
+	// A fresh Get must see the original values.
+	second, _ := r.Get(IDGenericMCPHTTP)
+	if got := second.Surfaces[0].AuthMethods[0]; got == "POISONED" {
+		t.Errorf("AuthMethods[0] mutation leaked back into the registry: got %q", got)
+	}
+	if got := second.Surfaces[0].EventTypes[0]; got == "POISONED" {
+		t.Errorf("EventTypes[0] mutation leaked back into the registry: got %q", got)
+	}
+	if got := second.Surfaces[0].Surface; got == "POISONED" {
+		t.Errorf("Surface mutation leaked back into the registry: got %q", got)
+	}
+
+	// Same contract via List and Infer.
+	for _, c := range r.List() {
+		if c.ID == IDGenericMCPHTTP {
+			if c.Surfaces[0].AuthMethods[0] == "POISONED" {
+				t.Error("List returned a poisoned connector")
+			}
+		}
+	}
+	inferred := r.Infer(map[string]bool{"gateway_bearer": true}, nil)
+	if inferred.Surfaces[0].AuthMethods[0] == "POISONED" {
+		t.Error("Infer returned a poisoned connector")
 	}
 }

--- a/internal/connectors/types.go
+++ b/internal/connectors/types.go
@@ -1,0 +1,91 @@
+// Package connectors holds the capability-based connector registry the
+// Phase 2B.1 coverage matrix uses to label a principal's runtime
+// integration. A "connector" here is the bundle of surfaces, token
+// types, auth methods, and event types a known client (or the
+// "Custom client" / "Unknown source" buckets) is expected to use.
+//
+// The registry is deliberately capability-driven, not named-client
+// driven: nothing in this package branches on "claude-code" or
+// "codex" or any other client name. The dashboard and policy paths
+// must keep working when a new client appears in the wild — they
+// just see a connector with the matching capability shape.
+//
+// PR4 ships the in-process built-in registry and the Infer entry
+// point Compute uses. PR5 wires the dashboard drill-down on top.
+// Future PRs may add a YAML-driven custom connector layer; the
+// Registry interface is stable enough for that to slot in without
+// touching callers.
+package connectors
+
+// SurfaceCapability describes one (surface, token type) pair the
+// connector knows how to participate in. The fields are descriptive
+// metadata for the dashboard and the inference logic; they are not a
+// policy contract on their own. Auth methods and event types are
+// listed so a future operator-facing view can show "this connector
+// uses bearer_token on mcp_http and emits mcp.tool_call events" with
+// stable strings.
+type SurfaceCapability struct {
+	Surface         string   // resolve.Surface / activity.Surface wire value
+	TokenType       string   // config.PrincipalTokenConfig.Type value
+	AuthMethods     []string // resolve.AuthMethod wire values the surface honors
+	EventTypes      []string // activity.EventType wire values the surface emits
+	CanBlock        bool     // true when oktsec sits in the path before action
+	DefaultCoverage string   // coverage.CoverageMode wire value when the capability is realized
+	Caveat          string   // optional one-sentence display caveat
+}
+
+// Connector is the registry record for one integration shape. ID is
+// the stable wire value the dashboard pivots on; DisplayName is the
+// only operator-visible string. Kind groups connectors for filtering
+// without having to enumerate every ID.
+type Connector struct {
+	ID          string
+	DisplayName string
+	Kind        string
+	Surfaces    []SurfaceCapability
+}
+
+// Registry is the contract callers depend on. It hides the storage
+// layer (in-process map today, possibly YAML-driven later) and bundles
+// the Infer step so coverage code does not have to reach into the
+// connector table itself.
+type Registry interface {
+	// Get returns the connector with the given ID. The bool is false
+	// when the ID is not registered; callers should treat that as
+	// IDUnknown rather than panicking.
+	Get(id string) (Connector, bool)
+
+	// List returns every registered connector. Order is stable and
+	// deterministic so dashboard rendering does not flicker.
+	List() []Connector
+
+	// Infer chooses the connector that best matches the evidence at
+	// hand. activeTokenTypes maps the principal's currently-valid
+	// (non-revoked, non-expired) token types to true. observedAuthMethods
+	// maps auth methods the principal could plausibly use on at least
+	// one surface (e.g. "trusted_loopback" when local-mode loopback is
+	// honored anywhere) to true. The implementation must never panic
+	// on missing keys; callers may pass nil for either input.
+	Infer(activeTokenTypes map[string]bool, observedAuthMethods map[string]bool) Connector
+}
+
+// Connector ID constants. Wire values match the Phase 2B.1 spec table.
+// Kept exported so callers can compare without re-deriving the strings.
+const (
+	IDGenericMCPHTTP       = "generic-mcp-http"
+	IDGenericEgressProxy   = "generic-egress-proxy"
+	IDGenericHooks         = "generic-hooks"
+	IDCustomClient         = "custom-client"
+	IDLegacyLoopbackHeader = "legacy-loopback-header"
+	IDUnknown              = "unknown"
+)
+
+// Connector kind constants. Used by Connector.Kind. Kept narrow on
+// purpose — new kinds should be added consciously, not from
+// free-form strings.
+const (
+	KindGeneric = "generic"
+	KindCustom  = "custom"
+	KindLegacy  = "legacy"
+	KindUnknown = "unknown"
+)

--- a/internal/coverage/activity_reader.go
+++ b/internal/coverage/activity_reader.go
@@ -11,10 +11,17 @@ import (
 // lookup so a stalled or locked activity DB cannot pin a dashboard
 // render. The hybrid reader catches the resulting error and falls
 // back to the audit reader, so the operator sees the audit-backed
-// value instead of a hung page. 1.5s is generous for a single
-// indexed SELECT and tight enough that 3N queries per render
-// (principals × surfaces) stay bounded under failure.
-const activityLastSeenTimeout = 1500 * time.Millisecond
+// value instead of a hung page.
+//
+// 250ms is the per-cell ceiling: an indexed SELECT is sub-millisecond
+// in normal operation, so 250ms is ~250x normal latency. Combined
+// with the per-render circuit breaker (see CircuitBreakerReader),
+// the worst-case render-time contribution from a stalled activity
+// store is bounded at activityLastSeenTimeout × breaker_threshold
+// regardless of principal count. Without the smaller ceiling and the
+// breaker, 1.5s × 3 surfaces × N principals could stack into
+// multi-minute renders for enterprise-size deployments.
+const activityLastSeenTimeout = 250 * time.Millisecond
 
 // ActivityLastSeen adapts an activity.Store into the AuditReader
 // interface coverage.Compute expects. It exists because activity.Store

--- a/internal/coverage/activity_reader.go
+++ b/internal/coverage/activity_reader.go
@@ -1,0 +1,34 @@
+package coverage
+
+import (
+	"context"
+
+	"github.com/oktsec/oktsec/internal/activity"
+)
+
+// ActivityLastSeen adapts an activity.Store into the AuditReader
+// interface coverage.Compute expects. It exists because activity.Store
+// takes a context.Context (its query is async-friendly and may be
+// cancelled by an enclosing request) while AuditReader is the older,
+// context-free shape coverage was built around.
+//
+// The adapter passes context.Background to keep the LastSeen lookup
+// independent of a request lifecycle: coverage is computed on
+// dashboard render, and a client cancellation must not blank a column
+// that other in-flight requests are about to read. The underlying
+// activity.SQLStore already enforces its own bounded query timeouts,
+// so an unbounded background context is safe in practice.
+type ActivityLastSeen struct {
+	Store activity.Store
+}
+
+// LastSeenByPrincipalSurface delegates to the activity store. A nil
+// store is a valid no-op state (the dashboard wires this when the
+// audit store does not expose a *sql.DB) — return the empty result
+// so the hybrid reader can fall back to audit.
+func (a ActivityLastSeen) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	if a.Store == nil {
+		return "", nil
+	}
+	return a.Store.LastSeenByPrincipalSurface(context.Background(), principalID, surface)
+}

--- a/internal/coverage/activity_reader.go
+++ b/internal/coverage/activity_reader.go
@@ -2,9 +2,19 @@ package coverage
 
 import (
 	"context"
+	"time"
 
 	"github.com/oktsec/oktsec/internal/activity"
 )
+
+// activityLastSeenTimeout bounds a single activity-store LastSeen
+// lookup so a stalled or locked activity DB cannot pin a dashboard
+// render. The hybrid reader catches the resulting error and falls
+// back to the audit reader, so the operator sees the audit-backed
+// value instead of a hung page. 1.5s is generous for a single
+// indexed SELECT and tight enough that 3N queries per render
+// (principals × surfaces) stay bounded under failure.
+const activityLastSeenTimeout = 1500 * time.Millisecond
 
 // ActivityLastSeen adapts an activity.Store into the AuditReader
 // interface coverage.Compute expects. It exists because activity.Store
@@ -12,23 +22,26 @@ import (
 // cancelled by an enclosing request) while AuditReader is the older,
 // context-free shape coverage was built around.
 //
-// The adapter passes context.Background to keep the LastSeen lookup
-// independent of a request lifecycle: coverage is computed on
-// dashboard render, and a client cancellation must not blank a column
-// that other in-flight requests are about to read. The underlying
-// activity.SQLStore already enforces its own bounded query timeouts,
-// so an unbounded background context is safe in practice.
+// The adapter detaches from the inbound HTTP request context on
+// purpose: coverage is computed on dashboard render, and a client
+// cancellation must not blank a column that other in-flight requests
+// are about to read. It then bounds the lookup with its own short
+// timeout so a stalled activity store cannot hang the render.
 type ActivityLastSeen struct {
 	Store activity.Store
 }
 
-// LastSeenByPrincipalSurface delegates to the activity store. A nil
-// store is a valid no-op state (the dashboard wires this when the
-// audit store does not expose a *sql.DB) — return the empty result
-// so the hybrid reader can fall back to audit.
+// LastSeenByPrincipalSurface delegates to the activity store with a
+// bounded background context. A nil store is a valid no-op state
+// (the dashboard wires this when the audit store does not expose a
+// *sql.DB) — return the empty result so the hybrid reader can fall
+// back to audit. Errors propagate up so the hybrid reader can swallow
+// them and reach for the audit fallback.
 func (a ActivityLastSeen) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
 	if a.Store == nil {
 		return "", nil
 	}
-	return a.Store.LastSeenByPrincipalSurface(context.Background(), principalID, surface)
+	ctx, cancel := context.WithTimeout(context.Background(), activityLastSeenTimeout)
+	defer cancel()
+	return a.Store.LastSeenByPrincipalSurface(ctx, principalID, surface)
 }

--- a/internal/coverage/circuit_breaker.go
+++ b/internal/coverage/circuit_breaker.go
@@ -1,0 +1,75 @@
+package coverage
+
+// CircuitBreakerReader wraps an AuditReader and stops calling the
+// underlying reader once consecutive failures exceed a threshold.
+// Once tripped it returns ("", nil) for the remainder of its
+// lifetime, which the hybrid reader treats as "no row" and falls
+// back to its other reader.
+//
+// The breaker is per-instance state and is NOT goroutine-safe:
+// callers must build a fresh wrapper per render so that
+//   - a transient stall does not permanently disable the underlying
+//     reader across requests, and
+//   - the breaker state from one render does not leak into another.
+//
+// This design exists because LastSeen is called once per
+// (principal, surface) pair: 50 principals × 3 surfaces = 150
+// per-cell calls per render. Without a breaker, a stalled activity
+// store would burn the per-cell timeout 150 times before the audit
+// fallback ever ran. With threshold=3 the worst case is bounded at
+// timeout × 3, regardless of principal count.
+type CircuitBreakerReader struct {
+	inner            AuditReader
+	threshold        int
+	consecutiveFails int
+	tripped          bool
+}
+
+// NewCircuitBreakerReader returns an AuditReader that calls inner at
+// most threshold consecutive times after the first failure before
+// short-circuiting for the rest of its lifetime. threshold must be
+// >= 1; values < 1 are treated as 1 (trip on the first failure).
+func NewCircuitBreakerReader(inner AuditReader, threshold int) *CircuitBreakerReader {
+	if threshold < 1 {
+		threshold = 1
+	}
+	return &CircuitBreakerReader{inner: inner, threshold: threshold}
+}
+
+// LastSeenByPrincipalSurface delegates to the inner reader unless the
+// breaker has tripped. Each error increments the consecutive-failure
+// counter; a successful call resets it. Once the counter reaches the
+// threshold the breaker stays tripped for the rest of the wrapper's
+// lifetime — building a fresh wrapper per render is the recovery
+// mechanism.
+//
+// A nil inner reader behaves as a no-op (empty result, no error) so
+// callers can wire the breaker unconditionally without nil-checking.
+func (c *CircuitBreakerReader) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	if c == nil || c.inner == nil {
+		return "", nil
+	}
+	if c.tripped {
+		return "", nil
+	}
+	ts, err := c.inner.LastSeenByPrincipalSurface(principalID, surface)
+	if err != nil {
+		c.consecutiveFails++
+		if c.consecutiveFails >= c.threshold {
+			c.tripped = true
+		}
+		return "", err
+	}
+	c.consecutiveFails = 0
+	return ts, nil
+}
+
+// Tripped reports whether the breaker has stopped calling the inner
+// reader. Exported so the dashboard can surface a one-time warning
+// without poking at private state.
+func (c *CircuitBreakerReader) Tripped() bool {
+	if c == nil {
+		return false
+	}
+	return c.tripped
+}

--- a/internal/coverage/circuit_breaker_test.go
+++ b/internal/coverage/circuit_breaker_test.go
@@ -1,0 +1,131 @@
+package coverage
+
+import (
+	"errors"
+	"testing"
+)
+
+// countingReader wraps a stub-style AuditReader and records call
+// count so the breaker tests can prove the inner reader stops being
+// called once the threshold is hit.
+type countingReader struct {
+	stamp string
+	err   error
+	calls int
+}
+
+func (c *countingReader) LastSeenByPrincipalSurface(_, _ string) (string, error) {
+	c.calls++
+	return c.stamp, c.err
+}
+
+// 1. The breaker is transparent in the happy path: every call hits
+// the inner reader and the consecutive-fail counter never advances.
+func TestCircuitBreaker_HappyPath(t *testing.T) {
+	inner := &countingReader{stamp: "2026-04-26T10:00:00Z"}
+	br := NewCircuitBreakerReader(inner, 3)
+
+	for i := 0; i < 10; i++ {
+		got, err := br.LastSeenByPrincipalSurface("p", "s")
+		if err != nil {
+			t.Fatalf("call %d: err = %v", i, err)
+		}
+		if got != "2026-04-26T10:00:00Z" {
+			t.Errorf("call %d: got %q; want stamp", i, got)
+		}
+	}
+	if inner.calls != 10 {
+		t.Errorf("inner calls = %d; want 10 (breaker should be transparent)", inner.calls)
+	}
+	if br.Tripped() {
+		t.Error("breaker tripped on a clean run")
+	}
+}
+
+// 2. Threshold consecutive errors trip the breaker. The next call
+// short-circuits — empty result, nil error, inner reader untouched.
+// Bounds the worst-case render-time contribution at timeout × threshold
+// regardless of how many cells follow.
+func TestCircuitBreaker_TripsAfterThresholdFailures(t *testing.T) {
+	inner := &countingReader{err: errors.New("simulated activity stall")}
+	br := NewCircuitBreakerReader(inner, 3)
+
+	// 3 errors trip the breaker.
+	for i := 0; i < 3; i++ {
+		_, err := br.LastSeenByPrincipalSurface("p", "s")
+		if err == nil {
+			t.Errorf("call %d: err = nil; want error", i)
+		}
+	}
+	if !br.Tripped() {
+		t.Fatal("breaker should be tripped after threshold consecutive failures")
+	}
+	beforeShort := inner.calls
+
+	// Subsequent calls do not touch the inner reader.
+	for i := 0; i < 100; i++ {
+		got, err := br.LastSeenByPrincipalSurface("p", "s")
+		if err != nil {
+			t.Errorf("post-trip call %d: err = %v; want nil (short-circuit)", i, err)
+		}
+		if got != "" {
+			t.Errorf("post-trip call %d: got %q; want empty (short-circuit)", i, got)
+		}
+	}
+	if inner.calls != beforeShort {
+		t.Errorf("inner calls = %d; want %d (no calls should reach a tripped breaker)", inner.calls, beforeShort)
+	}
+}
+
+// 3. A successful call resets the consecutive-fail counter. Two
+// failures followed by a success followed by two more failures must
+// not trip a threshold=3 breaker — the counter never reaches 3 in a
+// row.
+func TestCircuitBreaker_SuccessResetsCounter(t *testing.T) {
+	inner := &countingReader{}
+	br := NewCircuitBreakerReader(inner, 3)
+
+	inner.err = errors.New("fail-1")
+	_, _ = br.LastSeenByPrincipalSurface("p", "s")
+	inner.err = errors.New("fail-2")
+	_, _ = br.LastSeenByPrincipalSurface("p", "s")
+
+	inner.err = nil
+	inner.stamp = "2026-04-26T10:00:00Z"
+	if got, err := br.LastSeenByPrincipalSurface("p", "s"); err != nil || got == "" {
+		t.Fatalf("success after failures: got=%q err=%v; want stamp/nil", got, err)
+	}
+
+	inner.err = errors.New("fail-3")
+	_, _ = br.LastSeenByPrincipalSurface("p", "s")
+	inner.err = errors.New("fail-4")
+	_, _ = br.LastSeenByPrincipalSurface("p", "s")
+
+	if br.Tripped() {
+		t.Error("breaker tripped despite a success resetting the consecutive-fail counter")
+	}
+}
+
+// 4. Threshold values < 1 are clamped to 1 so callers cannot disable
+// the breaker by accident. A zero or negative threshold trips on the
+// first failure, which is the safest behavior.
+func TestCircuitBreaker_ThresholdClampedToOne(t *testing.T) {
+	inner := &countingReader{err: errors.New("boom")}
+	br := NewCircuitBreakerReader(inner, 0)
+
+	_, _ = br.LastSeenByPrincipalSurface("p", "s")
+	if !br.Tripped() {
+		t.Error("threshold=0 must clamp to 1 and trip on the first failure")
+	}
+}
+
+// 5. A nil inner reader is a valid no-op state. The breaker returns
+// ("", nil) so callers can wire the wrapper unconditionally without
+// nil-checking the underlying store.
+func TestCircuitBreaker_NilInnerIsNoop(t *testing.T) {
+	br := NewCircuitBreakerReader(nil, 3)
+	got, err := br.LastSeenByPrincipalSurface("p", "s")
+	if err != nil || got != "" {
+		t.Errorf("nil inner: got=%q err=%v; want empty/nil", got, err)
+	}
+}

--- a/internal/coverage/compute.go
+++ b/internal/coverage/compute.go
@@ -72,7 +72,7 @@ func ComputeWith(cfg *config.Config, ar AuditReader, reg connectors.Registry) []
 // labeled accordingly. For PR4 the config-derived signal is enough to
 // keep local-mode deployments labeled as legacy-loopback-header (the
 // existing behavior) and enterprise-mode deployments without working
-// tokens labeled as unknown (an honest improvement).
+// tokens labeled as unknown (a more precise current-state label).
 func observedAuthMethodsFromConfig(cfg *config.Config) map[string]bool {
 	out := map[string]bool{}
 	if cfg == nil {

--- a/internal/coverage/compute.go
+++ b/internal/coverage/compute.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors"
 )
 
 // Compute folds the current configuration and audit observations into a
@@ -15,16 +16,31 @@ import (
 // The function is intentionally pure: it does not query the audit store
 // directly (callers pass a narrow AuditReader) and does not mutate cfg.
 // Tests can drive it with a fake AuditReader and any *config.Config.
+//
+// Connector inference goes through the package-level connectors.Default
+// registry so a future operator-defined connector layer can swap in
+// without touching coverage. Callers that want to inject a different
+// registry can use ComputeWith.
 func Compute(cfg *config.Config, ar AuditReader) []CoverageCell {
+	return ComputeWith(cfg, ar, connectors.Default())
+}
+
+// ComputeWith is Compute with an explicit Registry. Used by tests that
+// want to inject a custom registry; production wiring uses Compute.
+func ComputeWith(cfg *config.Config, ar AuditReader, reg connectors.Registry) []CoverageCell {
 	if cfg == nil {
 		return nil
 	}
+	if reg == nil {
+		reg = connectors.Default()
+	}
 	now := time.Now()
+	observedMethods := observedAuthMethodsFromConfig(cfg)
 
 	var cells []CoverageCell
 	for _, p := range cfg.Identity.Principals {
 		tokensByType := activeTokenTypes(p, now)
-		connector := inferConnectorIDFromActive(tokensByType)
+		connector := reg.Infer(tokensByType, observedMethods).ID
 		for _, surface := range AllSurfaces {
 			cell := computeCell(cfg, p, connector, surface, tokensByType)
 			if ar != nil {
@@ -42,6 +58,31 @@ func Compute(cfg *config.Config, ar AuditReader) []CoverageCell {
 		return cells[i].Surface < cells[j].Surface
 	})
 	return cells
+}
+
+// observedAuthMethodsFromConfig derives the auth-method evidence map
+// the registry needs from current configuration. Today the only piece
+// of evidence that comes from config (rather than from the activity
+// store) is whether the loopback header is honored on at least one
+// surface — that determines the legacy-loopback-header vs unknown
+// fork in the registry's inference rule.
+//
+// PR5 will plumb live activity-derived evidence on top of this so a
+// principal that has only ever shown wrapper-signed activity can be
+// labeled accordingly. For PR4 the config-derived signal is enough to
+// keep local-mode deployments labeled as legacy-loopback-header (the
+// existing behavior) and enterprise-mode deployments without working
+// tokens labeled as unknown (an honest improvement).
+func observedAuthMethodsFromConfig(cfg *config.Config) map[string]bool {
+	out := map[string]bool{}
+	if cfg == nil {
+		return out
+	}
+	if isLocalLoopbackHeaderActive(cfg, cfg.Gateway.SurfaceAuthConfig) ||
+		isLocalLoopbackHeaderActive(cfg, cfg.ForwardProxy.SurfaceAuthConfig) {
+		out["trusted_loopback"] = true
+	}
+	return out
 }
 
 // activeTokenTypes returns the set of TokenTypes the principal currently

--- a/internal/coverage/compute_test.go
+++ b/internal/coverage/compute_test.go
@@ -237,8 +237,8 @@ func TestCompute_RevokedTokenDoesNotProtect(t *testing.T) {
 // as generic-mcp-http. The coverage layer filters revoked/expired tokens
 // before calling the connector registry, so an expired token is invisible
 // to both. In enterprise profile there is no loopback fallback either,
-// so the honest connector label is "Unknown source": the principal
-// exists in config but has no working auth path.
+// so the connector label is "Unknown source": the principal exists in
+// config but has no working auth path on any surface.
 func TestCompute_ExpiredTokenDoesNotInferConnector(t *testing.T) {
 	p := principalWith("local-codex", "gateway_bearer")
 	p.Tokens[0].ExpiresAt = "2026-01-02T00:00:00Z" // already in the past

--- a/internal/coverage/compute_test.go
+++ b/internal/coverage/compute_test.go
@@ -134,8 +134,8 @@ func TestCompute_LegacyLoopbackHeaderObservedNotProtected(t *testing.T) {
 	if mcp.TrustLevel != "trusted_local" {
 		t.Errorf("MCP trust level = %q; want trusted_local", mcp.TrustLevel)
 	}
-	if mcp.ConnectorID != ConnectorLegacyLocalHeader {
-		t.Errorf("connector = %q; want %s", mcp.ConnectorID, ConnectorLegacyLocalHeader)
+	if mcp.ConnectorID != ConnectorLegacyLoopbackHeader {
+		t.Errorf("connector = %q; want %s", mcp.ConnectorID, ConnectorLegacyLoopbackHeader)
 	}
 }
 
@@ -234,10 +234,11 @@ func TestCompute_RevokedTokenDoesNotProtect(t *testing.T) {
 }
 
 // 9b. An expired-only gateway_bearer token must NOT label the principal
-// as generic-mcp-http. inferConnectorIDFromActive uses the same active
-// set Compute uses for coverage, so an expired token is invisible to
-// both. Without this guard, the matrix would advertise a connector the
-// principal cannot actually use.
+// as generic-mcp-http. The coverage layer filters revoked/expired tokens
+// before calling the connector registry, so an expired token is invisible
+// to both. In enterprise profile there is no loopback fallback either,
+// so the honest connector label is "Unknown source": the principal
+// exists in config but has no working auth path.
 func TestCompute_ExpiredTokenDoesNotInferConnector(t *testing.T) {
 	p := principalWith("local-codex", "gateway_bearer")
 	p.Tokens[0].ExpiresAt = "2026-01-02T00:00:00Z" // already in the past
@@ -249,9 +250,9 @@ func TestCompute_ExpiredTokenDoesNotInferConnector(t *testing.T) {
 	cells := Compute(cfg, nil)
 
 	mcp := pickCell(t, cells, "local-codex", SurfaceMCPHTTP)
-	if mcp.ConnectorID != ConnectorLegacyLocalHeader {
-		t.Errorf("connector = %q; want %s when the only token is expired",
-			mcp.ConnectorID, ConnectorLegacyLocalHeader)
+	if mcp.ConnectorID != ConnectorUnknown {
+		t.Errorf("connector = %q; want %s when the only token is expired in enterprise mode",
+			mcp.ConnectorID, ConnectorUnknown)
 	}
 	if mcp.Coverage == CoverageProtected {
 		t.Errorf("MCP cell = %+v; an expired gateway_bearer must not protect", mcp)

--- a/internal/coverage/connector.go
+++ b/internal/coverage/connector.go
@@ -1,44 +1,16 @@
 package coverage
 
-// Connector identifiers reported in CoverageCell.ConnectorID. Phase 2A
-// infers these from the principal's token mix; later phases will move
-// to an explicit `connector:` field in PrincipalConfig.
+import "github.com/oktsec/oktsec/internal/connectors"
+
+// Connector identifiers reported in CoverageCell.ConnectorID. Re-exported
+// from the connectors package so callers in coverage can compare without
+// having to import a second package, and so existing tests keep working
+// across the registry refactor.
 const (
-	ConnectorGenericMCPHTTP    = "generic-mcp-http"
-	ConnectorGenericEgressProxy = "generic-egress-proxy"
-	ConnectorGenericHooks      = "generic-hooks"
-	ConnectorCustomClient      = "custom-client"     // multi-surface principal
-	ConnectorLegacyLocalHeader = "legacy-local-header"
+	ConnectorGenericMCPHTTP       = connectors.IDGenericMCPHTTP
+	ConnectorGenericEgressProxy   = connectors.IDGenericEgressProxy
+	ConnectorGenericHooks         = connectors.IDGenericHooks
+	ConnectorCustomClient         = connectors.IDCustomClient
+	ConnectorLegacyLoopbackHeader = connectors.IDLegacyLoopbackHeader
+	ConnectorUnknown              = connectors.IDUnknown
 )
-
-// inferConnectorIDFromActive picks a connector label from the set of
-// active token types the principal currently holds. Callers compute the
-// active set once with activeTokenTypes (which already filters revoked
-// and expired entries) and pass it in here, so an expired-only
-// gateway_bearer never ends up labeling the principal as
-// generic-mcp-http while Compute correctly marks every surface blind.
-func inferConnectorIDFromActive(active map[string]bool) string {
-	hasGW := active["gateway_bearer"]
-	hasProxy := active["proxy_basic"]
-	hasHook := active["hook_bearer"]
-
-	count := 0
-	for _, b := range []bool{hasGW, hasProxy, hasHook} {
-		if b {
-			count++
-		}
-	}
-	switch {
-	case count >= 2:
-		return ConnectorCustomClient
-	case hasGW:
-		return ConnectorGenericMCPHTTP
-	case hasProxy:
-		return ConnectorGenericEgressProxy
-	case hasHook:
-		return ConnectorGenericHooks
-	}
-	// No active tokens: the principal exists in config but only relies
-	// on the legacy X-Oktsec-Agent header for identity.
-	return ConnectorLegacyLocalHeader
-}

--- a/internal/coverage/display.go
+++ b/internal/coverage/display.go
@@ -15,8 +15,10 @@ func ConnectorDisplayName(id string) string {
 		return "Generic hooks"
 	case ConnectorCustomClient:
 		return "Custom client"
-	case ConnectorLegacyLocalHeader:
+	case ConnectorLegacyLoopbackHeader:
 		return "Legacy loopback header"
+	case ConnectorUnknown:
+		return "Unknown source"
 	}
 	return id
 }

--- a/internal/coverage/hybrid_reader.go
+++ b/internal/coverage/hybrid_reader.go
@@ -1,0 +1,43 @@
+package coverage
+
+// HybridLastSeenReader prefers an activity-backed reader for the
+// LastSeen attribution and falls back to an audit-backed reader when
+// activity has no row for the (principal, surface) pair. Either field
+// may be nil — callers can roll out the activity store incrementally
+// without touching coverage:
+//
+//   - Activity nil, Audit non-nil: behaves identically to Phase 2A.
+//   - Activity non-nil, Audit nil: activity-only (useful in tests).
+//   - Both non-nil: activity wins when it has a row, audit fills the
+//     long tail for events from before activity was wired up.
+//   - Both nil: every cell ends up with empty LastSeen.
+//
+// The reader satisfies AuditReader directly so coverage.Compute can
+// accept it without a wrapper.
+type HybridLastSeenReader struct {
+	Activity AuditReader
+	Audit    AuditReader
+}
+
+// LastSeenByPrincipalSurface returns the most recent timestamp the
+// hybrid reader can attribute to the (principal, surface) pair. The
+// activity reader wins when it has a non-empty row; an empty result
+// from activity is treated as "no activity-backed data" rather than
+// an authoritative miss, so the audit fallback still gets a chance.
+//
+// Errors from the activity reader are NOT propagated as failures —
+// they trigger the audit fallback the same way an empty row does.
+// The reasoning: activity is best-effort; an outage there must not
+// blank the LastSeen column the operator already trusts.
+func (h HybridLastSeenReader) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	if h.Activity != nil {
+		ts, err := h.Activity.LastSeenByPrincipalSurface(principalID, surface)
+		if err == nil && ts != "" {
+			return ts, nil
+		}
+	}
+	if h.Audit != nil {
+		return h.Audit.LastSeenByPrincipalSurface(principalID, surface)
+	}
+	return "", nil
+}

--- a/internal/coverage/hybrid_reader.go
+++ b/internal/coverage/hybrid_reader.go
@@ -1,15 +1,16 @@
 package coverage
 
+import "time"
+
 // HybridLastSeenReader prefers an activity-backed reader for the
-// LastSeen attribution and falls back to an audit-backed reader when
-// activity has no row for the (principal, surface) pair. Either field
-// may be nil — callers can roll out the activity store incrementally
-// without touching coverage:
+// LastSeen attribution but always cross-checks the audit-backed
+// reader and returns whichever timestamp represents the later moment
+// in time. Either field may be nil — callers can roll out the
+// activity store incrementally without touching coverage:
 //
 //   - Activity nil, Audit non-nil: behaves identically to Phase 2A.
-//   - Activity non-nil, Audit nil: activity-only (useful in tests).
-//   - Both non-nil: activity wins when it has a row, audit fills the
-//     long tail for events from before activity was wired up.
+//   - Activity non-nil, Audit nil: activity-only.
+//   - Both non-nil: the later of the two parsed timestamps wins.
 //   - Both nil: every cell ends up with empty LastSeen.
 //
 // The reader satisfies AuditReader directly so coverage.Compute can
@@ -20,24 +21,81 @@ type HybridLastSeenReader struct {
 }
 
 // LastSeenByPrincipalSurface returns the most recent timestamp the
-// hybrid reader can attribute to the (principal, surface) pair. The
-// activity reader wins when it has a non-empty row; an empty result
-// from activity is treated as "no activity-backed data" rather than
-// an authoritative miss, so the audit fallback still gets a chance.
+// hybrid reader can attribute to the (principal, surface) pair. Both
+// readers are queried when both are configured: activity writes are
+// async and best-effort, so audit can carry a newer row right after
+// an activity miss or a delayed insert. Returning the activity value
+// blindly would surface a stale "Last seen" on the dashboard, so the
+// reader compares the two timestamps and returns the later one.
 //
-// Errors from the activity reader are NOT propagated as failures —
-// they trigger the audit fallback the same way an empty row does.
-// The reasoning: activity is best-effort; an outage there must not
-// blank the LastSeen column the operator already trusts.
+// Errors from either reader are NOT propagated as failures — the
+// other reader still gets a chance. Activity is best-effort; an
+// outage there must not blank the LastSeen column the operator
+// already trusts. Unparseable timestamps lose to parseable ones; if
+// neither parses, the audit value wins (it is the compliance trail
+// and is the safer source for operator-visible state).
 func (h HybridLastSeenReader) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
-	if h.Activity != nil {
-		ts, err := h.Activity.LastSeenByPrincipalSurface(principalID, surface)
-		if err == nil && ts != "" {
-			return ts, nil
+	activityTS := readLastSeenQuiet(h.Activity, principalID, surface)
+	auditTS := readLastSeenQuiet(h.Audit, principalID, surface)
+	return pickLatestTimestamp(activityTS, auditTS), nil
+}
+
+// readLastSeenQuiet returns the LastSeen string for the given reader
+// or empty when the reader is nil or returns an error. Errors are
+// swallowed on purpose: a transient activity-store stall or a future
+// audit-store hiccup must not blank the LastSeen column for an
+// operator who is already looking at the matrix.
+func readLastSeenQuiet(r AuditReader, principalID, surface string) string {
+	if r == nil {
+		return ""
+	}
+	ts, err := r.LastSeenByPrincipalSurface(principalID, surface)
+	if err != nil {
+		return ""
+	}
+	return ts
+}
+
+// pickLatestTimestamp returns whichever of the two RFC3339 strings
+// represents the later moment in time. Conservative on parse errors:
+//
+//   - Empty string loses to any non-empty value.
+//   - Both parse: later instant wins.
+//   - One parses, one does not: the parseable value wins (never
+//     surface garbage just because the other reader got a row in).
+//   - Neither parses, both non-empty: the audit value wins because it
+//     is the compliance trail; when both are wrong we prefer the more
+//     conservative source.
+func pickLatestTimestamp(activityTS, auditTS string) string {
+	if activityTS == "" {
+		return auditTS
+	}
+	if auditTS == "" {
+		return activityTS
+	}
+	ta, errA := parseLastSeen(activityTS)
+	tb, errB := parseLastSeen(auditTS)
+	switch {
+	case errA == nil && errB == nil:
+		if tb.After(ta) {
+			return auditTS
 		}
+		return activityTS
+	case errA == nil:
+		return activityTS
+	case errB == nil:
+		return auditTS
 	}
-	if h.Audit != nil {
-		return h.Audit.LastSeenByPrincipalSurface(principalID, surface)
+	return auditTS
+}
+
+// parseLastSeen accepts both RFC3339 (audit's format) and
+// RFC3339Nano (what activity may emit when the wall clock has nanos).
+// time.RFC3339Nano alone does not match plain RFC3339 with no
+// fractional seconds, so the fallback is required.
+func parseLastSeen(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
 	}
-	return "", nil
+	return time.Parse(time.RFC3339, s)
 }

--- a/internal/coverage/hybrid_reader_test.go
+++ b/internal/coverage/hybrid_reader_test.go
@@ -1,0 +1,100 @@
+package coverage
+
+import (
+	"errors"
+	"testing"
+)
+
+// stubReader is the minimum AuditReader the hybrid reader tests need.
+// One canned timestamp string keyed by principal+surface, plus an
+// optional error so we can exercise the activity-failure fallback path.
+type stubReader struct {
+	stamps map[string]string
+	err    error
+}
+
+func (s stubReader) LastSeenByPrincipalSurface(principalID, surface string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.stamps[principalID+"|"+surface], nil
+}
+
+// 1. When the activity reader has a row, the hybrid reader returns
+// it and never consults the audit reader. This is the common path
+// once activity has been running for a while.
+func TestHybridLastSeenReader_ActivityWins(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:00Z"}},
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},
+	}
+	got, err := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	if got != "2026-04-26T10:00:00Z" {
+		t.Errorf("got = %q; want activity timestamp 2026-04-26T10:00:00Z", got)
+	}
+}
+
+// 2. When activity has no row for the pair, the audit fallback fills
+// in the LastSeen so historical events from before activity was wired
+// up still appear in the matrix.
+func TestHybridLastSeenReader_FallsBackToAudit(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{}}, // empty
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},
+	}
+	got, _ := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if got != "2026-04-25T08:00:00Z" {
+		t.Errorf("got = %q; want audit fallback 2026-04-25T08:00:00Z", got)
+	}
+}
+
+// 3. An activity error is treated the same as an empty row: the audit
+// fallback still gets a chance. Activity is best-effort; an outage
+// there must not blank columns the operator already trusts.
+func TestHybridLastSeenReader_ActivityErrorFallsBack(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{err: errors.New("simulated activity outage")},
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},
+	}
+	got, err := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if err != nil {
+		t.Fatalf("err = %v; want nil (activity error swallowed)", err)
+	}
+	if got != "2026-04-25T08:00:00Z" {
+		t.Errorf("got = %q; want audit fallback after activity error", got)
+	}
+}
+
+// 4. With both readers nil the hybrid returns empty cleanly. This is
+// the degenerate case Compute already handles by skipping the
+// LastSeen assignment, but the contract here keeps it from panicking.
+func TestHybridLastSeenReader_BothNil(t *testing.T) {
+	h := HybridLastSeenReader{}
+	got, err := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if err != nil {
+		t.Errorf("err = %v; want nil", err)
+	}
+	if got != "" {
+		t.Errorf("got = %q; want empty", got)
+	}
+}
+
+// 5. With activity present but audit nil, hybrid behaves like
+// activity-only. Useful in tests and a possible future state if the
+// audit store is replaced wholesale.
+func TestHybridLastSeenReader_ActivityOnly(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{"local-codex|hooks": "2026-04-26T11:00:00Z"}},
+	}
+	got, _ := h.LastSeenByPrincipalSurface("local-codex", "hooks")
+	if got != "2026-04-26T11:00:00Z" {
+		t.Errorf("got = %q; want activity-only timestamp", got)
+	}
+	// Pair with no row stays empty rather than erroring.
+	if got, _ = h.LastSeenByPrincipalSurface("local-codex", "mcp_http"); got != "" {
+		t.Errorf("got = %q; want empty for unknown pair", got)
+	}
+}

--- a/internal/coverage/hybrid_reader_test.go
+++ b/internal/coverage/hybrid_reader_test.go
@@ -20,10 +20,9 @@ func (s stubReader) LastSeenByPrincipalSurface(principalID, surface string) (str
 	return s.stamps[principalID+"|"+surface], nil
 }
 
-// 1. When the activity reader has a row, the hybrid reader returns
-// it and never consults the audit reader. This is the common path
-// once activity has been running for a while.
-func TestHybridLastSeenReader_ActivityWins(t *testing.T) {
+// 1. When activity carries the later timestamp, the hybrid reader
+// returns it. Common path once activity has been wired up.
+func TestHybridLastSeenReader_ActivityWinsWhenNewer(t *testing.T) {
 	h := HybridLastSeenReader{
 		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:00Z"}},
 		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},
@@ -37,7 +36,23 @@ func TestHybridLastSeenReader_ActivityWins(t *testing.T) {
 	}
 }
 
-// 2. When activity has no row for the pair, the audit fallback fills
+// 2. AUDIT can carry a NEWER row when activity missed an insert (the
+// dual-write goroutine raced with a query, the activity DB hiccupped,
+// etc.). The hybrid reader must surface the audit value in that case
+// so the dashboard does not show stale coverage. Regression guard for
+// the original "activity wins as soon as it has any row" bug.
+func TestHybridLastSeenReader_AuditWinsWhenNewer(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:00Z"}},
+	}
+	got, _ := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if got != "2026-04-26T10:00:00Z" {
+		t.Errorf("got = %q; want audit timestamp 2026-04-26T10:00:00Z (audit was newer)", got)
+	}
+}
+
+// 3. When activity has no row for the pair, the audit fallback fills
 // in the LastSeen so historical events from before activity was wired
 // up still appear in the matrix.
 func TestHybridLastSeenReader_FallsBackToAudit(t *testing.T) {
@@ -51,7 +66,7 @@ func TestHybridLastSeenReader_FallsBackToAudit(t *testing.T) {
 	}
 }
 
-// 3. An activity error is treated the same as an empty row: the audit
+// 4. An activity error is treated the same as an empty row: the audit
 // fallback still gets a chance. Activity is best-effort; an outage
 // there must not blank columns the operator already trusts.
 func TestHybridLastSeenReader_ActivityErrorFallsBack(t *testing.T) {
@@ -68,7 +83,7 @@ func TestHybridLastSeenReader_ActivityErrorFallsBack(t *testing.T) {
 	}
 }
 
-// 4. With both readers nil the hybrid returns empty cleanly. This is
+// 5. With both readers nil the hybrid returns empty cleanly. This is
 // the degenerate case Compute already handles by skipping the
 // LastSeen assignment, but the contract here keeps it from panicking.
 func TestHybridLastSeenReader_BothNil(t *testing.T) {
@@ -82,7 +97,7 @@ func TestHybridLastSeenReader_BothNil(t *testing.T) {
 	}
 }
 
-// 5. With activity present but audit nil, hybrid behaves like
+// 6. With activity present but audit nil, hybrid behaves like
 // activity-only. Useful in tests and a possible future state if the
 // audit store is replaced wholesale.
 func TestHybridLastSeenReader_ActivityOnly(t *testing.T) {
@@ -96,5 +111,34 @@ func TestHybridLastSeenReader_ActivityOnly(t *testing.T) {
 	// Pair with no row stays empty rather than erroring.
 	if got, _ = h.LastSeenByPrincipalSurface("local-codex", "mcp_http"); got != "" {
 		t.Errorf("got = %q; want empty for unknown pair", got)
+	}
+}
+
+// 7. Both readers parse, with sub-second precision differences. The
+// hybrid reader must compare instants, not strings, so an audit value
+// with no fractional seconds can still win against an activity value
+// from a few millis earlier.
+func TestHybridLastSeenReader_NanosecondPrecisionCompared(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:00.500Z"}},
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:01Z"}},
+	}
+	got, _ := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if got != "2026-04-26T10:00:01Z" {
+		t.Errorf("got = %q; want audit timestamp (0.5s later than activity)", got)
+	}
+}
+
+// 8. An unparseable timestamp on one side loses to a parseable one
+// on the other. The reader must not surface garbage just because the
+// "preferred" reader returned a malformed string.
+func TestHybridLastSeenReader_UnparseableLosesToParseable(t *testing.T) {
+	h := HybridLastSeenReader{
+		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "not-a-timestamp"}},
+		Audit:    stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-26T10:00:00Z"}},
+	}
+	got, _ := h.LastSeenByPrincipalSurface("local-codex", "mcp_http")
+	if got != "2026-04-26T10:00:00Z" {
+		t.Errorf("got = %q; want audit timestamp; activity was unparseable", got)
 	}
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -227,7 +227,7 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	// Coverage matrix is computed once for the Overview render. Its rows
 	// are pivoted into per-principal table rows by the template; each
 	// surface column shows the corresponding cell's badge + limitation.
-	coverageRows := buildCoverageRows(coverage.Compute(s.cfg, s.audit))
+	coverageRows := buildCoverageRows(coverage.Compute(s.cfg, s.coverageReader()))
 
 	data := map[string]any{
 		"Active":        "overview",
@@ -4982,7 +4982,7 @@ func (s *Server) handleSaveCategoryWebhooks(w http.ResponseWriter, r *http.Reque
 // LastSeenByPrincipalSurface, so coverage.Compute can attribute the
 // "last seen" timestamp to each cell without extra wiring.
 func (s *Server) handleAPICoverage(w http.ResponseWriter, r *http.Request) {
-	cells := coverage.Compute(s.cfg, s.audit)
+	cells := coverage.Compute(s.cfg, s.coverageReader())
 	s.renderJSON(w, cells)
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -67,12 +67,15 @@ type Server struct {
 	graphCacheRange string
 	graphCacheTime  time.Time
 
-	// Lazily-built coverage reader: prefers activity-backed last-seen,
-	// falls back to the audit-backed reader for the long tail. Built
-	// once because activity.Migrate is idempotent but not free, and
-	// the resulting *activity.SQLStore is safe for concurrent use.
-	coverageReaderOnce sync.Once
-	coverageReaderVal  coverage.AuditReader
+	// Lazily-built activity store for coverage attribution. nil when
+	// the audit store does not expose a *sql.DB (test mocks) or when
+	// activity.Migrate failed at startup. Cached because Migrate is
+	// idempotent but not free; the resulting *activity.SQLStore is
+	// safe for concurrent use. The coverage reader wraps a fresh
+	// circuit breaker around this store on every render so a transient
+	// stall cannot permanently disable activity attribution.
+	coverageActivityOnce sync.Once
+	coverageActivityVal  activity.Store
 }
 
 // NewServer creates a dashboard server with access-code authentication.
@@ -121,52 +124,76 @@ func (s *Server) SetGatewayManaged() {
 	s.gwManaged = true
 }
 
+// coverageActivityBreakerThreshold is the number of consecutive
+// activity-store failures the per-render circuit breaker tolerates
+// before short-circuiting for the rest of the render. Combined with
+// coverage.activityLastSeenTimeout, this caps the worst-case render-
+// time contribution from a stalled activity store at
+// (timeout × threshold) regardless of principal count.
+const coverageActivityBreakerThreshold = 3
+
 // coverageReader returns the AuditReader coverage.Compute should use
-// for LastSeen attribution. Built lazily on first use:
+// for LastSeen attribution. The activity store is cached on first use
+// (sync.Once around the migrate-once dance), but the wrapper returned
+// here is built fresh per render so:
 //
-//   - When the audit store exposes a *sql.DB and a known dialect (the
-//     production case via *audit.Store), wrap an activity.SQLStore in
-//     a HybridLastSeenReader so activity-backed evidence wins and the
-//     audit fallback fills the long tail.
-//   - Otherwise (test mocks, future stores that do not expose DB
-//     access), return the audit reader directly. Phase 2A behavior is
-//     preserved without ceremony.
+//   - the per-render circuit breaker state does not leak between
+//     unrelated dashboard requests, and
+//   - a transient activity stall does not permanently disable
+//     activity attribution across the process lifetime.
 //
-// activity.Migrate is idempotent so re-running it on the same DB is
-// safe; the sync.Once just avoids the work on every coverage render.
+// When the audit store does not expose a *sql.DB (test mocks, future
+// stores), this returns the audit reader directly and Phase 2A
+// behavior is preserved.
 func (s *Server) coverageReader() coverage.AuditReader {
-	s.coverageReaderOnce.Do(func() {
-		s.coverageReaderVal = s.buildCoverageReader()
-	})
-	return s.coverageReaderVal
+	store := s.coverageActivityStore()
+	if store == nil {
+		return s.audit
+	}
+	activityReader := coverage.NewCircuitBreakerReader(
+		coverage.ActivityLastSeen{Store: store},
+		coverageActivityBreakerThreshold,
+	)
+	return coverage.HybridLastSeenReader{
+		Activity: activityReader,
+		Audit:    s.audit,
+	}
 }
 
-func (s *Server) buildCoverageReader() coverage.AuditReader {
+// coverageActivityStore returns the cached activity.Store the
+// coverage reader wraps, or nil when the audit store cannot back one.
+// Migrate is idempotent but not free, so the sync.Once avoids
+// re-running it on every coverage render.
+func (s *Server) coverageActivityStore() activity.Store {
+	s.coverageActivityOnce.Do(func() {
+		s.coverageActivityVal = s.buildActivityStoreForCoverage()
+	})
+	return s.coverageActivityVal
+}
+
+func (s *Server) buildActivityStoreForCoverage() activity.Store {
 	type dbBackedAuditStore interface {
 		DB() *sql.DB
 		DialectName() string
 	}
 	dbs, ok := s.audit.(dbBackedAuditStore)
 	if !ok {
-		return s.audit
+		return nil
 	}
 	db := dbs.DB()
 	if db == nil {
-		return s.audit
+		return nil
 	}
 	dialect := activity.Dialect(dbs.DialectName())
 	if dialect == "" {
 		s.logger.Warn("coverage reader: audit store reports unknown dialect; falling back to audit-only")
-		return s.audit
+		return nil
 	}
 	if err := activity.Migrate(db, dialect); err != nil {
 		s.logger.Warn("coverage reader: activity migrate failed; falling back to audit-only", "error", err)
-		return s.audit
+		return nil
 	}
-	return coverage.HybridLastSeenReader{
-		Activity: coverage.ActivityLastSeen{Store: activity.NewSQLStore(db, dialect)},
-		Audit:    s.audit,
-	}
+	return activity.NewSQLStore(db, dialect)
 }
 
 // SetLLMQueue attaches the LLM queue for budget status display.

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"database/sql"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -11,9 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/auditcheck"
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/coverage"
 	"github.com/oktsec/oktsec/internal/dashboard/static"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/graph"
@@ -63,6 +66,13 @@ type Server struct {
 	graphCache      *graph.AgentGraph
 	graphCacheRange string
 	graphCacheTime  time.Time
+
+	// Lazily-built coverage reader: prefers activity-backed last-seen,
+	// falls back to the audit-backed reader for the long tail. Built
+	// once because activity.Migrate is idempotent but not free, and
+	// the resulting *activity.SQLStore is safe for concurrent use.
+	coverageReaderOnce sync.Once
+	coverageReaderVal  coverage.AuditReader
 }
 
 // NewServer creates a dashboard server with access-code authentication.
@@ -109,6 +119,54 @@ func NewServer(cfg *config.Config, cfgPath string, auditStore audit.AuditStore, 
 // When set, the dashboard will not spawn a child gateway process.
 func (s *Server) SetGatewayManaged() {
 	s.gwManaged = true
+}
+
+// coverageReader returns the AuditReader coverage.Compute should use
+// for LastSeen attribution. Built lazily on first use:
+//
+//   - When the audit store exposes a *sql.DB and a known dialect (the
+//     production case via *audit.Store), wrap an activity.SQLStore in
+//     a HybridLastSeenReader so activity-backed evidence wins and the
+//     audit fallback fills the long tail.
+//   - Otherwise (test mocks, future stores that do not expose DB
+//     access), return the audit reader directly. Phase 2A behavior is
+//     preserved without ceremony.
+//
+// activity.Migrate is idempotent so re-running it on the same DB is
+// safe; the sync.Once just avoids the work on every coverage render.
+func (s *Server) coverageReader() coverage.AuditReader {
+	s.coverageReaderOnce.Do(func() {
+		s.coverageReaderVal = s.buildCoverageReader()
+	})
+	return s.coverageReaderVal
+}
+
+func (s *Server) buildCoverageReader() coverage.AuditReader {
+	type dbBackedAuditStore interface {
+		DB() *sql.DB
+		DialectName() string
+	}
+	dbs, ok := s.audit.(dbBackedAuditStore)
+	if !ok {
+		return s.audit
+	}
+	db := dbs.DB()
+	if db == nil {
+		return s.audit
+	}
+	dialect := activity.Dialect(dbs.DialectName())
+	if dialect == "" {
+		s.logger.Warn("coverage reader: audit store reports unknown dialect; falling back to audit-only")
+		return s.audit
+	}
+	if err := activity.Migrate(db, dialect); err != nil {
+		s.logger.Warn("coverage reader: activity migrate failed; falling back to audit-only", "error", err)
+		return s.audit
+	}
+	return coverage.HybridLastSeenReader{
+		Activity: coverage.ActivityLastSeen{Store: activity.NewSQLStore(db, dialect)},
+		Audit:    s.audit,
+	}
 }
 
 // SetLLMQueue attaches the LLM queue for budget status display.


### PR DESCRIPTION
## Summary

Phase 2B.1 PR4 introduces a capability-based connector registry and switches the dashboard coverage matrix to a hybrid LastSeen reader that compares activity-backed and audit-backed evidence and returns the later timestamp. Sets up PR5 (drill-down) without changing the matrix layout.

No request-path changes. No audit row changes. Coverage matrix output stays compatible — same JSON shape, same per-cell semantics. Two connector-label refinements:
- `legacy-local-header` -> `legacy-loopback-header` (matches the spec wire value).
- Enterprise principals with no working auth path now show `unknown` ("Unknown source") instead of `legacy-loopback-header` (more precise current-state label).

## What changed

### `internal/connectors` (new package)
- **`types.go`** — `Registry` interface (`Get` / `List` / `Infer`), `SurfaceCapability`, `Connector`, plus all six ID constants (`generic-mcp-http`, `generic-egress-proxy`, `generic-hooks`, `custom-client`, `legacy-loopback-header`, `unknown`).
- **`builtin.go`** — Six built-in connectors per the Phase 2B.1 spec table. Each `SurfaceCapability` records token type, auth methods, event types, and whether the surface can block before action.
- **`registry.go`** — `BuiltinRegistry` implementing the interface plus a process-wide `Default()`. Inference is purely capability-based and never branches on a named client:
  - 2+ active surface tokens -> `custom-client`
  - exactly 1 surface token -> matching `generic-{surface}`
  - 0 active tokens, loopback evidence -> `legacy-loopback-header`
  - 0 active tokens, no evidence -> `unknown`
  - `Get` / `List` / `Infer` return deep-copied Connector values via `cloneConnector` so callers cannot mutate registry state through the returned slices.
- **`registry_test.go`** — 7 spec-table rows + `Get`/`List` determinism + nil-input safety + custom-client surface coverage + immutability regression test.

### `internal/coverage`
- **`connector.go`** — drops the local `inferConnectorIDFromActive` helper and re-exports the registry IDs as the existing `ConnectorXxx` constants. Renames `ConnectorLegacyLocalHeader` -> `ConnectorLegacyLoopbackHeader`, adds `ConnectorUnknown`.
- **`compute.go`** — `Compute` now calls `connectors.Default().Infer(...)` with active token types and config-derived observed auth methods. `ComputeWith(cfg, ar, reg)` accepts an explicit registry for tests. The observed evidence today only carries `trusted_loopback` derived from per-surface auth posture; PR5 will plumb live activity-derived evidence on top.
- **`activity_reader.go`** — `ActivityLastSeen` adapts `activity.Store` into the `AuditReader` shape `Compute` expects. Detaches from the inbound HTTP context and bounds each lookup with a 250ms `context.WithTimeout` so a stalled activity store cannot pin a render.
- **`hybrid_reader.go`** — `HybridLastSeenReader` queries both readers when both are configured and returns whichever parsed timestamp is later (audit can carry a newer row when an async activity write missed or was delayed). Conservative on parse errors: empty loses to non-empty, parseable wins over unparseable, and when both are unparseable the audit value wins (it is the compliance trail).
- **`circuit_breaker.go`** — `CircuitBreakerReader` short-circuits after threshold consecutive failures so the per-cell timeout cannot stack across N principals × 3 surfaces. Per-instance state is not goroutine-safe on purpose; the dashboard builds a fresh wrapper per render. Worst-case render-time contribution from a stalled activity store is bounded at `timeout × threshold` (250ms × 3 = 750ms) regardless of principal count.
- **`hybrid_reader_test.go`** — 8 cases: activity-newer, audit-newer (regression for stale-activity bug), audit-fallback on empty, activity-error fallback, both-nil, activity-only, nanosecond-precision compare, unparseable-loses-to-parseable.
- **`circuit_breaker_test.go`** — 5 cases: happy path, trip after threshold, success resets counter, threshold clamped to 1, nil-inner no-op.
- **`display.go`** — handles the renamed and new connector IDs.
- **`compute_test.go`** — test #4 updated for the renamed constant; test #9b now expects `unknown` for the enterprise + expired-only-token case.

### `internal/dashboard`
- **`server.go`** — caches the `activity.Store` via `sync.Once` (Migrate is idempotent but not free), then wraps a fresh `CircuitBreakerReader` + `HybridLastSeenReader` on every render. Type-asserts the audit store for `DB()` / `DialectName()` so in-memory test mocks fall through to audit-only without ceremony.
- **`handlers.go`** — both `coverage.Compute` call sites now use `s.coverageReader()`.

## Acceptance criteria

- [x] Expired/revoked tokens never reach `Infer` — coverage filters in `activeTokenTypes` before calling the registry.
- [x] Phase 2A matrix output remains compatible: same JSON shape, same per-cell semantics; only label changes are the two intentional refinements above.
- [x] Multi-surface principal labeled "Custom client" without named-client logic.
- [x] Connector inference is capability-based (no `claude-code` / `codex` / `cursor` branching anywhere).
- [x] Worst-case render time is bounded under activity stall: per-cell 250ms × 3-call breaker = ~750ms total before audit-only fallback, regardless of N principals.

## Not included

- Dashboard activity drill-down — PR5.
- `/dashboard/api/activity` endpoint — PR5.
- Activity-derived live evidence for `observedAuthMethods` (e.g. wrapper-signed activity attribution) — PR5 plumbs this on top of the config-derived signal.
- Batched LastSeen lookup (single SQL for all principals × surfaces) — also PR5+ when we have enterprise-size data to drive the design.
- YAML-driven custom connectors — explicitly out of scope per the spec.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 9 new tests in `internal/connectors`, 13 new tests in `internal/coverage` (8 hybrid + 5 circuit breaker).
- [ ] Manual smoke: load `/dashboard`, confirm coverage matrix renders the same Connector labels as before for principals with active tokens; confirm an enterprise principal with no tokens shows "Unknown source".