### PR TITLE
Fix Gateway runtime contradiction + suppress orphan Overview sparkline

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -836,8 +836,11 @@ func TestServer_GatewayDisabledBanner(t *testing.T) {
 	if !strings.Contains(body, "Configured Port") {
 		t.Error("gateway disabled should show 'Configured Port'")
 	}
-	if !strings.Contains(body, "configured but not routing") {
-		t.Error("gateway disabled should explain it's not routing traffic")
+	if !strings.Contains(body, "Gateway is disabled") {
+		t.Error("gateway disabled banner should say 'Gateway is disabled'")
+	}
+	if !strings.Contains(body, "start routing tool calls") {
+		t.Error("gateway disabled banner should describe what enabling does")
 	}
 }
 

--- a/internal/dashboard/gateway_runtime_state_test.go
+++ b/internal/dashboard/gateway_runtime_state_test.go
@@ -1,0 +1,139 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// GatewayRunning is the single source of truth for the Gateway page
+// status pill AND the green "Routing tool calls" banner. Before
+// DP-SMOKE-01 it only checked the legacy child-process pointer
+// (s.gwCmd), so the in-process gateway path used by `oktsec run`
+// rendered the page in a contradictory state — status "offline",
+// port "Listening on Port 9091", banner "Routing tool calls"
+// — even when the gateway was actually serving traffic.
+//
+// This test pins the new contract: when the in-process readiness
+// callback has fired (SetGatewayManaged()), GatewayRunning() must
+// return true AND the rendered banner must read as "Routing".
+func TestGatewayRuntimeState_InProcessReadyShowsRouting(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Gateway.Enabled = true
+	srv.SetGatewayManaged() // simulates the readiness callback firing post-bind
+
+	if !srv.GatewayRunning() {
+		t.Fatal("GatewayRunning must return true when SetGatewayManaged has fired")
+	}
+
+	body := getGatewayPage(t, srv)
+	if !strings.Contains(body, "Routing tool calls through Oktsec") {
+		t.Errorf("in-process ready gateway must render the green Routing banner; body lacks it")
+	}
+	if strings.Contains(body, "not yet listening") {
+		t.Error("in-process ready gateway must NOT show the 'not yet listening' banner")
+	}
+	if strings.Contains(body, "Gateway is disabled") {
+		t.Error("in-process ready gateway must NOT show the disabled banner")
+	}
+}
+
+// Enabled but the readiness callback has not fired (NewGateway
+// failure, bind failure, or just race-window before bind): the
+// page must show the amber "enabled but not yet listening"
+// banner, not the green "Routing" banner. The status pill and
+// banner must agree.
+func TestGatewayRuntimeState_EnabledButNotLiveShowsAmber(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Gateway.Enabled = true
+	// Deliberately do NOT call SetGatewayManaged.
+
+	if srv.GatewayRunning() {
+		t.Fatal("GatewayRunning must return false when no readiness callback fired and no child process exists")
+	}
+
+	body := getGatewayPage(t, srv)
+	if !strings.Contains(body, "not yet listening") {
+		t.Errorf("enabled-but-not-live gateway must render the 'not yet listening' banner; body lacks it")
+	}
+	if strings.Contains(body, "Routing tool calls through Oktsec") {
+		t.Error("enabled-but-not-live gateway must NOT show the green Routing banner")
+	}
+}
+
+// Disabled gateway: amber disabled banner, no green Routing,
+// no "not yet listening" (which only applies to enabled-but-not-
+// live). Three-way state check that keeps the banner contract
+// from collapsing back into a binary enabled/disabled flag.
+func TestGatewayRuntimeState_DisabledShowsDisabledBanner(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Gateway.Enabled = false
+
+	if srv.GatewayRunning() {
+		t.Fatal("GatewayRunning must return false when gateway is disabled")
+	}
+
+	body := getGatewayPage(t, srv)
+	if !strings.Contains(body, "Gateway is disabled") {
+		t.Errorf("disabled gateway must render the disabled banner; body lacks it")
+	}
+	if strings.Contains(body, "Routing tool calls through Oktsec") {
+		t.Error("disabled gateway must NOT show the green Routing banner")
+	}
+	if strings.Contains(body, "not yet listening") {
+		t.Error("disabled gateway must NOT show the 'not yet listening' banner")
+	}
+}
+
+// /dashboard/api/gateway/health is the HTMX partial that drives the
+// status pill in the corner of the Gateway card. It used to check
+// only the child-process pointer and would render "offline" while
+// the in-process gateway was actually serving. This test pins that
+// the partial agrees with the page-level Routing banner.
+func TestGatewayRuntimeState_HealthEndpointAgreesWithBanner(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Gateway.Enabled = true
+	srv.SetGatewayManaged()
+	// One configured backend so the partial does not short-circuit
+	// with the "no backends" warning.
+	if srv.cfg.MCPServers == nil {
+		srv.cfg.MCPServers = map[string]config.MCPServerConfig{}
+	}
+	srv.cfg.MCPServers["echo"] = config.MCPServerConfig{Transport: "stdio", Command: "true"}
+
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/api/gateway/health", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, ">online<") {
+		t.Errorf("health partial must read 'online' when in-process gateway is ready; body = %s", body)
+	}
+}
+
+// getGatewayPage renders /dashboard/gateway with an authenticated
+// session and returns the body. Small helper so the four state
+// tests above stay focused on assertions rather than wiring.
+func getGatewayPage(t *testing.T, srv *Server) string {
+	t.Helper()
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/gateway", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/dashboard/gateway status = %d, want 200", rr.Code)
+	}
+	return rr.Body.String()
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -534,6 +534,15 @@ func (s *Server) getHourlyChart() []hourlyBar {
 			maxCount = c
 		}
 	}
