### PR TITLE
Add dashboard activity drill-down (Phase 2B.1 PR5)

### DIFF
--- a/internal/activity/store.go
+++ b/internal/activity/store.go
@@ -213,6 +213,18 @@ func buildWhere(d Dialect, q Query) (string, []any) {
 		args = append(args, val)
 	}
 	add("principal_id", q.PrincipalID)
+	if len(q.PrincipalIDs) > 0 {
+		// IN clause for the multi-principal filter the dashboard's
+		// connector_id drill-down uses. Each value gets its own
+		// placeholder so the dialect-aware placeholder() keeps
+		// SQLite "?" and Postgres "$N" both correct.
+		ph := make([]string, len(q.PrincipalIDs))
+		for i, id := range q.PrincipalIDs {
+			ph[i] = placeholder(d, len(args)+1)
+			args = append(args, id)
+		}
+		clauses = append(clauses, "principal_id IN ("+strings.Join(ph, ", ")+")")
+	}
 	add("surface", q.Surface)
 	add("connector_id", q.ConnectorID)
 	add("workspace_id", q.WorkspaceID)

--- a/internal/activity/store_test.go
+++ b/internal/activity/store_test.go
@@ -187,6 +187,84 @@ func TestSQLStore_QueryFiltersComposeAcrossPrincipalAndSurface(t *testing.T) {
 	}
 }
 
