### PR TITLE
Add desktop acceptance smoke: all pages render under both modes

### DIFF
--- a/internal/dashboard/all_pages_smoke_test.go
+++ b/internal/dashboard/all_pages_smoke_test.go
@@ -1,0 +1,133 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// allDashboardPageRoutes is the page-route inventory the desktop
+// acceptance smoke walks. Routes that take a path parameter (event
+// detail, agent detail, rule detail, session trace, MCP server
+// detail) are exercised by their own focused tests once the
+// prerequisites are seeded; this list is the "every top-level
+// surface renders" gate.
+//
+// Kept separate from topbar_mode_test.go's identical list on
+// purpose — the topbar test asserts on the mode pill, this one
+// asserts on the basic render contract. A single source-of-truth
+// list would couple the two regressions; keeping them parallel
+// means a route added to one place still gets the other test
+// loudly when CI catches the divergence.
+var allDashboardPageRoutes = []string{
+	"/dashboard",
+	"/dashboard/events",
+	"/dashboard/sessions",
+	"/dashboard/alerts",
+	"/dashboard/agents",
+	"/dashboard/rules",
+	"/dashboard/audit",
+	"/dashboard/llm",
+	"/dashboard/graph",
+	"/dashboard/gateway",
+	"/dashboard/settings",
+}
+
+// TestAllPagesRender_HappyPath is the consolidated desktop
+// acceptance gate: every top-level dashboard page must return 200
+// with an authenticated session, ship a strict CSP that does not
+// contain unsafe-eval, and not surface obvious failure markers
+// (panic stack traces, generic "Internal Server Error", or 404
+// titles for routes that should exist).
+//
+// Individual contract tests (topbar mode, public-artifact sweep,
+// drawer wording, typography) cover the deeper invariants per page.
+// This test is the single fast check that everything still loads
+// before anyone records a walkthrough.
+func TestAllPagesRender_HappyPath(t *testing.T) {
+	srv := newTestServer(t)
+	// Seed enough state so pages don't render the empty state and
+	// hide whole UI sections from the smoke. One agent + an
+	// enabled gateway is the minimum that exercises the populated
+	// rendering paths across every surface.
+	srv.cfg.Agents["smoke-agent"] = config.Agent{}
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	for _, path := range allDashboardPageRoutes {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.AddCookie(cookie)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body snippet = %s",
+					rr.Code, snippetForSmoke(rr.Body.String(), 200))
+			}
+
+			// Strict CSP must hold across every page so the cell
+			// drill-down (and any future HTMX wiring) keeps working.
+			csp := rr.Header().Get("Content-Security-Policy")
+			if strings.Contains(csp, "unsafe-eval") {
+				t.Errorf("page %s relaxes CSP with unsafe-eval; got %q", path, csp)
+			}
+
+			// Failure markers we should never ship into a render path.
+			body := rr.Body.String()
+			for _, marker := range []string{
+				"runtime error: ",
+				"goroutine ",
+				"Internal Server Error",
+				"<title>404",
+			} {
+				if strings.Contains(body, marker) {
+					t.Errorf("page %s contains failure marker %q", path, marker)
+				}
+			}
+		})
+	}
+}
+
+// TestAllPagesRender_RequireSignatureFlipsOK is the same smoke
+// against require_signature: true (the production-leaning config).
+// A handler that breaks under enforce-mode rendering would be
+// invisible to TestAllPagesRender_HappyPath alone; running the
+// inventory under both modes is cheap and catches a class of
+// "I added a code path that only runs in enforce" regressions.
+func TestAllPagesRender_RequireSignatureFlipsOK(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.RequireSignature = true
+	srv.cfg.Agents["smoke-agent"] = config.Agent{}
+	srv.cfg.Gateway.Enabled = true
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	for _, path := range allDashboardPageRoutes {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.AddCookie(cookie)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (require_signature=true); body snippet = %s",
+					rr.Code, snippetForSmoke(rr.Body.String(), 200))
+			}
+		})
+	}
+}
+
+// snippetForSmoke trims a long response body down to a chunk that
+// is useful for diagnostics without flooding the test output.
+func snippetForSmoke(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}


