### PR TITLE
Evidence freeze: keep-forever default + archive-before-delete

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -219,9 +219,13 @@ func autoSetup(configPath string, opts runOpts) error {
 		},
 		"mcp_servers": mcpServers,
 		"quarantine": map[string]any{
-			"enabled":        true,
-			"expiry_hours":   24,
-			"retention_days": 90,
+			"enabled":      true,
+			"expiry_hours": 24,
+			// retention_days: 0 keeps audit evidence forever. Set a positive
+			// value AND quarantine.archive_dir to enable archive-before-delete
+			// auto-purge; without an archive directory, oktsec refuses to
+			// purge so installs can be debugged after the fact.
+			"retention_days": 0,
 		},
 		"rate_limit": map[string]any{
 			"per_agent": 100,
@@ -423,9 +427,12 @@ func writeMinimalConfig(configPath string) error {
 		"agents": map[string]any{},
 		"rules":  []map[string]any{},
 		"quarantine": map[string]any{
-			"enabled":        true,
-			"expiry_hours":   24,
-			"retention_days": 90,
+			"enabled":      true,
+			"expiry_hours": 24,
+			// retention_days: 0 keeps audit evidence forever. Set a positive
+			// value AND quarantine.archive_dir to enable archive-before-delete
+			// auto-purge.
+			"retention_days": 0,
 		},
 		"rate_limit": map[string]any{
 			"per_agent": 100,

--- a/internal/audit/archive.go
+++ b/internal/audit/archive.go
@@ -1,0 +1,242 @@
+package audit
+
+import (
+	"compress/gzip"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ArchivedEntry is the on-disk shape of one archived audit_log row.
+// The JSON schema is intentionally stable so external tooling can read
+// archives without depending on the internal evolution of audit.Entry.
+type ArchivedEntry struct {
+	ID                string `json:"id"`
+	Timestamp         string `json:"timestamp"`
+	FromAgent         string `json:"from_agent"`
+	ToAgent           string `json:"to_agent"`
+	ToolName          string `json:"tool_name,omitempty"`
+	ContentHash       string `json:"content_hash"`
+	SignatureVerified int    `json:"signature_verified"`
+	PubkeyFingerprint string `json:"pubkey_fingerprint,omitempty"`
+	Status            string `json:"status"`
+	RulesTriggered    string `json:"rules_triggered,omitempty"`
+	PolicyDecision    string `json:"policy_decision"`
+	LatencyMs         int64  `json:"latency_ms"`
+	Intent            string `json:"intent,omitempty"`
+	SessionID         string `json:"session_id,omitempty"`
+	PrevHash          string `json:"prev_hash,omitempty"`
+	EntryHash         string `json:"entry_hash,omitempty"`
+	ProxySignature    string `json:"proxy_signature,omitempty"`
+}
+
+// archiveSelectSQL is the column-stable SELECT used by every archive
+// writer in this package. Callers append a WHERE clause and ORDER BY.
+const archiveSelectSQL = `SELECT id, timestamp, from_agent, to_agent, COALESCE(tool_name,''),
+content_hash, signature_verified, pubkey_fingerprint, status,
+COALESCE(rules_triggered,''), policy_decision, latency_ms,
+COALESCE(intent,''), COALESCE(session_id,''),
+COALESCE(prev_hash,''), COALESCE(entry_hash,''), COALESCE(proxy_signature,'')
+FROM audit_log`
+
+// writeArchive streams rows that satisfy whereSQL+args to a fresh
+// gzipped JSONL file at outPath, returning the row count written. Uses
+// O_EXCL so an existing file is never overwritten; the caller picks a
+// timestamped name.
+func writeArchive(db *sql.DB, outPath, whereSQL string, args ...any) (count int, err error) {
+	q := archiveSelectSQL
+	if whereSQL != "" {
+		q += " WHERE " + whereSQL
+	}
+	q += " ORDER BY rowid ASC"
+
+	rows, qErr := db.Query(q, args...)
+	if qErr != nil {
+		return 0, fmt.Errorf("query rows for archive: %w", qErr)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o700); err != nil {
+		return 0, fmt.Errorf("creating archive dir: %w", err)
+	}
+	f, fErr := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if fErr != nil {
+		return 0, fmt.Errorf("creating archive file: %w", fErr)
+	}
+	gz := gzip.NewWriter(f)
+	enc := json.NewEncoder(gz)
+
+	for rows.Next() {
+		var rec ArchivedEntry
+		if scanErr := rows.Scan(&rec.ID, &rec.Timestamp, &rec.FromAgent, &rec.ToAgent, &rec.ToolName,
+			&rec.ContentHash, &rec.SignatureVerified, &rec.PubkeyFingerprint, &rec.Status,
+			&rec.RulesTriggered, &rec.PolicyDecision, &rec.LatencyMs,
+			&rec.Intent, &rec.SessionID,
+			&rec.PrevHash, &rec.EntryHash, &rec.ProxySignature); scanErr != nil {
+			_ = gz.Close()
+			_ = f.Close()
+			_ = os.Remove(outPath)
+			return 0, fmt.Errorf("scanning row for archive: %w", scanErr)
+		}
+		if encErr := enc.Encode(&rec); encErr != nil {
+			_ = gz.Close()
+			_ = f.Close()
+			_ = os.Remove(outPath)
+			return 0, fmt.Errorf("encoding row to archive: %w", encErr)
+		}
+		count++
+	}
+	if rErr := rows.Err(); rErr != nil {
+		_ = gz.Close()
+		_ = f.Close()
+		_ = os.Remove(outPath)
+		return 0, fmt.Errorf("iterating rows for archive: %w", rErr)
+	}
+	if gzErr := gz.Close(); gzErr != nil {
+		_ = f.Close()
+		_ = os.Remove(outPath)
+		return 0, fmt.Errorf("flushing gzip: %w", gzErr)
+	}
+	if cErr := f.Close(); cErr != nil {
+		_ = os.Remove(outPath)
+		return 0, fmt.Errorf("closing archive: %w", cErr)
+	}
+	return count, nil
+}
+
+// SetArchiveDir records the directory the store will write archives to
+// before any auto-purge. When empty, the auto-purge loop refuses to
+// delete even if RetentionDays is positive — the evidence-freeze
+// contract is "never delete without an archive".
+func (s *Store) SetArchiveDir(dir string) {
+	s.archiveDir = dir
+}
+
+// ArchiveDir returns the configured archive directory, or "" when none.
+func (s *Store) ArchiveDir() string {
+	return s.archiveDir
+}
+
+// ArchiveAndPurgeOldEntries archives audit_log rows older than
+// retentionDays to a gzipped JSONL file inside archiveDir, then deletes
+// them. Refuses to run when retentionDays <= 0 or archiveDir is empty,
+// so callers can never short-circuit the archive step. Returns the
+// rows archived and the absolute archive path (empty when nothing was
+// eligible for deletion).
+func (s *Store) ArchiveAndPurgeOldEntries(retentionDays int, archiveDir string) (int, string, error) {
+	if retentionDays <= 0 {
+		return 0, "", nil
+	}
+	if archiveDir == "" {
+		return 0, "", fmt.Errorf("archive_dir is required to purge audit entries; refusing to delete without an archive")
+	}
+	cutoff := time.Now().AddDate(0, 0, -retentionDays).UTC().Format(time.RFC3339)
+	return s.archiveAndDelete(archiveDir, "audit-purge", "timestamp < ?", []any{cutoff})
+}
+
+// ArchiveAndClearAll archives every audit_log row to archiveDir, then
+// deletes them. This is the only safe path to clear the audit log from
+// product surfaces; ClearAll() must not be invoked from dashboard or
+// API handlers.
+func (s *Store) ArchiveAndClearAll(archiveDir string) (int, string, error) {
+	if archiveDir == "" {
+		return 0, "", fmt.Errorf("archive_dir is required to clear audit log; refusing to delete without an archive")
+	}
+	return s.archiveAndDelete(archiveDir, "audit-clear", "", nil)
+}
+
+// archiveAndDelete is the single chokepoint for archive-then-delete. It
+// writes the gzipped JSONL archive first; only when the archive is
+// closed cleanly does it issue the DELETE. If DELETE fails, the archive
+// is preserved as evidence the attempt happened.
+func (s *Store) archiveAndDelete(archiveDir, kind, whereSQL string, args []any) (int, string, error) {
+	if s.readOnly {
+		return 0, "", fmt.Errorf("audit store is read-only")
+	}
+	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
+		return 0, "", fmt.Errorf("creating archive dir: %w", err)
+	}
+	timestamp := time.Now().UTC().Format("20060102T150405Z")
+	out := filepath.Join(archiveDir, fmt.Sprintf("%s-%s.jsonl.gz", kind, timestamp))
+
+	count, err := writeArchive(s.db, out, whereSQL, args...)
+	if err != nil {
+		return 0, "", err
+	}
+	if count == 0 {
+		// Empty archive is meaningless; remove the file to avoid clutter.
+		_ = os.Remove(out)
+		return 0, "", nil
+	}
+
+	deleteSQL := "DELETE FROM audit_log"
+	if whereSQL != "" {
+		deleteSQL += " WHERE " + whereSQL
+	}
+	res, err := s.db.Exec(deleteSQL, args...)
+	if err != nil {
+		return count, out, fmt.Errorf("delete after archive: %w", err)
+	}
+	deleted, _ := res.RowsAffected()
+	if int(deleted) != count {
+		// Rows added between archive write and delete is a benign race;
+		// surface the mismatch so it shows up in logs but do not fail.
+		s.logger.Warn("archive/delete row count mismatch",
+			"archived", count, "deleted", deleted, "archive", out)
+	}
+	return count, out, nil
+}
+
+// EvidenceStatus snapshots the audit store's state for visibility
+// surfaces (dashboard, doctor command). It does not include the DB
+// path because Store does not own that string; the caller wraps the
+// snapshot with whatever path it loaded the store from.
+type EvidenceStatus struct {
+	TotalRows        int    `json:"total_rows"`
+	OldestTimestamp  string `json:"oldest_timestamp,omitempty"`
+	NewestTimestamp  string `json:"newest_timestamp,omitempty"`
+	RetentionDays    int    `json:"retention_days"`
+	RetentionPolicy  string `json:"retention_policy"`
+	ArchiveDirectory string `json:"archive_directory,omitempty"`
+}
+
+// EvidenceStatus returns a snapshot of the audit log size and retention
+// policy. Reading the policy string is enough to know whether a future
+// auto-purge could delete evidence:
+//
+//	keep_forever                                  -- safe; no purge
+//	configured_without_archive_will_not_purge     -- retention set but no archive_dir; refuses to delete
+//	purge_after_<N>_days_with_archive             -- archive-then-delete enabled
+func (s *Store) EvidenceStatus() (EvidenceStatus, error) {
+	st := EvidenceStatus{
+		RetentionDays:    s.retentionDays,
+		ArchiveDirectory: s.archiveDir,
+	}
+	switch {
+	case s.retentionDays <= 0:
+		st.RetentionPolicy = "keep_forever"
+	case s.archiveDir == "":
+		st.RetentionPolicy = "configured_without_archive_will_not_purge"
+	default:
+		st.RetentionPolicy = fmt.Sprintf("purge_after_%d_days_with_archive", s.retentionDays)
+	}
+
+	var total int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM audit_log`).Scan(&total); err != nil {
+		return st, fmt.Errorf("counting audit_log rows: %w", err)
+	}
+	st.TotalRows = total
+	if total == 0 {
+		return st, nil
+	}
+	var oldest, newest sql.NullString
+	if err := s.db.QueryRow(`SELECT MIN(timestamp), MAX(timestamp) FROM audit_log`).Scan(&oldest, &newest); err != nil {
+		return st, fmt.Errorf("range timestamps: %w", err)
+	}
+	st.OldestTimestamp = oldest.String
+	st.NewestTimestamp = newest.String
+	return st, nil
+}

--- a/internal/audit/archive_test.go
+++ b/internal/audit/archive_test.go
@@ -1,0 +1,245 @@
+package audit
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStoreWithRetention(t *testing.T, retentionDays int) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store, err := NewStore(dbPath, logger, retentionDays)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// seedRows inserts a fixed set of audit_log rows whose timestamps span
+// from N days ago up to now. Returns the cutoff index used so callers
+// can assert how many rows fall on either side.
+func seedRows(t *testing.T, s *Store, daysAgoSpread []int) {
+	t.Helper()
+	now := time.Now().UTC()
+	for i, days := range daysAgoSpread {
+		ts := now.AddDate(0, 0, -days).Format(time.RFC3339)
+		s.Log(Entry{
+			ID:             "e" + string(rune('a'+i)),
+			Timestamp:      ts,
+			FromAgent:      "a",
+			ToAgent:        "b",
+			ContentHash:    "h",
+			Status:         "delivered",
+			PolicyDecision: "allow",
+		})
+	}
+	s.Flush()
+}
+
+func countRows(t *testing.T, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM audit_log").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// TestArchiveAndPurge_RefusesWithoutArchiveDir locks in the contract
+// that the auto-purge path can never delete without writing an archive
+// first. A configured retention with empty archive_dir must error and
+// leave every row in place.
+func TestArchiveAndPurge_RefusesWithoutArchiveDir(t *testing.T) {
+	s := newTestStoreWithRetention(t, 7)
+	seedRows(t, s, []int{30, 20, 10, 1})
+
+	count, archive, err := s.ArchiveAndPurgeOldEntries(7, "")
+	if err == nil {
+		t.Fatal("expected error when archive_dir is empty")
+	}
+	if count != 0 || archive != "" {
+		t.Errorf("expected (0, \"\"), got (%d, %q)", count, archive)
+	}
+	if got := countRows(t, s); got != 4 {
+		t.Errorf("rows after refused purge = %d, want 4 (no rows should be deleted)", got)
+	}
+}
+
+// TestArchiveAndPurge_WritesArchiveBeforeDeleting verifies that rows
+// older than the cutoff land in a .jsonl.gz file before the DELETE
+// runs, and that the archive contains exactly the deleted rows.
+func TestArchiveAndPurge_WritesArchiveBeforeDeleting(t *testing.T) {
+	s := newTestStoreWithRetention(t, 7)
+	seedRows(t, s, []int{30, 20, 10, 1})
+
+	dir := t.TempDir()
+	count, archive, err := s.ArchiveAndPurgeOldEntries(7, dir)
+	if err != nil {
+		t.Fatalf("archive-and-purge: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("archived count = %d, want 3", count)
+	}
+	if archive == "" {
+		t.Fatal("archive path should be set when count > 0")
+	}
+	// Live DB should retain only the row from 1 day ago.
+	if got := countRows(t, s); got != 1 {
+		t.Errorf("rows after purge = %d, want 1", got)
+	}
+
+	// Archive file must exist and round-trip the deleted rows.
+	f, err := os.Open(archive)
+	if err != nil {
+		t.Fatalf("opening archive: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer func() { _ = gz.Close() }()
+	dec := json.NewDecoder(gz)
+	var archived []ArchivedEntry
+	for {
+		var rec ArchivedEntry
+		if err := dec.Decode(&rec); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("decoding archive line: %v", err)
+		}
+		archived = append(archived, rec)
+	}
+	if len(archived) != 3 {
+		t.Errorf("archive contained %d rows, want 3", len(archived))
+	}
+}
+
+// TestArchiveAndPurge_NoEligibleRows leaves the live DB untouched and
+// does not write a stub archive file, so an operator's archive
+// directory does not fill with empty gz files on every tick.
+func TestArchiveAndPurge_NoEligibleRows(t *testing.T) {
+	s := newTestStoreWithRetention(t, 30)
+	seedRows(t, s, []int{1, 2, 3})
+
+	dir := t.TempDir()
+	count, archive, err := s.ArchiveAndPurgeOldEntries(30, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 || archive != "" {
+		t.Errorf("expected (0, \"\"), got (%d, %q)", count, archive)
+	}
+	if got := countRows(t, s); got != 3 {
+		t.Errorf("rows = %d, want 3 untouched", got)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no archive files written, got %d", len(entries))
+	}
+}
+
+// TestArchiveAndClearAll_RefusesWithoutArchiveDir locks in the contract
+// that no product surface can wipe the audit log without an archive
+// directory. The earlier behavior (handleAuditClear -> ClearAll with no
+// archive) destroyed evidence on first click.
+func TestArchiveAndClearAll_RefusesWithoutArchiveDir(t *testing.T) {
+	s := newTestStoreWithRetention(t, 0)
+	seedRows(t, s, []int{1, 2, 3})
+
+	count, archive, err := s.ArchiveAndClearAll("")
+	if err == nil {
+		t.Fatal("expected error when archive_dir is empty")
+	}
+	if count != 0 || archive != "" {
+		t.Errorf("expected (0, \"\"), got (%d, %q)", count, archive)
+	}
+	if got := countRows(t, s); got != 3 {
+		t.Errorf("rows after refused clear = %d, want 3", got)
+	}
+}
+
+// TestArchiveAndClearAll_WritesArchiveThenDeletes verifies the safe
+// dashboard path: every row lands in a .jsonl.gz before the DELETE.
+func TestArchiveAndClearAll_WritesArchiveThenDeletes(t *testing.T) {
+	s := newTestStoreWithRetention(t, 0)
+	seedRows(t, s, []int{1, 2, 3})
+
+	dir := t.TempDir()
+	count, archive, err := s.ArchiveAndClearAll(dir)
+	if err != nil {
+		t.Fatalf("archive-and-clear: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("archived = %d, want 3", count)
+	}
+	if archive == "" {
+		t.Fatal("archive path should be set")
+	}
+	if got := countRows(t, s); got != 0 {
+		t.Errorf("rows after clear = %d, want 0", got)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Errorf("archive file missing: %v", err)
+	}
+}
+
+// TestEvidenceStatus_KeepForeverPolicy spells out the user-visible
+// retention policy string for the default install.
+func TestEvidenceStatus_KeepForeverPolicy(t *testing.T) {
+	s := newTestStoreWithRetention(t, 0)
+	seedRows(t, s, []int{0, 0, 0})
+
+	st, err := s.EvidenceStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.RetentionPolicy != "keep_forever" {
+		t.Errorf("policy = %q, want keep_forever", st.RetentionPolicy)
+	}
+	if st.TotalRows != 3 {
+		t.Errorf("rows = %d, want 3", st.TotalRows)
+	}
+}
+
+// TestEvidenceStatus_ConfiguredWithoutArchive surfaces the trap state:
+// an operator set retention but did not configure an archive dir, so
+// the auto-purge will refuse. The dashboard reads this string verbatim
+// to warn the user.
+func TestEvidenceStatus_ConfiguredWithoutArchive(t *testing.T) {
+	s := newTestStoreWithRetention(t, 7)
+	st, err := s.EvidenceStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.RetentionPolicy != "configured_without_archive_will_not_purge" {
+		t.Errorf("policy = %q, want configured_without_archive_will_not_purge", st.RetentionPolicy)
+	}
+}
+
+// TestEvidenceStatus_ArchiveAwarePurgePolicy reports the safe
+// archive-then-delete state, with the configured retention in days.
+func TestEvidenceStatus_ArchiveAwarePurgePolicy(t *testing.T) {
+	s := newTestStoreWithRetention(t, 14)
+	s.SetArchiveDir(t.TempDir())
+	st, err := s.EvidenceStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.RetentionPolicy != "purge_after_14_days_with_archive" {
+		t.Errorf("policy = %q, want purge_after_14_days_with_archive", st.RetentionPolicy)
+	}
+}

--- a/internal/audit/iface.go
+++ b/internal/audit/iface.go
@@ -123,9 +123,20 @@ type ChainVerifier interface {
 }
 
 // AuditAdmin handles maintenance operations.
+//
+// PurgeOldEntries and ClearAll are deprecated low-level primitives kept
+// for tests and tooling that opt out of archiving. Product surfaces
+// must call ArchiveAndPurgeOldEntries / ArchiveAndClearAll so deleted
+// rows are preserved on disk first. EvidenceStatus exposes retention
+// policy and row counts so the dashboard can prove evidence is intact.
 type AuditAdmin interface {
 	PurgeOldEntries(retentionDays int) (int, error)
 	ClearAll() error
+	ArchiveAndPurgeOldEntries(retentionDays int, archiveDir string) (int, string, error)
+	ArchiveAndClearAll(archiveDir string) (int, string, error)
+	SetArchiveDir(dir string)
+	ArchiveDir() string
+	EvidenceStatus() (EvidenceStatus, error)
 }
 
 // EventHub provides real-time audit event pub/sub.

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -164,6 +164,8 @@ type Store struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	retentionDays int
+	archiveDir    string             // directory where archive-before-delete writes; empty disables auto-purge
+	purgeWarnedNoArchive bool        // single-shot warning latch when retention>0 but archiveDir==""
 	proxyKey      ed25519.PrivateKey // proxy signing key for audit chain (nil = no signing)
 	lastHash      string             // last entry hash for chain continuity
 	lastHashMu    sync.Mutex
@@ -1826,6 +1828,12 @@ func (s *Store) QueryAvgLatency() (int, error) {
 
 // PurgeOldEntries deletes audit log entries older than the given number of days.
 // Returns the number of deleted rows.
+//
+// Deprecated: this is a low-level primitive that bypasses the
+// archive-before-delete contract. Production surfaces (the auto-purge
+// loop, the dashboard, the CLI) must use ArchiveAndPurgeOldEntries
+// instead. PurgeOldEntries is retained for tests and tooling that
+// genuinely want to skip archiving (e.g. throwaway in-memory stores).
 func (s *Store) PurgeOldEntries(retentionDays int) (int, error) {
 	if retentionDays <= 0 {
 		return 0, nil
@@ -1839,7 +1847,14 @@ func (s *Store) PurgeOldEntries(retentionDays int) (int, error) {
 	return int(n), nil
 }
 
-// ClearAll deletes all audit log entries. Used for demo/dev resets.
+// ClearAll deletes all audit log entries.
+//
+// Deprecated: this is a low-level primitive that destroys evidence
+// without writing an archive. Product surfaces (dashboard handlers,
+// HTTP/MCP API) must call ArchiveAndClearAll instead so the deleted
+// rows are preserved on disk first. ClearAll is kept for tests and
+// genuinely throwaway flows; it must never be wired to a UI button or
+// public API.
 func (s *Store) ClearAll() error {
 	_, err := s.db.Exec(`DELETE FROM audit_log`)
 	return err
@@ -1960,10 +1975,20 @@ func (s *Store) expiryLoop() {
 				s.logger.Info("quarantine items expired", "count", n)
 			}
 			if s.retentionDays > 0 {
-				if n, err := s.PurgeOldEntries(s.retentionDays); err != nil {
-					s.logger.Error("audit log purge failed", "error", err)
+				if s.archiveDir == "" {
+					if !s.purgeWarnedNoArchive {
+						s.logger.Warn("audit log auto-purge disabled: retention configured but quarantine.archive_dir is empty; refusing to delete without an archive",
+							"retention_days", s.retentionDays)
+						s.purgeWarnedNoArchive = true
+					}
+					continue
+				}
+				n, archive, err := s.ArchiveAndPurgeOldEntries(s.retentionDays, s.archiveDir)
+				if err != nil {
+					s.logger.Error("audit log archive-and-purge failed", "error", err)
 				} else if n > 0 {
-					s.logger.Info("audit log entries purged", "count", n)
+					s.logger.Info("audit log entries archived and purged",
+						"count", n, "archive", archive)
 				}
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,10 +329,17 @@ type EgressPolicy struct {
 }
 
 // QuarantineConfig configures the quarantine queue behavior.
+//
+// RetentionDays controls auto-purge of audit_log rows. The default is 0
+// (keep forever). When set to a positive value, the audit store will not
+// purge unless an archive directory is configured via ArchiveDir; this is
+// the evidence-freeze contract: never delete evidence without writing an
+// archive first.
 type QuarantineConfig struct {
-	Enabled       bool `yaml:"enabled"`
-	ExpiryHours   int  `yaml:"expiry_hours"`
-	RetentionDays int  `yaml:"retention_days"` // auto-purge audit entries older than N days (0 = keep forever)
+	Enabled       bool   `yaml:"enabled"`
+	ExpiryHours   int    `yaml:"expiry_hours"`
+	RetentionDays int    `yaml:"retention_days"` // auto-purge audit entries older than N days (0 = keep forever)
+	ArchiveDir    string `yaml:"archive_dir,omitempty"` // directory where archive-before-delete writes .jsonl.gz files
 }
 
 // RuleAction maps a rule ID to an enforcement action.
@@ -553,9 +560,12 @@ func Load(path string) (*Config, error) {
 			RequireSignature: true,
 		},
 		Quarantine: QuarantineConfig{
-			Enabled:       true,
-			ExpiryHours:   24,
-			RetentionDays: 90,
+			Enabled:     true,
+			ExpiryHours: 24,
+			// RetentionDays defaults to 0 (keep audit evidence forever).
+			// Operators must opt in to deletion explicitly, and they must
+			// also set ArchiveDir for the audit store to honor purges.
+			RetentionDays: 0,
 		},
 		RateLimit: RateLimitConfig{
 			PerAgent: 100,
@@ -580,9 +590,10 @@ func Load(path string) (*Config, error) {
 	if cfg.RateLimit.WindowS == 0 {
 		cfg.RateLimit.WindowS = 60
 	}
-	if cfg.Quarantine.RetentionDays == 0 {
-		cfg.Quarantine.RetentionDays = 90
-	}
+	// Quarantine.RetentionDays intentionally not coerced from 0:
+	// 0 means "keep audit evidence forever". Earlier builds silently
+	// promoted 0 to 90, which destroyed the evidence we need to validate
+	// installs. See documentation/engineering/specs/2026-04-27-claude-code-detection-posture-evidence-spec.md.
 	if cfg.Anomaly.CheckIntervalS == 0 {
 		cfg.Anomaly.CheckIntervalS = 60
 	}
@@ -631,7 +642,7 @@ func Defaults() *Config {
 		Quarantine: QuarantineConfig{
 			Enabled:       true,
 			ExpiryHours:   24,
-			RetentionDays: 90,
+			RetentionDays: 0,
 		},
 		RateLimit: RateLimitConfig{
 			PerAgent: 100,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,78 @@ func TestDefaults(t *testing.T) {
 	}
 }
 
+// TestQuarantineRetentionDefaultKeepsForever locks in the evidence-freeze
+// contract: a config that does not set quarantine.retention_days must
+// not cause the audit store to auto-purge anything. Earlier builds
+// silently promoted 0 to 90 days, which destroyed the evidence needed to
+// validate fresh installs.
+func TestQuarantineRetentionDefaultKeepsForever(t *testing.T) {
+	if got := Defaults().Quarantine.RetentionDays; got != 0 {
+		t.Errorf("Defaults().Quarantine.RetentionDays = %d, want 0 (keep forever)", got)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	// Minimal config that omits quarantine entirely. The previous default
+	// would have stamped retention_days=90 here.
+	content := `
+version: "1"
+server:
+  port: 8080
+  log_level: info
+identity:
+  keys_dir: ./keys
+  require_signature: false
+agents: {}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Quarantine.RetentionDays != 0 {
+		t.Errorf("Load(omitted quarantine).RetentionDays = %d, want 0 (keep forever)",
+			cfg.Quarantine.RetentionDays)
+	}
+}
+
+// TestQuarantineRetentionRespectsExplicitValue confirms the post-unmarshal
+// default does not clobber an explicit retention setting.
+func TestQuarantineRetentionRespectsExplicitValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	content := `
+version: "1"
+server:
+  port: 8080
+  log_level: info
+identity:
+  keys_dir: ./keys
+  require_signature: false
+agents: {}
+quarantine:
+  enabled: true
+  expiry_hours: 24
+  retention_days: 30
+  archive_dir: /tmp/oktsec-archives
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Quarantine.RetentionDays != 30 {
+		t.Errorf("RetentionDays = %d, want 30", cfg.Quarantine.RetentionDays)
+	}
+	if cfg.Quarantine.ArchiveDir != "/tmp/oktsec-archives" {
+		t.Errorf("ArchiveDir = %q, want /tmp/oktsec-archives", cfg.Quarantine.ArchiveDir)
+	}
+}
+
 func TestValidate_ValidConfig(t *testing.T) {
 	cfg := Defaults()
 	if err := cfg.Validate(); err != nil {

--- a/internal/dashboard/audit_clear_safety_test.go
+++ b/internal/dashboard/audit_clear_safety_test.go
@@ -1,0 +1,161 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity"
+)
+
+// newAuditClearTestServer wires a Server backed by a real audit store
+// in a temp dir so we can hit /dashboard/api/audit/clear and inspect the
+// archive directory afterwards. Returns the server, the bound store,
+// and the temp dir (which doubles as the cfgPath dir for default
+// archive resolution).
+func newAuditClearTestServer(t *testing.T) (*Server, *audit.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store, err := audit.NewStore(filepath.Join(dir, "test.db"), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 0},
+		DBPath:  filepath.Join(dir, "test.db"),
+		Agents: map[string]config.Agent{
+			"agent-a": {CanMessage: []string{"agent-b"}},
+		},
+	}
+	srv := NewServer(cfg, filepath.Join(dir, "oktsec.yaml"), store, identity.NewKeyStore(), sharedScanner, logger)
+
+	// Seed three rows so we can prove they survive a refused clear.
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, id := range []string{"r1", "r2", "r3"} {
+		store.Log(audit.Entry{
+			ID: id, Timestamp: now, FromAgent: "agent-a", ToAgent: "agent-b",
+			ContentHash: "h", Status: "delivered", PolicyDecision: "allow",
+		})
+	}
+	store.Flush()
+	return srv, store, dir
+}
+
+// TestAuditClear_RefusesWithoutConfirmToken proves the dashboard cannot
+// destroy evidence on a bare POST. Earlier behavior wiped the audit log
+// silently the moment any caller hit the endpoint; now the request
+// returns an explicit refusal and rows stay intact.
+func TestAuditClear_RefusesWithoutConfirmToken(t *testing.T) {
+	srv, store, _ := newAuditClearTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("POST", "/dashboard/api/audit/clear", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got := body["status"]; got != "refused" {
+		t.Errorf("status field = %v, want refused", got)
+	}
+
+	st, err := store.EvidenceStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.TotalRows != 3 {
+		t.Errorf("rows after refused clear = %d, want 3 (evidence must survive)", st.TotalRows)
+	}
+}
+
+// TestAuditClear_WritesArchiveBeforeDeleting confirms the safe path
+// produces a .jsonl.gz under <cfgDir>/archives and only then deletes.
+func TestAuditClear_WritesArchiveBeforeDeleting(t *testing.T) {
+	srv, store, dir := newAuditClearTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("POST", "/dashboard/api/audit/clear?confirm=archive-and-clear", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got := body["status"]; got != "cleared" {
+		t.Errorf("status = %v, want cleared", got)
+	}
+	if got, _ := body["archived_rows"].(float64); int(got) != 3 {
+		t.Errorf("archived_rows = %v, want 3", body["archived_rows"])
+	}
+	archive, _ := body["archive"].(string)
+	if archive == "" {
+		t.Fatal("archive path missing in response")
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Errorf("archive file missing: %v", err)
+	}
+	// Default archive dir lives next to the config file.
+	wantPrefix := filepath.Join(dir, "archives")
+	if filepath.Dir(archive) != wantPrefix {
+		t.Errorf("archive dir = %q, want %q", filepath.Dir(archive), wantPrefix)
+	}
+
+	st, err := store.EvidenceStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.TotalRows != 0 {
+		t.Errorf("rows after clear = %d, want 0", st.TotalRows)
+	}
+}
+
+// TestEvidenceStatus_EndpointReportsKeepForever proves the visible
+// status block reads the right policy string for the default install.
+func TestEvidenceStatus_EndpointReportsKeepForever(t *testing.T) {
+	srv, _, _ := newAuditClearTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("GET", "/dashboard/api/evidence/status", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if body["retention_policy"] != "keep_forever" {
+		t.Errorf("retention_policy = %v, want keep_forever", body["retention_policy"])
+	}
+	if got, _ := body["total_rows"].(float64); int(got) != 3 {
+		t.Errorf("total_rows = %v, want 3", body["total_rows"])
+	}
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -461,6 +461,23 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		}(),
 	}
 
+	// Evidence store visibility. The block proves the audit log survives
+	// across restarts and reports the retention policy verbatim, so an
+	// operator can tell at a glance whether a future auto-purge could
+	// delete anything.
+	if st, err := s.audit.EvidenceStatus(); err == nil {
+		data["Evidence"] = map[string]any{
+			"DBPath":           s.cfg.DBPath,
+			"DBBackend":        s.cfg.DBBackend,
+			"TotalRows":        st.TotalRows,
+			"OldestTimestamp":  st.OldestTimestamp,
+			"NewestTimestamp":  st.NewestTimestamp,
+			"RetentionDays":    st.RetentionDays,
+			"RetentionPolicy":  st.RetentionPolicy,
+			"ArchiveDirectory": st.ArchiveDirectory,
+		}
+	}
+
 	s.renderTemplate(w, auditTmpl, data)
 }
 
@@ -4249,16 +4266,77 @@ func (s *Server) handleAPIGraph(w http.ResponseWriter, r *http.Request) {
 	s.renderJSON(w, g)
 }
 
-func (s *Server) handleAuditClear(w http.ResponseWriter, r *http.Request) {
-	if err := s.audit.ClearAll(); err != nil {
-		s.logger.Error("audit clear failed", "error", err)
+// handleEvidenceStatus returns a snapshot of the audit store's row
+// counts, time range, and retention policy. The dashboard renders this
+// in the Audit page so an operator can prove evidence is intact and see
+// at a glance whether a future auto-purge could delete anything.
+func (s *Server) handleEvidenceStatus(w http.ResponseWriter, r *http.Request) {
+	st, err := s.audit.EvidenceStatus()
+	if err != nil {
+		s.logger.Error("evidence status failed", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	// Remove all agents so the graph starts truly empty.
-	// They auto-register again when the gateway receives traffic.
+	out := map[string]any{
+		"db_path":           s.cfg.DBPath,
+		"db_backend":        s.cfg.DBBackend,
+		"total_rows":        st.TotalRows,
+		"oldest_timestamp":  st.OldestTimestamp,
+		"newest_timestamp":  st.NewestTimestamp,
+		"retention_days":    st.RetentionDays,
+		"retention_policy":  st.RetentionPolicy,
+		"archive_directory": st.ArchiveDirectory,
+	}
+	s.renderJSON(w, out)
+}
+
+// handleAuditClear is the dashboard endpoint that clears the audit log.
+// It refuses to delete unless the caller passes confirm=archive-and-clear
+// and the store has an archive directory configured. The archive is
+// written first; only then are rows deleted. If anything fails the audit
+// log is left untouched.
+//
+// The earlier behavior (call ClearAll() with no archive, no confirmation)
+// destroyed evidence the user needed to validate that oktsec was working.
+// See documentation/engineering/specs/2026-04-27-claude-code-detection-posture-evidence-spec.md
+// section 8 (Evidence Durability).
+func (s *Server) handleAuditClear(w http.ResponseWriter, r *http.Request) {
+	confirm := r.URL.Query().Get("confirm")
+	if confirm != "archive-and-clear" {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "refused",
+			"reason": "missing confirm=archive-and-clear; the audit log can only be cleared after writing an archive",
+		})
+		return
+	}
+	archiveDir := s.audit.ArchiveDir()
+	if archiveDir == "" {
+		// Fall back to a sibling of the config file so a fresh install can
+		// still safely clear without manual configuration.
+		base := filepath.Dir(s.cfgPath)
+		if base == "" || base == "." {
+			base = "."
+		}
+		archiveDir = filepath.Join(base, "archives")
+	}
+	count, archive, err := s.audit.ArchiveAndClearAll(archiveDir)
+	if err != nil {
+		s.logger.Error("audit archive-and-clear failed", "error", err, "archive_dir", archiveDir)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Remove all agents so the graph starts truly empty. They auto-register
+	// again when the gateway receives traffic.
 	s.cfg.Agents = make(map[string]config.Agent)
-	s.renderJSON(w, map[string]string{"status": "cleared"})
+	s.renderJSON(w, map[string]any{
+		"status":         "cleared",
+		"archived_rows":  count,
+		"archive":        archive,
+		"archive_dir":    archiveDir,
+	})
 }
 
 // handleAuditFix applies an auto-fix for a single finding and returns an HTML

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -409,6 +409,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/api/graph", s.handleAPIGraph)
 	s.mux.HandleFunc("GET /dashboard/api/graph/edge", s.handleEdgeDetail)
 	s.mux.HandleFunc("POST /dashboard/api/audit/clear", s.handleAuditClear)
+	s.mux.HandleFunc("GET /dashboard/api/evidence/status", s.handleEvidenceStatus)
 	s.mux.HandleFunc("POST /dashboard/api/audit/fix/{checkID}", s.handleAuditFix)
 	s.mux.HandleFunc("POST /dashboard/api/audit/fix-all", s.handleAuditFixAll)
 	s.mux.HandleFunc("POST /dashboard/api/audit/enrich", s.handleAuditEnrich)

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -155,6 +155,34 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
   {{end}}
 </div>
 
+{{with .Evidence}}
+<!-- Evidence store status -->
+<div class="ps-section-title">Evidence store</div>
+<div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:16px 20px;margin-bottom:20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;font-size:0.8125rem">
+  <div>
+    <div style="color:var(--text3);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:4px">Rows</div>
+    <div style="color:var(--text);font-weight:600">{{formatNum .TotalRows}}</div>
+  </div>
+  <div>
+    <div style="color:var(--text3);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:4px">Oldest</div>
+    <div style="color:var(--text2);font-family:var(--mono);font-size:0.75rem">{{if .OldestTimestamp}}{{.OldestTimestamp}}{{else}}—{{end}}</div>
+  </div>
+  <div>
+    <div style="color:var(--text3);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:4px">Newest</div>
+    <div style="color:var(--text2);font-family:var(--mono);font-size:0.75rem">{{if .NewestTimestamp}}{{.NewestTimestamp}}{{else}}—{{end}}</div>
+  </div>
+  <div>
+    <div style="color:var(--text3);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:4px">Retention</div>
+    <div style="color:var(--text2);font-family:var(--mono);font-size:0.75rem">{{.RetentionPolicy}}</div>
+  </div>
+  <div style="grid-column:1 / -1">
+    <div style="color:var(--text3);font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:4px">Database</div>
+    <div style="color:var(--text2);font-family:var(--mono);font-size:0.75rem;word-break:break-all">{{if .DBBackend}}{{.DBBackend}}: {{end}}{{.DBPath}}</div>
+    {{if .ArchiveDirectory}}<div style="color:var(--text3);font-size:0.7rem;margin-top:4px">Archives written to <span style="font-family:var(--mono)">{{.ArchiveDirectory}}</span> before any auto-purge.</div>{{end}}
+  </div>
+</div>
+{{end}}
+
 <!-- Findings -->
 <div class="ps-section-title">Findings</div>
 {{if gt .TotalChecks 0}}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -309,6 +309,8 @@ func NewGateway(cfg *config.Config, logger *slog.Logger, sharedStore *audit.Stor
 		if err != nil {
 			return nil, fmt.Errorf("opening audit store: %w", err)
 		}
+		// Wire archive_dir so the auto-purge loop honors retention safely.
+		auditStore.SetArchiveDir(cfg.Quarantine.ArchiveDir)
 	}
 
 	webhooks := proxy.NewWebhookNotifier(cfg.Webhooks, logger)

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -83,6 +83,10 @@ func NewServer(cfg *config.Config, cfgPath string, logger *slog.Logger) (*Server
 	if err != nil {
 		return nil, fmt.Errorf("opening audit store: %w — if another oktsec instance is running, stop it first", err)
 	}
+	// Wire archive_dir so the auto-purge loop can honor retention safely.
+	// Empty archive_dir + positive retention causes the loop to refuse to
+	// delete and warn once instead.
+	auditStore.SetArchiveDir(cfg.Quarantine.ArchiveDir)
 
 	// Proxy signing key for audit chain integrity
 	if cfg.Identity.KeysDir != "" {


### PR DESCRIPTION
## Summary

- Default `quarantine.retention_days` now `0` (keep forever); `oktsec run` no longer writes a silent 90-day purge into fresh configs.
- New `audit.ArchiveAndPurgeOldEntries` / `audit.ArchiveAndClearAll` write a gzipped JSONL archive of the rows being deleted before issuing the DELETE; the auto-purge loop refuses to run when retention is set without an `archive_dir`.
- Dashboard `POST /dashboard/api/audit/clear` now requires `?confirm=archive-and-clear` and writes an archive under `<configDir>/archives/` first.
- New `audit.Store.EvidenceStatus()` and `GET /dashboard/api/evidence/status`; the Audit page renders DB path, row count, oldest/newest timestamp, and retention policy in a visible block.
- Tests cover: keep-forever default for omitted/explicit YAML, archive-then-delete round-trip, refusal paths for both auto-purge (no `archive_dir`) and dashboard clear (no confirm token).

## Test plan

- [x] `make build`
- [x] `make test` (all packages green)
- [x] `make vet`
- [x] `make lint` (0 issues)
- [ ] `make integration-test` — `internal/proxy/oktsec.db` (gitignored, dated Mar 6) makes the proxy integration suite fail with `no such column: session_id`. Pre-existing flake unrelated to this branch; the test setup does not isolate `DBPath` to a tempdir. Out of scope for this PR.