### PR TITLE
Constrain coverage cell short labels to a closed allowed set

### DIFF
--- a/internal/coverage/display.go
+++ b/internal/coverage/display.go
@@ -56,13 +56,41 @@ func CoverageDisplayName(c CoverageMode) string {
 	return string(c)
 }
 
-// LimitationShortLabel reduces the full Limitation sentence to a small
-// inline tag the cell can show under the badge without bloating the
-// row. The full text remains available as a tooltip; this is just a
-// summary that keeps the matrix scannable.
+// AllowedShortLabels is the closed set of short labels a coverage
+// cell may show under the badge. The dashboard UX spec keeps this
+// list small on purpose so the matrix stays scannable: any
+// limitation that does not map cleanly into one of these labels
+// shows nothing inline, and the operator opens the drawer for the
+// full sentence. A test asserts every value LimitationShortLabel
+// returns is either empty or in this set, so a future addition has
+// to update both places consciously.
+var AllowedShortLabels = []string{
+	"Surface off",
+	"Loopback only",
+	"No token",
+	"Telemetry only",
+	"Pre-action only",
+	"Post-action only",
+	"Domain only",
+}
+
+// LimitationShortLabel reduces the full Limitation sentence to one
+// of the AllowedShortLabels. Returns empty when the limitation does
+// not map to a label in that set — long copy never lands inside a
+// table cell. The full sentence remains in the badge tooltip and
+// in the drill-down drawer for cases that need it.
 //
-// Returns empty when the cell has no caveat (clean Protected, or a
-// Blind cell whose Limitation is already self-explanatory).
+// Case order matters: hook limitations describe both the pre- and
+// post-action stages in a single sentence ("pre-action hooks block
+// when client honors the decision; post-action hooks are observed
+// only"), so the more specific "pre-action hooks block" branch must
+// run before any bare "post-action" check.
+//
+// "Domain only" only fires for the pure CONNECT-tunneled case; the
+// protected-egress sentences that mention "domain-only" as one half
+// of a longer caveat ("bodies inspected ... HTTPS CONNECT is
+// domain-only ...") fall through to empty so the cell stays clean
+// and the drawer carries the full explanation.
 func LimitationShortLabel(c CoverageCell) string {
 	if c.Limitation == "" {
 		return ""
@@ -83,17 +111,13 @@ func LimitationShortLabel(c CoverageCell) string {
 		return "Telemetry only"
 	case strings.Contains(lim, "pre-action hooks block"):
 		return "Pre-action only"
-	case strings.Contains(lim, "domain-only"):
+	case strings.Contains(lim, "post-action hooks") &&
+		!strings.Contains(lim, "pre-action"):
+		return "Post-action only"
+	case strings.HasPrefix(lim, "domain-only"):
 		return "Domain only"
-	case strings.Contains(lim, "request bodies inspected"):
-		return "Request bodies inspected"
-	case strings.Contains(lim, "plain http bodies inspected"):
-		return "HTTP bodies inspected"
 	}
-	// Unknown limitation: take the first clause so something inline
-	// still appears; the tooltip carries the full detail.
-	if i := strings.IndexAny(lim, ".—;"); i > 0 {
-		return strings.TrimSpace(c.Limitation[:i])
-	}
-	return c.Limitation
+	// No mapping. Keep the cell quiet and let the drawer carry the
+	// full explanation when the operator clicks in.
+	return ""
 }

--- a/internal/coverage/display_test.go
+++ b/internal/coverage/display_test.go
@@ -1,0 +1,59 @@
+package coverage
+
+import "testing"
+
+// LimitationShortLabel must only ever return a value in
+// AllowedShortLabels or the empty string. Long copy in a table cell
+// breaks the matrix layout (paragraph wrap, row-height instability)
+// and the drill-down drawer is the right place for full sentences.
+// This test pins the contract so a future "add one more case" cannot
+// silently widen the set without updating AllowedShortLabels.
+func TestLimitationShortLabel_OnlyReturnsAllowedSet(t *testing.T) {
+	allowed := map[string]bool{}
+	for _, s := range AllowedShortLabels {
+		allowed[s] = true
+	}
+
+	cases := []struct {
+		name string
+		lim  string
+		want string
+	}{
+		{"empty limitation -> empty", "", ""},
+		{"gateway not enabled -> Surface off", "gateway not enabled", "Surface off"},
+		{"forward proxy not enabled -> Surface off", "forward proxy not enabled", "Surface off"},
+		{"hooks gateway disabled -> Surface off", "hooks endpoint not exposed (gateway disabled)", "Surface off"},
+		{"loopback caveat -> Loopback only", "loopback header only — issue a gateway_bearer token for stronger auth", "Loopback only"},
+		{"no gateway token -> No token", "no gateway_bearer token configured", "No token"},
+		{"no proxy token -> No token", "no proxy_basic token configured", "No token"},
+		{"hooks no token, surface requires auth -> No token", "no hook_bearer token; surface requires authenticated identity", "No token"},
+		{"hooks unauth telemetry -> Telemetry only", "no hook_bearer token; events accepted as observed telemetry only", "Telemetry only"},
+		{"hooks pre-action -> Pre-action only", "pre-action hooks block when client honors the decision; post-action hooks are observed only", "Pre-action only"},
+		{"egress domain-only -> Domain only", "domain-only (HTTPS CONNECT and disabled body scanning)", "Domain only"},
+
+		// The previously-emitted long labels for protected egress with
+		// HTTPS body inspection have no scannable short form, so the
+		// cell shows nothing inline. The drawer carries the full text.
+		{"plain HTTP body inspection -> empty", "plain HTTP bodies inspected; HTTPS CONNECT is domain-only unless inspection is enabled", ""},
+		{"request body inspection only -> empty", "request bodies inspected on plain HTTP; HTTPS CONNECT is domain-only", ""},
+
+		// Defensive: an unrecognized limitation produces no inline
+		// label so the cell never grows a paragraph.
+		{"unknown wording -> empty", "some future limitation we have not seen", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LimitationShortLabel(CoverageCell{Limitation: tc.lim})
+			if got != tc.want {
+				t.Errorf("LimitationShortLabel(%q) = %q; want %q", tc.lim, got, tc.want)
+			}
+			// Closed-set invariant: every non-empty return must be
+			// in AllowedShortLabels. A future addition has to update
+			// both the function and the catalog.
+			if got != "" && !allowed[got] {
+				t.Errorf("LimitationShortLabel(%q) returned %q which is not in AllowedShortLabels %v",
+					tc.lim, got, AllowedShortLabels)
+			}
+		})
+	}
+}