### PR DESCRIPTION
## Summary

PR4 of the desktop product polish slice — the closer. Adds one consolidated regression test that walks every dashboard page route, asserts each returns 200 with strict CSP and no obvious failure markers, and runs the same walk under `require_signature: true`.

The deeper per-page contracts (topbar mode consistency, gateway port label, drawer wording, public-artifact phrases, no negative tracking, contrast floor) stay covered by the focused regressions landed in PRs 1–3 of this slice. This PR is the single fast "everything still loads" gate operators run before recording.

## What changed

### `internal/dashboard/all_pages_smoke_test.go` (new) — 2 tests

- **`TestAllPagesRender_HappyPath`** seeds a default test server with one configured agent + an enabled gateway (so pages render their populated state, not the empty-state hides), authenticates a session, and walks the page-route inventory:
  - Each page must return `200 OK`.
  - The `Content-Security-Policy` header must not contain `unsafe-eval` (carries the PR1-of-the-UX-slice CSP fix forward).
  - The body must not contain failure markers: `runtime error:`, `goroutine `, `Internal Server Error`, `<title>404`.
- **`TestAllPagesRender_RequireSignatureFlipsOK`** runs the same walk with `Identity.RequireSignature: true`. Catches the class of "I added a code path that only runs in enforce mode" regressions that the happy-path test would hide.

### Why a separate route inventory from `topbar_mode_test.go`'s

A shared list would couple the two regressions. Keeping them parallel means a route added to one place triggers the other test loudly when CI catches the divergence. The two tests assert different things — topbar pins the mode pill class; this one pins the basic render contract.

## Acceptance per spec

The desktop acceptance checklist from the spec maps to landed regressions across the four PRs of this slice:

| Spec bullet | Covered by |
|---|---|
| Build the binary from the target commit | `make build` (CI) |
| Login screen has no unsupported auth claims | `TestLogin_DoesNotAdvertiseUnsupportedAuth` (PR4 of the UX slice) |
| Login renders without visual asset failures | `TestLogin_StaticAssetsBypassAuth` (PR4 of the UX slice) |
| Every page renders | **This PR** (`TestAllPagesRender_HappyPath`) |
| Every page's topbar mode agrees with the active config | `TestTopbarMode_AllPagesAgreeWithConfig*` (PR1 of this slice) |
| Gateway page does not mislabel configured port as live listener | `TestGatewayPage_PortLabelHonorsLiveOrConfigured` + `TestGateway_SetReadyCallback_FiresAfterBind` (PR1 of this slice) |
| Coverage drawer shows neutral, scoped copy | `TestCoverageCellDrawer_*` (PRs 2–3 of the UX slice) |
| Startup terminal contains no universal visibility claims | `TestPrintBanner_DoesNotOverclaim` (PR2 of this slice) |
| Dashboard templates contain no universal visibility claims | `TestPublicArtifactSweep_*` (PRs 2 of this slice + 5 of the UX slice) |
| Ctrl+C shutdown exits without panic | `TestStore_CloseIsIdempotent` (PR1 of this slice) |
| Body/sidebar use neutral letter spacing | `TestTypography_NoNegativeLetterSpacing*` (PR3 of this slice) |
| Muted text remains readable on recording compression | `TestTypography_Text3MeetsContrastFloor` (PR3 of this slice) |

What stays manual:
- Browser console errors (genuinely needs a real browser).
- Visual screenshot review at 1440px / 1920px.
- Final post-merge smoke before recording.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues.
- [x] `make vet` — clean.
- [x] 2 new tests in `internal/dashboard/all_pages_smoke_test.go`.
- [ ] Manual desktop walkthrough at 1440px and 1920px (operator step before recording).