### PR TITLE
Public wording sweep: scope visibility claims to Oktsec-routed surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  Oktsec runs locally between AI agents and the tools they execute. It sees MCP calls, shell/file/browser actions, agent-to-agent messages and outbound requests, then applies policy before those actions become production changes.
+  Oktsec runs locally between AI agents and the tools they execute. For surfaces routed through it — MCP calls, shell/file/browser actions, agent-to-agent messages, and outbound requests — Oktsec applies policy before those actions become production changes.
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@
 
 ---
 
-- **See** every tool call in a real-time dashboard.
+- **See** every tool call routed through Oktsec in a real-time dashboard.
 - **Control** which agents can call which tools and services.
 - **Block or quarantine** risky actions before execution.
 - **Prove what happened** with tamper-evident, hash-chained audit logs.
@@ -108,7 +108,7 @@ Traditional security tools sit at the network edge (WAFs) or the model boundary 
 
 ### Common use cases
 
-- Observe every tool call from Claude Code, Cursor or Claude Desktop.
+- Observe every tool call routed through Oktsec from Claude Code, Cursor or Claude Desktop.
 - Block shell, file and network actions that match risky patterns.
 - Audit which agent accessed which tool and why.
 - Add policy before exposing internal MCP servers to agents.

--- a/cmd/oktsec/commands/banner_wording_test.go
+++ b/cmd/oktsec/commands/banner_wording_test.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// printBanner is the static (non-TUI) startup banner the operator
+// sees when running oktsec without an interactive terminal. It must
+// not carry the universal-visibility wording the dashboard UX spec
+// hard-bans. The TUI tagline and the dashboard templates already
+// have regression coverage for the same contract; this test extends
+// the public-artifact sweep to the terminal-output path so the next
+// sweep run cannot miss it.
+func TestPrintBanner_DoesNotOverclaim(t *testing.T) {
+	// printBanner writes to os.Stdout via fmt.Print*, so we swap
+	// stdout for a pipe, capture, and restore. The package already
+	// has a captureStdout helper for tokens_test.go but it takes a
+	// func(*os.File) and the caller writes to that file directly;
+	// printBanner does not accept a writer parameter so we inline
+	// the capture here rather than refactor the production code
+	// path just for testability.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.Bytes()
+	}()
+
+	printBanner(&config.Config{
+		Server: config.ServerConfig{Port: 8080},
+	}, "12345678")
+
+	_ = w.Close()
+	os.Stdout = old
+	out := string(<-done)
+
+	plain := stripBannerANSI(out)
+	lower := strings.ToLower(plain)
+
+	for _, banned := range []string{
+		"see everything",
+		"sees everything",
+		"sees all",
+		"every tool call your ai agents make",
+		"every tool call scanned",
+		"all ai agent tool calls",
+		"complete coverage",
+		"complete protection",
+		"fully protected",
+	} {
+		if strings.Contains(lower, banned) {
+			t.Errorf("startup banner contains banned phrase %q\nbanner output:\n%s", banned, plain)
+		}
+	}
+
+	// Positive direction: the qualified replacement copy must be
+	// present, so a future revert of the wording fix fires this
+	// test too.
+	if !strings.Contains(plain, "Visibility into the tool calls your AI agents route through Oktsec") {
+		t.Errorf("startup banner missing the qualified visibility tagline; got:\n%s", plain)
+	}
+}
+
+// stripBannerANSI removes ANSI SGR escape sequences (the only kind
+// the banner emits via the fatih/color package) so banned-phrase
+// assertions don't have to thread through color codes.
+func stripBannerANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if i+1 < len(s) && s[i] == 0x1b && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && (s[j] < 0x40 || s[j] > 0x7e) {
+				j++
+			}
+			if j < len(s) {
+				j++ // include the final byte
+			}
+			i = j
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/cmd/oktsec/commands/serve.go
+++ b/cmd/oktsec/commands/serve.go
@@ -52,7 +52,7 @@ func printBanner(cfg *config.Config, dashCode string) {
 
 	fmt.Println()
 	fmt.Printf("  %s %s\n", bold("oktsec"), dim(version))
-	fmt.Printf("  %s\n", dim("See everything your AI agents execute"))
+	fmt.Printf("  %s\n", dim("Visibility into the tool calls your AI agents route through Oktsec"))
 	fmt.Println()
 	fmt.Printf("  %s  %s\n", dim("Dashboard"), cyan(fmt.Sprintf("http://%s:%d/dashboard", bindAddr, cfg.Server.Port)))
 	fmt.Printf("  %s       %s\n", dim("Code"), color.New(color.FgYellow, color.Bold).Sprint(dashCode))

--- a/internal/dashboard/public_artifact_sweep_test.go
+++ b/internal/dashboard/public_artifact_sweep_test.go
@@ -41,6 +41,15 @@ var bannedOverviewPhrases = []string{
 	// tool calls") are allowed and intentionally not in the list.
 	"every tool call your ai agents make",
 	"every tool call scanned",
+	"every tool your agents use passes",
+	"all ai agent tool calls",
+	"across all agents and tools",
+	// AI Analysis must not promise it catches what rules cannot.
+	// Optional async analysis can REVIEW patterns, not catch them
+	// for the operator. "catches what rules" / "auto-generates"
+	// reintroduce the overclaim PR2 of the desktop polish removed.
+	"catches what rules alone",
+	"auto-generates new detection rules",
 	// Unsupported auth/edition feature terms.
 	"sso",
 	"saml",
@@ -174,6 +183,36 @@ func TestPublicArtifactSweep_LLMPageStaysAccurate(t *testing.T) {
 	for _, stale := range []string{"230 detection rules", "230 rules", "oktsec's 230"} {
 		if strings.Contains(body, stale) {
 			t.Errorf("LLM page shows stale literal rule count %q; should be {{.RuleCount}}", stale)
+		}
+	}
+}
+
+// 5. The Gateway page is the most visible surface for the desktop
+// demo recording. It must follow the same banned-phrase contract as
+// Overview and the LLM page, AND the page-desc must qualify tool
+// calls as routed through Oktsec rather than implying every tool an
+// agent uses passes through (which would contradict the Blind cells
+// in the coverage matrix). Regression for DP-06.
+func TestPublicArtifactSweep_GatewayPageStaysAccurate(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/gateway", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	lower := strings.ToLower(body)
+	for _, banned := range bannedOverviewPhrases {
+		if strings.Contains(lower, banned) {
+			t.Errorf("Gateway page body contains banned phrase %q", banned)
 		}
 	}
 }

--- a/internal/dashboard/tmpl_gateway.go
+++ b/internal/dashboard/tmpl_gateway.go
@@ -11,7 +11,7 @@ var gatewayTmpl = template.Must(template.New("gateway").Funcs(tmplFuncs).Parse(l
 .gw-panel{display:none}
 .gw-panel.active{display:block}
 </style>
-<p class="page-desc">The Gateway is the secure checkpoint for all AI agent tool calls. Every tool your agents use passes through here for security scanning and access control.</p>
+<p class="page-desc">The Gateway is the security checkpoint for tool calls routed through Oktsec. Configured tool calls pass through Oktsec scanning and access control.</p>
 
 <div class="gw-tabs" role="tablist">
   <button class="gw-tab {{if ne .Tab "discovery"}}active{{end}}" onclick="gwTab('config')">Configuration</button>

--- a/internal/dashboard/tmpl_llm.go
+++ b/internal/dashboard/tmpl_llm.go
@@ -74,20 +74,20 @@ var llmTmpl = template.Must(template.New("llm").Funcs(tmplFuncs).Parse(layoutHea
 @media(max-width:768px){.llm-hero{grid-template-columns:repeat(2,1fr)}.llm-grid{grid-template-columns:1fr}}
 </style>
 
-<p class="page-desc">AI-powered threat analysis catches what rules alone can't see. Runs async, never blocks message delivery.</p>
+<p class="page-desc">Optional async analysis can review patterns deterministic rules may miss. Runs after the security decision; never blocks message delivery.</p>
 
 {{if not .Enabled}}
 <!-- Setup state -->
 <div class="card">
   <h2 style="font-size:1rem;margin-bottom:12px">Enable AI-Powered Detection</h2>
   <p style="color:var(--text2);font-size:0.82rem;line-height:1.6;margin-bottom:8px">
-    oktsec's {{.RuleCount}} rules catch known threats instantly. Add an AI layer to detect what patterns miss:
+    oktsec's {{.RuleCount}} deterministic rules run on every routed tool call. Add an optional AI layer to review patterns those rules may not match:
   </p>
   <ul style="color:var(--text2);font-size:0.82rem;line-height:1.8;margin:0 0 20px 18px;padding:0">
     <li>Semantic data exfiltration disguised as normal messages</li>
     <li>Social engineering between agents</li>
     <li>Intent drift (agent doing something it shouldn't)</li>
-    <li>Auto-generates new detection rules from findings</li>
+    <li>Surfaces rule suggestions from findings for operator review</li>
   </ul>
 
   <form method="POST" action="/dashboard/settings/llm">

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -60,7 +60,7 @@ a.ov-metric:hover{background:var(--surface2)}
 @media(max-width:768px){.hero-stats{grid-template-columns:repeat(2,1fr)}.ov-grid{grid-template-columns:1fr}}
 </style>
 
-<p class="page-desc">Real-time security overview across all agents and tools. <span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
+<p class="page-desc">Real-time security overview for agents and tools routed through Oktsec. <span class="sse-indicator" id="sse-status"><span class="sse-dot" id="sse-dot"></span> <span id="sse-label">connecting</span></span></p>
 <noscript><div style="padding:8px 12px;background:rgba(210,153,34,0.08);border:1px solid rgba(210,153,34,0.2);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--warn);margin-bottom:var(--sp-4)">Live updates require JavaScript.</div></noscript>
 
 {{if and (eq .Stats.TotalMessages 0) (eq .AgentCount 0)}}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -381,7 +381,7 @@ func (m Model) View() string {
 
 	header := lipgloss.JoinVertical(lipgloss.Left,
 		hx[0]+" "+hx[1]+"  "+headerStyle.Render("oktsec")+" "+dimStyle.Render(m.cfg.Version),
-		hx[2]+" "+hx[3]+"  "+taglineStyle.Render("See everything your AI agents execute"),
+		hx[2]+" "+hx[3]+"  "+taglineStyle.Render("Visibility into the tool calls your AI agents route through Oktsec"),
 	)
 
 	currentMode := m.cfg.Mode


### PR DESCRIPTION
## Summary

PR2 of the desktop product polish slice. Four DP findings (DP-04..DP-07) all in the same "implies coverage Oktsec does not have" failure mode. Every change qualifies a previously universal claim with the surface scope Oktsec actually observes (routed/configured), and the regression test adds the new banned phrases plus the Gateway page to the existing public-artifact sweep.

## What changed

### DP-04 — terminal/TUI/README

- **`internal/tui/model.go`** — TUI tagline `See everything your AI agents execute` is exactly the spec-banned superlative. Now reads `Visibility into the tool calls your AI agents route through Oktsec`.
- **`README.md`** — hero paragraph said "It sees MCP calls, shell/file/browser actions, agent-to-agent messages and outbound requests". Reworded to "For surfaces routed through it — MCP calls, ... — Oktsec applies policy". The bullet `See every tool call in a real-time dashboard` and the use-case `Observe every tool call from Claude Code/Cursor/Claude Desktop` both qualified with "routed through Oktsec".

### DP-05 — Overview header

- **`internal/dashboard/tmpl_overview.go`** — `Real-time security overview across all agents and tools` → `Real-time security overview for agents and tools routed through Oktsec`.

### DP-06 — Gateway header

- **`internal/dashboard/tmpl_gateway.go`** — `The Gateway is the secure checkpoint for all AI agent tool calls. Every tool your agents use passes through here for security scanning and access control.` → `The Gateway is the security checkpoint for tool calls routed through Oktsec. Configured tool calls pass through Oktsec scanning and access control.`

### DP-07 — AI Analysis page

- **`internal/dashboard/tmpl_llm.go`** — three rewrites:
  - page-desc: `AI-powered threat analysis catches what rules alone can't see` → `Optional async analysis can review patterns deterministic rules may miss. Runs after the security decision; never blocks message delivery.`
  - setup copy: `oktsec's {{.RuleCount}} rules catch known threats instantly. Add an AI layer to detect what patterns miss` → `oktsec's {{.RuleCount}} deterministic rules run on every routed tool call. Add an optional AI layer to review patterns those rules may not match`.
  - bullet: `Auto-generates new detection rules from findings` → `Surfaces rule suggestions from findings for operator review`. Generated rules carry `Status: "pending_review"` in `internal/llm/rulegen.go`, so the operator still gates them; "auto-generates" was overclaiming.

### `internal/dashboard/public_artifact_sweep_test.go` (extended)

- Adds five new banned phrases to `bannedOverviewPhrases`:
  - `every tool your agents use passes`
  - `all ai agent tool calls`
  - `across all agents and tools`
  - `catches what rules alone`
  - `auto-generates new detection rules`
- New `TestPublicArtifactSweep_GatewayPageStaysAccurate` walks the Gateway page body against the same banned-phrase contract — the Gateway page is the most visible surface during the desktop recording walkthrough and was the only major page not yet guarded.

## Acceptance per spec

- [x] DP-04: terminal/TUI/README qualified consistently as visibility into tool calls routed through Oktsec.
- [x] DP-05: Overview header scoped to "agents and tools routed through Oktsec".
- [x] DP-06: Gateway copy says configured/routed tool calls pass through Oktsec scanning and access control.
- [x] DP-07: AI Analysis copy describes optional async analysis that can review patterns rules may miss, and surfaces rule suggestions for operator review (matches `pending_review` default in `rulegen.go`).

## Not included

- DP-08 + DP-09 typography/contrast — PR3 of the slice.
- Final browser smoke + acceptance checklist — PR4 of the slice.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues.
- [x] `make vet` — clean.
- [x] Sweep tests now cover Overview empty + populated, LLM page setup, and Gateway page; banned-phrase list grew by 5 entries.
- [ ] Manual desktop walkthrough at 1440px and 1920px: confirm Overview/Gateway/AI Analysis read with the qualified copy and no marketing-tagline regressions.