### PR TITLE
Polish login page and bypass auth for /dashboard/static/

### DIFF
--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -240,6 +240,17 @@ func (a *Auth) Middleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		// Allow static assets (fonts, JS, images) without auth so the
+		// login page itself can render correctly. The redirect path
+		// would otherwise hand the browser an HTML 302 in place of a
+		// woff2/CSS/JS payload, which fails to decode and produces a
+		// console error before the operator can even sign in. Static
+		// assets are read-only from the embedded FS and contain no
+		// session-scoped data, so exempting them is safe.
+		if strings.HasPrefix(r.URL.Path, "/dashboard/static/") {
+			next.ServeHTTP(w, r)
+			return
+		}
 
 		cookie, err := r.Cookie(sessionCookieName)
 		if err != nil || !a.ValidateSession(cookie.Value) {

--- a/internal/dashboard/login_test.go
+++ b/internal/dashboard/login_test.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 1. The login page renders with 200 and carries the contract copy
+// the dashboard UX spec defines: brand, "Dashboard access" title,
+// the "oktsec run" reference, and the visible "Access code" label.
+// Each one is the operator-facing text that has to stay stable so a
+// well-known login page renders the same way across releases.
+func TestLogin_RendersContractCopy(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/login", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		`>oktsec<`,
+		"Dashboard access",
+		"Access code",
+		"oktsec run",
+		"Local dashboard",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("login body missing %q", want)
+		}
+	}
+}
+
+// 2. The login page must not mention auth features that do not exist
+// in the community edition. The dashboard UX spec lists these as
+// hard-banned terms; a regression here would mislead operators or
+// reviewers into thinking the local access-code flow is something
+// it is not.
+func TestLogin_DoesNotAdvertiseUnsupportedAuth(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/login", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := strings.ToLower(rr.Body.String())
+	for _, banned := range []string{"sso", "saml", "passkey", "rbac", "cloud login", "user account", "admin console", "enterprise login"} {
+		if strings.Contains(body, banned) {
+			t.Errorf("login body contains forbidden auth term %q", banned)
+		}
+	}
+}
+
+// 3. Form contract: posts to /dashboard/login, the input has the
+// numeric constraints the access-code flow expects, and the visible
+// label is wired to the input via for/id (not just sr-only). Spec
+// rule: keep visible label, autocomplete=off, inputmode=numeric,
+// pattern=\d{8}, maxlength=8, autofocus.
+func TestLogin_FormContract(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/login", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	for _, want := range []string{
+		`action="/dashboard/login"`,
+		`autocomplete="off"`,
+		`<label for="login-code"`,
+		`id="login-code"`,
+		`name="code"`,
+		`maxlength="8"`,
+		`pattern="\d{8}"`,
+		`inputmode="numeric"`,
+		`autofocus`,
+		`type="submit"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("login form missing required attribute / element %q", want)
+		}
+	}
+}
+
+// 4. Error renders inside a role="alert" so screen readers announce
+// it the moment the page reaches the user. Spec contract.
+func TestLogin_ErrorUsesAlertRole(t *testing.T) {
+	var buf strings.Builder
+	if err := loginTmpl.Execute(&buf, struct{ Error string }{Error: "Invalid code"}); err != nil {
+		t.Fatalf("execute login template: %v", err)
+	}
+	body := buf.String()
+	if !strings.Contains(body, `role="alert"`) {
+		t.Errorf("error block must use role=\"alert\"; body = %s", body)
+	}
+	if !strings.Contains(body, "Invalid code") {
+		t.Errorf("error message text not rendered; body = %s", body)
+	}
+}
+
+// 5. Dashboard static assets (fonts, JS, images) must be reachable
+// without a session. Otherwise the auth middleware redirects the
+// browser's pre-auth font request to /dashboard/login HTML, which
+// the browser tries to decode as a font and fails with a console
+// error before the operator can sign in. Regression guard for the
+// pre-auth asset 302 issue observed during dashboard smoke testing.
+func TestLogin_StaticAssetsBypassAuth(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	for _, path := range []string{
+		"/dashboard/static/dashboard.css",
+		"/dashboard/static/fonts/Inter.woff2",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code == http.StatusFound {
+			t.Errorf("GET %s without session returned 302 to login; static assets must bypass auth", path)
+		}
+		// 200 (asset present) and 404 (asset absent in this build) are
+		// both acceptable here — the regression we are guarding is
+		// "the browser gets HTML when it asks for a binary".
+		if rr.Code != http.StatusOK && rr.Code != http.StatusNotFound {
+			t.Errorf("GET %s status = %d; want 200 or 404", path, rr.Code)
+		}
+	}
+}

--- a/internal/dashboard/login_test.go
+++ b/internal/dashboard/login_test.go
@@ -106,12 +106,19 @@ func TestLogin_ErrorUsesAlertRole(t *testing.T) {
 	}
 }
 
-// 5. Dashboard static assets (fonts, JS, images) must be reachable
-// without a session. Otherwise the auth middleware redirects the
-// browser's pre-auth font request to /dashboard/login HTML, which
-// the browser tries to decode as a font and fails with a console
-// error before the operator can sign in. Regression guard for the
-// pre-auth asset 302 issue observed during dashboard smoke testing.
+// 5. Dashboard static assets that the login page itself loads must
+// be reachable without a session AND must actually serve the asset.
+// Otherwise the auth middleware redirects the pre-auth request to
+// /dashboard/login HTML, which the browser tries to decode as a
+// font / CSS / JS and fails with a console error before the operator
+// can sign in. Regression guard for the pre-auth asset 302 issue
+// observed during dashboard smoke testing AND for an embed-path
+// regression that would silently drop the Inter font.
+//
+// We assert 200 + a non-HTML response: a 404 here would mean the
+// embed pattern (//go:embed fonts/*.woff2) stopped including the
+// font, and the login would silently fall back to a system font
+// without anyone noticing.
 func TestLogin_StaticAssetsBypassAuth(t *testing.T) {
 	srv := newTestServer(t)
 	handler := srv.Handler()
@@ -123,14 +130,23 @@ func TestLogin_StaticAssetsBypassAuth(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
+
 		if rr.Code == http.StatusFound {
 			t.Errorf("GET %s without session returned 302 to login; static assets must bypass auth", path)
 		}
-		// 200 (asset present) and 404 (asset absent in this build) are
-		// both acceptable here — the regression we are guarding is
-		// "the browser gets HTML when it asks for a binary".
-		if rr.Code != http.StatusOK && rr.Code != http.StatusNotFound {
-			t.Errorf("GET %s status = %d; want 200 or 404", path, rr.Code)
+		if rr.Code != http.StatusOK {
+			t.Errorf("GET %s status = %d; want 200 (login depends on this asset)", path, rr.Code)
+			continue
+		}
+		// The login page references each of these assets directly.
+		// If we ever start handing the browser an HTML body in their
+		// place the embed/path regression must fail this test.
+		ctype := rr.Header().Get("Content-Type")
+		if strings.HasPrefix(ctype, "text/html") {
+			t.Errorf("GET %s returned Content-Type %q; required login asset must not be HTML", path, ctype)
+		}
+		if bytes := rr.Body.Bytes(); len(bytes) > 0 && bytes[0] == '<' {
+			t.Errorf("GET %s body looks like HTML (first byte %q); required login asset must not be HTML", path, bytes[0])
 		}
 	}
 }

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -434,8 +434,8 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;-webkit-font-smoothing:antialiased}
 .login-shell{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
 .login-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;max-width:420px;width:100%}
-.login-brand{font-family:var(--mono);font-size:1.05rem;font-weight:700;color:var(--text2);margin-bottom:20px;letter-spacing:-0.2px}
-.login-card h1{font-size:1.25rem;font-weight:600;color:var(--text);margin:0 0 8px 0;letter-spacing:-0.2px}
+.login-brand{font-family:var(--mono);font-size:1.05rem;font-weight:700;color:var(--text2);margin-bottom:20px;letter-spacing:0}
+.login-card h1{font-size:1.25rem;font-weight:600;color:var(--text);margin:0 0 8px 0;letter-spacing:0}
 .login-copy{color:var(--text2);font-size:0.9rem;margin:0 0 20px 0;line-height:1.5}
 .login-copy code{font-family:var(--mono);font-size:0.82rem;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:1px 6px;color:var(--text)}
 .login-error{margin:0 0 16px 0;padding:10px 12px;background:var(--danger-muted);border:1px solid var(--danger-border);border-radius:var(--radius-sm);color:var(--danger);font-size:0.85rem;line-height:1.4}

--- a/internal/dashboard/templates.go
+++ b/internal/dashboard/templates.go
@@ -422,67 +422,50 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 *{margin:0;padding:0;box-sizing:border-box}
 :root{
   color-scheme:dark;
-  /* Canvas & Surfaces */
-  --bg:#0d1117;--surface:#161b22;--surface2:#21262d;--border:#30363d;--border-muted:#21262d;
-  /* Text - WCAG AA validated */
-  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;--text-on-emphasis:#ffffff;
-  /* Accent / Info */
-  --accent:#58a6ff;--accent-light:#58a6ff;--accent-dim:#1f6feb;--accent-muted:rgba(56,139,253,0.15);--accent-border:rgba(56,139,253,0.30);
-  /* Semantic */
-  --danger:#f85149;--danger-emphasis:#da3633;--danger-muted:rgba(248,81,73,0.15);--danger-border:rgba(248,81,73,0.30);
-  --success:#3fb950;--success-emphasis:#238636;--success-muted:rgba(63,185,80,0.15);--success-border:rgba(63,185,80,0.30);
-  --warn:#d29922;--warn-emphasis:#9e6a03;--warn-muted:rgba(210,153,34,0.15);--warn-border:rgba(210,153,34,0.30);
-  /* Purple (agent/session identity) */
-  --purple:#bc8cff;--purple-emphasis:#8b5cf6;--purple-muted:rgba(188,140,255,0.15);--purple-border:rgba(188,140,255,0.30);
-  /* Typography */
+  --bg:#0d1117;--surface:#161b22;--surface2:#21262d;--border:#30363d;
+  --text:#e6edf3;--text2:#9ca3af;--text3:#848d97;
+  --accent:#58a6ff;--accent-dim:#1f6feb;--accent-border:rgba(56,139,253,0.30);
+  --danger:#f85149;--danger-muted:rgba(248,81,73,0.10);--danger-border:rgba(248,81,73,0.30);
+  --radius-sm:6px;--radius-md:8px;--radius-lg:12px;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;
   --sans:'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans',Helvetica,Arial,sans-serif;
 }
 @font-face{font-family:'Inter';src:url('/dashboard/static/fonts/Inter.woff2') format('woff2');font-weight:100 900;font-style:normal;font-display:swap}
-@keyframes fadeIn{from{opacity:0;transform:translateY(12px)}to{opacity:1;transform:translateY(0)}}
-body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;display:flex;align-items:center;justify-content:center;-webkit-font-smoothing:antialiased}
-.backdrop{display:none}
-.login-card{position:relative;z-index:1;background:#161b22;border:1px solid #30363d;border-radius:12px;padding:48px 40px;max-width:400px;width:100%;text-align:center;box-shadow:0 8px 24px rgba(0,0,0,0.4);animation:fadeIn 0.4s ease-out}
-.icon{margin-bottom:20px}
-.icon svg{width:48px;height:48px;color:var(--accent)}
-.logo{font-family:var(--mono);font-size:1.5rem;font-weight:700;letter-spacing:-0.3px;margin-bottom:8px;color:var(--text)}
-.subtitle{color:var(--text2);font-size:0.85rem;margin-bottom:32px}
-.help{color:var(--text3);font-size:0.78rem;margin-bottom:24px;line-height:1.6}
-.help code{background:#21262d;padding:2px 6px;border-radius:4px;font-family:var(--mono);font-size:0.75rem;color:#e6edf3;border:1px solid #30363d}
-input[type=text]{
-  width:100%;padding:12px 16px;background:#0d1117;border:1px solid #30363d;
-  border-radius:8px;color:var(--text);font-family:var(--mono);font-size:1.2rem;
-  text-align:center;letter-spacing:4px;outline:none;transition:border-color 0.15s,box-shadow 0.15s;
-}
-input[type=text]:focus{border-color:#58a6ff;box-shadow:0 0 0 3px rgba(56,139,253,0.15)}
-input[type=text]::placeholder{letter-spacing:0;font-size:0.85rem;color:var(--text3)}
-button{
-  width:100%;padding:12px 16px;margin-top:16px;background:#1f6feb;color:#fff;
-  border:1px solid rgba(56,139,253,0.30);border-radius:8px;font-size:1rem;font-weight:600;cursor:pointer;
-  transition:background 0.15s,transform 0.1s;
-}
-button:hover{background:#388bfd}
-button:active{transform:scale(0.98)}
-.error{display:flex;align-items:center;gap:8px;justify-content:center;margin-top:14px;padding:10px 14px;background:rgba(248,81,73,0.1);border:1px solid rgba(248,81,73,0.2);border-radius:8px;color:var(--danger);font-size:0.82rem}
-.error svg{flex-shrink:0;width:16px;height:16px}
-.footer{margin-top:32px;color:var(--text3);font-size:0.72rem}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;-webkit-font-smoothing:antialiased}
+.login-shell{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+.login-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;max-width:420px;width:100%}
+.login-brand{font-family:var(--mono);font-size:1.05rem;font-weight:700;color:var(--text2);margin-bottom:20px;letter-spacing:-0.2px}
+.login-card h1{font-size:1.25rem;font-weight:600;color:var(--text);margin:0 0 8px 0;letter-spacing:-0.2px}
+.login-copy{color:var(--text2);font-size:0.9rem;margin:0 0 20px 0;line-height:1.5}
+.login-copy code{font-family:var(--mono);font-size:0.82rem;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:1px 6px;color:var(--text)}
+.login-error{margin:0 0 16px 0;padding:10px 12px;background:var(--danger-muted);border:1px solid var(--danger-border);border-radius:var(--radius-sm);color:var(--danger);font-size:0.85rem;line-height:1.4}
+.login-field{display:block;font-size:0.78rem;font-weight:500;color:var(--text2);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.04em}
+.login-input{width:100%;padding:11px 14px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-md);color:var(--text);font-family:var(--mono);font-size:1.1rem;text-align:center;letter-spacing:4px;outline:none;transition:border-color 0.15s,box-shadow 0.15s}
+.login-input:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(56,139,253,0.15)}
+.login-input::placeholder{color:var(--text3);letter-spacing:0;font-size:0.85rem}
+.login-submit{width:100%;margin-top:14px;padding:11px 14px;background:var(--accent-dim);color:#fff;border:1px solid var(--accent-border);border-radius:var(--radius-md);font-size:0.95rem;font-weight:600;cursor:pointer;transition:background 0.15s}
+.login-submit:hover{background:var(--accent)}
+.login-submit:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.login-foot{margin:20px 0 0 0;color:var(--text3);font-size:0.78rem}
 </style>
 </head>
 <body>
-<div class="backdrop"></div>
-<div class="login-card">
-  <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><rect x="9" y="11" width="6" height="5" rx="1"/><path d="M12 11V9a2 2 0 0 0-4 0"/></svg></div>
-  <div class="logo">oktsec</div>
-  <div class="subtitle">Dashboard Access</div>
-  <p class="help">Enter the access code shown in your terminal.<br>Run <code>oktsec run</code> to get a code.<br><small style="color:#9ca3af">Code changes each time the server restarts.</small></p>
-  <form method="POST" action="/dashboard/login" autocomplete="off">
-    <label for="login-code" class="sr-only">Access code</label>
-    <input type="text" id="login-code" name="code" placeholder="00000000" maxlength="8" pattern="\d{8}" inputmode="numeric" autofocus required>
-    <button type="submit">Authenticate</button>
-  </form>
-  {{if .Error}}<div class="error"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>{{.Error}}</div>{{end}}
-  <p class="footer">Local access only <span style="opacity:0.4;margin:0 6px">&middot;</span> 127.0.0.1</p>
-</div>
+<main class="login-shell">
+  <section class="login-card" aria-labelledby="login-title">
+    <div class="login-brand">oktsec</div>
+    <h1 id="login-title">Dashboard access</h1>
+    <p class="login-copy">Enter the 8-digit access code printed by <code>oktsec run</code>. The code rotates each time the server restarts.</p>
+    {{if .Error}}<div class="login-error" role="alert">{{.Error}}</div>{{end}}
+    <form method="POST" action="/dashboard/login" autocomplete="off">
+      <label for="login-code" class="login-field">Access code</label>
+      <input class="login-input" type="text" id="login-code" name="code"
+             placeholder="00000000" maxlength="8" pattern="\d{8}" inputmode="numeric"
+             autocomplete="off" autofocus required aria-describedby="login-code-help">
+      <button type="submit" class="login-submit">Continue</button>
+    </form>
+    <p id="login-code-help" class="login-foot">Local dashboard &middot; code rotates on restart</p>
+  </section>
+</main>
 </body>
 </html>`))
 


