### PR TITLE
Add "Why this state" section to coverage drawer

### DIFF
--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -208,10 +208,13 @@ func (s *Server) connectorIDsByPrincipal() map[string]string {
 // JSON, because the rest of the dashboard's drill-down infrastructure
 // (the slide-in panel, panel-overlay, openPanel JS) is HTMX-driven.
 //
-// The fragment shows: principal, surface, coverage label, connector,
-// then the last drillDownEventLimit activity events newest-first.
-// Empty state is explicit so the operator sees "No activity recorded
-// for this surface yet." instead of a blank pane.
+// The fragment shows: principal, surface, coverage label, connector;
+// a short "Why this state" explanation that translates the wire-level
+// label into operator language; an optional next-action link when
+// coverage is not Protected; then the last drillDownEventLimit
+// activity events newest-first. Empty state is explicit so the
+// operator sees "No activity recorded for this surface yet." instead
+// of a blank pane.
 func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request) {
 	principalID := r.URL.Query().Get("principal_id")
 	surface := r.URL.Query().Get("surface")
@@ -236,6 +239,8 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		CoverageLabel string
 		ConnectorID   string
 		Connector     string
+		Explanation   string
+		NextAction    coverageAction
 		Events        []activityEventDTO
 		Limit         int
 	}{
@@ -246,6 +251,8 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		CoverageLabel: coverageBadgeLabel(cellCoverage),
 		ConnectorID:   cellConnector,
 		Connector:     coverage.ConnectorDisplayName(cellConnector),
+		Explanation:   coverageExplanation(cellCoverage),
+		NextAction:    coverageNextAction(cellCoverage, surface),
 		Limit:         drillDownEventLimit,
 	}
 
@@ -314,6 +321,56 @@ func coverageBadgeLabel(c string) string {
 	return ""
 }
 
+// coverageExplanation returns the operator-facing one-sentence
+// answer to "why is this cell in this state?". Wording is the
+// canonical contract from the Phase 2B.1 dashboard UX spec — change
+// it here, not in the template, so all three coverage states stay in
+// lock-step. Deliberately neutral (no "fully", "complete", "blind
+// failure"): Protected does not imply global coverage and Observed
+// does not imply blocking.
+func coverageExplanation(coverage string) string {
+	switch coverage {
+	case "protected":
+		return "Oktsec is in the pre-action path with authenticated identity for this surface."
+	case "observed":
+		return "Oktsec has telemetry for this surface, but cannot claim pre-action blocking."
+	case "blind":
+		return "Oktsec has no active protection or usable telemetry for this surface."
+	}
+	return "No coverage state is available for this surface."
+}
+
+// coverageAction is the optional next step the drawer surfaces when
+// coverage is not Protected. Empty Label means "render nothing"; the
+// template skips the link in that case so a Protected cell stays
+// quiet and a Blind cell does not get a misleading "fix this"
+// affordance when no in-app route applies.
+type coverageAction struct {
+	Label string
+	Href  string
+}
+
+// coverageNextAction picks the surface-specific link that improves
+// coverage when the cell is not Protected. We point at the in-app
+// Settings page for every surface (it is the single route where
+// tokens, profile auth, and surface enablement are configured) so
+// we never link to a route that does not exist. Protected cells
+// return the zero value and the template renders no link.
+func coverageNextAction(coverage, surface string) coverageAction {
+	if coverage == "protected" {
+		return coverageAction{}
+	}
+	switch surface {
+	case "mcp_http":
+		return coverageAction{Label: "Issue a gateway bearer token", Href: "/dashboard/settings"}
+	case "http_egress_proxy":
+		return coverageAction{Label: "Configure egress proxy auth", Href: "/dashboard/settings"}
+	case "hooks":
+		return coverageAction{Label: "Configure hook token", Href: "/dashboard/settings"}
+	}
+	return coverageAction{Label: "Review coverage settings", Href: "/dashboard/settings"}
+}
+
 // coverageCellDrawerTmpl renders the slide-in drawer body for one
 // (principal, surface) cell. Inline CSS is scoped to .cd-* so it
 // cannot collide with the rest of the dashboard.
@@ -328,6 +385,11 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
 .cd-badge.protected{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.30)}
 .cd-badge.observed{background:rgba(88,166,255,0.10);color:var(--accent);border:1px solid rgba(88,166,255,0.25)}
 .cd-badge.blind{background:transparent;color:var(--text3);border:1px solid var(--border)}
