### PR TITLE
Sweep public artifacts for unsupported claims and stale wording

### DIFF
--- a/internal/connectors/registry_test.go
+++ b/internal/connectors/registry_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// The Phase 2B.1 spec table is reproduced here as a single source of
-// truth: every row in the spec corresponds to one row in this table.
+// The Phase 2B.1 spec table is reproduced here as a single reference
+// point: every row in the spec corresponds to one row in this table.
 // A failure here means the wire-level connector inference would drift
 // from the documented matrix.
 func TestBuiltinRegistry_Infer(t *testing.T) {

--- a/internal/coverage/display_test.go
+++ b/internal/coverage/display_test.go
@@ -31,9 +31,9 @@ func TestLimitationShortLabel_OnlyReturnsAllowedSet(t *testing.T) {
 		{"hooks pre-action -> Pre-action only", "pre-action hooks block when client honors the decision; post-action hooks are observed only", "Pre-action only"},
 		{"egress domain-only -> Domain only", "domain-only (HTTPS CONNECT and disabled body scanning)", "Domain only"},
 
-		// The previously-emitted long labels for protected egress with
-		// HTTPS body inspection have no scannable short form, so the
-		// cell shows nothing inline. The drawer carries the full text.
+		// Long labels for protected egress with HTTPS body inspection
+		// have no scannable short form, so the cell shows nothing
+		// inline. The drawer carries the full text.
 		{"plain HTTP body inspection -> empty", "plain HTTP bodies inspected; HTTPS CONNECT is domain-only unless inspection is enabled", ""},
 		{"request body inspection only -> empty", "request bodies inspected on plain HTTP; HTTPS CONNECT is domain-only", ""},
 

--- a/internal/coverage/types.go
+++ b/internal/coverage/types.go
@@ -66,10 +66,10 @@ type CoverageCell struct {
 
 	Coverage CoverageMode `json:"coverage"`
 
-	// Limitation is the one-sentence operator-facing reason a cell is not
-	// fully protected. Examples: "no proxy_basic token configured",
-	// "domain-only (HTTPS CONNECT)", "post-action only". Empty when
-	// Coverage is protected and there is no caveat.
+	// Limitation is the one-sentence operator-facing reason a cell is
+	// not in the protected state. Examples: "no proxy_basic token
+	// configured", "domain-only (HTTPS CONNECT)", "post-action only".
+	// Empty when Coverage is protected and there is no caveat.
 	Limitation string `json:"limitation,omitempty"`
 
 	// LastSeen is the most recent audit timestamp attributing activity

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -3237,6 +3237,11 @@ func (s *Server) handleLLM(w http.ResponseWriter, r *http.Request) {
 
 	triageCounts := s.audit.QueryLLMTriageCounts()
 
+	ruleCount := 0
+	if s.scanner != nil {
+		ruleCount = s.scanner.RulesCount(r.Context())
+	}
+
 	data := map[string]any{
 		"Active":       "llm",
 		"Enabled":      s.cfg.LLM.Enabled,
@@ -3245,6 +3250,7 @@ func (s *Server) handleLLM(w http.ResponseWriter, r *http.Request) {
 		"Analyses":     analyses,
 		"BudgetStatus": budgetStatus,
 		"Triage":       triageCounts,
+		"RuleCount":    ruleCount,
 	}
 
 	s.renderTemplate(w, llmTmpl, data)

--- a/internal/dashboard/public_artifact_sweep_test.go
+++ b/internal/dashboard/public_artifact_sweep_test.go
@@ -22,7 +22,10 @@ import (
 // banned term in one place does not silently expand the rule for
 // every surface.
 var bannedOverviewPhrases = []string{
-	// Hard-banned product claims (spec "Avoid public claims").
+	// Hard-banned product claims that imply universal visibility
+	// or coverage Oktsec does not have. The coverage matrix has
+	// explicit Blind states; this list keeps the empty state and
+	// the populated state from claiming otherwise.
 	"sees all",
 	"sees everything",
 	"see everything",
@@ -32,7 +35,13 @@ var bannedOverviewPhrases = []string{
 	"complete runtime protection",
 	"all agents are protected",
 	"fully protected",
-	// Unsupported auth/edition features (spec "Truth Constraints").
+	// Unqualified "every tool call" promises imply universal
+	// visibility; only routed calls are observable. Qualified
+	// forms ("every tool call routed through Oktsec", "routed
+	// tool calls") are allowed and intentionally not in the list.
+	"every tool call your ai agents make",
+	"every tool call scanned",
+	// Unsupported auth/edition feature terms.
 	"sso",
 	"saml",
 	"passkey",
@@ -127,6 +136,44 @@ func TestPublicArtifactSweep_EmptyStateRuleCountIsLive(t *testing.T) {
 	for _, stale := range []string{"230 detection rules", "230 rules"} {
 		if strings.Contains(body, stale) {
 			t.Errorf("empty state shows stale literal rule count %q; should be {{.RuleCount}}", stale)
+		}
+	}
+}
+
+// 4. The LLM page setup state (LLM disabled, the default for a
+// fresh install) reads as a public marketing surface. It must
+// follow the same banned-phrase contract as the Overview AND must
+// not carry a hardcoded rule-count literal — the count must come
+// from the live scanner. Regression for the drift the PR review
+// caught after the Overview-only first pass.
+func TestPublicArtifactSweep_LLMPageStaysAccurate(t *testing.T) {
+	srv := newTestServer(t)
+	// LLM is disabled by default in newTestServer's config, which
+	// hits the setup-state branch in tmpl_llm.go.
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/llm", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// Same banned-phrase contract.
+	lower := strings.ToLower(body)
+	for _, banned := range bannedOverviewPhrases {
+		if strings.Contains(lower, banned) {
+			t.Errorf("LLM page body contains banned phrase %q", banned)
+		}
+	}
+	// Same stale-literal-count contract.
+	for _, stale := range []string{"230 detection rules", "230 rules", "oktsec's 230"} {
+		if strings.Contains(body, stale) {
+			t.Errorf("LLM page shows stale literal rule count %q; should be {{.RuleCount}}", stale)
 		}
 	}
 }

--- a/internal/dashboard/public_artifact_sweep_test.go
+++ b/internal/dashboard/public_artifact_sweep_test.go
@@ -1,0 +1,132 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// The community dashboard is a public repository. UI copy must not
+// claim capabilities the product does not have, must not use
+// reviewer-attribution wording, and must not reach for marketing
+// superlatives the security positioning explicitly avoids. The
+// dashboard UX spec hard-bans the strings below; this test pins the
+// rule against the rendered Overview body so a future copy edit
+// cannot reintroduce a banned phrase without a test failure first.
+//
+// The list lives here (next to the surface it guards) rather than in
+// a shared package so each surface owns its own contract — adding a
+// banned term in one place does not silently expand the rule for
+// every surface.
+var bannedOverviewPhrases = []string{
+	// Hard-banned product claims (spec "Avoid public claims").
+	"sees all",
+	"sees everything",
+	"see everything",
+	"full coverage",
+	"complete coverage",
+	"complete protection",
+	"complete runtime protection",
+	"all agents are protected",
+	"fully protected",
+	// Unsupported auth/edition features (spec "Truth Constraints").
+	"sso",
+	"saml",
+	"passkey",
+	"cloud login",
+	"hosted dashboard",
+	"admin console",
+	// Reviewer attribution / temporal framing the public-artifact
+	// rule keeps out of source-rendered HTML.
+	"honest",
+	"honesty",
+	"lying",
+	"fabricated",
+	"previously",
+}
+
+// 1. The Overview empty state must not contain any banned phrase.
+// The empty state is the first screen a brand-new operator sees, so
+// it is the highest-leverage surface to keep accurate.
+func TestPublicArtifactSweep_OverviewEmptyStateStaysAccurate(t *testing.T) {
+	srv := newTestServer(t)
+	// Default state: zero messages, zero agents — empty state path.
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := strings.ToLower(rr.Body.String())
+	for _, banned := range bannedOverviewPhrases {
+		if strings.Contains(body, banned) {
+			t.Errorf("overview empty-state body contains banned phrase %q", banned)
+		}
+	}
+}
+
+// 2. The Overview populated state (>= 1 message, >= 1 agent) renders
+// the live coverage matrix instead of the empty state. The same
+// banned-phrase contract applies: the matrix and surrounding cards
+// must not reach for marketing superlatives or unsupported-feature
+// language.
+func TestPublicArtifactSweep_OverviewPopulatedStateStaysAccurate(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.Principals = append(srv.cfg.Identity.Principals, config.PrincipalConfig{
+		ID:          "local-codex",
+		DisplayName: "local-codex",
+		Kind:        "agent",
+		Tokens: []config.PrincipalTokenConfig{{
+			ID: "gw1", Type: "gateway_bearer", Hash: "sha256:dummy",
+			CreatedAt: "2026-04-26T00:00:00Z",
+		}},
+	})
+	srv.cfg.Gateway.Enabled = true
+	// One agent in the agents map flips Overview off the empty state.
+	srv.cfg.Agents["local-codex"] = config.Agent{}
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := strings.ToLower(rr.Body.String())
+	for _, banned := range bannedOverviewPhrases {
+		if strings.Contains(body, banned) {
+			t.Errorf("overview populated-state body contains banned phrase %q", banned)
+		}
+	}
+}
+
+// 3. The empty-state rule count must be the live count from the
+// scanner, not a stale literal. A bare regex for "230 detection
+// rules" guards the most recent drift; if the empty-state copy
+// reverts to a hardcoded number this test fires.
+func TestPublicArtifactSweep_EmptyStateRuleCountIsLive(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	for _, stale := range []string{"230 detection rules", "230 rules"} {
+		if strings.Contains(body, stale) {
+			t.Errorf("empty state shows stale literal rule count %q; should be {{.RuleCount}}", stale)
+		}
+	}
+}

--- a/internal/dashboard/tmpl_llm.go
+++ b/internal/dashboard/tmpl_llm.go
@@ -81,7 +81,7 @@ var llmTmpl = template.Must(template.New("llm").Funcs(tmplFuncs).Parse(layoutHea
 <div class="card">
   <h2 style="font-size:1rem;margin-bottom:12px">Enable AI-Powered Detection</h2>
   <p style="color:var(--text2);font-size:0.82rem;line-height:1.6;margin-bottom:8px">
-    oktsec's 230 rules catch known threats instantly. Add an AI layer to detect what patterns miss:
+    oktsec's {{.RuleCount}} rules catch known threats instantly. Add an AI layer to detect what patterns miss:
   </p>
   <ul style="color:var(--text2);font-size:0.82rem;line-height:1.8;margin:0 0 20px 18px;padding:0">
     <li>Semantic data exfiltration disguised as normal messages</li>

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -67,7 +67,7 @@ a.ov-metric:hover{background:var(--surface2)}
 <div class="empty-state">
   <svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
   <h2>Welcome to oktsec</h2>
-  <div class="tagline">Real-time visibility into every tool call your AI agents make</div>
+  <div class="tagline">Real-time visibility into the tool calls your AI agents route through Oktsec</div>
   <p>Real-time monitoring for every tool call routed through Oktsec. Your pipeline is running. Start using your tools and activity will appear here.</p>
   <div class="empty-steps">
     <div class="empty-step">
@@ -80,7 +80,7 @@ a.ov-metric:hover{background:var(--surface2)}
     </div>
     <div class="empty-step">
       <span class="step-num">3</span>
-      <div><strong>Monitor in real time</strong><div class="step-desc">Every tool call scanned, threats flagged, audit trail built</div></div>
+      <div><strong>Monitor in real time</strong><div class="step-desc">Routed tool calls scanned, threats flagged, audit trail built</div></div>
     </div>
   </div>
 </div>

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -67,12 +67,12 @@ a.ov-metric:hover{background:var(--surface2)}
 <div class="empty-state">
   <svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
   <h2>Welcome to oktsec</h2>
-  <div class="tagline">See everything your AI agents execute</div>
-  <p>Real-time monitoring for every tool call. Your pipeline is running. Start using your tools and activity will appear here.</p>
+  <div class="tagline">Real-time visibility into every tool call your AI agents make</div>
+  <p>Real-time monitoring for every tool call routed through Oktsec. Your pipeline is running. Start using your tools and activity will appear here.</p>
   <div class="empty-steps">
     <div class="empty-step">
       <span class="step-done">&#10003;</span>
-      <div><strong>Pipeline ready</strong> <code>oktsec run</code><div class="step-desc">230 detection rules loaded, hooks configured</div></div>
+      <div><strong>Pipeline ready</strong> <code>oktsec run</code><div class="step-desc">{{.RuleCount}} detection rules loaded, hooks configured</div></div>
     </div>
     <div class="empty-step">
       <span class="step-num">2</span>


### PR DESCRIPTION
## Summary

Final PR in the dashboard UX slice. Walks the spec's regex over README, documentation, and the in-tree Go packages with public output (`internal/dashboard`, `internal/activity`, `internal/coverage`, `internal/connectors`), then fixes the spots that flagged real public-artifact issues. Adds a regression test that reproduces the scan against the rendered Overview body AND the LLM page setup state so future copy edits cannot silently drift back.

## What changed

### `internal/dashboard/tmpl_overview.go`
- Empty-state tagline read **"See everything your AI agents execute"**, then briefly **"Real-time visibility into every tool call your AI agents make"**. Both implied universal visibility — Oktsec only sees calls routed through its gateway/proxy/hooks, and the coverage matrix has explicit Blind states. Final wording: `Real-time visibility into the tool calls your AI agents route through Oktsec`.
- Empty-state step #3 read **"Every tool call scanned, threats flagged, audit trail built"**. Same overclaim. Final wording: `Routed tool calls scanned, threats flagged, audit trail built`.
- Empty-state step #1 was hardcoded **"230 detection rules loaded, hooks configured"** while the engine actually loads 268 rules today. Switched to `{{.RuleCount}}`, which is already on the template data and stays accurate as the rule catalog evolves.

### `internal/dashboard/tmpl_llm.go` + `internal/dashboard/handlers.go`
- LLM page setup-state copy still hardcoded **"oktsec's 230 rules catch known threats instantly"**. Switched to `oktsec's {{.RuleCount}} rules`. Wired `RuleCount` into `handleLLM` via `s.scanner.RulesCount(r.Context())`, mirroring the Overview pattern.

### `internal/connectors/registry_test.go`
- Comment said "single source of **truth**". Spec asks to keep "truth/honest" wording out of source/test comments. Replaced with "single reference point".

### `internal/coverage/types.go`
- `Limitation` field doc said "reason a cell is not **fully protected**". `"fully protected"` is on the spec's banned list. Switched to "reason a cell is not in the protected state".

### `internal/coverage/display_test.go`
- Comment said "**previously**-emitted long labels". Spec rule: avoid "previously" / "used to" framing in public artifacts. Switched to present-tense framing.

### `internal/dashboard/public_artifact_sweep_test.go` (new) — 4 tests
- **`TestPublicArtifactSweep_OverviewEmptyStateStaysAccurate`** walks the rendered empty-state Overview body and asserts none of the spec-banned phrases appear (hard-banned product claims like `sees everything` and the unqualified `every tool call your ai agents make` / `every tool call scanned`, unsupported-feature terms like `sso`, `passkey`, `hosted dashboard`, and reviewer-attribution wording like `honest`, `fabricated`, `previously`).
- **`TestPublicArtifactSweep_OverviewPopulatedStateStaysAccurate`** exercises the same rule against the populated state (>= 1 agent, >= 1 message) so the live coverage matrix and surrounding cards are guarded too.
- **`TestPublicArtifactSweep_EmptyStateRuleCountIsLive`** guards the literal-count drift the empty state hit: any `"230 detection rules"` / `"230 rules"` string in the body fires the test.
- **`TestPublicArtifactSweep_LLMPageStaysAccurate`** loads `/dashboard/llm` in setup state and runs both contracts (banned-phrase list + literal `230 rules` / `oktsec's 230` check) so a future revert cannot reintroduce the stale count or a banned phrase on this page.

The qualified forms (`every tool call routed through Oktsec`, `routed tool calls`) stay allowed and are intentionally not in the banned list.

## False positives intentionally left alone

The spec's regex matches several legitimate strings; reviewing each:
- **`Ed25519`** mentions — regex partial match on `255`. All references describe the cryptographic algorithm and are accurate.
- **`fake` / `unsafe-eval`** inside the existing banned-vocabulary test tables — those strings are the assertions enforcing the rule; removing them would weaken coverage.
- **Test-fixture struct names** like `fakeAuditReader` — test-internal, not user-facing copy.
- **`enterprise`** in the bearer-token guide — `Deployment.Profile = "enterprise"` is a real config value defined in `internal/config/config.go` and `internal/identity/resolve/resolver.go`.
- **`fake CoT`** in `documentation/reference/rules.md` — describes detection content (IPI Arena attack class), explicitly allowed by the spec.

## Acceptance per spec

- [x] Product UI contains no unsupported feature claims (sweep + 4 regression tests).
- [x] Source comments are neutral (`truth`/`honest`/`previously` removed from non-assertion code).
- [x] Tests are named by positive invariants where possible (`StaysAccurate` / `RuleCountIsLive`).
- [x] README/docs touched by this slice do not contradict current product behavior (Overview and LLM page now read live `{{.RuleCount}}` from the scanner instead of any literal).

## Not included

- Renaming `fakeAuditReader` test fixture — test-internal naming, not UI claim.
- Sweeping internal docs in `DOCS/` — explicitly excluded by the spec.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues (golangci-lint v2).
- [x] `make vet` — clean.
- [x] 4 new regression tests + the source/comment fixes.
- [ ] Manual browser smoke: load a clean `/dashboard`, confirm the empty state shows the live rule count and the qualified "routed through Oktsec" tagline. Load `/dashboard/llm` with LLM disabled, confirm the setup-state copy reads `oktsec's <live count> rules`.