### PR DESCRIPTION
## Summary

Two issues addressed in one PR — both surfaced by the dashboard UX spec and dashboard smoke testing.

### 1. Static assets blocked behind auth

The auth middleware redirected every non-`/dashboard/login` request without a session to `/dashboard/login`. The login page itself loads its Inter font via `@font-face` from `/dashboard/static/fonts/Inter.woff2`; that pre-auth request hit the middleware, got a 302 to the login HTML, and the browser then tried to decode an HTML page as a font. Console error before the operator could even sign in.

`Auth.Middleware` now lets `/dashboard/static/*` through unauthenticated. The static FS is read-only embedded content with no session-scoped data.

### 2. Login page rewrite per UX spec

The previous template was functional but visually scattered (centered hero icon, oversized logo, unlabeled input) and used wording the spec asked to neutralize. Rewrite to a single quiet panel with the spec's canonical layout and copy.

## What changed

### `internal/dashboard/auth.go`
- `Middleware` short-circuits `/dashboard/static/*` paths the same way it short-circuits `/dashboard/login`. Comment explains why exempting static assets is safe (read-only embedded FS, no session-scoped data) and why not doing so breaks font/asset loading on the login page.

### `internal/dashboard/templates.go`
- `loginTmpl` rewritten:
  - `<main class="login-shell">` + `<section class="login-card">` with `aria-labelledby`.
  - Brand: `oktsec` (mono, muted).
  - Title: `Dashboard access` (h1).
  - Copy: "Enter the 8-digit access code printed by `oktsec run`. The code rotates each time the server restarts."
  - Error block carries `role="alert"` and only renders when present.
  - Visible `<label for="login-code">Access code</label>` (replaces sr-only).
  - Input keeps `autocomplete="off"`, `inputmode="numeric"`, `pattern="\d{8}"`, `maxlength="8"`, `autofocus`, plus `aria-describedby` linking to the footer help text.
  - Button text: `Continue` (replaces `Authenticate`).
  - Footer: `Local dashboard · code rotates on restart` (drops the previous `127.0.0.1` claim — the bind address is config-driven; "Local dashboard" is the safe phrasing).
  - CSS uses dashboard color tokens end-to-end (`var(--bg)`, `var(--surface)`, `var(--accent)`, etc.). Panel max-width 420px. No decorative blobs / hero icon.
  - Submit button has a visible focus-visible outline.