+// 4b. Query.PrincipalIDs filters with an IN clause and AND-combines
+// with the other constraints. The dashboard uses this to push a
+// connector_id drill-down into SQL: it resolves the connector to the
+// set of currently-matching principals and passes them here so the
+// LIMIT applies AFTER the connector filter, not before.
+func TestSQLStore_QueryPrincipalIDsInClause(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	a := validEvent("a") // local-codex
+	b := validEvent("b")
+	b.PrincipalID = "researcher"
+	c := validEvent("c")
+	c.PrincipalID = "third-party"
+	for _, e := range []Event{a, b, c} {
+		if err := store.Insert(ctx, e); err != nil {
+			t.Fatalf("insert %s: %v", e.ID, err)
+		}
+	}
+
+	got, err := store.Query(ctx, Query{
+		PrincipalIDs: []string{"local-codex", "researcher"},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("PrincipalIDs IN clause returned %d events; want 2 (a + b)", len(got))
+	}
+	gotIDs := map[string]bool{}
+	for _, e := range got {
+		gotIDs[e.ID] = true
+	}
+	if !gotIDs["a"] || !gotIDs["b"] || gotIDs["c"] {
+		t.Errorf("returned IDs = %v; want exactly {a, b}", gotIDs)
+	}
+}
+
+// 4c. Newer events from non-matching principals do not push older
+// matching events out of a Limit-bounded result. This is the
+// connector_id drill-down regression: with the IN clause pushed into
+// SQL, asking for limit=1 of {a, c} where c is newer must return c —
+// b ("researcher", newest) is excluded by the filter, not by the
+// limit. Without the IN-in-SQL change, the same query would order by
+// timestamp first and lose c to a post-filter.
+func TestSQLStore_PrincipalIDsLimitAppliesAfterFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	old := validEvent("old")
+	old.Timestamp = time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+	newish := validEvent("newish")
+	newish.PrincipalID = "researcher"
+	newish.Timestamp = time.Date(2026, 4, 26, 11, 0, 0, 0, time.UTC) // newest, but not in IN set
+	matching := validEvent("matching")
+	matching.PrincipalID = "third-party"
+	matching.Timestamp = time.Date(2026, 4, 26, 10, 30, 0, 0, time.UTC)
+	for _, e := range []Event{old, newish, matching} {
+		if err := store.Insert(ctx, e); err != nil {
+			t.Fatalf("insert %s: %v", e.ID, err)
+		}
+	}
+
+	// Filter to {old, matching}, limit 1: must return matching (the
+	// newer of the two), NOT newish (which is newer overall but not
+	// in the IN set).
+	got, err := store.Query(ctx, Query{
+		PrincipalIDs: []string{"local-codex", "third-party"},
+		Limit:        1,
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "matching" {
+		t.Errorf("limit-with-IN result = %v; want exactly [matching]", ids(got))
+	}
+}
+
 // 5. Query Limit is bounded: zero or negative inputs default; oversized
 // inputs are capped. Forgetting to set Limit cannot accidentally page
 // through the entire table.

--- a/internal/activity/types.go
+++ b/internal/activity/types.go
@@ -130,16 +130,28 @@ type Event struct {
 // Limit defaults to DefaultQueryLimit and is capped at MaxQueryLimit so
 // no caller can ask for an unbounded result set — even a forgotten limit
 // will not exhaust memory or DB resources.
+//
+// PrincipalIDs is the multi-principal counterpart to PrincipalID and
+// turns into a SQL IN clause. Used by the dashboard's connector_id
+// drill-down: connector membership is config-derived, so the handler
+// resolves the connector to its principal set and pushes the filter
+// into SQL — the LIMIT then applies AFTER the connector filter, not
+// before. Both PrincipalID and PrincipalIDs may be set; the store
+// AND-combines them, which lets a caller scope to "this principal,
+// AND it must be in this connector's set" if it wants. An empty
+// PrincipalIDs slice is ignored (matches everything); pass a sentinel
+// with a known-impossible value if you want IN () semantics.
 type Query struct {
-	PrincipalID string
-	Surface     string
-	ConnectorID string
-	WorkspaceID string
-	SessionID   string
-	Coverage    string
-	Since       time.Time
-	Until       time.Time
-	Limit       int
+	PrincipalID  string
+	PrincipalIDs []string
+	Surface      string
+	ConnectorID  string
+	WorkspaceID  string
+	SessionID    string
+	Coverage     string
+	Since        time.Time
+	Until        time.Time
+	Limit        int
 }
 
 // Bounds enforced by the Store implementation on every Query.

--- a/internal/coverage/hybrid_reader_test.go
+++ b/internal/coverage/hybrid_reader_test.go
@@ -39,8 +39,9 @@ func TestHybridLastSeenReader_ActivityWinsWhenNewer(t *testing.T) {
 // 2. AUDIT can carry a NEWER row when activity missed an insert (the
 // dual-write goroutine raced with a query, the activity DB hiccupped,
 // etc.). The hybrid reader must surface the audit value in that case
-// so the dashboard does not show stale coverage. Regression guard for
-// the original "activity wins as soon as it has any row" bug.
+// so the dashboard does not show stale coverage. Regression guard:
+// always surface the latest evidence regardless of which reader
+// recorded it.
 func TestHybridLastSeenReader_AuditWinsWhenNewer(t *testing.T) {
 	h := HybridLastSeenReader{
 		Activity: stubReader{stamps: map[string]string{"local-codex|mcp_http": "2026-04-25T08:00:00Z"}},

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -1,0 +1,313 @@
+package dashboard
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/activity"
+	"github.com/oktsec/oktsec/internal/coverage"
+)
+
+// activityQueryTimeout bounds the activity Store.Query call the
+// drill-down handler issues so a stalled or locked activity DB cannot
+// pin a dashboard request. Larger than the per-cell LastSeen budget
+// because Query returns a result set (up to MaxQueryLimit rows) and
+// is paged on the surface index, but still tight enough that a real
+// stall fails fast and the operator sees an empty drawer instead of
+// a hung tab.
+const activityQueryTimeout = 2 * time.Second
+
+// drillDownEventLimit is how many activity events the cell drawer
+// shows per render. The spec calls for "the last 20 activity events"
+// so the drawer stays scannable. The /dashboard/api/activity JSON
+// endpoint accepts a higher limit (capped at MaxQueryLimit) for
+// scripting use.
+const drillDownEventLimit = 20
+
+// activityEventDTO is the JSON shape /dashboard/api/activity returns.
+// Field names are the Phase 2B.1 spec's canonical contract — distinct
+// from activity.Event's struct tags so the API stays stable even if
+// internal field names move (for example principal_trust_level vs
+// trust_level here is a deliberate rename to match the spec).
+//
+// EvidenceJSON is intentionally NOT exposed: surface adapters write
+// it as a bounded redacted blob, but the operator-facing drill-down
+// has no need for it today and excluding it keeps the response small.
+// Future diagnostics can opt into a separate endpoint.
+type activityEventDTO struct {
+	ID             string `json:"id"`
+	Timestamp      string `json:"timestamp"`
+	PrincipalID    string `json:"principal_id"`
+	ReportedActor  string `json:"reported_actor,omitempty"`
+	ConnectorID    string `json:"connector_id,omitempty"`
+	Surface        string `json:"surface"`
+	EventType      string `json:"event_type"`
+	CoverageMode   string `json:"coverage_mode"`
+	AuthMethod     string `json:"auth_method,omitempty"`
+	TrustLevel     string `json:"trust_level,omitempty"`
+	ResourceType   string `json:"resource_type,omitempty"`
+	ResourceLabel  string `json:"resource_label,omitempty"`
+	Status         string `json:"status,omitempty"`
+	PolicyDecision string `json:"policy_decision,omitempty"`
+	Confidence     int    `json:"confidence"`
+	AuditEntryID   string `json:"audit_entry_id,omitempty"`
+	SessionID      string `json:"session_id,omitempty"`
+}
+
+// handleAPIActivity returns activity events as JSON for scripting
+// callers and the in-dashboard drill-down. Filters mirror the spec:
+//
+//	GET /dashboard/api/activity?principal_id=&surface=&connector_id=
+//	    &workspace_id=&coverage=&limit=
+//
+// Auth is handled by the dashboard's existing session middleware.
+// Limit is bounded at MaxQueryLimit (500) regardless of input.
+// ConnectorID is attached from the coverage matrix per principal:
+// activity.Event itself does not carry a ConnectorID because that
+// would denormalize a value that already lives in config (and
+// changes when tokens are revoked).
+func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
+	store := s.coverageActivityStore()
+	if store == nil {
+		// No activity store wired (test mocks, future stores). Empty
+		// result is the correct response — callers should treat this
+		// as "no activity data available" rather than an error.
+		s.renderJSON(w, []activityEventDTO{})
+		return
+	}
+
+	q := activity.Query{
+		PrincipalID: r.URL.Query().Get("principal_id"),
+		Surface:     r.URL.Query().Get("surface"),
+		ConnectorID: r.URL.Query().Get("connector_id"),
+		WorkspaceID: r.URL.Query().Get("workspace_id"),
+		Coverage:    r.URL.Query().Get("coverage"),
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			q.Limit = n
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), activityQueryTimeout)
+	defer cancel()
+	events, err := store.Query(ctx, q)
+	if err != nil {
+		s.logger.Warn("activity query failed", "error", err,
+			"principal_id", q.PrincipalID, "surface", q.Surface)
+		http.Error(w, "activity query failed", http.StatusInternalServerError)
+		return
+	}
+
+	connByPrincipal := s.connectorIDsByPrincipal()
+	out := make([]activityEventDTO, 0, len(events))
+	for _, e := range events {
+		out = append(out, eventDTO(e, connByPrincipal[e.PrincipalID]))
+	}
+	s.renderJSON(w, out)
+}
+
+// eventDTO converts an activity.Event to its API-facing shape. The
+// connectorID is computed by the caller (handleAPIActivity does it
+// once per principal so we do not re-resolve for every row).
+func eventDTO(e activity.Event, connectorID string) activityEventDTO {
+	return activityEventDTO{
+		ID:             e.ID,
+		Timestamp:      e.Timestamp.UTC().Format(time.RFC3339Nano),
+		PrincipalID:    e.PrincipalID,
+		ReportedActor:  e.ReportedActor,
+		ConnectorID:    connectorID,
+		Surface:        string(e.Surface),
+		EventType:      string(e.EventType),
+		CoverageMode:   string(e.CoverageMode),
+		AuthMethod:     e.AuthMethod,
+		TrustLevel:     e.PrincipalTrustLevel,
+		ResourceType:   e.ResourceType,
+		ResourceLabel:  e.ResourceLabel,
+		Status:         e.Status,
+		PolicyDecision: e.PolicyDecision,
+		Confidence:     e.Confidence,
+		AuditEntryID:   e.AuditEntryID,
+		SessionID:      e.SessionID,
+	}
+}
+
+// connectorIDsByPrincipal computes the coverage matrix once and
+// returns a per-principal connector ID lookup. The matrix already
+// knows the connector for each principal (it is computed once per
+// row regardless of surface), so attaching it to per-event JSON
+// avoids re-deriving the same value.
+func (s *Server) connectorIDsByPrincipal() map[string]string {
+	out := map[string]string{}
+	for _, c := range coverage.Compute(s.cfg, s.coverageReader()) {
+		// All cells for the same principal share the same connector.
+		// First write wins; later cells just overwrite with the same
+		// value, which is harmless.
+		out[c.PrincipalID] = c.ConnectorID
+	}
+	return out
+}
+
+// handleCoverageCellDrawer renders the per-cell HTMX fragment the
+// Overview matrix opens when a cell is clicked. It returns HTML, not
+// JSON, because the rest of the dashboard's drill-down infrastructure
+// (the slide-in panel, panel-overlay, openPanel JS) is HTMX-driven.
+//
+// The fragment shows: principal, surface, coverage label, connector,
+// then the last drillDownEventLimit activity events newest-first.
+// Empty state is explicit so the operator sees "No activity recorded
+// for this surface yet." instead of a blank pane.
+func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request) {
+	principalID := r.URL.Query().Get("principal_id")
+	surface := r.URL.Query().Get("surface")
+	if principalID == "" || surface == "" {
+		http.Error(w, "principal_id and surface are required", http.StatusBadRequest)
+		return
+	}
+
+	cells := coverage.Compute(s.cfg, s.coverageReader())
+	cellCoverage, cellConnector := lookupCell(cells, principalID, surface)
+
+	data := struct {
+		PrincipalID   string
+		Surface       string
+		SurfaceLabel  string
+		Coverage      string
+		CoverageLabel string
+		ConnectorID   string
+		Connector     string
+		Events        []activityEventDTO
+		Limit         int
+	}{
+		PrincipalID:   principalID,
+		Surface:       surface,
+		SurfaceLabel:  surfaceDisplayName(surface),
+		Coverage:      cellCoverage,
+		CoverageLabel: coverageBadgeLabel(cellCoverage),
+		ConnectorID:   cellConnector,
+		Connector:     coverage.ConnectorDisplayName(cellConnector),
+		Limit:         drillDownEventLimit,
+	}
+
+	store := s.coverageActivityStore()
+	if store != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), activityQueryTimeout)
+		defer cancel()
+		events, err := store.ListByCoverageCell(ctx, principalID, surface, drillDownEventLimit)
+		if err != nil {
+			s.logger.Warn("coverage cell drawer: activity list failed", "error", err,
+				"principal_id", principalID, "surface", surface)
+		} else {
+			for _, e := range events {
+				data.Events = append(data.Events, eventDTO(e, cellConnector))
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := coverageCellDrawerTmpl.Execute(w, data); err != nil {
+		s.logger.Error("coverage cell drawer template failed", "error", err)
+	}
+}
+
+// lookupCell finds the (coverage, connector) for one (principal,
+// surface) pair from the live coverage matrix. Returns ("", "") when
+// the pair is not in the matrix — the template renders an empty
+// header row in that case rather than failing the request.
+func lookupCell(cells []coverage.CoverageCell, principalID, surface string) (coverageStr, connector string) {
+	for _, c := range cells {
+		if c.PrincipalID == principalID && c.Surface == surface {
+			return string(c.Coverage), c.ConnectorID
+		}
+	}
+	return "", ""
+}
+
+// surfaceDisplayName humanizes a surface wire value for the drawer
+// header. Mirrors the column names in tmpl_overview.go so the drawer
+// title matches the cell the operator clicked.
+func surfaceDisplayName(s string) string {
+	switch s {
+	case "mcp_http":
+		return "MCP Gateway"
+	case "http_egress_proxy":
+		return "Egress Proxy"
+	case "hooks":
+		return "Hooks"
+	}
+	return s
+}
+
+// coverageBadgeLabel returns the badge text for a coverage wire
+// value. Kept local to the drawer to avoid pulling the coverage
+// package's display helper into this file's surface area.
+func coverageBadgeLabel(c string) string {
+	switch c {
+	case "protected":
+		return "Protected"
+	case "observed":
+		return "Observed only"
+	case "blind":
+		return "Blind"
+	}
+	return ""
+}
+
+// coverageCellDrawerTmpl renders the slide-in drawer body for one
+// (principal, surface) cell. Inline CSS is scoped to .cd-* so it
+// cannot collide with the rest of the dashboard.
+var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").Parse(`
+<style>
+.cd-hdr{padding:var(--sp-3) var(--sp-4);border-bottom:1px solid var(--border-subtle)}
+.cd-title{font-size:var(--text-base);font-weight:600;color:var(--text);margin:0 0 4px 0}
+.cd-meta{display:flex;flex-wrap:wrap;gap:var(--sp-2);font-size:var(--text-xs);color:var(--text2);align-items:center}
+.cd-meta span{color:var(--text2)}
+.cd-meta b{color:var(--text);font-weight:500}
+.cd-badge{display:inline-block;padding:2px 8px;border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:600;letter-spacing:0.02em}
+.cd-badge.protected{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.30)}
+.cd-badge.observed{background:rgba(88,166,255,0.10);color:var(--accent);border:1px solid rgba(88,166,255,0.25)}
+.cd-badge.blind{background:transparent;color:var(--text3);border:1px solid var(--border)}
+.cd-events{padding:var(--sp-3) var(--sp-4)}
+.cd-events h4{margin:0 0 var(--sp-2) 0;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);color:var(--text3)}
+.cd-event{padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle);font-size:var(--text-sm)}
+.cd-event:last-child{border-bottom:none}
+.cd-event-row{display:flex;justify-content:space-between;gap:var(--sp-2);align-items:baseline}
+.cd-event-resource{font-family:var(--mono);color:var(--text);font-size:var(--text-sm)}
+.cd-event-time{font-family:var(--mono);font-size:var(--text-xs);color:var(--text3);white-space:nowrap}
+.cd-event-meta{font-size:var(--text-xs);color:var(--text2);margin-top:2px}
+.cd-empty{padding:var(--sp-4);text-align:center;color:var(--text3);font-size:var(--text-sm)}
+</style>
+<div class="cd-hdr">
+  <h3 class="cd-title">{{.PrincipalID}} on {{.SurfaceLabel}}</h3>
+  <div class="cd-meta">
+    {{if .CoverageLabel}}<span><b>Coverage:</b> <span class="cd-badge {{.Coverage}}">{{.CoverageLabel}}</span></span>{{end}}
+    {{if .Connector}}<span><b>Connector:</b> {{.Connector}}</span>{{end}}
+    <span><b>Surface:</b> {{.Surface}}</span>
+  </div>
+</div>
+<div class="cd-events">
+  <h4>Last {{.Limit}} activity events</h4>
+  {{if .Events}}
+    {{range .Events}}
+    <div class="cd-event">
+      <div class="cd-event-row">
+        <span class="cd-event-resource">{{if .ResourceLabel}}{{.ResourceLabel}}{{else}}—{{end}}</span>
+        <span class="cd-event-time" data-ts="{{.Timestamp}}">{{.Timestamp}}</span>
+      </div>
+      <div class="cd-event-meta">
+        {{.EventType}} &middot;
+        status: {{if .Status}}{{.Status}}{{else}}—{{end}} &middot;
+        auth: {{if .AuthMethod}}{{.AuthMethod}}{{else}}—{{end}} &middot;
+        coverage: {{.CoverageMode}}
+      </div>
+    </div>
+    {{end}}
+  {{else}}
+    <div class="cd-empty">No activity recorded for this surface yet.</div>
+  {{end}}
+</div>
+`))

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -68,12 +68,13 @@ type activityEventDTO struct {
 //
 // ConnectorID is a DERIVED filter: surface adapters do not persist
 // activity.Event.ConnectorID (it would denormalize a value already
-// in config that changes when tokens are revoked). The query goes to
-// the store WITHOUT a connector_id constraint, then the post-filter
-// keeps only rows whose principal currently maps to the requested
-// connector. To preserve the spec's "<= 500 rows in the response"
-// guarantee, the post-filter happens AFTER the bounded query, and
-// the post-filter never grows the result set.
+// in config that changes when tokens are revoked). When the caller
+// passes connector_id, the handler resolves it to the set of
+// principals currently in that connector and pushes the filter into
+// SQL via PrincipalIDs (an IN clause), so the LIMIT applies AFTER
+// the connector filter. Without this, asking for limit=100 of an
+// uncommon connector could return [] just because the last 100
+// global rows happened to belong to other connectors.
 func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 	store := s.coverageActivityStore()
 	if store == nil {
@@ -85,18 +86,48 @@ func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestedConnector := r.URL.Query().Get("connector_id")
+	requestedPrincipal := r.URL.Query().Get("principal_id")
+	connByPrincipal := s.connectorIDsByPrincipal()
+
+	if requestedConnector != "" {
+		// If the caller pinned a single principal, just verify its
+		// connector matches and short-circuit if it does not. Saves a
+		// round-trip and avoids a redundant IN clause of size 1.
+		if requestedPrincipal != "" {
+			if connByPrincipal[requestedPrincipal] != requestedConnector {
+				s.renderJSON(w, []activityEventDTO{})
+				return
+			}
+		}
+	}
+
 	q := activity.Query{
-		PrincipalID: r.URL.Query().Get("principal_id"),
+		PrincipalID: requestedPrincipal,
 		Surface:     r.URL.Query().Get("surface"),
 		WorkspaceID: r.URL.Query().Get("workspace_id"),
 		Coverage:    r.URL.Query().Get("coverage"),
-		// Intentional: ConnectorID is NOT passed to the store. See
-		// post-filter below.
+		// Intentional: ConnectorID is NOT passed to the store; the
+		// PrincipalIDs filter below pushes the connector membership
+		// into SQL instead.
 	}
 	if v := r.URL.Query().Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			q.Limit = n
 		}
+	}
+
+	if requestedConnector != "" && requestedPrincipal == "" {
+		// Resolve the connector to its principal set and push the
+		// filter into SQL so the bounded LIMIT applies AFTER the
+		// connector filter. Empty match set means no principal
+		// belongs to this connector — short-circuit with [] instead
+		// of issuing an IN () (which is invalid SQL on most engines).
+		matching := principalsForConnector(connByPrincipal, requestedConnector)
+		if len(matching) == 0 {
+			s.renderJSON(w, []activityEventDTO{})
+			return
+		}
+		q.PrincipalIDs = matching
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), activityQueryTimeout)
@@ -109,16 +140,24 @@ func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connByPrincipal := s.connectorIDsByPrincipal()
 	out := make([]activityEventDTO, 0, len(events))
 	for _, e := range events {
-		conn := connByPrincipal[e.PrincipalID]
-		if requestedConnector != "" && conn != requestedConnector {
-			continue
-		}
-		out = append(out, eventDTO(e, conn))
+		out = append(out, eventDTO(e, connByPrincipal[e.PrincipalID]))
 	}
 	s.renderJSON(w, out)
+}
+
+// principalsForConnector returns every principal ID currently mapped
+// to the requested connector. Order is not guaranteed; callers feed
+// this straight into an IN clause where order does not matter.
+func principalsForConnector(connByPrincipal map[string]string, connector string) []string {
+	out := make([]string, 0)
+	for principal, id := range connByPrincipal {
+		if id == connector {
+			out = append(out, principal)
+		}
+	}
+	return out
 }
 
 // eventDTO converts an activity.Event to its API-facing shape. The

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -65,10 +65,15 @@ type activityEventDTO struct {
 //
 // Auth is handled by the dashboard's existing session middleware.
 // Limit is bounded at MaxQueryLimit (500) regardless of input.
-// ConnectorID is attached from the coverage matrix per principal:
-// activity.Event itself does not carry a ConnectorID because that
-// would denormalize a value that already lives in config (and
-// changes when tokens are revoked).
+//
+// ConnectorID is a DERIVED filter: surface adapters do not persist
+// activity.Event.ConnectorID (it would denormalize a value already
+// in config that changes when tokens are revoked). The query goes to
+// the store WITHOUT a connector_id constraint, then the post-filter
+// keeps only rows whose principal currently maps to the requested
+// connector. To preserve the spec's "<= 500 rows in the response"
+// guarantee, the post-filter happens AFTER the bounded query, and
+// the post-filter never grows the result set.
 func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 	store := s.coverageActivityStore()
 	if store == nil {
@@ -79,12 +84,14 @@ func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	requestedConnector := r.URL.Query().Get("connector_id")
 	q := activity.Query{
 		PrincipalID: r.URL.Query().Get("principal_id"),
 		Surface:     r.URL.Query().Get("surface"),
-		ConnectorID: r.URL.Query().Get("connector_id"),
 		WorkspaceID: r.URL.Query().Get("workspace_id"),
 		Coverage:    r.URL.Query().Get("coverage"),
+		// Intentional: ConnectorID is NOT passed to the store. See
+		// post-filter below.
 	}
 	if v := r.URL.Query().Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -105,7 +112,11 @@ func (s *Server) handleAPIActivity(w http.ResponseWriter, r *http.Request) {
 	connByPrincipal := s.connectorIDsByPrincipal()
 	out := make([]activityEventDTO, 0, len(events))
 	for _, e := range events {
-		out = append(out, eventDTO(e, connByPrincipal[e.PrincipalID]))
+		conn := connByPrincipal[e.PrincipalID]
+		if requestedConnector != "" && conn != requestedConnector {
+			continue
+		}
+		out = append(out, eventDTO(e, conn))
 	}
 	s.renderJSON(w, out)
 }
@@ -135,14 +146,16 @@ func eventDTO(e activity.Event, connectorID string) activityEventDTO {
 	}
 }
 
-// connectorIDsByPrincipal computes the coverage matrix once and
-// returns a per-principal connector ID lookup. The matrix already
-// knows the connector for each principal (it is computed once per
-// row regardless of surface), so attaching it to per-event JSON
-// avoids re-deriving the same value.
+// connectorIDsByPrincipal computes the connector ID for each
+// configured principal. We pass nil for the AuditReader because the
+// connector label is derived purely from config (active token mix +
+// loopback posture); LastSeen would just trigger N×3 hybrid reader
+// calls per /api/activity request for a value the JSON does not use.
+// This keeps the JSON endpoint cheap regardless of activity-store
+// health.
 func (s *Server) connectorIDsByPrincipal() map[string]string {
 	out := map[string]string{}
-	for _, c := range coverage.Compute(s.cfg, s.coverageReader()) {
+	for _, c := range coverage.Compute(s.cfg, nil) {
 		// All cells for the same principal share the same connector.
 		// First write wins; later cells just overwrite with the same
 		// value, which is harmless.
@@ -168,7 +181,12 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	cells := coverage.Compute(s.cfg, s.coverageReader())
+	// Coverage label and connector ID are config-derived; LastSeen is
+	// the only column on a CoverageCell that depends on the audit /
+	// activity readers. The drawer body shows the events list itself
+	// (queried separately below) so LastSeen is redundant here. Pass
+	// nil to keep this handler independent of activity-store health.
+	cells := coverage.Compute(s.cfg, nil)
 	cellCoverage, cellConnector := lookupCell(cells, principalID, surface)
 
 	data := struct {

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -297,3 +297,104 @@ func TestOverview_CoverageCellsAreClickable(t *testing.T) {
 		}
 	}
 }
+
+// 9. Coverage cells must activate on Enter and Space, not just mouse
+// click. tabindex=0 + role=button only makes a <td> focusable;
+// browsers do not synthesize click on Enter/Space for non-button
+// elements, so the hx-trigger must spell out the keyboard events
+// explicitly. Regression guard for keyboard-only operators (and
+// screen readers) being unable to open the drawer.
+func TestOverview_CoverageCellsActivateOnKeyboard(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	// HTMX trigger spec: comma-separated event filters. Enter and
+	// Space both must be present so keyboard activation works.
+	wantTrigger := `hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"`
+	hits := strings.Count(body, wantTrigger)
+	// One per (principal, surface) cell — three surfaces, one principal.
+	if hits != 3 {
+		t.Errorf("hx-trigger keyboard wiring count = %d; want 3 (one per surface column)", hits)
+	}
+}
+
+// 10. connector_id is a derived filter (not a persisted column on
+// activity_events). The handler must query the store WITHOUT a
+// connector_id constraint and then post-filter by the connector
+// derived from each event's principal. Regression guard for the
+// original bug where connector_id was passed straight through to
+// activity.Query and matched zero rows because surface adapters
+// never populate Event.ConnectorID.
+func TestActivityAPI_ConnectorIDFilterPostQueryDerived(t *testing.T) {
+	srv := newTestServer(t)
+	// Two principals: one custom-client (gateway + hook tokens),
+	// one generic-mcp-http (gateway only).
+	seedPrincipalWithGatewayBearer(srv, "single-surface")
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          "multi-surface",
+		DisplayName: "multi-surface",
+		Kind:        "agent",
+		Tokens: []config.PrincipalTokenConfig{
+			{ID: "ms-gw", Type: "gateway_bearer", Hash: "sha256:dummy", CreatedAt: "2026-04-26T00:00:00Z"},
+			{ID: "ms-hk", Type: "hook_bearer", Hash: "sha256:dummy", CreatedAt: "2026-04-26T00:00:00Z"},
+		},
+	})
+
+	// One event for each principal. Both leave Event.ConnectorID
+	// empty, mirroring how the surface adapters write today.
+	seedActivityForTest(t, srv, "single-surface", "mcp_http", "tool-single")
+	seedActivityForTest(t, srv, "multi-surface", "mcp_http", "tool-multi")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Filter by connector_id=generic-mcp-http: must return only the
+	// single-surface principal even though neither event row has the
+	// connector ID persisted.
+	req := httptest.NewRequest("GET", "/dashboard/api/activity?connector_id="+connectors.IDGenericMCPHTTP, nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var got []activityEventDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events; want 1 (only single-surface principal matches generic-mcp-http); body = %s",
+			len(got), rr.Body.String())
+	}
+	if got[0].PrincipalID != "single-surface" {
+		t.Errorf("returned principal = %q; want single-surface", got[0].PrincipalID)
+	}
+	if got[0].ConnectorID != connectors.IDGenericMCPHTTP {
+		t.Errorf("returned connector_id = %q; want %s", got[0].ConnectorID, connectors.IDGenericMCPHTTP)
+	}
+
+	// Filter by connector_id=custom-client: must return only the
+	// multi-surface principal.
+	req = httptest.NewRequest("GET", "/dashboard/api/activity?connector_id="+connectors.IDCustomClient, nil)
+	req.AddCookie(cookie)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got) != 1 || got[0].PrincipalID != "multi-surface" {
+		t.Errorf("custom-client filter returned %d events; want 1 multi-surface; body = %s",
+			len(got), rr.Body.String())
+	}
+}

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -328,12 +329,12 @@ func TestOverview_CoverageCellsActivateOnKeyboard(t *testing.T) {
 }
 
 // 10. connector_id is a derived filter (not a persisted column on