+	// Suppress the sparkline entirely when no hour bucket has any
+	// traffic. A 24-bar zero-height chart renders as an unlabelled
+	// blue strip on the Overview, which reads as a broken
+	// placeholder in a desktop walkthrough. Returning nil lets the
+	// template's `{{if .Chart}}` skip the section cleanly until
+	// real data exists.
+	if maxCount == 0 {
+		return nil
+	}
 
 	bars := make([]hourlyBar, 24)
 	for i := range 24 {
@@ -4573,11 +4582,13 @@ func (s *Server) handleGateway(w http.ResponseWriter, r *http.Request) {
 	}
 
 	gw := s.cfg.Gateway
+	gwLive := s.GatewayRunning()
 	data := map[string]any{
 		"Active":            "gateway",
 		"Gateway":           gw,
 		"GatewayEnabled":    gw.Enabled,
-		"GatewayPortIsLive": s.gwManaged.Load(), // see template note on Listening on vs Configured port
+		"GatewayLive":       gwLive,
+		"GatewayPortIsLive": gwLive, // template uses this for the port label too
 		"Servers":           servers,
 		"Discovered":        discovered,
 		"Tab":               r.URL.Query().Get("tab"),

--- a/internal/dashboard/overview_sparkline_test.go
+++ b/internal/dashboard/overview_sparkline_test.go
@@ -1,0 +1,80 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// On a fresh dashboard with no audit traffic, the Overview hourly
+// sparkline used to render as 24 zero-height bars inside an
+// unlabelled container — visible on desktop walkthroughs as a
+// standalone blue strip with no context. DP-SMOKE-02. The fix:
+// getHourlyChart returns nil when the maximum bucket count is 0,
+// and the template's `{{if .Chart}}` skips the section.
+func TestOverviewSparkline_SuppressedWithoutTraffic(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents["smoke-agent"] = config.Agent{}
+	// Deliberately do not log any audit entries.
+
+	body := getOverviewBody(t, srv)
+	if strings.Contains(body, `class="sparkline-chart"`) {
+		t.Errorf("Overview must not render the sparkline when no audit traffic exists; body contains sparkline-chart")
+	}
+	if strings.Contains(body, "Hourly activity (last 24h)") {
+		t.Errorf("Overview must not render the Hourly activity heading when there is no traffic to chart")
+	}
+}
+
+// When the sparkline does render (real traffic in at least one
+// hour bucket) it must be wrapped in a labelled card so it carries
+// visible context. The label "Hourly activity (last 24h)" is the
+// stable contract; the bars themselves still come from the
+// sparkline-chart container the CSS targets.
+func TestOverviewSparkline_LabelledCardWhenDataExists(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents["smoke-agent"] = config.Agent{}
+
+	// Log one real audit entry so QueryHourlyStats has data.
+	srv.audit.Log(audit.Entry{
+		ID:             "smoke-1",
+		Timestamp:      "2026-04-27T10:00:00Z",
+		FromAgent:      "smoke-agent",
+		ToAgent:        "echo",
+		ContentHash:    "h",
+		Status:         audit.StatusDelivered,
+		PolicyDecision: "allow",
+	})
+	srv.audit.Flush()
+
+	body := getOverviewBody(t, srv)
+	if !strings.Contains(body, `class="sparkline-chart"`) {
+		t.Fatal("Overview must render the sparkline when audit traffic exists; body lacks sparkline-chart")
+	}
+	if !strings.Contains(body, "Hourly activity (last 24h)") {
+		t.Errorf("Overview sparkline must carry the labelled card heading; body lacks 'Hourly activity'")
+	}
+}
+
+// getOverviewBody renders /dashboard with an authenticated session
+// and returns the body. The Overview empty state hides the matrix
+// when there are zero agents AND zero messages; both sparkline
+// tests configure at least one agent so the populated layout
+// (and the sparkline section) is reachable.
+func getOverviewBody(t *testing.T, srv *Server) string {
+	t.Helper()
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/dashboard status = %d, want 200", rr.Code)
+	}
+	return rr.Body.String()
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -319,11 +319,26 @@ func (s *Server) stopGateway() {
 	s.logger.Info("gateway process stopped")
 }
 
-// GatewayRunning returns true if the gateway child process is alive.
+// GatewayRunning returns true when the dashboard has authoritative
+// evidence that a gateway is currently listening on cfg.Gateway.Port.
+// Two paths:
+//
+//   - The legacy child-process path: the dashboard spawned `oktsec
+//     gateway` as a subprocess and is tracking its os.Process.
+//   - The in-process path: the gateway built by `oktsec run` invoked
+//     SetGatewayManaged via its readiness callback after
+//     netutil.ListenAutoPort succeeded.
+//
+// The Gateway page reads this flag to decide whether to render the
+// "online" status pill and the green "Routing tool calls" banner.
+// Both must agree — claiming online while showing the disabled
+// banner (or vice versa) is the contradictory state DP-SMOKE-01
+// flagged. Keep the two surfaces wired through this single source.
 func (s *Server) GatewayRunning() bool {
 	s.gwMu.Lock()
-	defer s.gwMu.Unlock()
-	return s.gwCmd != nil && s.gwCmd.Process != nil
+	childAlive := s.gwCmd != nil && s.gwCmd.Process != nil
+	s.gwMu.Unlock()
+	return childAlive || s.gwManaged.Load()
 }
 
 // cachedRunChecks returns cached auditcheck.RunChecks results, refreshing if older than 30s.

--- a/internal/dashboard/tmpl_gateway.go
+++ b/internal/dashboard/tmpl_gateway.go
@@ -48,8 +48,9 @@ function gwTab(name){
     </div>
   </div>
   {{if eq (len .Servers) 0}}<div style="text-align:center;padding-bottom:8px"><a href="#add-server" class="btn btn-sm btn-outline" style="text-decoration:none">+ Add tool server</a></div>{{end}}
-  {{if .GatewayEnabled}}<div style="padding:10px 16px;background:rgba(63,185,80,0.06);border:1px solid rgba(63,185,80,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--success);margin-top:8px">Routing tool calls through Oktsec security pipeline.</div>
-  {{else}}<div style="padding:10px 16px;background:rgba(210,153,34,0.06);border:1px solid rgba(210,153,34,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--warn);margin-top:8px">Gateway is configured but not routing traffic. Enable it in your configuration file and restart to protect tool calls.</div>
+  {{if .GatewayLive}}<div style="padding:10px 16px;background:rgba(63,185,80,0.06);border:1px solid rgba(63,185,80,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--success);margin-top:8px">Routing tool calls through Oktsec security pipeline.</div>
+  {{else if .GatewayEnabled}}<div style="padding:10px 16px;background:rgba(210,153,34,0.06);border:1px solid rgba(210,153,34,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--warn);margin-top:8px">Gateway is enabled but not yet listening on the configured port. Watch the terminal for bind errors.</div>
+  {{else}}<div style="padding:10px 16px;background:rgba(210,153,34,0.06);border:1px solid rgba(210,153,34,0.15);border-radius:8px;font-size:var(--text-sm);color:var(--warn);margin-top:8px">Gateway is disabled. Enable it in your configuration file to start routing tool calls through the security pipeline.</div>
   {{end}}
 </div>
 

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -319,10 +319,19 @@ a.ov-metric:hover{background:var(--surface2)}
 </div>
 
 {{if .Chart}}
-<!-- Activity sparkline -->
-<div class="sparkline-wrap">
-  <div class="sparkline-chart">
-    {{range .Chart}}<div class="sparkline-bar" style="height:{{.Percent}}%" title="{{.Label}}: {{.Count}} msgs"></div>{{end}}
+<!-- Activity sparkline. Wrapped in an ov-card with a heading so
+     the bar strip carries visible context. The chart itself is
+     suppressed by handlers.go when no hour bucket has traffic, so
+     reaching this template path means there is data to show. -->
+<div class="ov-card" style="margin-bottom:var(--sp-4)">
+  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--sp-3)">
+    <h3 style="margin:0">Hourly activity (last 24h)</h3>
+    <span style="font-size:var(--text-xs);color:var(--text3)">Routed tool calls per hour</span>
+  </div>
+  <div class="sparkline-wrap">
+    <div class="sparkline-chart">
+      {{range .Chart}}<div class="sparkline-bar" style="height:{{.Percent}}%" title="{{.Label}}: {{.Count}} msgs"></div>{{end}}
+    </div>
   </div>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

Two desktop-walkthrough findings flagged as merge-blockers for the recording. Both are visual coherence bugs that read as a broken demo even though the underlying runtime is fine.

## What changed

### DP-SMOKE-01 — Gateway page contradicts itself

After the runtime accuracy slice (PR #148) removed the dashboard's child-gateway auto-spawn, `GatewayRunning()` (which only checked `s.gwCmd`) always returned false in `oktsec run` mode. The Gateway card status pill rendered `offline` while the page port label showed `Listening on Port 9091` (correct, fed by the readiness callback) and the green banner said `Routing tool calls` (fed only by `Gateway.Enabled`). The in-process gateway was actually serving — the dashboard just had three different views of its state.

Fix:
- **`internal/dashboard/server.go`** — `GatewayRunning()` returns true when EITHER the legacy child process is alive OR `s.gwManaged.Load()` is true (the readiness callback fired post-bind). New doc comment names this as the single source of truth for the Gateway page status pill AND the green Routing banner.
- **`internal/dashboard/handlers.go`** — `handleGateway` passes a single `GatewayLive` flag (`= GatewayRunning()`) into the template; `GatewayPortIsLive` now also reads from this same value so the port label and banner cannot drift apart.
- **`internal/dashboard/tmpl_gateway.go`** — banner is a three-way switch:
  - `GatewayLive` → green `Routing tool calls through Oktsec security pipeline.`
  - `GatewayEnabled` (but not live) → amber `Gateway is enabled but not yet listening on the configured port. Watch the terminal for bind errors.`
  - else → amber `Gateway is disabled. Enable it in your configuration file to start routing tool calls...`

### DP-SMOKE-02 — Overview sparkline rendered as orphan blue strip

`getHourlyChart` used to return 24 zero-height bars when `QueryHourlyStats` had no data. The template wrapped them in an unlabelled `.sparkline-wrap` div, which on a desktop walkthrough read as a standalone blue rectangle with no axis or heading — broken-placeholder territory in a recording.

Fix:
- **`internal/dashboard/handlers.go`** — `getHourlyChart` returns `nil` when `maxCount == 0`, so the existing `{{if .Chart}}` guard suppresses the section cleanly until there is real data.
- **`internal/dashboard/tmpl_overview.go`** — when `Chart` does render, the sparkline is wrapped in an `.ov-card` with an `Hourly activity (last 24h)` heading and a `Routed tool calls per hour` caption.

## Tests

`internal/dashboard/gateway_runtime_state_test.go` (new) — 4 tests:
- `TestGatewayRuntimeState_InProcessReadyShowsRouting` — green banner fires after `SetGatewayManaged()`.
- `TestGatewayRuntimeState_EnabledButNotLiveShowsAmber` — pre-bind / NewGateway-failure / bind-failure window shows the new amber banner, not green.
- `TestGatewayRuntimeState_DisabledShowsDisabledBanner` — third state, forbids the other two banners.
- `TestGatewayRuntimeState_HealthEndpointAgreesWithBanner` — `/dashboard/api/gateway/health` HTMX partial reads `online` from the same source of truth, so the status pill cannot drift back.

`internal/dashboard/overview_sparkline_test.go` (new) — 2 tests:
- `TestOverviewSparkline_SuppressedWithoutTraffic` — fresh server with no audit entries renders no `.sparkline-chart` and no `Hourly activity` heading.
- `TestOverviewSparkline_LabelledCardWhenDataExists` — one logged audit entry is enough to render both the chart container and the heading.

`internal/dashboard/coverage_test.go` — `TestServer_GatewayDisabledBanner` updated for the new copy (`Gateway is disabled` / `start routing tool calls`); the old `configured but not routing` wording moved to the new amber-but-enabled case.

## Acceptance per spec

- [x] DP-SMOKE-01: Gateway status pill, port label, and routing banner all read from `GatewayRunning()`. In-process ready gateway renders `online` + `Listening on` + `Routing` together. Configured-but-not-live renders amber (no green). Disabled renders amber with the disabled wording.
- [x] DP-SMOKE-02: Empty audit DB renders no sparkline. With data, sparkline lives inside a labelled `Hourly activity (last 24h)` card.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues.
- [x] `make vet` — clean.
- [x] 6 new dashboard tests + 1 updated coverage test.
- [ ] Manual desktop rerun at 1440px / 1920px: confirm the Gateway card no longer contradicts itself and the Overview no longer carries an unlabelled sparkline strip.