--- a/internal/dashboard/handlers_activity_test.go
+++ b/internal/dashboard/handlers_activity_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/connectors"
+	"github.com/oktsec/oktsec/internal/coverage"
 )
 
 // seedActivityForTest writes one event into the test server's activity
@@ -484,6 +485,70 @@ func TestOverview_CoverageCellsAreClickable(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("overview missing clickable wiring %q", want)
 		}
+	}
+}
+
+// 8b. Whatever short label the cell renders under the badge must
+// be in coverage.AllowedShortLabels. Long copy in a table cell
+// breaks the matrix layout and the drawer is the right home for
+// full sentences. Regression guard for "the function fell through
+// to a free-form fallback".
+func TestOverview_CoverageCellsShortLabelStaysInAllowedSet(t *testing.T) {
+	srv := newTestServer(t)
+	// Seed three principals that exercise the three coverage states
+	// for at least one surface each — token-protected, loopback
+	// observed, and a Blind cell from disabled forward proxy.
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals,
+		config.PrincipalConfig{
+			ID: "with-gw", DisplayName: "with-gw", Kind: "agent",
+			Tokens: []config.PrincipalTokenConfig{{
+				ID: "gw1", Type: "gateway_bearer", Hash: "sha256:dummy",
+				CreatedAt: "2026-04-26T00:00:00Z",
+			}},
+		},
+		config.PrincipalConfig{ID: "loopback-only", DisplayName: "loopback-only", Kind: "agent"},
+	)
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	allowed := map[string]bool{}
+	for _, s := range coverage.AllowedShortLabels {
+		allowed[s] = true
+	}
+
+	// Walk every <span class="cov-short" ...>SHORT</span> in the body
+	// and verify SHORT is in the closed set. Hand-rolled extraction so
+	// the test does not pull in an HTML parser for one assertion.
+	const open = `<span class="cov-short"`
+	const close = "</span>"
+	for i := 0; ; {
+		j := strings.Index(body[i:], open)
+		if j < 0 {
+			break
+		}
+		j += i
+		gt := strings.Index(body[j:], ">")
+		if gt < 0 {
+			break
+		}
+		end := strings.Index(body[j+gt:], close)
+		if end < 0 {
+			break
+		}
+		got := strings.TrimSpace(body[j+gt+1 : j+gt+end])
+		if got != "" && !allowed[got] {
+			t.Errorf("cov-short rendered %q which is not in AllowedShortLabels %v",
+				got, coverage.AllowedShortLabels)
+		}
+		i = j + gt + end + len(close)
 	}
 }
 


