### PR TITLE
Render coverage cells as native buttons under strict CSP

### DIFF
--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -299,13 +299,15 @@ func TestOverview_CoverageCellsAreClickable(t *testing.T) {
 	}
 }
 
-// 9. Coverage cells must activate on Enter and Space, not just mouse
-// click. tabindex=0 + role=button only makes a <td> focusable;
-// browsers do not synthesize click on Enter/Space for non-button
-// elements, so the hx-trigger must spell out the keyboard events
-// explicitly. Regression guard for keyboard-only operators (and
-// screen readers) being unable to open the drawer.
-func TestOverview_CoverageCellsActivateOnKeyboard(t *testing.T) {
+// 9. Coverage cells render as native buttons under strict CSP.
+// HTMX trigger filters like keyup[key=='Enter'] use eval() under the
+// hood, which is blocked by script-src 'self' 'unsafe-inline' (no
+// 'unsafe-eval'). Native <button> elements activate on click, Enter,
+// and Space without any filter expression, so the cell stays
+// keyboard-accessible without relaxing CSP. Regression guard
+// asserting both halves of the contract: buttons present, no filter
+// expressions emitted, no CSP relaxation.
+func TestOverview_CoverageCellsUseCSPSafeButtons(t *testing.T) {
 	srv := newTestServer(t)
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
 
@@ -318,13 +320,25 @@ func TestOverview_CoverageCellsActivateOnKeyboard(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	body := rr.Body.String()
-	// HTMX trigger spec: comma-separated event filters. Enter and
-	// Space both must be present so keyboard activation works.
-	wantTrigger := `hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"`
-	hits := strings.Count(body, wantTrigger)
-	// One per (principal, surface) cell — three surfaces, one principal.
-	if hits != 3 {
-		t.Errorf("hx-trigger keyboard wiring count = %d; want 3 (one per surface column)", hits)
+
+	// Native buttons, one per surface column.
+	if got := strings.Count(body, `class="cov-cell-btn"`); got < 3 {
+		t.Errorf("cov-cell-btn count = %d; want at least 3 (one per surface)", got)
+	}
+	if !strings.Contains(body, `<button type="button" class="cov-cell-btn"`) {
+		t.Error("coverage cells must render as <button type=\"button\">")
+	}
+
+	// HTMX trigger filters require eval() and are blocked by CSP.
+	// Native buttons make them unnecessary.
+	if strings.Contains(body, "keyup[") || strings.Contains(body, "keydown[") {
+		t.Error("coverage cells must not emit HTMX trigger filters that require eval()")
+	}
+
+	// CSP must stay strict.
+	csp := rr.Header().Get("Content-Security-Policy")
+	if strings.Contains(csp, "unsafe-eval") {
+		t.Errorf("dashboard CSP must not include 'unsafe-eval'; got %q", csp)
 	}
 }
 

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -167,9 +167,10 @@ a.ov-metric:hover{background:var(--surface2)}
 .cov-empty{padding:24px;text-align:center;color:var(--text3);font-size:var(--text-sm)}
 .cov-empty a{color:var(--accent);text-decoration:none}
 .cov-empty a:hover{text-decoration:underline}
-.cov-cell{cursor:pointer;transition:background 0.12s ease}
-.cov-cell:hover{background:rgba(88,166,255,0.06)}
-.cov-cell:focus{outline:2px solid var(--accent);outline-offset:-2px}
+.cov-cell{padding:0;vertical-align:top;white-space:nowrap}
+.cov-cell-btn{width:100%;min-height:52px;display:flex;flex-direction:column;align-items:flex-start;gap:4px;padding:10px 12px;background:transparent;border:0;color:inherit;font:inherit;text-align:left;cursor:pointer;border-radius:var(--radius-sm);transition:background 0.12s ease}
+.cov-cell-btn:hover{background:rgba(88,166,255,0.06)}
+.cov-cell-btn:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
 </style>
 <div class="ov-card" style="margin-bottom:var(--sp-4)">
   <div style="display:flex;align-items:center;gap:var(--sp-3);margin-bottom:var(--sp-3)">
@@ -197,30 +198,39 @@ a.ov-metric:hover{background:var(--surface2)}
         <td><span class="cov-connector">{{.ConnectorLabel}}</span></td>
         {{$pid := .PrincipalID}}
         {{with index .Cells "mcp_http"}}
-        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on MCP Gateway"
-            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=mcp_http"
-            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
-            hx-target="#panel-content" hx-swap="innerHTML">
-          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
-          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        <td class="cov-cell">
+          <button type="button" class="cov-cell-btn"
+                  aria-label="Show activity for {{$pid}} on MCP Gateway"
+                  hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=mcp_http"
+                  hx-trigger="click"
+                  hx-target="#panel-content" hx-swap="innerHTML">
+            <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+            {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+          </button>
         </td>
         {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
         {{with index .Cells "http_egress_proxy"}}
-        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Egress Proxy"
-            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=http_egress_proxy"
-            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
-            hx-target="#panel-content" hx-swap="innerHTML">
-          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
-          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        <td class="cov-cell">
+          <button type="button" class="cov-cell-btn"
+                  aria-label="Show activity for {{$pid}} on Egress Proxy"
+                  hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=http_egress_proxy"
+                  hx-trigger="click"
+                  hx-target="#panel-content" hx-swap="innerHTML">
+            <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+            {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+          </button>
         </td>
         {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
         {{with index .Cells "hooks"}}
-        <td class="cov-cell" tabindex="0" role="button" aria-label="Show activity for {{$pid}} on Hooks"
-            hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=hooks"
-            hx-trigger="click, keyup[key=='Enter'], keyup[key==' ']"
-            hx-target="#panel-content" hx-swap="innerHTML">
-          <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
-          {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+        <td class="cov-cell">
+          <button type="button" class="cov-cell-btn"
+                  aria-label="Show activity for {{$pid}} on Hooks"
+                  hx-get="/dashboard/api/coverage/cell?principal_id={{$pid}}&surface=hooks"
+                  hx-trigger="click"
+                  hx-target="#panel-content" hx-swap="innerHTML">
+            <span class="cov-badge {{.Coverage}}" title="{{.Limitation}}">{{covLabel (printf "%s" .Coverage)}}</span>
+            {{$short := covShort .}}{{if $short}}<span class="cov-short" title="{{.Limitation}}">{{$short}}</span>{{end}}
+          </button>
         </td>
         {{else}}<td><span class="cov-badge blind">Blind</span></td>{{end}}
         <td><span class="cov-identity">{{.IdentityList}}</span></td>


### PR DESCRIPTION
## Summary

`oktsec verify action-evidence --file <bundle.json>` (a bare positional path is accepted too) verifies, offline, a portable action-evidence bundle (`oktsec_action_evidence_bundle.v1`) exported from the control plane: every node-signed receipt batch it carries, every receipt's hash and runtime signature, and each action's lifecycle chain across the batches. Read-only and self-contained: no network, no store, nothing written.

The node consumes the producer's frozen schema; it does not define a competing one. The producer's golden fixture is vendored byte for byte and pinned by SHA-256 (`9ad52ef1…d65f4`, the `surface: "gateway"` revision); the node has no bundle generator.

### What the verdict says, and what it does not

- **self-consistent** (no `--expected-node-fingerprint`): the included evidence verifies against the identity key the bundle itself carries.
- **pinned** (`--expected-node-fingerprint sha256:…`): the same, checked against the enrolled node identity supplied out of band. Bundle v1 is one identity cohort: the pin must match the manifest, the sole key and every batch.
- **incomplete** is reported separately from **invalid**: cryptographically sound evidence whose window does not show a closed lifecycle fails by default with exit 6; `--allow-incomplete` accepts it explicitly. Each action is checked against the exact lifecycle grammar the control plane's read model derives from (`decision_issued` → `dispatch_started` → `dispatch_completed`/`dispatch_failed` → `response_released`/`response_withheld`; `not_dispatched_*` terminal; `not_dispatched_quarantined` → `approval_settled`), with the same reason codes. A signed but impossible transition, a legacy `approval_settled` at sequence 1, a window starting past sequence 1 or with a hole are all incomplete: authentic evidence that does not show the lifecycle, never a successful action. A contradiction between receipts that are both present (broken adjacent link, hash that does not recompute, duplicate sequence, a receipt the producer or the control plane would refuse) is invalid, whatever else is missing.
- `coverage_assurance` (`included_batches_only`) travels in the result: the bundle proves the batches it includes, not that none was omitted.

### Exit codes

`0` valid and complete (or incomplete with `--allow-incomplete`) · `1` usage/file error · `2` unsupported bundle schema · `3` malformed bundle (shape, encoding, limits, selection arithmetic) · `4` cryptographic or chain failure · `5` expected node fingerprint mismatch · `6` valid but incomplete. Codes travel via `CommandExitCode()` (no `os.Exit` in `RunE`); `--json` echoes `exit_code` and, on a refusal, the same `result_schema` with the refusal as its single failure.

Precedence: invalid evidence wins (exit 4). A fingerprint mismatch (exit 5) is only reported as the verdict over evidence that is itself cryptographically sound, so "intact evidence of the wrong node" is never said of a bundle that was also altered; when both hold, both findings stay in the result and the verdict line says so. A bundle that does not agree with itself about its node (manifest ≠ key ≠ batches) is a cryptographic/identity failure, never a pin mismatch: there is no identity to pin against.

### Changes

- `internal/audit/receipts_window.go`: `ClassifyActionReceiptWindow` — complete / incomplete / invalid over a bounded window, with the lifecycle grammar mirrored line by line from the control plane's read model (same states, same reason codes) and `ValidateReceiptWire` = the producer's write-time rule (`audit.ValidateReceipt`, now exported) plus the control plane's ingest constraints (identifier shape, 4096-byte scalars, 512-entry lists, no NUL, JSON-array list fields, canonical UTC RFC 3339 timestamp, lowercase SHA-256 hash). Signatures stay per batch, since a window may span runtime keys. `VerifyActionReceipts` is untouched; over a gapless chain from 1 the two agree (test).
- `internal/node/evidence_bundle.go`: strict decoder (`DisallowUnknownFields` + EOF), shape validation (frozen manifest values → unsupported; wrong shapes/encodings/limits/selection → malformed), per-batch node attestation (batch hash over `CanonicalActionReceiptsBatchBytes`, node signature over `ActionReceiptsEnvelopeSigningPayload`, runtime fingerprint), per-receipt `ComputeReceiptHash` + `VerifyEntrySignature`, per-action window. Exports `FingerprintPublicKey`. Failures are bounded (200 reported + `failures_truncated`).
- `cmd/oktsec/commands/verify_action_evidence.go`: the command. `verify` is promoted to a parent (bare `oktsec verify` still validates the config; `Args: NoArgs` so a mistyped subcommand errors instead of silently running the config check) and is no longer hidden.
- Docs: `documentation/reference/cli.md`, `CHANGELOG.md`.

Wire contracts (`action_receipt.v1`, `node_action_receipts.v1`, `node_action_receipts_envelope.v1`) and canonicalization are untouched.

## Tests

- Golden pin (SHA-256) + the producer's deterministic key labels re-derived and checked against the golden's node fingerprint (ties the fixture to its keys).
- Golden verifies complete, self-consistent / pinned; wrong pin → `expected_fingerprint_mismatch`, still `valid: true`.
- Tamper matrix (29 cases), including "valid signatures over a contradictory chain", an unknown stage, a non-canonical timestamp, a `verified_applied` without its citation, a null list field and a NUL byte — all built by re-signing mutated receipts and re-sealing the envelope with the producer's keys, the cases a signature-only verifier misses. Re-seal of untouched content reproduces the golden hashes (test). A signed impossible transition (re-linked and re-sealed across both batches) verifies valid, incomplete, `invalid_dispatch_start_transition`.
- Refusal matrix (22 cases): unsupported (schema v2/missing, canonicalization tag, hash algorithm, coverage assurance) vs malformed (not JSON, trailing data, unknown fields at bundle/envelope/receipt level, key count, encodings, batch order, selection arithmetic, byte and batch limits).
- Incomplete windows by dropping either batch (later batch missing → `dispatch_in_progress`; earlier missing → `chain_does_not_start_at_one`, first sequence 3).
- Window classifier: 47 cases — every sequence the grammar closes, every open state, every impossible transition (incomplete, never complete or invalid), legacy `approval_settled` at sequence 1 (incomplete), `observed_after_action` (incomplete), and every contradiction or shape refusal (invalid).
- CLI: exit codes for every class and their precedence (tamper wins over a wrong fingerprint; the verdict names both), `--json` result and refusal shapes, oversize file (sparse 25 MiB + 1), symlink and missing file as plain errors, parent command behaviour.
- Import guards: neither the verifier nor the command imports `net*`, `os/exec`, `database/sql` (the verifier also not `os`).

Gate: `go vet ./...`, `golangci-lint` clean on touched packages, `go test -race` on `internal/audit`, `internal/node`, `internal/gateway`, `cmd/action-bench`, `cmd/oktsec/commands`.

## Review round 1 (producer, 2026-08-28) — all five resolved

1. Lifecycle grammar: exact mirror of the consumer's `DeriveLifecycle` (states + reason codes); `decision_issued → response_released` is incomplete (`invalid_dispatch_start_transition`), never complete.
2. Legacy `approval_settled` at sequence 1: `valid: true`, `complete: false`, `legacy_settlement_without_decision`.
3. Receipt shape: `audit.ValidateReceipt` exported and applied to every receipt, plus the ingest constraints, in both the bundle verifier (`receipt_shape_invalid`) and the window classifier.
4. Precedence: invalid (4) beats fingerprint mismatch (5); both findings kept; verdict never calls altered evidence intact.
5. Golden re-vendored at `9ad52ef1…d65f4` (`surface: "gateway"`), pin updated.

## Review round 2 (producer, 2026-08-28) — all three resolved

1. `--file <bundle.json>` is the contract form (spec §8); the positional path stays for compatibility; two different paths or none is a plain usage error (exit 1).
2. Grammar output identical to the consumer's: `pending_approval` and `dispatch_in_progress` carry an empty `reason` (the state is the reason), as in `DeriveLifecycle`.
3. Terminal output neutralizes every bundle-derived string (`terminalSafe`: C0 including ESC/BEL/newline, DEL, C1, invalid UTF-8 → `\xNN` / `\uNNNN`; printable Unicode untouched), including the refusal message. Tests: ESC/CSI in `node_id`, newline in a receipt id, OSC+BEL in a batch hash, ESC in the refusal path; the injected text never starts a line and the verdict stays first. `--json` is unchanged (encoding/json escapes control characters).

## Residual

- Bundle v1 is single-cohort by contract; a bundle spanning a node identity rotation is malformed here (two keys) or a cryptographic failure (a batch naming another key), matching the producer's 409.
- The window classifier's reason codes are a superset of the consumer's: `sequence_gap_in_window` (hole between present receipts, incomplete) and the invalid-class codes (`broken_receipt_chain`, `duplicate_sequence`, `sequence_one_has_predecessor`, `receipt_hash_mismatch`, `receipt_shape_invalid`, `mixed_action_ids`) exist only offline, where hashes are recomputed.