### `internal/dashboard/login_test.go` (new) — 5 tests
1. `TestLogin_RendersContractCopy` — brand, "Dashboard access" title, "oktsec run" reference, "Local dashboard" footer, visible "Access code" label all present in body.
2. `TestLogin_DoesNotAdvertiseUnsupportedAuth` — body never contains `sso`, `saml`, `passkey`, `rbac`, `cloud login`, `user account`, `admin console`, `enterprise login`. Spec hard-bans these terms because the community login is local access-code only.
3. `TestLogin_FormContract` — form action, `autocomplete="off"`, `<label for="login-code">`, `name="code"`, `maxlength="8"`, `pattern="\d{8}"`, `inputmode="numeric"`, `autofocus`, `type="submit"` all present.
4. `TestLogin_ErrorUsesAlertRole` — error block carries `role="alert"` and renders the error text.
5. `TestLogin_StaticAssetsBypassAuth` — GET `/dashboard/static/dashboard.css` and `/dashboard/static/fonts/Inter.woff2` without a session never return 302 to login. Regression guard for the pre-auth font redirect.

## Acceptance per spec

- [x] Login looks like part of Oktsec, not a placeholder (clean panel, dashboard tokens).
- [x] No unsupported auth claims in the body.
- [x] No external assets (fonts and CSS still served from the embedded FS).
- [x] No CSP errors (no script tags added; CSS-only changes).
- [x] Existing login / rate-limit / session behavior unchanged (all prior tests still pass).
- [x] Static asset 302 issue from smoke testing is fixed.

## Not included

This is PR4 in the dashboard UX slice. PR5 (public artifact sweep for UI claims across README/docs/source) is the last one in the slice.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 5 new login tests + the existing login-flow / auth-middleware tests still green.
- [ ] Manual browser smoke: load `/dashboard/login` from a clean session, confirm the Inter font loads (no 302 in DevTools network panel for `/dashboard/static/...`), confirm the visible "Access code" label, confirm "Continue" button, confirm error renders with `role="alert"` on a wrong code submit.