+.cd-explain{padding:var(--sp-3) var(--sp-4);border-bottom:1px solid var(--border-subtle)}
+.cd-explain-title{margin:0 0 var(--sp-2) 0;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);color:var(--text3);font-weight:600}
+.cd-explain-body{margin:0;font-size:var(--text-sm);color:var(--text);line-height:1.5}
+.cd-next{display:inline-block;margin-top:var(--sp-2);font-size:var(--text-sm);color:var(--accent);text-decoration:none}
+.cd-next:hover{text-decoration:underline}
 .cd-events{padding:var(--sp-3) var(--sp-4)}
 .cd-events h4{margin:0 0 var(--sp-2) 0;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);color:var(--text3)}
 .cd-event{padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle);font-size:var(--text-sm)}
@@ -345,6 +407,11 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
     {{if .Connector}}<span><b>Connector:</b> {{.Connector}}</span>{{end}}
     <span><b>Surface:</b> {{.Surface}}</span>
   </div>
+</div>
+<div class="cd-explain">
+  <h4 class="cd-explain-title">Why this state</h4>
+  <p class="cd-explain-body">{{.Explanation}}</p>
+  {{if .NextAction.Label}}<a class="cd-next" href="{{.NextAction.Href}}">{{.NextAction.Label}} &rarr;</a>{{end}}
 </div>
 <div class="cd-events">
   <h4>Last {{.Limit}} activity events</h4>

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -212,11 +212,11 @@ func (s *Server) connectorIDsByPrincipal() map[string]string {
 //
 // The fragment shows: principal, surface, coverage label, connector;
 // a short "Why this state" explanation that translates the wire-level
-// label into operator language; an optional next-action link when
-// coverage is not Protected; then the last drillDownEventLimit
-// activity events newest-first. Empty state is explicit so the
-// operator sees "No activity recorded for this surface yet." instead
-// of a blank pane.
+// label into operator language; an optional next-action block (a CLI
+// command operators can copy-paste) when coverage is not Protected;
+// then the last drillDownEventLimit activity events newest-first.
+// Empty state is explicit so the operator sees "No activity recorded
+// for this surface yet." instead of a blank pane.
 func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request) {
 	principalID := r.URL.Query().Get("principal_id")
 	surface := r.URL.Query().Get("surface")
@@ -353,12 +353,13 @@ type coverageAction struct {
 	Command string
 }
 
-// coverageNextAction returns the truthful next step a non-Protected
-// cell can take. Token issuance lives in `oktsec tokens create`, so
-// the action shows that CLI command pre-filled with the principal
-// id rather than a link to /dashboard/settings (which exists, but
-// does not currently issue gateway_bearer / proxy_basic / hook_bearer
-// tokens — that would violate the community-repo truth constraint).
+// coverageNextAction returns the next step a non-Protected cell can
+// take, as the actual CLI command an operator runs. Token issuance
+// lives in `oktsec tokens create`, so the action shows that command
+// pre-filled with the principal id rather than a link to
+// /dashboard/settings (which exists, but does not currently issue
+// gateway_bearer / proxy_basic / hook_bearer tokens — pointing
+// there would describe a capability the UI does not have).
 //
 // The principal id is shell-quoted via shellQuotePrincipal so a
 // crafted query string (or an unusual configured principal name)

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -252,7 +252,7 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		ConnectorID:   cellConnector,
 		Connector:     coverage.ConnectorDisplayName(cellConnector),
 		Explanation:   coverageExplanation(cellCoverage),
-		NextAction:    coverageNextAction(cellCoverage, surface),
+		NextAction:    coverageNextAction(cellCoverage, surface, principalID),
 		Limit:         drillDownEventLimit,
 	}
 
@@ -341,34 +341,52 @@ func coverageExplanation(coverage string) string {
 }
 
 // coverageAction is the optional next step the drawer surfaces when
-// coverage is not Protected. Empty Label means "render nothing"; the
-// template skips the link in that case so a Protected cell stays
-// quiet and a Blind cell does not get a misleading "fix this"
-// affordance when no in-app route applies.
+// coverage is not Protected. It carries a one-sentence Hint plus the
+// CLI Command an operator can copy-paste — token issuance is a CLI
+// workflow today, not a dashboard one, so the drawer must not link
+// to an in-app screen that cannot perform the action. Empty Hint
+// means "render nothing" and the template skips the block.
 type coverageAction struct {
-	Label string
-	Href  string
+	Hint    string
+	Command string
 }
 
