### PR TITLE
Auto-fit Agents grid + wrap Pipeline summary on narrower desktops

### DIFF
--- a/internal/dashboard/agents_grid_test.go
+++ b/internal/dashboard/agents_grid_test.go
@@ -1,0 +1,67 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// The Agents page used a fixed two-column grid
+// (grid-template-columns: 1fr 1fr). With one configured agent the
+// right column rendered as a large empty gray panel — the
+// DP-SMOKE-03 walkthrough finding. The fix switches to
+// `repeat(auto-fit, minmax(320px, 1fr))` so a single agent fills
+// the row instead of stranding an empty track.
+//
+// This test pins both halves of the new contract: the grid must
+// use the auto-fit form, AND the legacy 1fr 1fr form (or the
+// 768px-only collapse media query that paired with it) must not
+// reappear.
+func TestAgentsGrid_UsesAutoFit(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents["solo-agent"] = config.Agent{}
+
+	body := getAgentsPage(t, srv)
+
+	if !strings.Contains(body, "grid-template-columns:repeat(auto-fit,minmax(320px,1fr))") {
+		t.Errorf("Agents page must use auto-fit grid so a single card fills the row; body lacks it")
+	}
+	if strings.Contains(body, "grid-template-columns:1fr 1fr") {
+		t.Errorf("Agents page must not reintroduce the fixed two-column grid that left a blank panel for solo agents")
+	}
+}
+
+// A populated Agents page with multiple agents must still render
+// every card. The auto-fit grid does not change card structure;
+// this test guards against an accidental template change that
+// drops the loop.
+func TestAgentsGrid_RendersEveryConfiguredAgent(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Agents["alpha"] = config.Agent{}
+	srv.cfg.Agents["beta"] = config.Agent{}
+	srv.cfg.Agents["gamma"] = config.Agent{}
+
+	body := getAgentsPage(t, srv)
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("Agents page must render configured agent %q; body lacks it", name)
+		}
+	}
+}
+
+func getAgentsPage(t *testing.T, srv *Server) string {
+	t.Helper()
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/agents", nil)
+	req.AddCookie(cookie)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/dashboard/agents status = %d, want 200", rr.Code)
+	}
+	return rr.Body.String()
+}