-// activity_events). The handler must query the store WITHOUT a
-// connector_id constraint and then post-filter by the connector
-// derived from each event's principal. Regression guard for the
-// original bug where connector_id was passed straight through to
-// activity.Query and matched zero rows because surface adapters
-// never populate Event.ConnectorID.
+// activity_events). The handler resolves the connector to the set of
+// matching principals and pushes the filter into SQL via PrincipalIDs
+// so the LIMIT applies AFTER the connector filter, never before.
+// Regression guard for the original bug where connector_id was passed
+// straight through to activity.Query and matched zero rows because
+// surface adapters never populate Event.ConnectorID.
 func TestActivityAPI_ConnectorIDFilterPostQueryDerived(t *testing.T) {
 	srv := newTestServer(t)
 	// Two principals: one custom-client (gateway + hook tokens),
@@ -396,5 +397,126 @@ func TestActivityAPI_ConnectorIDFilterPostQueryDerived(t *testing.T) {
 	if len(got) != 1 || got[0].PrincipalID != "multi-surface" {
 		t.Errorf("custom-client filter returned %d events; want 1 multi-surface; body = %s",
 			len(got), rr.Body.String())
+	}
+}
+
+// 11. The connector_id filter must survive the LIMIT cutoff. Codex's
+// scenario: many recent events from one connector, plus one older
+// event from a different connector. Asking for limit=N of the rare
+// connector must still return its event even when the recent N+
+// events all belong to other connectors. Regression guard for the
+// "post-filter after LIMIT" bug — the fix pushes the connector
+// filter into SQL via PrincipalIDs so LIMIT applies AFTER.
+func TestActivityAPI_ConnectorIDFilterSurvivesLimit(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "noisy-single-surface")
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          "rare-multi-surface",
+		DisplayName: "rare-multi-surface",
+		Kind:        "agent",
+		Tokens: []config.PrincipalTokenConfig{
+			{ID: "rare-gw", Type: "gateway_bearer", Hash: "sha256:dummy", CreatedAt: "2026-04-26T00:00:00Z"},
+			{ID: "rare-hk", Type: "hook_bearer", Hash: "sha256:dummy", CreatedAt: "2026-04-26T00:00:00Z"},
+		},
+	})
+
+	// Seed: one OLD event for rare-multi-surface (custom-client),
+	// then 60 newer events for noisy-single-surface (generic-mcp-http).
+	// The old event must still surface when we filter by custom-client
+	// even though it would not be in the most-recent 50 globally.
+	store := srv.coverageActivityStore()
+	if store == nil {
+		t.Fatal("activity store not wired")
+	}
+	rare := activity.Event{
+		ID:           "rare-old",
+		Timestamp:    time.Date(2026, 4, 26, 8, 0, 0, 0, time.UTC),
+		PrincipalID:  "rare-multi-surface",
+		AuthMethod:   "bearer_token",
+		Surface:      activity.SurfaceMCPHTTP,
+		EventType:    activity.EventMCPToolCall,
+		EvidenceType: activity.EvidenceGateway,
+		CoverageMode: activity.CoverageProtected,
+		Confidence:   100,
+		ResourceType: "mcp_tool",
+		ResourceID:   "rare-tool",
+	}
+	if err := store.Insert(context.Background(), rare); err != nil {
+		t.Fatalf("seed rare event: %v", err)
+	}
+	// 60 newer noisy events. 60 > DefaultQueryLimit (50)? No,
+	// DefaultQueryLimit is 100. Use enough to push the rare event
+	// past any reasonable post-filter cutoff: 60 newer events with a
+	// limit=50 query would have lost rare under the old code.
+	for i := 0; i < 60; i++ {
+		ev := activity.Event{
+			ID:           "noisy-" + strconv.Itoa(i),
+			Timestamp:    time.Date(2026, 4, 26, 9, i, 0, 0, time.UTC),
+			PrincipalID:  "noisy-single-surface",
+			AuthMethod:   "bearer_token",
+			Surface:      activity.SurfaceMCPHTTP,
+			EventType:    activity.EventMCPToolCall,
+			EvidenceType: activity.EvidenceGateway,
+			CoverageMode: activity.CoverageProtected,
+			Confidence:   100,
+			ResourceType: "mcp_tool",
+			ResourceID:   "noisy-tool",
+		}
+		if err := store.Insert(context.Background(), ev); err != nil {
+			t.Fatalf("seed noisy event %d: %v", i, err)
+		}
+	}
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// limit=50: under the old "post-filter after LIMIT" code, the
+	// store would return the 50 most recent events (all noisy), the
+	// post-filter would discard all of them, and the response would
+	// be []. With the IN-clause-in-SQL fix, the rare event survives.
+	req := httptest.NewRequest("GET",
+		"/dashboard/api/activity?connector_id="+connectors.IDCustomClient+"&limit=50", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []activityEventDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events; want 1 (rare must survive LIMIT cutoff); body = %s",
+			len(got), rr.Body.String())
+	}
+	if got[0].ID != "rare-old" {
+		t.Errorf("returned event ID = %q; want rare-old", got[0].ID)
+	}
+}
+
+// 12. Asking for a connector that has no matching principals must
+// short-circuit cleanly. Without the guard, the IN clause would be
+// "principal_id IN ()" which is invalid SQL on most engines.
+func TestActivityAPI_ConnectorIDWithNoMatchingPrincipalsReturnsEmpty(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	seedActivityForTest(t, srv, "local-codex", "mcp_http", "tool")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/activity?connector_id="+connectors.IDLegacyLoopbackHeader, nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := strings.TrimSpace(rr.Body.String())
+	if body != "[]" {
+		t.Errorf("body = %q; want [] (no principal matches the requested connector)", body)
 	}
 }

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -332,9 +332,9 @@ func TestOverview_CoverageCellsActivateOnKeyboard(t *testing.T) {
 // activity_events). The handler resolves the connector to the set of
 // matching principals and pushes the filter into SQL via PrincipalIDs
 // so the LIMIT applies AFTER the connector filter, never before.
-// Regression guard for the original bug where connector_id was passed
-// straight through to activity.Query and matched zero rows because
-// surface adapters never populate Event.ConnectorID.
+// Regression guard: connector_id must match rows whose principal
+// currently maps to that connector even when Event.ConnectorID is
+// empty (which surface adapters always leave it).
 func TestActivityAPI_ConnectorIDFilterPostQueryDerived(t *testing.T) {
 	srv := newTestServer(t)
 	// Two principals: one custom-client (gateway + hook tokens),
@@ -400,13 +400,13 @@ func TestActivityAPI_ConnectorIDFilterPostQueryDerived(t *testing.T) {
 	}
 }
 
-// 11. The connector_id filter must survive the LIMIT cutoff. Codex's
-// scenario: many recent events from one connector, plus one older
-// event from a different connector. Asking for limit=N of the rare
-// connector must still return its event even when the recent N+
-// events all belong to other connectors. Regression guard for the
-// "post-filter after LIMIT" bug — the fix pushes the connector
-// filter into SQL via PrincipalIDs so LIMIT applies AFTER.
+// 11. The connector_id filter must survive the LIMIT cutoff.
+// Limit-cutoff regression scenario: many recent events from one
+// connector, plus one older event from a different connector.
+// Asking for limit=N of the rare connector must still return its
+// event even when the recent N+ events all belong to other
+// connectors. The connector filter has to apply BEFORE the LIMIT,
+// which is why PrincipalIDs is pushed into SQL.
 func TestActivityAPI_ConnectorIDFilterSurvivesLimit(t *testing.T) {
 	srv := newTestServer(t)
 	seedPrincipalWithGatewayBearer(srv, "noisy-single-surface")
@@ -470,10 +470,11 @@ func TestActivityAPI_ConnectorIDFilterSurvivesLimit(t *testing.T) {
 	handler := srv.Handler()
 	cookie := loginSession(t, srv, handler)
 
-	// limit=50: under the old "post-filter after LIMIT" code, the
-	// store would return the 50 most recent events (all noisy), the
-	// post-filter would discard all of them, and the response would
-	// be []. With the IN-clause-in-SQL fix, the rare event survives.
+	// limit=50: with the connector filter pushed into SQL via the
+	// PrincipalIDs IN clause, the store returns the 50 most recent
+	// events from the matching principal set (rare-multi-surface).
+	// Without the SQL push-down, a post-filter applied AFTER the
+	// LIMIT would discard all 50 noisy rows and return [].
 	req := httptest.NewRequest("GET",
 		"/dashboard/api/activity?connector_id="+connectors.IDCustomClient+"&limit=50", nil)
 	req.AddCookie(cookie)

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -1,0 +1,299 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/activity"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors"
+)
+
+// seedActivityForTest writes one event into the test server's activity
+// store so the drill-down handlers have something to render. Returns
+// the seeded event so assertions can compare against fields we own.
+func seedActivityForTest(t *testing.T, srv *Server, principalID, surface, tool string) activity.Event {
+	t.Helper()
+	store := srv.coverageActivityStore()
+	if store == nil {
+		t.Fatal("seedActivityForTest: activity store not wired (audit store is not DB-backed)")
+	}
+	ev := activity.Event{
+		ID:                  "act-" + tool + "-" + principalID,
+		Timestamp:           time.Now().UTC(),
+		PrincipalID:         principalID,
+		AuthMethod:          "bearer_token",
+		PrincipalTrustLevel: "authenticated",
+		Surface:             activity.Surface(surface),
+		EventType:           activity.EventMCPToolCall,
+		EvidenceType:        activity.EvidenceGateway,
+		Status:              "allow",
+		PolicyDecision:      "ok",
+		CoverageMode:        activity.CoverageProtected,
+		Confidence:          100,
+		ResourceType:        "mcp_tool",
+		ResourceID:          tool,
+		ResourceLabel:       tool,
+		AuditEntryID:        "audit-" + tool,
+	}
+	if err := store.Insert(context.Background(), ev); err != nil {
+		t.Fatalf("seed activity insert: %v", err)
+	}
+	return ev
+}
+
+// seedPrincipalWithGatewayBearer adds a principal with one active
+// gateway_bearer token so the connector inference produces
+// generic-mcp-http and the coverage matrix includes the cell.
+func seedPrincipalWithGatewayBearer(srv *Server, id string) {
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          id,
+		DisplayName: id,
+		Kind:        "agent",
+		Tokens: []config.PrincipalTokenConfig{{
+			ID:        id + "-gw",
+			Type:      "gateway_bearer",
+			Hash:      "sha256:dummy",
+			CreatedAt: "2026-04-26T00:00:00Z",
+		}},
+	})
+	srv.cfg.Gateway.Enabled = true
+}
+
+// 1. GET /dashboard/api/activity returns the seeded event as JSON,
+// with the spec field names (trust_level, not principal_trust_level)
+// and the connector_id derived from the principal's token mix.
+func TestActivityAPI_ReturnsSeededEvent(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	seedActivityForTest(t, srv, "local-codex", "mcp_http", "filesystem.read_file")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/activity?principal_id=local-codex&surface=mcp_http", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var got []activityEventDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v; body = %s", err, rr.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events; want 1; body = %s", len(got), rr.Body.String())
+	}
+	ev := got[0]
+	if ev.PrincipalID != "local-codex" {
+		t.Errorf("principal_id = %q; want local-codex", ev.PrincipalID)
+	}
+	if ev.Surface != "mcp_http" {
+		t.Errorf("surface = %q; want mcp_http", ev.Surface)
+	}
+	if ev.TrustLevel != "authenticated" {
+		t.Errorf("trust_level = %q; want authenticated (DTO renames principal_trust_level)", ev.TrustLevel)
+	}
+	if ev.CoverageMode != "protected" {
+		t.Errorf("coverage_mode = %q; want protected", ev.CoverageMode)
+	}
+	if ev.ConnectorID != connectors.IDGenericMCPHTTP {
+		t.Errorf("connector_id = %q; want generic-mcp-http (derived from token mix)", ev.ConnectorID)
+	}
+	if ev.ResourceLabel != "filesystem.read_file" {
+		t.Errorf("resource_label = %q; want filesystem.read_file", ev.ResourceLabel)
+	}
+}
+
+// 2. The endpoint requires an authenticated dashboard session. API
+// routes return 401 (not the 302 redirect HTML pages get) so a
+// scripted caller sees an explicit auth failure instead of HTML.
+func TestActivityAPI_RequiresAuth(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest("GET", "/dashboard/api/activity", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated GET status = %d; want 401", rr.Code)
+	}
+}
+
+// 3. limit query param is honored and capped. activity.MaxQueryLimit
+// is 500; passing limit=10000 must not return more than 500 rows.
+// The test seeds two events and asserts the bound applies via the
+// returned slice length.
+func TestActivityAPI_LimitIsBounded(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	seedActivityForTest(t, srv, "local-codex", "mcp_http", "tool-a")
+	seedActivityForTest(t, srv, "local-codex", "mcp_http", "tool-b")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// limit=10000 (way above the cap) must still succeed and return
+	// just our two rows — the bound is a max, not a min.
+	req := httptest.NewRequest("GET", "/dashboard/api/activity?principal_id=local-codex&limit=10000", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []activityEventDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %d events; want 2", len(got))
+	}
+	// Activity cap (500) is enforced at the store layer; this test
+	// proves the dashboard does not reject a wildly oversized limit
+	// (which would be a regression making oversized scripts fail
+	// hard instead of silently being bounded).
+}
+
+// 4. With no events seeded the endpoint returns an empty JSON array,
+// not null. Scripted callers can then iterate without nil-checking.
+func TestActivityAPI_EmptyReturnsEmptyArray(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/activity?principal_id=local-codex", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := strings.TrimSpace(rr.Body.String())
+	if body != "[]" {
+		t.Errorf("empty result body = %q; want []", body)
+	}
+}
+
+// 5. The drill-down drawer renders the coverage badge, connector,
+// and seeded events. Empty-state copy must not appear when at least
+// one event exists.
+func TestCoverageCellDrawer_RendersHeaderAndEvents(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	seedActivityForTest(t, srv, "local-codex", "mcp_http", "filesystem.read_file")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface=mcp_http", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		"local-codex",
+		"MCP Gateway",
+		"Protected",
+		"Generic MCP HTTP",
+		"filesystem.read_file",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("drawer body missing %q; body = %s", want, body)
+		}
+	}
+	if strings.Contains(body, "No activity recorded") {
+		t.Error("drawer should not show empty state when an event exists")
+	}
+}
+
+// 6. Empty-state copy is shown when no activity is recorded for the
+// (principal, surface) pair. The header still renders so the operator
+// can see "yes I clicked the right cell, it just has no data yet".
+func TestCoverageCellDrawer_EmptyState(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	// No activity seeded.
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface=hooks", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "No activity recorded for this surface yet.") {
+		t.Errorf("drawer body missing empty-state copy; body = %s", body)
+	}
+	if !strings.Contains(body, "local-codex") || !strings.Contains(body, "Hooks") {
+		t.Errorf("drawer header missing principal/surface; body = %s", body)
+	}
+}
+
+// 7. Missing required query params return a 400, not a 500. Catches
+// the simple "operator pasted the URL wrong" case.
+func TestCoverageCellDrawer_MissingParamsReturns400(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (missing surface)", rr.Code)
+	}
+}
+
+// 8. The Overview matrix renders the cells with the drill-down
+// HTMX attributes so the cell click actually wires through to the
+// drawer. Regression guard for an accidental template revert.
+func TestOverview_CoverageCellsAreClickable(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		`hx-get="/dashboard/api/coverage/cell?principal_id=local-codex&surface=mcp_http"`,
+		`hx-get="/dashboard/api/coverage/cell?principal_id=local-codex&surface=http_egress_proxy"`,
+		`hx-get="/dashboard/api/coverage/cell?principal_id=local-codex&surface=hooks"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("overview missing clickable wiring %q", want)
+		}
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -418,6 +418,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/api/graph/tables", s.handleAPIGraphTables)
 	s.mux.HandleFunc("GET /dashboard/api/graph/events", s.handleAPIGraphEvents)
 
+	// Phase 2B.1 PR5: activity drill-down. JSON endpoint for scripting
+	// callers; HTML fragment endpoint feeds the Overview cell drawer.
+	s.mux.HandleFunc("GET /dashboard/api/activity", s.handleAPIActivity)
+	s.mux.HandleFunc("GET /dashboard/api/coverage/cell", s.handleCoverageCellDrawer)
+
 	// Export & Report
 	s.mux.HandleFunc("GET /dashboard/api/export/csv", s.handleExportCSV)
 	s.mux.HandleFunc("GET /dashboard/api/export/json", s.handleExportJSON)

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -199,6 +199,7 @@ a.ov-metric:hover{background:var(--surface2)}
         {{with index .Cells "mcp_http"}}
         <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on MCP Gateway"
             hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=mcp_http"
+            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
             hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
@@ -207,6 +208,7 @@ a.ov-metric:hover{background:var(--surface2)}
         {{with index .Cells "http_egress_proxy"}}
         <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Egress Proxy"
             hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=http_egress_proxy"
+            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
             hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
@@ -215,6 +217,7 @@ a.ov-metric:hover{background:var(--surface2)}
         {{with index .Cells "hooks"}}
         <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Hooks"
             hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=hooks"
+            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
             hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -167,6 +167,9 @@ a.ov-metric:hover{background:var(--surface2)}
 .cov-empty{padding:24px;text-align:center;color:var(--text3);font-size:var(--text-sm)}
 .cov-empty a{color:var(--accent);text-decoration:none}
 .cov-empty a:hover{text-decoration:underline}
+.cov-cell{cursor:pointer;transition:background 0.12s ease}
+.cov-cell:hover{background:rgba(88,166,255,0.06)}
+.cov-cell:focus{outline:2px solid var(--accent);outline-offset:-2px}
 </style>
 <div class="ov-card" style="margin-bottom:var(--sp-4)">
   <div style="display:flex;align-items:center;gap:var(--sp-3);margin-bottom:var(--sp-3)">
@@ -192,20 +195,27 @@ a.ov-metric:hover{background:var(--surface2)}
       <tr>
         <td><span class="cov-principal">{{.PrincipalID}}</span></td>
         <td><span class="cov-connector">{{.ConnectorLabel}}</span></td>
+        {{$pid := .PrincipalID}}
         {{with index .Cells "mcp_http"}}
-        <td>
+        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on MCP Gateway"
+            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=mcp_http"
+            hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
         </td>
         {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
         {{with index .Cells "http_egress_proxy"}}
-        <td>
+        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Egress Proxy"
+            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=http_egress_proxy"
+            hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
         </td>
         {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
         {{with index .Cells "hooks"}}
-        <td>
+        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Hooks"
+            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=hooks"
+            hx-target="#panel-content" hx-swap="innerHTML">
           <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
           {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
         </td>


### PR DESCRIPTION
## Summary

Closes the Phase 2B.1 slice. Every coverage cell on the Overview can now show the activity events behind it. Two endpoints land:

- `GET /dashboard/api/activity?principal_id=&surface=&connector_id=&workspace_id=&coverage=&limit=` — JSON for scripting callers and future tooling.
- `GET /dashboard/api/coverage/cell?principal_id=&surface=` — HTML fragment the slide-in drawer renders on cell click.

No request-path changes. No audit row changes. No matrix layout change — the cells are the same; clicking them now opens the existing `panel-overlay` drawer.

## What changed

### `internal/activity` (extended)
- **`types.go`** — `Query.PrincipalIDs []string` is the multi-principal counterpart to `PrincipalID`. The dashboard's connector_id drill-down resolves the connector to its principal set and pushes the filter into SQL via this field, so the bounded LIMIT applies AFTER the connector filter rather than before.
- **`store.go`** — `buildWhere` AND-combines a `principal_id IN (?, ?, ...)` clause when `PrincipalIDs` is non-empty. Dialect-aware so SQLite `?` and Postgres `$N` both work.

### `internal/dashboard/handlers_activity.go` (new)
- **`activityEventDTO`** — API-stable JSON shape per the spec response example. Renames `principal_trust_level` → `trust_level` so the wire contract matches the spec verbatim. `EvidenceJSON` is excluded — surface adapters bound and redact it but the operator-facing drill-down does not need it today, and excluding keeps the payload small.
- **`handleAPIActivity`** — parses the spec query params under a 2s context timeout. `connector_id` is a derived filter (surface adapters do not persist `Event.ConnectorID`); the handler resolves the requested connector to the set of currently-matching principals and pushes the filter into SQL via `PrincipalIDs`. `principal_id` + `connector_id` together short-circuits with `[]` when the principal is not in the connector's set. A connector with no matching principals also short-circuits cleanly. Empty result is `[]`, not `null`. Limit honored and bounded at `activity.MaxQueryLimit` (500).
- **`handleCoverageCellDrawer`** — returns the HTML fragment the panel-overlay drawer renders via HTMX. Header carries principal, surface, coverage badge, connector; body lists last `drillDownEventLimit` (20) events newest-first; empty state copy is "No activity recorded for this surface yet." per spec. Calls `coverage.Compute(s.cfg, nil)` for the header — connector and coverage labels are config-derived, so opening the drawer no longer fans out LastSeen queries.
- **`coverageCellDrawerTmpl`** — inline-CSS template scoped to `.cd-*` classes so it cannot collide with the rest of the dashboard.
- 2s timeout on each activity Store call so a stalled DB cannot hang the drawer; warn-logs and renders empty state on error.

### `internal/dashboard/server.go`
- Registers the two new GET routes under the existing auth + CSRF middleware. No new struct fields — reuses `coverageActivityStore` cached on first use (PR4).

### `internal/dashboard/tmpl_overview.go`
- Coverage cells become clickable: each surface column TD now carries `hx-get` to the new drawer endpoint, `hx-target="#panel-content"`, `hx-swap="innerHTML"`, plus `hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"` so keyboard-only operators (and screen readers) can open the drawer too. New `.cov-cell` hover/focus styles.

## Tests

`internal/activity` (2 new):
1. `TestSQLStore_QueryPrincipalIDsInClause` — the IN clause filters as expected and AND-combines with other constraints.
2. `TestSQLStore_PrincipalIDsLimitAppliesAfterFilter` — newer events from non-matching principals do not push older matching events out of a Limit-bounded result.

`internal/dashboard` (10 new):
1. `/api/activity` returns the seeded event with `connector_id` derived from the principal token mix and the `trust_level` field rename.
2. `/api/activity` rejects unauthenticated requests with 401.
3. `limit=10000` is bounded silently rather than erroring.
4. Empty result is `[]` not `null`.
5. Drawer renders header (principal, surface, coverage label, connector) plus seeded events.
6. Drawer empty state copy fires when no activity exists.
7. Missing query params return 400, not 500.
8. Overview matrix renders the clickable HTMX wiring on every surface column.
9. Coverage cells activate on Enter and Space (counts the `hx-trigger` occurrences).
10. `connector_id` filter post-query derives from the current coverage matrix.
11. **Limit-cutoff regression scenario** — 60 noisy events from `generic-mcp-http` plus one older event from `custom-client`. With `limit=50` the API still returns the rare event because the connector filter is pushed into SQL.
12. `connector_id` with no matching principals returns `[]` without issuing an invalid `IN ()`.

## Acceptance per spec

- [x] Every coverage cell can explain its supporting activity (drawer).
- [x] Empty states are clear (explicit copy).
- [x] No raw prompt/tool arguments in `/api/activity` (DTO excludes `EvidenceJSON`; surface adapters never wrote raw payloads anyway).
- [x] Dashboard auth protected (existing session middleware).
- [x] Returns at most 500 events (`activity.MaxQueryLimit`).
- [x] `connector_id` is a reliable API filter regardless of result-set ordering.
- [x] Keyboard-only operators can open the drawer.
- [x] Drill-down does not fan out LastSeen queries (uses `coverage.Compute(s.cfg, nil)`).
- [x] No Graph v2.

## Not included

- Cross-surface filter UI on the matrix — adds noise to the Overview, deferrable.
- Workspace filter UI — `workspace_id` is already a query param on the JSON endpoint, but no surface populates it yet.
- A standalone `/dashboard/activity` page — spec says "Prefer the smallest UI that can ship safely"; the drawer covers the use case without a new page.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 12 new tests across `internal/activity` and `internal/dashboard`.
- [ ] Manual smoke: load `/dashboard`, click a coverage cell on a token-authenticated principal — drawer opens with the expected events; click a never-used surface — empty-state copy fires; keyboard tab + Enter from a focused cell opens the same drawer.