-// coverageNextAction picks the surface-specific link that improves
-// coverage when the cell is not Protected. We point at the in-app
-// Settings page for every surface (it is the single route where
-// tokens, profile auth, and surface enablement are configured) so
-// we never link to a route that does not exist. Protected cells
-// return the zero value and the template renders no link.
-func coverageNextAction(coverage, surface string) coverageAction {
+// coverageNextAction returns the truthful next step a non-Protected
+// cell can take. Token issuance lives in `oktsec tokens create`, so
+// the action shows that CLI command pre-filled with the principal
+// id rather than a link to /dashboard/settings (which exists, but
+// does not currently issue gateway_bearer / proxy_basic / hook_bearer
+// tokens — that would violate the community-repo truth constraint).
+//
+// Protected cells return the zero value and the template renders
+// nothing — Protected is the goal state and a "fix this" affordance
+// would be misleading.
+func coverageNextAction(coverage, surface, principalID string) coverageAction {
 	if coverage == "protected" {
 		return coverageAction{}
 	}
+	pid := principalID
+	if pid == "" {
+		pid = "<principal>"
+	}
 	switch surface {
 	case "mcp_http":
-		return coverageAction{Label: "Issue a gateway bearer token", Href: "/dashboard/settings"}
+		return coverageAction{
+			Hint:    "Issue a gateway bearer token from the CLI:",
+			Command: "oktsec tokens create --principal " + pid + " --type gateway_bearer",
+		}
 	case "http_egress_proxy":
-		return coverageAction{Label: "Configure egress proxy auth", Href: "/dashboard/settings"}
+		return coverageAction{
+			Hint:    "Issue a forward-proxy token from the CLI:",
+			Command: "oktsec tokens create --principal " + pid + " --type proxy_basic",
+		}
 	case "hooks":
-		return coverageAction{Label: "Configure hook token", Href: "/dashboard/settings"}
+		return coverageAction{
+			Hint:    "Issue a hook bearer token from the CLI:",
+			Command: "oktsec tokens create --principal " + pid + " --type hook_bearer",
+		}
 	}
-	return coverageAction{Label: "Review coverage settings", Href: "/dashboard/settings"}
+	return coverageAction{}
 }
 
 // coverageCellDrawerTmpl renders the slide-in drawer body for one
@@ -388,8 +406,8 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
 .cd-explain{padding:var(--sp-3) var(--sp-4);border-bottom:1px solid var(--border-subtle)}
 .cd-explain-title{margin:0 0 var(--sp-2) 0;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);color:var(--text3);font-weight:600}
 .cd-explain-body{margin:0;font-size:var(--text-sm);color:var(--text);line-height:1.5}
-.cd-next{display:inline-block;margin-top:var(--sp-2);font-size:var(--text-sm);color:var(--accent);text-decoration:none}
-.cd-next:hover{text-decoration:underline}
+.cd-next-hint{margin:var(--sp-2) 0 4px 0;font-size:var(--text-sm);color:var(--text2)}
+.cd-next-cmd{margin:0;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);font-family:var(--mono);font-size:var(--text-xs);color:var(--accent-light);white-space:pre-wrap;word-break:break-all;overflow-x:auto}
 .cd-events{padding:var(--sp-3) var(--sp-4)}
 .cd-events h4{margin:0 0 var(--sp-2) 0;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-wide);color:var(--text3)}
 .cd-event{padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle);font-size:var(--text-sm)}
@@ -411,7 +429,10 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
 <div class="cd-explain">
   <h4 class="cd-explain-title">Why this state</h4>
   <p class="cd-explain-body">{{.Explanation}}</p>
