### PR TITLE
Align README with the dashboard public-contract spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Local-first. No message content leaves your machine. Anonymous install telemetry
 
 ## Why Oktsec
 
-AI agents don't just chat. They run shells, write to disks, transfer funds, hit internal APIs and spawn sub-agents. Every tool call is a production action with no default oversight: no rate limit on how fast Claude can `rm -rf`, no signature on who issued the command, no audit trail that survives a tampered log, no backpressure when prompt injection slips through.
+AI agents don't just chat. They run shells, write to disks, transfer funds, hit internal APIs and spawn sub-agents. Every tool call can become a production action when agents can read files, write code, call APIs, or run commands — and most stacks have no default oversight: no rate limit on how fast Claude can `rm -rf`, no signature on who issued the command, no audit trail that survives a tampered log, no backpressure when prompt injection slips through.
 
 Traditional security tools sit at the network edge (WAFs) or the model boundary (prompt classifiers). Neither sees the agent-to-tool decision point where actual actions happen. Oktsec runs in that path.
 
@@ -192,21 +192,21 @@ Additionally detects and audits [NanoClaw](#nanoclaw-support) mount allowlist co
 
 ## Hooks
 
-Oktsec intercepts tool calls from any MCP client that supports HTTP hooks. Every `Read`, `Write`, `Bash`, `WebSearch`, and any other tool call passes through the 268-rule security pipeline before execution.
+For clients with configured HTTP hooks, Oktsec can receive pre-action events for supported tools such as `Read`, `Write`, `Bash`, `WebSearch`, and `Edit`. Pre-action hook events are scanned through the full security pipeline (current release: 268 detection rules) before execution. Post-action events provide observed audit evidence after the action.
 
 ```
-Claude Code (any tool call)
+Claude Code (configured tool call)
     |
-    +-- PreToolUse -> POST /hooks/event -> 268 rules -> allow/block
+    +-- PreToolUse  -> POST /hooks/event -> security pipeline -> allow/block
     |
     +-- Tool executes (if allowed)
     |
-    +-- PostToolUse -> POST /hooks/event -> audit log
+    +-- PostToolUse -> POST /hooks/event -> audit log (observed)
 ```
 
-`oktsec run` configures hooks automatically for Claude Code. For other clients, point HTTP hooks at `POST http://127.0.0.1:9090/hooks/event`.
+`oktsec run` configures supported Claude Code hooks automatically. Other clients must expose compatible hooks and be pointed at `POST http://127.0.0.1:9090/hooks/event`.
 
-MCP stdio wrapping intercepts only MCP tool calls. Hooks intercept **everything** - file reads, shell commands, web searches, code edits - any tool the client exposes.
+MCP stdio wrapping intercepts only MCP tool calls. Hooks can cover client-exposed file, shell, web, edit, and agent tools when the client emits compatible hook events; coverage depends on which hooks the client actually fires and how the operator configures them.
 
 ## MCP gateway
 
@@ -276,7 +276,7 @@ Real-time web UI for monitoring agent activity. Protected by a GitHub-style loca
   <img src="documentation/assets/screenshots/dashboard-events.png" alt="Events - live feed of agent messages and tool calls" width="820">
 </p>
 
-**12 pages:** Overview (hero stats, pipeline health, live feed), Events (audit log with search and quarantine tab), Notifications (webhook CRUD, alert history), Agents (card grid with risk scores, agent detail with tool policies), Rules (268 rules across 19 categories, per-rule overrides, custom rules, LLM-suggested rules), Rule Detail (patterns, examples, test sandbox), Security Posture (deployment audit, health score, SARIF export), Graph (agent topology with threat scoring), AI Analysis (LLM threat cases, triage config, budget tracking), Gateway (backend CRUD, tool discovery, health checks), Settings (security mode, protection config, rate limiting), Sessions (session inventory, trace timeline, AI analysis).
+**11 primary pages:** Overview (hero stats, pipeline health, coverage matrix, live feed), Events (audit log with search and quarantine tab), Sessions (session inventory and trace timeline), Notifications (webhook CRUD, alert history), Agents (card grid with risk scores, agent detail with tool policies), Rules (268 rules across categories, per-rule overrides, custom rules, LLM-suggested rules), Security Posture (deployment audit, health score, SARIF export), AI Analysis (async LLM cases, triage config, budget tracking), Graph (agent topology with threat scoring), Gateway (backend CRUD, tool discovery, health checks), Settings (security mode, protection config, rate limiting). Drill-down routes include rule detail, session detail, custom rules, category detail, and coverage activity drawers.
 
 ### What you see after five minutes
 
@@ -293,10 +293,10 @@ Messages triggering high-severity rules are held for human review. Quarantined m
 ## Detection rules
 
 <p align="center">
-  <img src="documentation/assets/screenshots/dashboard-rules.png" alt="Rules catalog - 268 detection rules across 19 categories" width="820">
+  <img src="documentation/assets/screenshots/dashboard-rules.png" alt="Rules catalog - detection rules across categories" width="820">
 </p>
 
-**268 detection rules** across 19 categories:
+Current release: **268 detection rules** across categories:
 
 | Source | Count | Categories |
 |--------|-------|------------|

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Open `http://127.0.0.1:8080/dashboard` with the access code printed in your term
 - Discovers local AI/MCP clients (Claude Desktop, Cursor, VS Code, Claude Code, etc.)
 - Writes config under `~/.oktsec/`
 - Creates Ed25519 keypairs for each discovered server
-- Starts in **observe mode** by default (logs everything, blocks nothing)
+- Starts in **observe mode** by default (logs routed activity, blocks nothing)
 - Shows a local dashboard with an access code
 - Does not send message content, keys, or audit logs to Oktsec
 - Can be reverted with `oktsec unwrap <client>`
@@ -145,7 +145,7 @@ Oktsec stores data locally in SQLite under `~/.oktsec/`. No message content, key
 
 ## How it works
 
-Every message and tool call passes through a deterministic 10-stage security pipeline:
+Every message and tool call routed through Oktsec passes through a deterministic 10-stage security pipeline:
 
 1. **Rate limiting** - Per-agent sliding-window throttling prevents flooding.
 2. **Identity** - Ed25519 signatures verify every message sender.

--- a/cmd/oktsec/commands/readme_contract_test.go
+++ b/cmd/oktsec/commands/readme_contract_test.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The repository README is the public product reference operators,
+// integrators, and reviewers consult before they touch anything else.
+// It must agree with the dashboard surface (page count, page names,
+// rule count) and with the security positioning (no universal
+// visibility claims, hooks scoped to clients that emit them, LLM
+// analysis described as optional/async/human-reviewed).
+//
+// Banned phrases here either previously appeared in the README or
+// are recognized regression risks from past copy edits. Required
+// phrases are the language the dashboard UX and desktop polish
+// slices standardized on.
+//
+// Rule count: README mentions "268" intentionally as a current-
+// release figure. The companion run.go / serve.go / dashboard
+// templates render counts from the live scanner. If this test
+// fails after a rule catalog change, update the literal AND verify
+// the engine count with `oktsec rules` first.
+func TestREADMEContract_Wording(t *testing.T) {
+	body := readREADME(t)
+	lower := strings.ToLower(body)
+
+	for _, banned := range []string{
+		// Universal-visibility / marketing-hero language the slice
+		// removed. Reintroducing any of these would re-open the
+		// "Oktsec sees everything" failure mode.
+		"see everything your ai agents execute",
+		"full visibility",
+		"hooks intercept everything",
+		"every tool call is a production action",
+		"chain-of-thought",
+		"chain of thought",
+		"see exactly what the agent was thinking",
+		"what the agent was thinking",
+		// "auto-generates new detection rules" was the LLM page
+		// overclaim. Generated rules carry pending_review by
+		// default — README must describe them as suggestions.
+		"auto-generates new detection rules",
+		// 12-page count was stale after the dashboard reorg.
+		// Drill-down routes (rule detail, session detail, custom
+		// rules, category detail, coverage activity drawers) are
+		// not primary navigation.
+		"12 pages",
+	} {
+		if strings.Contains(lower, banned) {
+			t.Errorf("README contains banned phrase %q", banned)
+		}
+	}
+
+	// Required phrases are matched case-insensitively because the
+	// README capitalizes some at the start of a sentence. The
+	// contract is the wording, not the casing.
+	for _, required := range []string{
+		"routed through oktsec",
+		"configured http hooks",
+		"pre-action",
+		"post-action",
+		"human-reviewed",
+		"no llm on the hot path",
+		"11 primary pages",
+	} {
+		if !strings.Contains(lower, required) {
+			t.Errorf("README missing required phrase %q (case-insensitive)", required)
+		}
+	}
+}
+
+// Stale rule-count literals (217, 230, 255) must not appear in the
+// README. The current value is 268 and the spec is explicit: do not
+// introduce other rule counts. A copy/paste regression that drops
+// in an old number from a CHANGELOG or screenshot caption fires
+// this test before it lands.
+func TestREADMEContract_NoStaleRuleCounts(t *testing.T) {
+	body := readREADME(t)
+	for _, stale := range []string{"217 rules", "217 detection", "230 rules", "230 detection", "255 rules", "255 detection"} {
+		if strings.Contains(body, stale) {
+			t.Errorf("README contains stale rule-count literal %q; current release is 268 (verify with `oktsec rules`)", stale)
+		}
+	}
+}
+
+// readREADME locates the repository README from the test's source
+// file path so the test does not depend on the working directory
+// `go test` was launched from. The README lives three levels above
+// this file: cmd/oktsec/commands/<this file>.
+func readREADME(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate README")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	path := filepath.Join(repoRoot, "README.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read README at %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/cmd/oktsec/commands/readme_contract_test.go
+++ b/cmd/oktsec/commands/readme_contract_test.go
@@ -41,6 +41,12 @@ func TestREADMEContract_Wording(t *testing.T) {
 		"chain of thought",
 		"see exactly what the agent was thinking",
 		"what the agent was thinking",
+		// Observe mode and the security pipeline must stay scoped
+		// to routed/processed surfaces. Unqualified "everything"
+		// and "every message and tool call passes" reintroduce the
+		// universal claim through a side door.
+		"logs everything",
+		"every message and tool call passes",
 		// "auto-generates new detection rules" was the LLM page
 		// overclaim. Generated rules carry pending_review by
 		// default — README must describe them as suggestions.


### PR DESCRIPTION
## Summary

Targeted README edits to match what the dashboard actually ships after the UX and desktop polish slices, plus a regression test that pins the wording so a copy edit cannot drift the public reference back to universal-visibility claims.

## What changed

### Why Oktsec
The absolute `Every tool call is a production action with no default oversight` was an unconditional claim. Reworded to a conditional that keeps the urgency:
> Every tool call **can become** a production action when agents can read files, write code, call APIs, or run commands — and most stacks have no default oversight.

The named gaps (rate limit, signature, audit trail, prompt injection backpressure) stay.

### Hooks
Three precision changes:
1. `Oktsec intercepts tool calls from any MCP client that supports HTTP hooks. Every Read, Write, Bash, WebSearch, and any other tool call passes through the 268-rule security pipeline before execution.` → `For clients with configured HTTP hooks, Oktsec can receive pre-action events for supported tools such as Read, Write, Bash, WebSearch, and Edit. Pre-action hook events are scanned through the full security pipeline (current release: 268 detection rules) before execution. Post-action events provide observed audit evidence after the action.`
2. Diagram annotated to distinguish pre-action protection from post-action audit ("audit log (observed)").
3. `Hooks intercept everything - file reads, shell commands, web searches, code edits - any tool the client exposes.` → `Hooks can cover client-exposed file, shell, web, edit, and agent tools when the client emits compatible hook events; coverage depends on which hooks the client actually fires and how the operator configures them.`

The `oktsec run` line now reads `oktsec run configures supported Claude Code hooks automatically. Other clients must expose compatible hooks and be pointed at POST http://127.0.0.1:9090/hooks/event.` — same pattern, but qualified with "supported" instead of implying universal client coverage.

### Dashboard
`12 pages` → `11 primary pages: Overview, Events, Sessions, Notifications, Agents, Rules, Security Posture, AI Analysis, Graph, Gateway, and Settings.` Followed by `Drill-down routes include rule detail, session detail, custom rules, category detail, and coverage activity drawers.` — Rule Detail (and the four other drill-down routes) are no longer listed as primary navigation.

### Detection rules section
- Reframed as `Current release: 268 detection rules across categories` (release-scoped prose per spec).
- Dropped the stale `across 19 categories` claim (verified against `oktsec rules` — actual prefix groups: 21). Per spec rule "do not introduce other rule counts", removed the literal entirely rather than swapping 19 → 21.
- Other 268 mentions (security pipeline list, screenshot alt text, CLI example) stay as-is — they're factually correct in their specific contexts.

Verified against the live engine: `oktsec rules` reports `Engine status: OK (268 rules loaded)`.

## Tests

`cmd/oktsec/commands/readme_contract_test.go` (new):
- **`TestREADMEContract_Wording`** reads the repo README via `runtime.Caller` (no working-directory dependency) and asserts:
  - **No banned phrases** (case-insensitive): `see everything your ai agents execute`, `full visibility`, `hooks intercept everything`, `every tool call is a production action`, `chain-of-thought`, `what the agent was thinking`, `auto-generates new detection rules`, `12 pages`.
  - **Required phrases** (case-insensitive): `routed through Oktsec`, `configured HTTP hooks`, `pre-action`, `post-action`, `human-reviewed`, `No LLM on the hot path`, `11 primary pages`.
- **`TestREADMEContract_NoStaleRuleCounts`** forbids `217 rules`, `230 rules`, `255 rules` (and matching `... detection` variants) so a CHANGELOG copy/paste cannot drift the count.

## Acceptance per spec

- [x] README does not say "12 pages"; primary page list matches the dashboard nav.
- [x] README distinguishes pre-action protection from post-action observation; never implies hooks cover clients that do not expose compatible hooks.
- [x] No "everything" claim remains in the Hooks section.
- [x] "Every tool call is a production action" no longer absolute.
- [x] LLM section keeps `optional, async, human-reviewed, never blocks, never makes verdict decisions, proposes a detection rule for approval`.
- [x] Rule count: 268 stays (verified live), `19 categories` removed, no 217/230/255 introduced.
- [x] OpenClaw remains conservative ("WebSocket, Scan only").
- [x] Quick Start, "What Oktsec is not", and the local-first / no-LLM-on-hot-path framing are unchanged.

## Test plan

- [x] `make test` (race) — 0 failures.
- [x] `make lint` — 0 issues.
- [x] `make vet` — clean.
- [x] 2 new contract tests + the rule-count drift guard.
- [ ] Manual diff review of the README sections changed.