--- a/internal/dashboard/avatar_test.go
+++ b/internal/dashboard/avatar_test.go
@@ -1,42 +1,33 @@
 package dashboard
 
 import (
-	"slices"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// avIDPattern matches the avNN unique-id suffix the avatar SVG
+// emits (any digit count). The previous strip helper iterated
+// av1..av99 sequentially, but `av1` prefix-matches `av11` and
+// leaves the trailing digit — so once the package-level counter
+// crossed 9 (cumulative across all dashboard tests in the same
+// `go test` run) the deterministic check would diff on the suffix.
+// Regex match is order-independent.
+var avIDPattern = regexp.MustCompile(`av\d+`)
 
 func TestAgentAvatar_Deterministic(t *testing.T) {
 	a1 := string(agentAvatar("research-agent", 20))
 	a2 := string(agentAvatar("research-agent", 20))
 
-	// Strip unique IDs (av1, av2) to compare visual content
+	// Strip unique IDs so the comparison sees only the visual
+	// content (colors, pattern) — the gradient/clip ids are
+	// generated from a counter and are expected to differ.
 	strip := func(s string) string {
-		// The SVG content (colors, pattern) should be identical
-		// Only the gradient/clip IDs differ
-		for _, prefix := range []string{"av"} {
-			for i := 1; i < 100; i++ {
-				s = strings.ReplaceAll(s, prefix+itoa(i), prefix+"N")
-			}
-		}
-		return s
+		return avIDPattern.ReplaceAllString(s, "avN")
 	}
 	if strip(a1) != strip(a2) {
 		t.Errorf("same name produced different avatars:\n  %s\n  %s", a1, a2)
 	}
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	b := make([]byte, 0, 4)
-	for n > 0 {
-		b = append(b, byte('0'+n%10))
-		n /= 10
-	}
-	slices.Reverse(b)
-	return string(b)
 }
 
 func TestAgentAvatar_Unique(t *testing.T) {

--- a/internal/dashboard/pipeline_meta_test.go
+++ b/internal/dashboard/pipeline_meta_test.go
@@ -1,0 +1,37 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// At 1440px desktop widths the Pipeline Health row clipped its
+// last stage label ("Guard" → "Gua") because the heading + 11
+// stages + a long rules/mode/chain summary all shared one flex
+// row that overflowed mid-word. DP-SMOKE-04 fix: the summary
+// carries a .pipeline-meta class, and a max-width:1599px media
+// query flips it to flex-basis:100% so it wraps onto its own
+// row beneath the stages on narrower desktop widths. 1920px+
+// keeps the inline single-row layout.
+//
+// The test pins both halves of the contract: the .pipeline-meta
+// class is on the summary div, and the media query is present in
+// the rendered Overview <style> block. Removing either would let
+// the clip regress without firing this test.
+func TestPipelineMeta_HasResponsiveWrapHook(t *testing.T) {
+	srv := newTestServer(t)
+	// Populated state so the Overview renders the pipeline row
+	// (the empty state hides the matrix and surrounding cards).
+	srv.cfg.Agents["smoke-agent"] = config.Agent{}
+
+	body := getOverviewBody(t, srv)
+
+	if !strings.Contains(body, `class="pipeline-meta"`) {
+		t.Errorf("Pipeline Health summary must carry class=\"pipeline-meta\" so the responsive wrap rule can target it")
+	}
+	if !strings.Contains(body, "@media(max-width:1599px){.pipeline-meta") {
+		t.Errorf("Overview must include the .pipeline-meta media query that wraps the summary onto its own row at narrower desktop widths")
+	}
+}

--- a/internal/dashboard/tmpl_agents.go
+++ b/internal/dashboard/tmpl_agents.go
@@ -4,15 +4,21 @@ import "html/template"
 
 var agentsTmpl = template.Must(template.New("agents").Funcs(tmplFuncs).Parse(layoutHead + `
 <style>
-.ag-grid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border);border:1px solid var(--border);border-radius:12px;overflow:hidden}
-.ag-card{background:var(--surface);padding:16px 20px;cursor:pointer;transition:background var(--ease-default);text-decoration:none;color:inherit;display:block}
-.ag-card:hover{background:var(--surface-hover)}
+/* Auto-fit grid: a single configured agent fills the row instead of
+   leaving an empty gray panel beside it (the desktop walkthrough's
+   DP-SMOKE-03). With 2+ agents the grid still pours into 2 columns
+   on a typical 1440px+ viewport because each card claims at least
+   minmax(320px, 1fr). The gap+background trick that drew separator
+   lines between cards is replaced with explicit per-card borders so
+   collapsed empty tracks cannot leave a stray seam. */
+.ag-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:12px}
+.ag-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:16px 20px;cursor:pointer;transition:background var(--ease-default),border-color var(--ease-default);text-decoration:none;color:inherit;display:block}
+.ag-card:hover{background:var(--surface-hover);border-color:var(--border-hover)}
 .ag-card-head{display:flex;align-items:center;gap:10px;margin-bottom:8px}
 .ag-card-name{font-weight:600;font-size:0.88rem}
 .ag-card-desc{color:var(--text3);font-size:0.78rem;margin-bottom:10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ag-card-stats{display:flex;gap:16px;font-size:0.75rem;color:var(--text3)}
 .ag-card-stats .num{font-family:var(--mono);font-weight:600;color:var(--text2)}
-@media(max-width:768px){.ag-grid{grid-template-columns:1fr}}
 </style>
 
 <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -28,6 +28,13 @@ a.ov-metric:hover{background:var(--surface2)}
 .pipeline-stages{display:flex;gap:var(--sp-3);margin-bottom:var(--sp-4);overflow-x:auto}
 .pipeline-stage{display:flex;align-items:center;gap:5px;font-size:0.72rem;color:var(--text2);white-space:nowrap}
 .pipeline-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+/* At narrower desktop widths the Pipeline Health summary
+   (rules / mode / chain / latency) was sharing the same row as
+   the 11 stage labels and pushed the last stage ("Guard") into
+   an overflow-x clip mid-word. DP-SMOKE-04 fix: under 1600px the
+   summary wraps to its own row beneath the stages so every label
+   stays readable. 1920px keeps the inline single-row layout. */
+@media(max-width:1599px){.pipeline-meta{flex-basis:100%;margin-left:0 !important;padding-top:var(--sp-3);border-top:1px solid var(--border-subtle);text-align:left;white-space:normal !important}}
 .pipeline-dot.active{background:var(--success)}
 .pipeline-dot.inactive{background:var(--text3);opacity:0.4}
 .pipeline-summary{font-size:var(--text-sm);color:var(--text3);padding-top:var(--sp-3);border-top:1px solid var(--border)}
@@ -141,7 +148,7 @@ a.ov-metric:hover{background:var(--surface2)}
       </div>
       {{end}}
     </div>
-    <div style="font-size:var(--text-sm);color:var(--text3);white-space:nowrap;margin-left:auto">
+    <div class="pipeline-meta" style="font-size:var(--text-sm);color:var(--text3);white-space:nowrap;margin-left:auto">
       {{.RuleCount}} rules &middot; {{if .RequireSig}}enforce{{else}}observe{{end}} mode &middot; chain {{if .ChainValid}}verified{{else}}broken{{end}} ({{formatNum .ChainCount}})
       {{if .AvgLatency}}&middot; <span style="color:var(--text2);font-weight:600">{{.AvgLatency}}ms</span> median{{end}}
     </div>


### PR DESCRIPTION
## Summary

Two visual polish items from the desktop walkthrough rerun on `ad09188`. Both read as broken layout in screenshots even though the runtime is fine.

## What changed

### DP-SMOKE-03 — Agents page blank half-row
The Agents grid used `grid-template-columns: 1fr 1fr`. With one configured agent the right column rendered as a large empty gray panel — looked like an unfinished placeholder.

- **`internal/dashboard/tmpl_agents.go`** — switched to `repeat(auto-fit, minmax(320px, 1fr))` so a single card fills the row and 2+ cards still pour into multiple columns at typical 1440/1920 widths. The 768px collapse media query is gone — auto-fit handles that case naturally.
- The previous gap+border-line trick (`gap:1px;background:var(--border)`) depended on filled grid tracks; an auto-fit collapsed track would leave a stray seam. Each card now carries its own border + radius, and the grid uses a clean 12px gap.

### DP-SMOKE-04 — Pipeline Health clipped at 1440px
The Pipeline Health row tried to fit heading + 11 stage labels + a long rules/mode/chain/latency summary on one flex row. At 1440 the row overflowed and the last stage label ("Guard") clipped mid-word inside the `overflow-x:auto` container.

- **`internal/dashboard/tmpl_overview.go`** — the summary div now carries a `.pipeline-meta` class. A `@media(max-width:1599px)` rule flips it to `flex-basis:100%` with a subtle top border so it wraps onto its own row beneath the stages on narrower desktops. 1920px+ keeps the inline single-row layout that already fit cleanly there.

## Tests

- **`internal/dashboard/agents_grid_test.go`** (new):
  - `TestAgentsGrid_UsesAutoFit` pins the auto-fit grid string AND forbids the legacy `1fr 1fr` form so a copy-paste revert fires.
  - `TestAgentsGrid_RendersEveryConfiguredAgent` guards the loop in case the auto-fit migration accidentally drops the range.
- **`internal/dashboard/pipeline_meta_test.go`** (new):
  - `TestPipelineMeta_HasResponsiveWrapHook` pins both the `.pipeline-meta` class on the summary div and the `@media(max-width:1599px)` rule in the rendered Overview `<style>`.
- **`internal/dashboard/avatar_test.go`** — replaced the prefix-iterating strip helper in `TestAgentAvatar_Deterministic` with a regex (`avIDPattern`). The previous version iterated `av1..av99` sequentially, but `av1` prefix-matches `av11` and left the trailing digit, so once the package-level avatar counter crossed 9 cumulatively across all dashboard tests the deterministic check would diff on the suffix. The new agents-grid tests pushed the counter just enough to expose the latent bug. Regex replacement is order-independent; the unused `itoa` helper was removed.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues.
- [x] `make vet` — clean.
- [x] 2 new tests pin both contracts; pre-existing flake in `TestAgentAvatar_Deterministic` fixed.
- [ ] Manual desktop rerun at 1440px / 1920px: confirm the Agents page no longer leaves a blank half-row with one agent and the Pipeline Health row no longer clips "Guard" at 1440.