-  {{if .NextAction.Label}}<a class="cd-next" href="{{.NextAction.Href}}">{{.NextAction.Label}} &rarr;</a>{{end}}
+  {{if .NextAction.Hint}}
+  <p class="cd-next-hint">{{.NextAction.Hint}}</p>
+  <pre class="cd-next-cmd"><code>{{.NextAction.Command}}</code></pre>
+  {{end}}
 </div>
 <div class="cd-events">
   <h4>Last {{.Limit}} activity events</h4>

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"html/template"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/activity"
@@ -358,6 +360,11 @@ type coverageAction struct {
 // does not currently issue gateway_bearer / proxy_basic / hook_bearer
 // tokens — that would violate the community-repo truth constraint).
 //
+// The principal id is shell-quoted via shellQuotePrincipal so a
+// crafted query string (or an unusual configured principal name)
+// cannot produce a copy-paste-unsafe command. Plain identifiers stay
+// unquoted so the common case still reads cleanly.
+//
 // Protected cells return the zero value and the template renders
 // nothing — Protected is the goal state and a "fix this" affordance
 // would be misleading.
@@ -365,10 +372,7 @@ func coverageNextAction(coverage, surface, principalID string) coverageAction {
 	if coverage == "protected" {
 		return coverageAction{}
 	}
-	pid := principalID
-	if pid == "" {
-		pid = "<principal>"
-	}
+	pid := shellQuotePrincipal(principalID)
 	switch surface {
 	case "mcp_http":
 		return coverageAction{
@@ -387,6 +391,34 @@ func coverageNextAction(coverage, surface, principalID string) coverageAction {
 		}
 	}
 	return coverageAction{}
+}
+
+// safePrincipalCharsRE matches values that are safe to render as a
+// single shell argument without quoting: ASCII letters, digits, and
+// the three punctuation characters principals commonly use. Anything
+// outside this set goes through POSIX single-quote escaping so a
+// metacharacter cannot turn the rendered command into something the
+// operator would not knowingly run.
+var safePrincipalCharsRE = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// shellQuotePrincipal returns s wrapped for safe inclusion as a
+// single shell argument. Plain identifiers pass through unchanged so
+// the common command stays readable; anything else gets POSIX
+// single-quote escaping (wrap in '...', then replace embedded '
+// with '\''). Empty string becomes '' so the operator sees an
+// obviously-blank slot rather than a silently-missing argument.
+//
+// We cannot use shell-specific helpers (no shellescape package) so
+// the implementation stays small and dependency-free. POSIX rules
+// are intentionally portable across bash, zsh, and dash.
+func shellQuotePrincipal(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if safePrincipalCharsRE.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // coverageCellDrawerTmpl renders the slide-in drawer body for one

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -253,12 +253,12 @@ func TestCoverageCellDrawer_ProtectedExplanationNoNextAction(t *testing.T) {
 }
 
 // 5c. Observed drawer carries the telemetry-without-blocking
-// explanation and the truthful CLI command for issuing the right
+// explanation and the current CLI command for issuing the right
 // token. Token issuance is a CLI workflow today (oktsec tokens
 // create), not a dashboard one — the drawer must not link to a
 // Settings page that cannot perform the action. Regression guard
-// for the "promise capability the UI does not have" failure mode.
-func TestCoverageCellDrawer_ObservedShowsHonestCLICommand(t *testing.T) {
+// for the "describe capability the UI does not have" failure mode.
+func TestCoverageCellDrawer_ObservedShowsCLICommand(t *testing.T) {
 	srv := newTestServer(t)
 	// Hooks in local profile with no hook_bearer token => observed.
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
@@ -277,7 +277,7 @@ func TestCoverageCellDrawer_ObservedShowsHonestCLICommand(t *testing.T) {
 	}
 	wantCmd := "oktsec tokens create --principal local-codex --type hook_bearer"
 	if !strings.Contains(body, wantCmd) {
-		t.Errorf("Observed drawer must surface the truthful CLI command %q; body = %s", wantCmd, body)
+		t.Errorf("Observed drawer must surface the current CLI command %q; body = %s", wantCmd, body)
 	}
 	// Must NOT link to Settings — Settings cannot issue tokens today.
 	if strings.Contains(body, `href="/dashboard/settings"`) {
@@ -286,9 +286,9 @@ func TestCoverageCellDrawer_ObservedShowsHonestCLICommand(t *testing.T) {
 }
 
 // 5d. Blind drawer carries the no-protection explanation and the
-// truthful CLI command for the surface in question. Egress proxy
+// current CLI command for the surface in question. Egress proxy
 // off + no proxy_basic token reaches this state.
-func TestCoverageCellDrawer_BlindShowsHonestCLICommand(t *testing.T) {
+func TestCoverageCellDrawer_BlindShowsCLICommand(t *testing.T) {
 	srv := newTestServer(t)
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
 	// Egress surface is off in defaults; the principal has no proxy
@@ -361,7 +361,7 @@ func TestCoverageCellDrawer_PrincipalIDIsShellQuoted(t *testing.T) {
 
 // 5d4. The MCP gateway drawer surfaces the gateway_bearer CLI
 // command for non-Protected states. Covers the third surface so the
-// truthful-CLI contract is exhaustive across all three.
+// CLI-command contract is exhaustive across all three.
 func TestCoverageCellDrawer_MCPHTTPShowsGatewayBearerCommand(t *testing.T) {
 	srv := newTestServer(t)
 	// Add a principal with NO tokens so mcp_http resolves to a

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -311,7 +312,54 @@ func TestCoverageCellDrawer_BlindShowsHonestCLICommand(t *testing.T) {
 	}
 }
 
-// 5d2. The MCP gateway drawer surfaces the gateway_bearer CLI
+// 5d3. The CLI command surfaced by the drawer must be safe to copy
+// and paste. principalID flows in from the request query string and
+// from operator-controlled config, so a value with shell
+// metacharacters (spaces, semicolons, quotes) must be POSIX
+// single-quoted before it lands in the rendered command. Otherwise
+// the dashboard would teach an unsafe shell snippet to whoever pastes
+// it. Regression guard for that exact failure mode.
+func TestCoverageCellDrawer_PrincipalIDIsShellQuoted(t *testing.T) {
+	srv := newTestServer(t)
+	// Add a principal whose name contains shell metacharacters. The
+	// CLI command in the drawer must wrap it in single quotes so a
+	// copy-paste cannot run anything other than `oktsec tokens create
+	// --principal '<name>' ...`.
+	pid := "bad; echo pwned"
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          pid,
+		DisplayName: pid,
+		Kind:        "agent",
+	})
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET",
+		"/dashboard/api/coverage/cell?principal_id="+url.QueryEscape(pid)+"&surface=mcp_http", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	// html/template escapes the single quotes as &#39; in source so
+	// the HTML stays safe; browsers render and copy-paste the
+	// unescaped form 'bad; echo pwned'. The contract we assert here
+	// is that the escaped quotes wrap the principal — without them
+	// the operator would copy a command that runs `echo pwned`.
+	wantCmd := "oktsec tokens create --principal &#39;bad; echo pwned&#39; --type gateway_bearer"
+	if !strings.Contains(body, wantCmd) {
+		t.Errorf("drawer must shell-quote principal with metacharacters; want %q in body", wantCmd)
+	}
+	// Defense-in-depth: the unquoted form must not appear anywhere
+	// in the rendered command surface area.
+	if strings.Contains(body, "--principal bad; echo pwned --type") {
+		t.Error("drawer rendered the unquoted principal — copy-paste would execute the metacharacter")
+	}
+}
+
+// 5d4. The MCP gateway drawer surfaces the gateway_bearer CLI
 // command for non-Protected states. Covers the third surface so the
 // truthful-CLI contract is exhaustive across all three.
 func TestCoverageCellDrawer_MCPHTTPShowsGatewayBearerCommand(t *testing.T) {

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -225,8 +225,8 @@ func TestCoverageCellDrawer_RendersHeaderAndEvents(t *testing.T) {
 }
 
 // 5b. Protected drawer carries the pre-action explanation and does
-// NOT surface a next-action link — Protected is the goal state, so
-// pushing the operator toward Settings would be misleading.
+// NOT surface a next-action — Protected is the goal state, so
+// pushing the operator toward another action would be misleading.
 func TestCoverageCellDrawer_ProtectedExplanationNoNextAction(t *testing.T) {
 	srv := newTestServer(t)
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
@@ -246,15 +246,18 @@ func TestCoverageCellDrawer_ProtectedExplanationNoNextAction(t *testing.T) {
 	if !strings.Contains(body, "pre-action path") {
 		t.Errorf("Protected drawer must include 'pre-action path'; body = %s", body)
 	}
-	if strings.Contains(body, `class="cd-next"`) {
-		t.Error("Protected drawer must NOT show a next-action link")
+	if strings.Contains(body, `class="cd-next-hint"`) || strings.Contains(body, `class="cd-next-cmd"`) {
+		t.Error("Protected drawer must NOT show a next-action block")
 	}
 }
 
 // 5c. Observed drawer carries the telemetry-without-blocking
-// explanation and a next-action link. The wording is the operator-
-// facing translation of "Oktsec sees but cannot block".
-func TestCoverageCellDrawer_ObservedExplanationAndNextAction(t *testing.T) {
+// explanation and the truthful CLI command for issuing the right
+// token. Token issuance is a CLI workflow today (oktsec tokens
+// create), not a dashboard one — the drawer must not link to a
+// Settings page that cannot perform the action. Regression guard
+// for the "promise capability the UI does not have" failure mode.
+func TestCoverageCellDrawer_ObservedShowsHonestCLICommand(t *testing.T) {
 	srv := newTestServer(t)
 	// Hooks in local profile with no hook_bearer token => observed.
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
@@ -271,19 +274,20 @@ func TestCoverageCellDrawer_ObservedExplanationAndNextAction(t *testing.T) {
 	if !strings.Contains(body, "telemetry") {
 		t.Errorf("Observed drawer must include 'telemetry'; body = %s", body)
 	}
-	if !strings.Contains(body, "Configure hook token") {
-		t.Errorf("Observed drawer must surface a hooks-specific next-action; body = %s", body)
+	wantCmd := "oktsec tokens create --principal local-codex --type hook_bearer"
+	if !strings.Contains(body, wantCmd) {
+		t.Errorf("Observed drawer must surface the truthful CLI command %q; body = %s", wantCmd, body)
 	}
-	if !strings.Contains(body, `href="/dashboard/settings"`) {
-		t.Errorf("next-action link must point at an existing route; body = %s", body)
+	// Must NOT link to Settings — Settings cannot issue tokens today.
+	if strings.Contains(body, `href="/dashboard/settings"`) {
+		t.Error("drawer must not link the next-action to /dashboard/settings (cannot issue tokens)")
 	}
 }
 
-// 5d. Blind drawer carries the no-protection explanation and a
-// next-action link so the operator has somewhere to go to fix the
-// configuration. Egress proxy off + no proxy_basic token reaches
-// this state.
-func TestCoverageCellDrawer_BlindExplanationAndNextAction(t *testing.T) {
+// 5d. Blind drawer carries the no-protection explanation and the
+// truthful CLI command for the surface in question. Egress proxy
+// off + no proxy_basic token reaches this state.
+func TestCoverageCellDrawer_BlindShowsHonestCLICommand(t *testing.T) {
 	srv := newTestServer(t)
 	seedPrincipalWithGatewayBearer(srv, "local-codex")
 	// Egress surface is off in defaults; the principal has no proxy
@@ -301,8 +305,39 @@ func TestCoverageCellDrawer_BlindExplanationAndNextAction(t *testing.T) {
 	if !strings.Contains(body, "no active protection") {
 		t.Errorf("Blind drawer must include 'no active protection'; body = %s", body)
 	}
-	if !strings.Contains(body, "Configure egress proxy auth") {
-		t.Errorf("Blind drawer must surface egress-specific next-action; body = %s", body)
+	wantCmd := "oktsec tokens create --principal local-codex --type proxy_basic"
+	if !strings.Contains(body, wantCmd) {
+		t.Errorf("Blind drawer must surface the egress CLI command %q; body = %s", wantCmd, body)
+	}
+}
+
+// 5d2. The MCP gateway drawer surfaces the gateway_bearer CLI
+// command for non-Protected states. Covers the third surface so the
+// truthful-CLI contract is exhaustive across all three.
+func TestCoverageCellDrawer_MCPHTTPShowsGatewayBearerCommand(t *testing.T) {
+	srv := newTestServer(t)
+	// Add a principal with NO tokens so mcp_http resolves to a
+	// non-Protected state in local profile (loopback observed).
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          "claude-code",
+		DisplayName: "claude-code",
+		Kind:        "agent",
+	})
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=claude-code&surface=mcp_http", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	wantCmd := "oktsec tokens create --principal claude-code --type gateway_bearer"
+	if !strings.Contains(body, wantCmd) {
+		t.Errorf("non-Protected mcp_http drawer must surface the gateway_bearer CLI command %q; body = %s",
+			wantCmd, body)
 	}
 }
 

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -224,6 +224,111 @@ func TestCoverageCellDrawer_RendersHeaderAndEvents(t *testing.T) {
 	}
 }
 
+// 5b. Protected drawer carries the pre-action explanation and does
+// NOT surface a next-action link — Protected is the goal state, so
+// pushing the operator toward Settings would be misleading.
+func TestCoverageCellDrawer_ProtectedExplanationNoNextAction(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface=mcp_http", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "Why this state") {
+		t.Error("drawer must include Why this state section")
+	}
+	if !strings.Contains(body, "pre-action path") {
+		t.Errorf("Protected drawer must include 'pre-action path'; body = %s", body)
+	}
+	if strings.Contains(body, `class="cd-next"`) {
+		t.Error("Protected drawer must NOT show a next-action link")
+	}
+}
+
+// 5c. Observed drawer carries the telemetry-without-blocking
+// explanation and a next-action link. The wording is the operator-
+// facing translation of "Oktsec sees but cannot block".
+func TestCoverageCellDrawer_ObservedExplanationAndNextAction(t *testing.T) {
+	srv := newTestServer(t)
+	// Hooks in local profile with no hook_bearer token => observed.
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface=hooks", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "telemetry") {
+		t.Errorf("Observed drawer must include 'telemetry'; body = %s", body)
+	}
+	if !strings.Contains(body, "Configure hook token") {
+		t.Errorf("Observed drawer must surface a hooks-specific next-action; body = %s", body)
+	}
+	if !strings.Contains(body, `href="/dashboard/settings"`) {
+		t.Errorf("next-action link must point at an existing route; body = %s", body)
+	}
+}
+
+// 5d. Blind drawer carries the no-protection explanation and a
+// next-action link so the operator has somewhere to go to fix the
+// configuration. Egress proxy off + no proxy_basic token reaches
+// this state.
+func TestCoverageCellDrawer_BlindExplanationAndNextAction(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+	// Egress surface is off in defaults; the principal has no proxy
+	// token, so the egress cell is Blind.
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface=http_egress_proxy", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "no active protection") {
+		t.Errorf("Blind drawer must include 'no active protection'; body = %s", body)
+	}
+	if !strings.Contains(body, "Configure egress proxy auth") {
+		t.Errorf("Blind drawer must surface egress-specific next-action; body = %s", body)
+	}
+}
+
+// 5e. The explanation text must stay neutral. Forbidden vocabulary
+// from the public-artifact rule must not slip into the drawer body.
+func TestCoverageCellDrawer_ExplanationStaysNeutral(t *testing.T) {
+	srv := newTestServer(t)
+	seedPrincipalWithGatewayBearer(srv, "local-codex")
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	for _, surface := range []string{"mcp_http", "http_egress_proxy", "hooks"} {
+		req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id=local-codex&surface="+surface, nil)
+		req.AddCookie(cookie)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		body := strings.ToLower(rr.Body.String())
+		for _, banned := range []string{"fully protected", "complete coverage", "blind failure", "honest", "fake"} {
+			if strings.Contains(body, banned) {
+				t.Errorf("surface %q drawer contains forbidden phrase %q", surface, banned)
+			}
+		}
+	}
+}
+
 // 6. Empty-state copy is shown when no activity is recorded for the
 // (principal, surface) pair. The header still renders so the operator
 // can see "yes I clicked the right cell, it just has no data yet".

--- a/internal/dashboard/shellquote_test.go
+++ b/internal/dashboard/shellquote_test.go
@@ -1,0 +1,40 @@
+package dashboard
+
+import "testing"
+
+// shellQuotePrincipal is the only thing standing between operator-
+// controlled principal ids and a copy-pasteable shell command in
+// the coverage drawer. The table below is exhaustive on the
+// metacharacter classes a real-world principal id might contain so
+// a future "small simplification" cannot accidentally re-introduce
+// the unquoted form.
+func TestShellQuotePrincipal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain identifier passes through", "local-codex", "local-codex"},
+		{"underscores allowed", "team_alpha", "team_alpha"},
+		{"dots allowed", "acme.app", "acme.app"},
+		{"mixed safe punctuation", "acme.app_v2-prod", "acme.app_v2-prod"},
+		{"empty becomes empty quoted slot", "", "''"},
+		{"space gets quoted", "team alpha", "'team alpha'"},
+		{"semicolon gets quoted", "bad;echo", "'bad;echo'"},
+		{"semicolon with spaces", "bad; echo pwned", "'bad; echo pwned'"},
+		{"single quote uses POSIX escape", "it's mine", `'it'\''s mine'`},
+		{"backtick gets quoted", "x`whoami`", "'x`whoami`'"},
+		{"dollar sign gets quoted", "$(id)", "'$(id)'"},
+		{"pipe gets quoted", "a|b", "'a|b'"},
+		{"ampersand gets quoted", "a&b", "'a&b'"},
+		{"newline gets quoted", "a\nb", "'a\nb'"},
+		{"slash is not safe (could look like a path)", "a/b", "'a/b'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shellQuotePrincipal(tc.in); got != tc.want {
+				t.Errorf("shellQuotePrincipal(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Coverage drawer used to show metadata + activity events but never answered the operator's first question on click: *"why is this cell in this state?"* An operator looking at a Blind cell had to infer from the short label or click around to find the configuration entry point. This PR adds a one-sentence explanation between the header and the events list, plus a surface-specific next-action that shows the actual `oktsec tokens create` CLI command an operator needs to run.

Wording is the canonical contract from the dashboard UX spec — neutral, present-tense, and identical for all three coverage states regardless of which surface opened the drawer.

## What changed

### `internal/dashboard/handlers_activity.go`
- **`coverageExplanation(coverage string) string`** — returns the per-state operator-facing sentence:
  - `protected` → "Oktsec is in the pre-action path with authenticated identity for this surface."
  - `observed` → "Oktsec has telemetry for this surface, but cannot claim pre-action blocking."
  - `blind` → "Oktsec has no active protection or usable telemetry for this surface."
- **`coverageNextAction(coverage, surface, principalID string) coverageAction`** — surface-specific next step. Returns `coverageAction{}` (empty `Hint`) when coverage is Protected so the template renders nothing; otherwise returns a Hint sentence + the actual CLI command pre-filled with the principal id:
  - `mcp_http` → `oktsec tokens create --principal <pid> --type gateway_bearer`
  - `http_egress_proxy` → `oktsec tokens create --principal <pid> --type proxy_basic`
  - `hooks` → `oktsec tokens create --principal <pid> --type hook_bearer`
- **`shellQuotePrincipal(s string) string`** — plain identifiers (`[A-Za-z0-9._-]+`) pass through unchanged so the common command stays readable; anything else gets POSIX single-quote escaping. Empty becomes `''`. Implementation is dependency-free and portable across bash/zsh/dash.
- Drawer data struct carries `Explanation` and `NextAction` fields.
- `coverageCellDrawerTmpl` gets a `.cd-explain` block between the header and events list with a title, body sentence, and an optional `.cd-next-hint` paragraph + `.cd-next-cmd` `<pre><code>` block. Inline CSS scoped to `.cd-*`.

### `internal/dashboard/shellquote_test.go` (new)
- 15-row table covering plain identifiers, safe punctuation, empty, spaces, semicolons, single quotes, backticks, `$(...)`, pipes, ampersands, newlines, slashes.

### `internal/dashboard/handlers_activity_test.go` (5 new)
- `TestCoverageCellDrawer_ProtectedExplanationNoNextAction` — Protected body includes "pre-action path" and does NOT contain `cd-next-hint` / `cd-next-cmd`. Protected is the goal state.
- `TestCoverageCellDrawer_ObservedShowsCLICommand` — Observed (hooks) body includes "telemetry" and the `oktsec tokens create --principal local-codex --type hook_bearer` command. Explicitly forbids any `href="/dashboard/settings"` in the body — Settings cannot issue tokens today, so the drawer must not link there.
- `TestCoverageCellDrawer_BlindShowsCLICommand` — Blind (egress) body includes "no active protection" and the `proxy_basic` CLI command.
- `TestCoverageCellDrawer_PrincipalIDIsShellQuoted` — drives the drawer with `principalID="bad; echo pwned"` and asserts the rendered command quotes the principal so a copy-paste cannot execute the metacharacter.
- `TestCoverageCellDrawer_MCPHTTPShowsGatewayBearerCommand` — third-surface coverage so the CLI-command contract is exhaustive.
- `TestCoverageCellDrawer_ExplanationStaysNeutral` — drawer body for all three surfaces stays free of forbidden vocabulary (`fully protected`, `complete coverage`, `blind failure`, `honest`, `fake`).

## Acceptance per spec

- [x] Drawer is useful even when there are no activity events.
- [x] Empty state is explicit (PR142 covered this; still asserted).
- [x] Protected explanation does not imply global coverage.
- [x] Observed explanation does not imply blocking.
- [x] Blind explanation includes a path to improve configuration.
- [x] Next-action does not describe a capability the UI does not have (no link to Settings, which cannot issue tokens today).
- [x] Copy-pasteable command is shell-safe regardless of principal id contents.

## Not included

This is PR2 in the dashboard UX slice. Follow-ups (separate PRs):
- Coverage matrix visual polish.
- Login page polish (incl. font/asset redirect issue codex flagged).
- Public artifact sweep for UI claims.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 5 new drawer tests + 1 helper table test (15 rows).
- [ ] Manual browser smoke: open a Protected cell (no next-action block), an Observed cell (CLI command visible and quoted correctly), a Blind cell (CLI command visible). Copy-paste the command for a metacharacter principal and confirm the shell parses it as a single argument.