### PR DESCRIPTION
## Summary

The coverage matrix had two ways to leak long copy into a table cell:
1. `LimitationShortLabel` had a free-form fallback ("Unknown limitation: take the first clause") that emitted whatever the first sentence of an unrecognized limitation was.
2. Egress-protected cells with body-scanning caveats rendered descriptive labels like "Request bodies inspected" and "HTTP bodies inspected", which run wider than the table comfortably allows.

Both shapes break the scannable-matrix invariant the dashboard UX spec asks for. This PR constrains the function to a closed set of seven allowed short labels exported as `coverage.AllowedShortLabels`. Anything outside that set returns `""` so the cell stays quiet and the drill-down drawer (PR2's "Why this state" block) carries the full sentence.

## What changed

### `internal/coverage/display.go`
- New exported `AllowedShortLabels = []string{"Surface off", "Loopback only", "No token", "Telemetry only", "Pre-action only", "Post-action only", "Domain only"}`. The dashboard test below pins the closed-set invariant.
- `LimitationShortLabel` returns one of those labels or `""` — the free-form fallback is removed. Two case-ordering bugs the new tests caught:
  - Hooks limitation describes both stages in one sentence ("pre-action hooks block when client honors the decision; post-action hooks are observed only"). The "pre-action hooks block" branch now runs first, and the bare "post-action hooks" branch guards against the pre-action substring being present.
  - Egress-protected limitation contains "domain-only" as one half of a longer caveat ("plain HTTP bodies inspected; HTTPS CONNECT is domain-only..."). "Domain only" now requires the string to *start* with "domain-only" so body-inspection cells fall through to empty.

### `internal/coverage/display_test.go` (new)
- 14-row `TestLimitationShortLabel_OnlyReturnsAllowedSet` covering every observed limitation wording (gateway off, forward proxy off, hooks gateway disabled, loopback caveat, the three "no token" wordings, hooks unauth telemetry, hooks pre/post stage sentence, egress domain-only, egress with body inspection, an empty input, and an unknown future wording).
- Each row also asserts the closed-set invariant: any non-empty return must be in `AllowedShortLabels`.

### `internal/dashboard/handlers_activity_test.go` (1 new)
- `TestOverview_CoverageCellsShortLabelStaysInAllowedSet` walks every `<span class="cov-short">` in the rendered Overview body and verifies the text is empty or in `AllowedShortLabels`. Regression guard against a future "add one more case" that forgets to update the catalog.

## Acceptance per spec

- [x] No cell copy wraps into large paragraphs (closed-set short labels enforce this).
- [x] No card-inside-card layout (the cell button is the only interactive surface; PR1 already settled this).
- [x] Identity and Last seen columns accessible via horizontal scroll (`.cov-scroll{overflow-x:auto}` + `min-width:760px` already in place from prior PRs).
- [x] Badges readable on dark theme (semantic background + text color + 1px border, unchanged).
- [x] Stable row height (button cells already use `min-height: 52px` from PR1; non-button cells in the same row inherit that row height).

## Not included

This is PR3 in the dashboard UX slice. Follow-ups (separate PRs):
- Login page polish, including the font/static-asset redirect issue observed during dashboard smoke testing.
- Public artifact sweep for UI claims.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 14-row helper test + 1 dashboard regression test.
- [ ] Manual browser smoke: confirm every short label rendered under a badge is one of the seven allowed strings; cells with limitations that have no mapping render the badge alone (no inline copy).