### PR TITLE
Add read-only Claude Code connector inventory + doctor

### DIFF
--- a/cmd/oktsec/commands/doctor.go
+++ b/cmd/oktsec/commands/doctor.go
@@ -31,12 +31,15 @@ func newDoctorCmd() *cobra.Command {
 		Use:   "doctor",
 		Short: "Run diagnostic checks on your oktsec setup",
 		Example: `  oktsec doctor
-  oktsec doctor --repair`,
+  oktsec doctor --repair
+  oktsec doctor claude-code
+  oktsec doctor claude-code --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDoctor(repair)
 		},
 	}
 	cmd.Flags().BoolVar(&repair, "repair", false, "attempt to fix issues automatically")
+	cmd.AddCommand(newDoctorClaudeCodeCmd())
 	return cmd
 }
 

--- a/cmd/oktsec/commands/doctor_claude_code.go
+++ b/cmd/oktsec/commands/doctor_claude_code.go
@@ -1,0 +1,259 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+	"github.com/spf13/cobra"
+)
+
+// newDoctorClaudeCodeCmd is the read-only Phase 1 diagnostic for the
+// Claude Code connector. It walks the same files the spec lists in
+// section 1 (Inventory) and reports state without touching anything.
+//
+// Phase 1 contract: NO --repair flag. Hook installation comes in
+// Phase 2 (Hook Manifest V2). This command is safe to run on a fresh
+// machine and on a configured one alike; it never mutates Claude
+// state or oktsec config.
+func newDoctorClaudeCodeCmd() *cobra.Command {
+	var (
+		jsonOut    bool
+		projectDir string
+	)
+	cmd := &cobra.Command{
+		Use:   "claude-code",
+		Short: "Inspect Claude Code connector state (read-only)",
+		Long: `Reports what oktsec sees about the local Claude Code install:
+the CLI binary, user/project settings paths, hooks installed in each
+scope, MCP server entries (~/.claude.json, .mcp.json, project
+settings.json), and static .claude/agents files.
+
+This is a read-only diagnostic. It never writes to ~/.claude.json,
+~/.claude/settings.json, or any project Claude state. Hook
+installation comes in a separate phase.`,
+		Example: `  oktsec doctor claude-code
+  oktsec doctor claude-code --json
+  oktsec doctor claude-code --project /path/to/project`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctorClaudeCode(jsonOut, projectDir)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
+	cmd.Flags().StringVar(&projectDir, "project", "", "project directory to scope project/local settings to (defaults to cwd when reading project state)")
+	return cmd
+}
+
+func runDoctorClaudeCode(jsonOut bool, projectDir string) error {
+	if projectDir == "" {
+		// Default to cwd ONLY when the user passes nothing. This keeps
+		// the `--json` behavior from depending on which directory the
+		// shell happened to be in unless the operator opted in.
+		if cwd, err := os.Getwd(); err == nil {
+			projectDir = cwd
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	inv := claudecode.Read(ctx, claudecode.ReadOptions{
+		ProjectDir: projectDir,
+		// SkipVersionProbe defaults false — we want the version when we
+		// can get it, but the 10s timeout above guards against a hung
+		// CLI.
+	})
+
+	// Best-effort last-seen lookup. The audit DB may not exist yet on
+	// a fresh install; that is fine — DeriveHealth handles "" as "no
+	// event observed".
+	lastEvent := lookupLastEvent()
+
+	health := claudecode.DeriveHealth(inv, claudecode.HealthOptions{
+		LastEvent: lastEvent,
+	})
+
+	if jsonOut {
+		return emitDoctorJSON(inv, health)
+	}
+	emitDoctorHuman(inv, health)
+	if health.Status == "disconnected" || health.Status == "not_installed" {
+		return fmt.Errorf("claude code connector is %s", health.Status)
+	}
+	return nil
+}
+
+// lookupLastEvent opens the configured audit DB read-only and asks
+// for the most recent event attributed to the "claude-code"
+// principal on the hooks surface. Returns "" on any error so a
+// missing or stale DB never breaks the doctor.
+func lookupLastEvent() string {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return ""
+	}
+	dbPath := cfg.DBPath
+	if dbPath == "" {
+		dbPath = config.DefaultDBPath()
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return ""
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store, err := audit.NewStoreReadOnly(dbPath, logger)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = store.Close() }()
+
+	return claudecode.LookupLastEvent(store)
+}
+
+// emitDoctorJSON wraps the inventory + health together so external
+// tooling (the dashboard repair flow, future Phase 5 AI assistant)
+// can consume one stable shape.
+func emitDoctorJSON(inv claudecode.Inventory, health claudecode.ConnectorHealth) error {
+	out := struct {
+		Inventory claudecode.Inventory        `json:"inventory"`
+		Health    claudecode.ConnectorHealth  `json:"health"`
+	}{Inventory: inv, Health: health}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func emitDoctorHuman(inv claudecode.Inventory, health claudecode.ConnectorHealth) {
+	bold := color.New(color.Bold).SprintFunc()
+	dim := color.New(color.Faint).SprintFunc()
+
+	fmt.Println()
+	fmt.Printf("  %s\n", bold("oktsec doctor claude-code"))
+	fmt.Println("  ────────────────────────────────────────")
+
+	// Status pill mirrors the dashboard color contract: ready=green,
+	// stale=yellow, partial=yellow, disconnected/not_installed=red.
+	var pill string
+	switch health.Status {
+	case "ready":
+		pill = color.GreenString(health.Status)
+	case "partial", "stale":
+		pill = color.YellowString(health.Status)
+	default:
+		pill = color.RedString(health.Status)
+	}
+	fmt.Printf("  Status: %s — %s\n", pill, health.Reason)
+	fmt.Println()
+
+	fmt.Printf("  %s\n", bold("Detected"))
+	fmt.Printf("    CLI:           %s\n", orDash(inv.ClaudeCLIPath))
+	if inv.ClaudeVersion != "" {
+		fmt.Printf("    Version:       %s\n", strings.SplitN(inv.ClaudeVersion, "\n", 2)[0])
+	}
+	fmt.Printf("    User settings: %s %s\n", inv.UserSettingsPath, dim(existsTag(inv.UserSettingsPath)))
+	fmt.Printf("    Global state:  %s %s\n", inv.GlobalStatePath, dim(existsTag(inv.GlobalStatePath)))
+	if inv.CurrentProjectPath != "" {
+		fmt.Printf("    Project:       %s\n", inv.CurrentProjectPath)
+		fmt.Printf("    Project sett.: %s %s\n", inv.ProjectSettingsPath, dim(existsTag(inv.ProjectSettingsPath)))
+		fmt.Printf("    Local sett.:   %s %s\n", inv.LocalSettingsPath, dim(existsTag(inv.LocalSettingsPath)))
+	}
+	fmt.Println()
+
+	fmt.Printf("  %s (%d)\n", bold("Hooks"), len(inv.Hooks))
+	if len(inv.Hooks) == 0 {
+		fmt.Println("    none installed")
+	}
+	for _, h := range inv.Hooks {
+		marker := "  "
+		if h.IsOktsec {
+			marker = color.GreenString("✓ ")
+		}
+		desc := h.Type
+		if h.Command != "" {
+			desc = fmt.Sprintf("%s %s", h.Type, truncate(h.Command, 60))
+		} else if h.URL != "" {
+			desc = fmt.Sprintf("%s %s", h.Type, h.URL)
+		}
+		fmt.Printf("    %s%-20s %-8s %s\n", marker, h.Event, h.Scope, desc)
+	}
+	if missing := health.MissingExpectedEvents; len(missing) > 0 {
+		fmt.Printf("    %s %s\n", dim("missing (Phase 2 manifest):"), strings.Join(missing, ", "))
+	}
+	fmt.Println()
+
+	fmt.Printf("  %s (%d)\n", bold("MCP servers"), len(inv.MCPServers))
+	if len(inv.MCPServers) == 0 {
+		fmt.Println("    none configured")
+	}
+	for _, s := range inv.MCPServers {
+		marker := "  "
+		if s.IsOktsec {
+			marker = color.GreenString("✓ ")
+		}
+		ref := s.Command
+		if s.URL != "" {
+			ref = s.URL
+		}
+		fmt.Printf("    %s%-20s %-8s %-6s %s\n", marker, s.Name, s.Scope, s.Transport, truncate(ref, 60))
+	}
+	fmt.Println()
+
+	fmt.Printf("  %s (%d)\n", bold("Subagents"), len(inv.Subagents))
+	if len(inv.Subagents) == 0 {
+		fmt.Println("    no .claude/agents/*.md files found")
+	}
+	for _, sa := range inv.Subagents {
+		fmt.Printf("    %-24s %-8s %s\n", sa.Name, sa.Source, truncate(sa.Path, 60))
+	}
+	fmt.Println()
+
+	if len(inv.Problems) > 0 {
+		fmt.Printf("  %s\n", bold("Issues"))
+		yellow := color.New(color.FgYellow).SprintFunc()
+		for _, p := range inv.Problems {
+			fmt.Printf("    %s\n", yellow(fmt.Sprintf("[%s] %s", p.Severity, p.Title)))
+			if p.Detail != "" {
+				fmt.Printf("        %s\n", p.Detail)
+			}
+		}
+		fmt.Println()
+	}
+
+	if health.LastEvent != "" {
+		fmt.Printf("  Last event observed: %s\n", health.LastEvent)
+	} else {
+		fmt.Println("  Last event observed: never (oktsec has not received Claude Code activity yet)")
+	}
+	fmt.Println()
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+func existsTag(path string) string {
+	if _, err := os.Stat(path); err == nil {
+		return "(exists)"
+	}
+	return "(not present)"
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}

--- a/cmd/oktsec/commands/doctor_claude_code_test.go
+++ b/cmd/oktsec/commands/doctor_claude_code_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+)
+
+// TestDoctorClaudeCodeJSONShape locks in the JSON envelope external
+// tooling (the Phase 5 AI Fix Assistant, future repair flows) will
+// rely on. We exercise the helper directly instead of running the
+// cobra subcommand so the test does not depend on the user's HOME or
+// on the CLI being on PATH.
+func TestDoctorClaudeCodeJSONShape(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(home+"/.claude", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+
+	inv := claudecode.Read(context.Background(), claudecode.ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+	health := claudecode.DeriveHealth(inv, claudecode.HealthOptions{})
+
+	out, err := json.Marshal(struct {
+		Inventory claudecode.Inventory       `json:"inventory"`
+		Health    claudecode.ConnectorHealth `json:"health"`
+	}{Inventory: inv, Health: health})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Round-trip into a permissive map so the test fails on missing
+	// top-level keys rather than on field types we may extend later.
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v; payload=%s", err, out)
+	}
+	if _, ok := got["inventory"]; !ok {
+		t.Errorf("missing 'inventory' key in output: %s", out)
+	}
+	if _, ok := got["health"]; !ok {
+		t.Errorf("missing 'health' key in output: %s", out)
+	}
+}
+
+// TestDoctorClaudeCodeIsRegistered makes sure newDoctorCmd attaches
+// the claude-code subcommand and that it advertises the read-only
+// docs string. A future contributor that drops the AddCommand call
+// breaks the dashboard's expected workflow; this test catches it.
+func TestDoctorClaudeCodeIsRegistered(t *testing.T) {
+	root := newDoctorCmd()
+	sub, _, err := root.Find([]string{"claude-code"})
+	if err != nil || sub == nil || sub.Name() != "claude-code" {
+		t.Fatalf("doctor claude-code subcommand not registered: %v", err)
+	}
+	if sub.Long == "" {
+		t.Error("subcommand should carry a Long description")
+	}
+}

--- a/internal/connectors/claudecode/agents.go
+++ b/internal/connectors/claudecode/agents.go
@@ -1,0 +1,153 @@
+package claudecode
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// agentFrontmatter is the YAML block at the top of a .claude/agents/*.md
+// file. Field set follows the public docs at
+// code.claude.com/docs/en/sub-agents and only includes what the
+// inventory needs to display; extra YAML keys are ignored so future
+// Claude additions do not break parsing.
+type agentFrontmatter struct {
+	Name            string   `yaml:"name,omitempty"`
+	Description     string   `yaml:"description,omitempty"`
+	Tools           []string `yaml:"tools,omitempty"`
+	DisallowedTools []string `yaml:"disallowedTools,omitempty"`
+	MCPServers      []string `yaml:"mcpServers,omitempty"`
+	PermissionMode  string   `yaml:"permissionMode,omitempty"`
+	Hooks           any      `yaml:"hooks,omitempty"` // any: presence-only, we do not introspect
+}
+
+// readSubagents walks the user and project agents directories and
+// emits one SubagentRef per .md file. Subagents declared at runtime
+// via `claude --agents` are NOT visible from disk; Phase 3 will pick
+// those up from SubagentStart hook events.
+func readSubagents(opts ReadOptions) ([]SubagentRef, []ConnectorProblem) {
+	var refs []SubagentRef
+	var problems []ConnectorProblem
+
+	dirs := []struct {
+		source string
+		path   string
+	}{
+		{"user", filepath.Join(opts.HomeDir, ".claude", "agents")},
+	}
+	if opts.ProjectDir != "" {
+		dirs = append(dirs, struct {
+			source string
+			path   string
+		}{"project", filepath.Join(opts.ProjectDir, ".claude", "agents")})
+	}
+
+	for _, d := range dirs {
+		entries, err := os.ReadDir(d.path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			problems = append(problems, ConnectorProblem{
+				Code:     "CC-AGENTS-READ",
+				Severity: "warning",
+				Title:    fmt.Sprintf("Unable to read agents directory %s", d.path),
+				Detail:   err.Error(),
+			})
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			full := filepath.Join(d.path, e.Name())
+			ref, prob := parseSubagentFile(d.source, full)
+			if prob != nil {
+				problems = append(problems, *prob)
+			}
+			if ref != nil {
+				refs = append(refs, *ref)
+			}
+		}
+	}
+	sort.SliceStable(refs, func(i, j int) bool {
+		if refs[i].Name != refs[j].Name {
+			return refs[i].Name < refs[j].Name
+		}
+		return refs[i].Source < refs[j].Source
+	})
+	return refs, problems
+}
+
+// parseSubagentFile reads one agent markdown and returns the SubagentRef.
+// The file format is YAML frontmatter (between two `---` lines) followed
+// by free-form prose; only the frontmatter is parsed.
+func parseSubagentFile(source, path string) (*SubagentRef, *ConnectorProblem) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-AGENT-READ",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to read agent %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	front, err := extractFrontmatter(data)
+	if err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-AGENT-PARSE",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to parse agent %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	name := front.Name
+	if name == "" {
+		// Fall back to the file basename so an agent without a name
+		// field still appears in the inventory.
+		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+	return &SubagentRef{
+		Name:            name,
+		Source:          source,
+		Path:            path,
+		Tools:           front.Tools,
+		DisallowedTools: front.DisallowedTools,
+		MCPServers:      front.MCPServers,
+		PermissionMode:  front.PermissionMode,
+		HooksPresent:    front.Hooks != nil,
+	}, nil
+}
+
+// extractFrontmatter pulls the YAML block delimited by `---` lines at
+// the top of an agent markdown file. Returns an empty agentFrontmatter
+// when there is no frontmatter (so the inventory still surfaces the
+// file by name) and only errors on a malformed YAML block.
+func extractFrontmatter(data []byte) (agentFrontmatter, error) {
+	text := string(data)
+	if !strings.HasPrefix(strings.TrimLeft(text, " \t\r\n"), "---") {
+		return agentFrontmatter{}, nil
+	}
+	// Drop leading whitespace before the first delimiter.
+	text = strings.TrimLeft(text, " \t\r\n")
+	rest := text[3:] // skip the opening "---"
+	// Skip the newline that follows "---" if present.
+	rest = strings.TrimPrefix(rest, "\r\n")
+	rest = strings.TrimPrefix(rest, "\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return agentFrontmatter{}, nil
+	}
+	yamlBlock := rest[:end]
+	var front agentFrontmatter
+	if err := yaml.Unmarshal([]byte(yamlBlock), &front); err != nil {
+		return agentFrontmatter{}, err
+	}
+	return front, nil
+}

--- a/internal/connectors/claudecode/fixtures_test.go
+++ b/internal/connectors/claudecode/fixtures_test.go
@@ -1,0 +1,117 @@
+package claudecode
+
+// Fixtures live as Go string consts (instead of testdata/*.json files)
+// because the repo's root .gitignore excludes any testdata/ directory.
+// Embedding the fixtures keeps the tests reproducible across checkouts
+// without needing `git add -f` on ignored paths.
+
+const fixUserSettingsWithOktsec = `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/oktsec hook --port 9090"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/oktsec hook --port 9090"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo hello"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
+const fixUserSettingsNoOktsec = `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/some-other/lint --tool {tool}"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
+const fixClaudeJSON = `{
+  "mcpServers": {
+    "oktsec-gateway": {
+      "type": "http",
+      "url": "http://127.0.0.1:9090/mcp"
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  },
+  "projects": {
+    "/PROJECT_DIR_PLACEHOLDER": {
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        }
+      }
+    }
+  }
+}
+`
+
+const fixAgentCodeReviewer = "---\n" +
+	"name: code-reviewer\n" +
+	"description: Reviews diffs for security issues\n" +
+	"tools:\n" +
+	"  - Read\n" +
+	"  - Grep\n" +
+	"disallowedTools:\n" +
+	"  - Bash\n" +
+	"mcpServers:\n" +
+	"  - github\n" +
+	"permissionMode: confirmActions\n" +
+	"hooks:\n" +
+	"  PostToolUse: []\n" +
+	"---\n\n" +
+	"# Code reviewer\n\n" +
+	"Body prose ignored by the parser.\n"
+
+const fixAgentNoFrontmatter = "# general-purpose\n\n" +
+	"This file has no YAML frontmatter; the inventory should still surface\n" +
+	"it under the file basename.\n"
+
+// fixtureSources maps the filename test cases use to its embedded
+// content, so existing tests that say `read fixture X` keep their
+// readable form.
+var fixtureSources = map[string]string{
+	"user_settings_with_oktsec.json": fixUserSettingsWithOktsec,
+	"user_settings_no_oktsec.json":   fixUserSettingsNoOktsec,
+	"claude_json.json":               fixClaudeJSON,
+	"agent_code_reviewer.md":         fixAgentCodeReviewer,
+	"agent_no_frontmatter.md":        fixAgentNoFrontmatter,
+}

--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -1,0 +1,233 @@
+package claudecode
+
+import (
+	"time"
+)
+
+// PrincipalID is the canonical principal id oktsec uses for Claude
+// Code activity in the audit store. Centralised here so callers can
+// look up last-seen events without sprinkling the literal across the
+// dashboard or doctor code (see dashboard regression test that bans
+// hard-coded client names in graph code).
+const PrincipalID = "claude-code"
+
+// SurfaceHooks / SurfaceMCPHTTP are the audit-store surface names
+// the connector has historically been observed on. Phase 2 will add
+// dedicated hooks once the manifest lands; until then both fall back
+// to whichever surface saw activity.
+const (
+	SurfaceHooks   = "hooks"
+	SurfaceMCPHTTP = "mcp_http"
+)
+
+// LastSeenLookup is the narrow projection of audit.Store the
+// connector needs to derive freshness. Defined locally so the
+// dashboard handler does not have to thread the whole AuditStore
+// interface through this package and so tests can stub the lookup
+// without spinning up a real store.
+type LastSeenLookup interface {
+	LastSeenByPrincipalSurface(principalID, surface string) (string, error)
+}
+
+// LookupLastEvent returns the most recent timestamp the audit store
+// can attribute to Claude Code on the hooks surface, falling back to
+// the gateway HTTP surface for installs that route there. Returns ""
+// (and no error) when nothing has been observed; callers treat that
+// as the partial state.
+func LookupLastEvent(store LastSeenLookup) string {
+	if store == nil {
+		return ""
+	}
+	if ts, _ := store.LastSeenByPrincipalSurface(PrincipalID, SurfaceHooks); ts != "" {
+		return ts
+	}
+	ts, _ := store.LastSeenByPrincipalSurface(PrincipalID, SurfaceMCPHTTP)
+	return ts
+}
+
+// ConnectorHealth is the dashboard- and CLI-facing summary of one
+// Claude Code install. The fields are derived from an Inventory plus
+// (optionally) the audit store's last-seen signal for the principal.
+//
+// Status decision is intentionally simple and ordered from worst to
+// best so the UI can color-code without re-deriving a score:
+//
+//	not_installed    -- no Claude binary, no settings, no state file
+//	disconnected     -- Claude is here but no oktsec hook is installed
+//	partial          -- hook(s) installed but no recent event observed
+//	stale            -- last event older than the staleness threshold
+//	ready            -- recent event observed
+//
+// The derivation lives in DeriveHealth so callers (doctor, dashboard)
+// share one canonical mapping.
+type ConnectorHealth struct {
+	ConnectorID string `json:"connector_id"`
+	Status      string `json:"status"`
+
+	// Surface flags reported verbatim from the inventory so the UI
+	// does not have to re-read it.
+	Installed        bool `json:"installed"`
+	HookInstalled    bool `json:"hook_installed"`
+	GatewayConfigured bool `json:"gateway_configured"`
+
+	// Counts let the UI render "X subagent files, Y MCP servers"
+	// without exposing the full inventory.
+	SubagentsFound int `json:"subagents_found"`
+	MCPServersFound int `json:"mcp_servers_found"`
+
+	// LastEvent is the most recent activity timestamp the audit store
+	// could attribute to claude-code. Empty when no event has ever
+	// been observed.
+	LastEvent string `json:"last_event,omitempty"`
+
+	// MissingExpectedEvents is the Phase 2 hook events the operator
+	// should install to lift the connector to "ready" coverage. Empty
+	// when every expected event already has an oktsec hook.
+	MissingExpectedEvents []string `json:"missing_expected_events,omitempty"`
+
+	// Reason is the one-line explanation that the dashboard renders
+	// next to the status pill. Composed from inventory + last-seen so
+	// the UI never has to guess at "why partial?".
+	Reason string `json:"reason"`
+}
+
+// HealthOptions controls staleness thresholds and lets callers inject
+// the last-seen signal without depending on the audit store directly.
+// Phase 1 keeps both fields optional so the doctor can compute a
+// useful health snapshot even when no audit store is reachable.
+type HealthOptions struct {
+	// LastEvent is the most recent timestamp (RFC3339) attributable
+	// to claude-code, or "" when none. Callers typically derive this
+	// from audit.Store.LastSeenByPrincipalSurface(principalID, surface).
+	LastEvent string
+
+	// StaleAfter is the cutoff between "ready" and "stale". Defaults
+	// to 24h when zero, matching the spec's section 5 thresholds.
+	StaleAfter time.Duration
+
+	// Now is the clock seam for tests. Defaults to time.Now().
+	Now func() time.Time
+}
+
+// DeriveHealth maps an Inventory + observed signal to a ConnectorHealth.
+// Pure function: no I/O, no side effects, deterministic given inputs.
+func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.StaleAfter <= 0 {
+		opts.StaleAfter = 24 * time.Hour
+	}
+
+	h := ConnectorHealth{
+		ConnectorID:           "claude-code",
+		Installed:             inv.Detected,
+		HookInstalled:         hasOktsecHook(inv.Hooks),
+		GatewayConfigured:     hasOktsecGatewayMCP(inv.MCPServers),
+		SubagentsFound:        len(inv.Subagents),
+		MCPServersFound:       len(inv.MCPServers),
+		LastEvent:             opts.LastEvent,
+		MissingExpectedEvents: MissingExpectedEvents(inv.Hooks),
+	}
+
+	switch {
+	case !inv.Detected:
+		h.Status = "not_installed"
+		h.Reason = "Claude Code is not installed on this machine."
+	case !h.HookInstalled && !h.GatewayConfigured:
+		h.Status = "disconnected"
+		h.Reason = "Claude Code is installed, but no oktsec hook or gateway MCP entry was found in user/project settings."
+	case opts.LastEvent == "":
+		h.Status = "partial"
+		h.Reason = reasonPartial(h)
+	default:
+		ts, err := time.Parse(time.RFC3339, opts.LastEvent)
+		if err != nil {
+			// Unparseable timestamp is a data bug, not the operator's
+			// fault — surface it as partial so the dashboard does not
+			// claim "ready" on garbled input.
+			h.Status = "partial"
+			h.Reason = "An event was reported but its timestamp could not be parsed; treating as partial."
+			break
+		}
+		age := opts.Now().Sub(ts)
+		if age > opts.StaleAfter {
+			h.Status = "stale"
+			h.Reason = "Last Claude Code event observed " + humanizeAge(age) + " ago; coverage may be out of date."
+		} else {
+			h.Status = "ready"
+			h.Reason = "Claude Code connected. Last event observed " + humanizeAge(age) + " ago."
+		}
+	}
+	return h
+}
+
+func reasonPartial(h ConnectorHealth) string {
+	switch {
+	case h.HookInstalled && !h.GatewayConfigured:
+		return "Claude Code hooks are installed but no event has reached oktsec from this project yet."
+	case !h.HookInstalled && h.GatewayConfigured:
+		return "Claude Code's MCP gateway entry exists, but no oktsec hook is installed for pre-action coverage."
+	default:
+		return "Claude Code is wired to oktsec, but no event has been observed yet."
+	}
+}
+
+// hasOktsecGatewayMCP returns true when the inventory lists at least
+// one MCP server entry that points at the oktsec gateway. Helper
+// shared with DeriveHealth so the dashboard and doctor agree on what
+// counts as "gateway configured".
+func hasOktsecGatewayMCP(servers []MCPServerRef) bool {
+	for _, s := range servers {
+		if s.IsOktsec {
+			return true
+		}
+	}
+	return false
+}
+
+// humanizeAge returns a short ("2m", "3h", "5d") description suitable
+// for the dashboard. Local helper because importing a humanize
+// library for one string is overkill.
+func humanizeAge(d time.Duration) string {
+	if d < time.Minute {
+		return "less than a minute"
+	}
+	if d < time.Hour {
+		return formatUnit(int(d.Minutes()), "minute")
+	}
+	if d < 24*time.Hour {
+		return formatUnit(int(d.Hours()), "hour")
+	}
+	return formatUnit(int(d.Hours()/24), "day")
+}
+
+func formatUnit(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit
+	}
+	// Hand-rolled to avoid pulling in fmt for an expected hot path.
+	return itoa(n) + " " + unit + "s"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/connectors/claudecode/hooks.go
+++ b/internal/connectors/claudecode/hooks.go
@@ -1,0 +1,174 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// expectedEventFamilies is the Phase 2 hook manifest the spec calls for
+// (section 2). Phase 1 only reports which of these are missing; it
+// never installs them. Kept as a sorted slice so HookRef.Expected
+// renders the same on every run.
+var expectedEventFamilies = []string{
+	"PreToolUse",         // pre-action / blocking
+	"PostToolUse",        // observed / feedback
+	"PostToolUseFailure", // observed / failure surface
+	"PostToolBatch",      // observed / batched failures
+	"SubagentStart",      // observed actor lifecycle
+	"SubagentStop",
+	"SessionStart", // observed session lifecycle
+	"SessionEnd",
+	"InstructionsLoaded", // observed config-change surface
+	"CwdChanged",
+	"FileChanged",
+	"PermissionRequest", // pre-action / blocking
+	"PermissionDenied",
+	"Stop",
+	"StopFailure",
+	"TaskCreated",
+	"TaskCompleted",
+	"ConfigChange",
+}
+
+// blockingEventFamilies is the subset of hooks that can deny an
+// action before Claude executes it. Used to populate
+// HookRef.BlockingCap so the doctor can report "this hook is in a
+// blocking event family" without callers having to know the list.
+var blockingEventFamilies = map[string]bool{
+	"PreToolUse":        true,
+	"PermissionRequest": true,
+}
+
+// readHooks walks user + project + local settings files and emits one
+// HookRef per (event, hook handler) pair. Returns the inventory's
+// hooks list and any parse problems encountered. Read-only.
+//
+// Plugin / managed / agent-frontmatter hooks are deliberately
+// out-of-scope for Phase 1: they require resolving plugin metadata
+// from disk, and the spec marks that as a Phase 2 follow-up.
+func readHooks(opts ReadOptions) ([]HookRef, []ConnectorProblem) {
+	var hooks []HookRef
+	var problems []ConnectorProblem
+
+	scopes := []struct {
+		scope string
+		path  string
+	}{
+		{"user", opts.HomeDir + "/.claude/settings.json"},
+		{"project", opts.ProjectDir + "/.claude/settings.json"},
+		{"local", opts.ProjectDir + "/.claude/settings.local.json"},
+	}
+	for _, s := range scopes {
+		// Skip empty project/local scopes when no project was supplied —
+		// the path would be ".claude/settings.json" against cwd, which
+		// is misleading. The doctor's UI shows the inspected paths so
+		// the operator still sees what scope was checked.
+		if s.scope != "user" && opts.ProjectDir == "" {
+			continue
+		}
+		settings, prob := readSettings(s.path)
+		if prob != nil {
+			problems = append(problems, *prob)
+		}
+		if settings == nil || settings.Hooks == nil {
+			continue
+		}
+		hooks = append(hooks, parseHookEntries(s.scope, s.path, settings.Hooks)...)
+	}
+	return hooks, problems
+}
+
+// parseHookEntries flattens the {event: [{matcher, hooks: [handler]}]}
+// shape into a list of HookRef. Each handler becomes one row so the
+// doctor table can print "PreToolUse | * | command | oktsec hook --port"
+// without callers having to walk the nested array.
+func parseHookEntries(scope, path string, perEvent map[string]json.RawMessage) []HookRef {
+	var rows []HookRef
+	for _, event := range sortedKeys(perEvent) {
+		raw := perEvent[event]
+		var entries []rawHookEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			// Some configs store one entry as an object, not array;
+			// fall back to single-entry decode before giving up.
+			var single rawHookEntry
+			if err2 := json.Unmarshal(raw, &single); err2 != nil {
+				continue
+			}
+			entries = []rawHookEntry{single}
+		}
+		for _, entry := range entries {
+			for _, h := range entry.Hooks {
+				rows = append(rows, HookRef{
+					Scope:       scope,
+					Path:        path,
+					Event:       event,
+					Matcher:     entry.Matcher,
+					Type:        h.Type,
+					Command:     h.Command,
+					URL:         h.URL,
+					IsOktsec:    isOktsecHookHandler(h),
+					Expected:    isExpectedEvent(event),
+					BlockingCap: blockingEventFamilies[event],
+				})
+			}
+		}
+	}
+	return rows
+}
+
+// isOktsecHookHandler returns true when the handler clearly invokes
+// the oktsec hook subcommand. Conservative on purpose: matching only
+// "oktsec hook" as a token avoids flagging unrelated commands that
+// happen to contain "oktsec" in a path comment.
+func isOktsecHookHandler(h rawHookHandler) bool {
+	if h.Type == "command" {
+		// We accept either `oktsec hook` or a quoted path ending in
+		// `oktsec` followed by `hook`, because run.go writes the
+		// absolute binary path on first install.
+		cmd := strings.ToLower(h.Command)
+		if strings.Contains(cmd, "oktsec hook") {
+			return true
+		}
+		// Cover quoted absolute path: "/usr/local/bin/oktsec" hook
+		if strings.Contains(cmd, "/oktsec\" hook") || strings.Contains(cmd, "/oktsec hook") {
+			return true
+		}
+	}
+	if h.Type == "http" && strings.Contains(h.URL, "/hooks/event") {
+		return true
+	}
+	return false
+}
+
+// isExpectedEvent reports whether the named event family is part of
+// the Phase 2 hook manifest the spec calls for. Used to populate
+// HookRef.Expected so the doctor can show "yes this event is part of
+// the planned manifest" without re-reading the spec.
+func isExpectedEvent(event string) bool {
+	for _, e := range expectedEventFamilies {
+		if e == event {
+			return true
+		}
+	}
+	return false
+}
+
+// MissingExpectedEvents returns the Phase 2 events that are NOT yet
+// installed via an oktsec hook in any scope. Used by health.go and
+// the doctor command to report the gap without having to enumerate
+// the planned manifest at the call site.
+func MissingExpectedEvents(hooks []HookRef) []string {
+	covered := map[string]bool{}
+	for _, h := range hooks {
+		if h.IsOktsec {
+			covered[h.Event] = true
+		}
+	}
+	var missing []string
+	for _, e := range expectedEventFamilies {
+		if !covered[e] {
+			missing = append(missing, e)
+		}
+	}
+	return missing
+}

--- a/internal/connectors/claudecode/inventory.go
+++ b/internal/connectors/claudecode/inventory.go
@@ -1,0 +1,269 @@
+// Package claudecode is the read-only Claude Code connector inventory
+// used by `oktsec doctor claude-code` and the dashboard health endpoint.
+//
+// Phase 1 contract (see documentation/engineering/specs/2026-04-27-
+// claude-code-detection-posture-evidence-spec.md, Execution Decision):
+// this package never writes to ~/.claude.json, ~/.claude/settings.json,
+// project .claude/, or any other Claude state. Hook installation and
+// repair belong to Phase 2 (Hook Manifest V2). The job here is to look
+// at what is on disk, report it accurately, and let the operator decide
+// what to fix.
+//
+// The package is layered so a future repair PR can plug in writers
+// without touching the readers:
+//
+//	settings.go  -- parse user/project Claude settings JSON
+//	agents.go    -- parse .claude/agents/*.md frontmatter
+//	hooks.go     -- extract HookRef rows from settings (read-only)
+//	mcp.go       -- parse mcpServers from ~/.claude.json + .mcp.json
+//	health.go    -- derive ConnectorHealth from inventory + audit signal
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Inventory is the read-only snapshot of one Claude Code install on
+// this machine, scoped to one project. Every field reports what was
+// found on disk; nothing in this struct is a policy decision.
+type Inventory struct {
+	// Detected is true when the Claude CLI was found on PATH OR a
+	// Claude state file (~/.claude.json or ~/.claude/settings.json)
+	// exists. Either signal is enough to say "the user has used Claude
+	// Code on this machine".
+	Detected bool `json:"detected"`
+
+	// ClaudeCLIPath is the absolute path to the `claude` binary, or
+	// "" when not on PATH.
+	ClaudeCLIPath string `json:"claude_cli_path,omitempty"`
+
+	// ClaudeVersion is the captured `claude --version` output (best
+	// effort). Empty when the CLI is not on PATH or the call failed.
+	ClaudeVersion string `json:"claude_version,omitempty"`
+
+	// UserSettingsPath / ProjectSettingsPath / LocalSettingsPath are
+	// the paths the inventory inspected. They are reported even when
+	// the file does not exist so the operator can see exactly which
+	// path was checked.
+	UserSettingsPath    string `json:"user_settings_path"`
+	ProjectSettingsPath string `json:"project_settings_path,omitempty"`
+	LocalSettingsPath   string `json:"local_settings_path,omitempty"`
+
+	// GlobalStatePath is ~/.claude.json. Reported even when missing.
+	GlobalStatePath string `json:"global_state_path"`
+
+	// CurrentProjectPath is the project the inventory used as the
+	// project-scope source. Empty when no project was supplied.
+	CurrentProjectPath string `json:"current_project_path,omitempty"`
+
+	// MCPServers lists every (scope, server) pair the inventory found
+	// across user, project, .mcp.json, and the per-project entries
+	// inside ~/.claude.json. Order is deterministic for stable output.
+	MCPServers []MCPServerRef `json:"mcp_servers"`
+
+	// Subagents are the static .claude/agents/*.md files reachable from
+	// user and project scope. Subagents created at runtime via
+	// `claude --agents` are NOT listed here; Phase 3 will add
+	// `cli-observed` actors from hook events.
+	Subagents []SubagentRef `json:"subagents"`
+
+	// Hooks lists every hook entry the inventory found in the user and
+	// project settings files. Plugin / managed / agent-frontmatter
+	// hooks are not parsed in Phase 1 because they require resolving
+	// plugin metadata; the spec marks that as a Phase 2 follow-up.
+	Hooks []HookRef `json:"hooks"`
+
+	// Problems are operator-actionable issues the inventory noticed
+	// while reading. Severity is informational here; the doctor /
+	// dashboard layer decides what to do with each one.
+	Problems []ConnectorProblem `json:"problems"`
+}
+
+// MCPServerRef is one Claude Code MCP server entry.
+type MCPServerRef struct {
+	Name      string            `json:"name"`
+	Scope     string            `json:"scope"`             // user | project | local | mcp_json | global
+	Source    string            `json:"source"`            // path to the file the entry came from
+	Transport string            `json:"transport,omitempty"` // stdio | http (when known)
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	URL       string            `json:"url,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	IsOktsec  bool              `json:"is_oktsec,omitempty"` // true when the entry routes through oktsec
+}
+
+// HookRef is one hook entry as it appears on disk. The fields capture
+// just enough for the doctor to say "this hook would run X for event Y
+// in scope Z" without taking any action.
+type HookRef struct {
+	Scope        string `json:"scope"`             // user | project | local
+	Path         string `json:"path"`              // settings file the entry came from
+	Event        string `json:"event"`             // PreToolUse, PostToolUse, SessionStart, etc.
+	Matcher      string `json:"matcher,omitempty"` // tool-name matcher (regex/glob)
+	Type         string `json:"type"`              // command | http | mcp_tool | prompt | agent
+	Command      string `json:"command,omitempty"`
+	URL          string `json:"url,omitempty"`
+	IsOktsec     bool   `json:"is_oktsec"`         // command points at the `oktsec hook` subcommand
+	Expected     bool   `json:"expected"`          // event family Phase 2 will install (informational)
+	BlockingCap  bool   `json:"blocking_cap"`      // event family can deny the action (PreToolUse, etc.)
+}
+
+// SubagentRef is one .claude/agents/*.md file.
+type SubagentRef struct {
+	Name            string   `json:"name"`
+	Source          string   `json:"source"` // user | project
+	Path            string   `json:"path"`
+	Tools           []string `json:"tools,omitempty"`
+	DisallowedTools []string `json:"disallowed_tools,omitempty"`
+	MCPServers      []string `json:"mcp_servers,omitempty"`
+	PermissionMode  string   `json:"permission_mode,omitempty"`
+	HooksPresent    bool     `json:"hooks_present"`
+}
+
+// ConnectorProblem is one issue the inventory wants the operator (or
+// the doctor formatter) to know about. Severity controls how the
+// dashboard groups it; FixKind is a hint for Phase 5 (AI Fix
+// Assistant) about whether automation is safe.
+type ConnectorProblem struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"` // setup | warning | risk
+	Title    string `json:"title"`
+	Detail   string `json:"detail,omitempty"`
+	FixKind  string `json:"fix_kind,omitempty"` // auto | guided | manual
+	// FixCommand is a copy-paste snippet a future repair flow can run.
+	// Phase 1 only fills it for setup/install nudges; never destructive.
+	FixCommand []string `json:"fix_command,omitempty"`
+}
+
+// ReadOptions controls which paths the inventory inspects.
+//
+// HomeDir defaults to os.UserHomeDir; ProjectDir defaults to "" (no
+// project scope). Tests inject both so they can use t.TempDir without
+// touching the user's real Claude state. ClaudeBinary lets a test
+// stub the version probe.
+type ReadOptions struct {
+	HomeDir      string
+	ProjectDir   string
+	ClaudeBinary string // override `claude` binary path; "" means PATH lookup
+	// SkipVersionProbe avoids running `claude --version` even when the
+	// binary is found. The doctor sets this in --json mode so the
+	// command stays purely read-only on the filesystem.
+	SkipVersionProbe bool
+}
+
+// Read inspects on-disk Claude Code state and returns an Inventory.
+// It never writes to any Claude file. Errors during one reader (e.g.
+// a malformed settings.json) are recorded as Problems on the returned
+// Inventory rather than aborting the whole scan, so the doctor can
+// still report partial state.
+func Read(ctx context.Context, opts ReadOptions) Inventory {
+	if opts.HomeDir == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			opts.HomeDir = h
+		}
+	}
+
+	inv := Inventory{
+		UserSettingsPath: filepath.Join(opts.HomeDir, ".claude", "settings.json"),
+		GlobalStatePath:  filepath.Join(opts.HomeDir, ".claude.json"),
+	}
+	if opts.ProjectDir != "" {
+		inv.CurrentProjectPath = opts.ProjectDir
+		inv.ProjectSettingsPath = filepath.Join(opts.ProjectDir, ".claude", "settings.json")
+		inv.LocalSettingsPath = filepath.Join(opts.ProjectDir, ".claude", "settings.local.json")
+	}
+
+	// Detect Claude CLI. PATH lookup honors ClaudeBinary override so
+	// tests can fake an installed CLI without modifying $PATH.
+	if opts.ClaudeBinary != "" {
+		if _, err := os.Stat(opts.ClaudeBinary); err == nil {
+			inv.ClaudeCLIPath = opts.ClaudeBinary
+		}
+	} else if path, err := exec.LookPath("claude"); err == nil {
+		inv.ClaudeCLIPath = path
+	}
+	if inv.ClaudeCLIPath != "" && !opts.SkipVersionProbe {
+		// Best-effort version probe. We bound execution with the
+		// caller's context so a hung CLI cannot stall the doctor.
+		out, err := runClaudeVersion(ctx, inv.ClaudeCLIPath)
+		if err == nil {
+			inv.ClaudeVersion = strings.TrimSpace(out)
+		}
+	}
+
+	// Detect any signal that Claude has been used here. Either a CLI
+	// on PATH or a state file is enough.
+	if inv.ClaudeCLIPath != "" || pathExists(inv.UserSettingsPath) || pathExists(inv.GlobalStatePath) {
+		inv.Detected = true
+	}
+
+	// Settings, hooks, MCP, agents — each reader returns its own
+	// Problems entries instead of returning errors, so a single bad
+	// file never silences the rest of the scan.
+	hooks, settingsProblems := readHooks(opts)
+	inv.Hooks = hooks
+	inv.Problems = append(inv.Problems, settingsProblems...)
+
+	servers, mcpProblems := readMCPServers(opts)
+	inv.MCPServers = servers
+	inv.Problems = append(inv.Problems, mcpProblems...)
+
+	subagents, agentProblems := readSubagents(opts)
+	inv.Subagents = subagents
+	inv.Problems = append(inv.Problems, agentProblems...)
+
+	// Cross-cutting hint: if Claude is detected but no oktsec hook is
+	// installed yet, surface that as a setup nudge. Phase 2 will fix
+	// it; Phase 1 just reports.
+	if inv.Detected && !hasOktsecHook(inv.Hooks) {
+		inv.Problems = append(inv.Problems, ConnectorProblem{
+			Code:     "CC-HOOKS-MISSING",
+			Severity: "setup",
+			Title:    "No oktsec hook installed in Claude Code",
+			Detail:   "Phase 2 (Hook Manifest V2) will install pre/post-tool hooks; until then no Claude Code activity reaches the gateway via hooks.",
+			FixKind:  "guided",
+		})
+	}
+
+	return inv
+}
+
+// runClaudeVersion is a seam tests can override (see test file). It
+// uses exec.CommandContext so the doctor can cancel a hung probe.
+var runClaudeVersion = func(ctx context.Context, binary string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	//nolint:gosec // binary path is resolved by exec.LookPath / explicit user override
+	out, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return string(ee.Stderr), err
+		}
+		return "", err
+	}
+	return string(out), nil
+}
+
+func pathExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func hasOktsecHook(hooks []HookRef) bool {
+	for _, h := range hooks {
+		if h.IsOktsec {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectors/claudecode/inventory_test.go
+++ b/internal/connectors/claudecode/inventory_test.go
@@ -1,0 +1,391 @@
+package claudecode
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixtureHome assembles a fake $HOME with the given on-disk Claude
+// state, returning the temp dir so tests can pass it as opts.HomeDir.
+// Each map value names a fixture from fixtures_test.go (string consts
+// rather than testdata/ files because the repo gitignores testdata/).
+func fixtureHome(t *testing.T, files map[string]string) string {
+	t.Helper()
+	home := t.TempDir()
+	for rel, src := range files {
+		dst := filepath.Join(home, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		body, ok := fixtureSources[src]
+		if !ok {
+			t.Fatalf("unknown fixture %q (add it to fixtures_test.go)", src)
+		}
+		if err := os.WriteFile(dst, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+// TestRead_NoClaudeState confirms the doctor handles a fresh box
+// gracefully: no settings, no global state, no CLI -> Detected=false
+// and no Problems entries blaming the operator.
+func TestRead_NoClaudeState(t *testing.T) {
+	home := t.TempDir()
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		ClaudeBinary:     filepath.Join(home, "no-such-binary"),
+		SkipVersionProbe: true,
+	})
+
+	if inv.Detected {
+		t.Errorf("Detected = true, want false on a clean home")
+	}
+	if len(inv.Hooks) != 0 {
+		t.Errorf("Hooks = %d, want 0 on a clean home", len(inv.Hooks))
+	}
+	if len(inv.MCPServers) != 0 {
+		t.Errorf("MCPServers = %d, want 0", len(inv.MCPServers))
+	}
+	if inv.UserSettingsPath == "" {
+		t.Error("UserSettingsPath should be reported even when missing")
+	}
+	if hasProblemCode(inv.Problems, "CC-HOOKS-MISSING") {
+		t.Error("CC-HOOKS-MISSING should not fire when Claude itself is not detected")
+	}
+}
+
+// TestRead_OktsecHookInstalled exercises the happy path: oktsec hooks
+// already in user settings, gateway entry in ~/.claude.json.
+func TestRead_OktsecHookInstalled(t *testing.T) {
+	home := fixtureHome(t, map[string]string{
+		".claude/settings.json": "user_settings_with_oktsec.json",
+		".claude.json":          "claude_json.json",
+	})
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	if !inv.Detected {
+		t.Fatal("Detected = false, want true")
+	}
+	if !hasOktsecHook(inv.Hooks) {
+		t.Errorf("expected at least one oktsec hook, got %+v", inv.Hooks)
+	}
+	if !hasOktsecGatewayMCP(inv.MCPServers) {
+		t.Errorf("expected oktsec-gateway MCP entry, got %+v", inv.MCPServers)
+	}
+	if hasProblemCode(inv.Problems, "CC-HOOKS-MISSING") {
+		t.Error("CC-HOOKS-MISSING fired despite oktsec hooks being installed")
+	}
+
+	var pre HookRef
+	for _, h := range inv.Hooks {
+		if h.Event == "PreToolUse" {
+			pre = h
+			break
+		}
+	}
+	if !pre.IsOktsec {
+		t.Errorf("PreToolUse hook IsOktsec = false, want true; ref=%+v", pre)
+	}
+	if !pre.BlockingCap {
+		t.Error("PreToolUse should be marked BlockingCap=true")
+	}
+	if !pre.Expected {
+		t.Error("PreToolUse should be marked Expected=true (Phase 2 manifest)")
+	}
+}
+
+// TestRead_HookButNotOktsec proves we do not credit unrelated tooling
+// for our coverage. Settings carry a non-oktsec command hook only.
+func TestRead_HookButNotOktsec(t *testing.T) {
+	home := fixtureHome(t, map[string]string{
+		".claude/settings.json": "user_settings_no_oktsec.json",
+	})
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	if hasOktsecHook(inv.Hooks) {
+		t.Error("hasOktsecHook = true, want false (the command was a third-party linter)")
+	}
+	if !hasProblemCode(inv.Problems, "CC-HOOKS-MISSING") {
+		t.Error("expected CC-HOOKS-MISSING to flag the gap")
+	}
+}
+
+// TestRead_ProjectScopedMCPFromGlobalState exercises the
+// ~/.claude.json projects[X] path. The fixture has a placeholder
+// project key we rewrite to the temp dir at runtime so the parser
+// matches against the real opts.ProjectDir.
+func TestRead_ProjectScopedMCPFromGlobalState(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	rewritten := strings.ReplaceAll(fixtureSources["claude_json.json"], "/PROJECT_DIR_PLACEHOLDER", project)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(rewritten), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		ProjectDir:       project,
+		SkipVersionProbe: true,
+	})
+
+	var sawProjectScoped bool
+	for _, s := range inv.MCPServers {
+		if s.Name == "filesystem" && s.Scope == "global" {
+			sawProjectScoped = true
+		}
+	}
+	if !sawProjectScoped {
+		t.Errorf("expected project-scoped 'filesystem' entry from global state, got %+v", inv.MCPServers)
+	}
+}
+
+// TestRead_AgentMarkdownParsing verifies the static .claude/agents/*.md
+// reader picks up frontmatter fields and falls back to file basename
+// when name is missing.
+func TestRead_AgentMarkdownParsing(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, fix := range []string{"agent_code_reviewer.md", "agent_no_frontmatter.md"} {
+		body, ok := fixtureSources[fix]
+		if !ok {
+			t.Fatalf("unknown fixture %q", fix)
+		}
+		dst := filepath.Join(home, ".claude", "agents", fix)
+		if err := os.WriteFile(dst, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	if len(inv.Subagents) != 2 {
+		t.Fatalf("Subagents = %d, want 2", len(inv.Subagents))
+	}
+	byName := map[string]SubagentRef{}
+	for _, s := range inv.Subagents {
+		byName[s.Name] = s
+	}
+	rev, ok := byName["code-reviewer"]
+	if !ok {
+		t.Fatal("code-reviewer agent missing")
+	}
+	if rev.PermissionMode != "confirmActions" {
+		t.Errorf("permissionMode = %q, want confirmActions", rev.PermissionMode)
+	}
+	if !rev.HooksPresent {
+		t.Error("HooksPresent should be true when frontmatter has hooks key")
+	}
+	if len(rev.Tools) != 2 || rev.Tools[0] != "Read" {
+		t.Errorf("Tools = %v, want [Read Grep]", rev.Tools)
+	}
+
+	if _, ok := byName["agent_no_frontmatter"]; !ok {
+		t.Error("expected fallback name 'agent_no_frontmatter' for file with no name field")
+	}
+}
+
+// TestRead_MalformedSettingsRecordsProblem confirms a broken JSON
+// surfaces as a Problem and does not abort the rest of the scan.
+func TestRead_MalformedSettingsRecordsProblem(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(home, ".claude", "settings.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	if !hasProblemCode(inv.Problems, "CC-SETTINGS-PARSE") {
+		t.Errorf("expected CC-SETTINGS-PARSE problem, got %+v", inv.Problems)
+	}
+	if len(inv.Hooks) != 0 {
+		t.Errorf("Hooks should be empty when settings parse fails, got %+v", inv.Hooks)
+	}
+}
+
+// TestMissingExpectedEvents covers the Phase 2 manifest gap report.
+func TestMissingExpectedEvents(t *testing.T) {
+	home := fixtureHome(t, map[string]string{
+		".claude/settings.json": "user_settings_with_oktsec.json",
+	})
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	missing := MissingExpectedEvents(inv.Hooks)
+	// The fixture installs oktsec hooks for PreToolUse and PostToolUse,
+	// so neither should appear in the missing list, but everything
+	// else from the Phase 2 manifest should.
+	for _, e := range missing {
+		if e == "PreToolUse" || e == "PostToolUse" {
+			t.Errorf("Phase 2 missing list should not contain installed event %q", e)
+		}
+	}
+	if len(missing) == 0 {
+		t.Error("expected at least one missing Phase 2 event (e.g. SubagentStart)")
+	}
+}
+
+// TestDeriveHealth_StatusTransitions locks in the status mapping so
+// the dashboard can rely on these strings in Phase 4.
+func TestDeriveHealth_StatusTransitions(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	cases := []struct {
+		name      string
+		inv       Inventory
+		lastEvent string
+		want      string
+	}{
+		{
+			name: "not_installed",
+			inv:  Inventory{Detected: false},
+			want: "not_installed",
+		},
+		{
+			name: "disconnected when detected but no oktsec hook or gateway",
+			inv:  Inventory{Detected: true},
+			want: "disconnected",
+		},
+		{
+			name: "partial when oktsec hook installed but no event yet",
+			inv: Inventory{
+				Detected: true,
+				Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+			},
+			want: "partial",
+		},
+		{
+			name: "ready when last event is recent",
+			inv: Inventory{
+				Detected: true,
+				Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+			},
+			lastEvent: now.Add(-30 * time.Minute).Format(time.RFC3339),
+			want:      "ready",
+		},
+		{
+			name: "stale when last event is older than threshold",
+			inv: Inventory{
+				Detected: true,
+				Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+			},
+			lastEvent: now.Add(-48 * time.Hour).Format(time.RFC3339),
+			want:      "stale",
+		},
+		{
+			name: "partial on garbled timestamp",
+			inv: Inventory{
+				Detected: true,
+				Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+			},
+			lastEvent: "not-a-timestamp",
+			want:      "partial",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := DeriveHealth(tc.inv, HealthOptions{
+				LastEvent: tc.lastEvent,
+				Now:       clock,
+			})
+			if h.Status != tc.want {
+				t.Errorf("status = %q, want %q (reason: %s)", h.Status, tc.want, h.Reason)
+			}
+			if h.Reason == "" {
+				t.Error("Reason should always be populated for the dashboard pill")
+			}
+		})
+	}
+}
+
+// TestRead_NeverWritesToHome guards the Phase 1 read-only contract:
+// a baseline directory snapshot before Read must equal the snapshot
+// after Read. If a future change accidentally writes anything, the
+// snapshot diff catches it.
+func TestRead_NeverWritesToHome(t *testing.T) {
+	home := fixtureHome(t, map[string]string{
+		".claude/settings.json": "user_settings_with_oktsec.json",
+		".claude.json":          "claude_json.json",
+	})
+	before := snapshotTree(t, home)
+
+	_ = Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+
+	after := snapshotTree(t, home)
+	if before != after {
+		t.Errorf("Read mutated $HOME (Phase 1 must be read-only)\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// snapshotTree returns a stable string of (relpath, size, modtime)
+// for every file under root. Sufficient to detect any mutation by
+// Read without depending on file content order.
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+	var lines []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		lines = append(lines, rel+"\t"+info.ModTime().UTC().Format(time.RFC3339Nano)+"\t"+itoaInt64(info.Size()))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func itoaInt64(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func hasProblemCode(ps []ConnectorProblem, code string) bool {
+	for _, p := range ps {
+		if p.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectors/claudecode/mcp.go
+++ b/internal/connectors/claudecode/mcp.go
@@ -1,0 +1,243 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// rawMCPServer matches the on-disk shape Claude Code uses for an MCP
+// server entry across all three sources (~/.claude.json, project
+// .mcp.json, and per-project entries inside ~/.claude.json). Fields
+// not modeled here are ignored — the inventory only needs enough to
+// identify the server, its transport, and whether it routes through
+// oktsec.
+type rawMCPServer struct {
+	Type      string            `json:"type,omitempty"`
+	Transport string            `json:"transport,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	URL       string            `json:"url,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+}
+
+// rawClaudeJSON is just the slice of ~/.claude.json the inventory
+// touches: the global mcpServers map and the per-project nested map.
+// Everything else (history, plugin state, etc.) stays as raw JSON in
+// the parent map and is ignored.
+type rawClaudeJSON struct {
+	MCPServers map[string]rawMCPServer            `json:"mcpServers,omitempty"`
+	Projects   map[string]rawClaudeJSONProject    `json:"projects,omitempty"`
+}
+
+type rawClaudeJSONProject struct {
+	MCPServers map[string]rawMCPServer `json:"mcpServers,omitempty"`
+}
+
+// rawMCPJSON matches `<project>/.mcp.json` — Claude Code's
+// project-scoped MCP config.
+type rawMCPJSON struct {
+	MCPServers map[string]rawMCPServer `json:"mcpServers,omitempty"`
+}
+
+// readMCPServers gathers (scope, server) entries from every Claude
+// Code source the spec calls out:
+//
+//   - ~/.claude.json::mcpServers              -> scope "user"
+//   - ~/.claude.json::projects[X].mcpServers   -> scope "global" (per-project, but stored centrally)
+//   - <project>/.mcp.json::mcpServers          -> scope "mcp_json"
+//   - <project>/.claude/settings.json::mcpServers (if present) -> scope "project"
+//
+// Project / mcp_json scopes are skipped when no project directory is
+// supplied, so the doctor never reports cwd-relative state by accident.
+func readMCPServers(opts ReadOptions) ([]MCPServerRef, []ConnectorProblem) {
+	var refs []MCPServerRef
+	var problems []ConnectorProblem
+
+	// 1) ~/.claude.json (global state file).
+	globalPath := filepath.Join(opts.HomeDir, ".claude.json")
+	if global, prob := readClaudeJSON(globalPath); prob != nil {
+		problems = append(problems, *prob)
+	} else if global != nil {
+		for _, name := range sortedKeys(global.MCPServers) {
+			refs = append(refs, toMCPRef(name, "user", globalPath, global.MCPServers[name]))
+		}
+		// Per-project entries inside ~/.claude.json. We only surface
+		// the entries belonging to opts.ProjectDir so a doctor run
+		// scoped to one project does not leak unrelated projects.
+		if opts.ProjectDir != "" {
+			if proj, ok := global.Projects[opts.ProjectDir]; ok {
+				for _, name := range sortedKeys(proj.MCPServers) {
+					refs = append(refs, toMCPRef(name, "global", globalPath, proj.MCPServers[name]))
+				}
+			}
+		}
+	}
+
+	// 2) Project .mcp.json.
+	if opts.ProjectDir != "" {
+		mcpJSON := filepath.Join(opts.ProjectDir, ".mcp.json")
+		if mp, prob := readMCPJSON(mcpJSON); prob != nil {
+			problems = append(problems, *prob)
+		} else if mp != nil {
+			for _, name := range sortedKeys(mp.MCPServers) {
+				refs = append(refs, toMCPRef(name, "mcp_json", mcpJSON, mp.MCPServers[name]))
+			}
+		}
+
+		// 3) Project settings.json may also carry mcpServers (newer
+		// Claude builds). Reuse readSettings for consistent error paths
+		// but decode into a tiny private shape: settings.go already
+		// has rawSettings without mcpServers so we re-read here.
+		projSettings := filepath.Join(opts.ProjectDir, ".claude", "settings.json")
+		if servers, prob := readMCPFromSettings(projSettings); prob != nil {
+			problems = append(problems, *prob)
+		} else {
+			for _, name := range sortedKeys(servers) {
+				refs = append(refs, toMCPRef(name, "project", projSettings, servers[name]))
+			}
+		}
+	}
+
+	sort.SliceStable(refs, func(i, j int) bool {
+		if refs[i].Name != refs[j].Name {
+			return refs[i].Name < refs[j].Name
+		}
+		return refs[i].Scope < refs[j].Scope
+	})
+	return refs, problems
+}
+
+func readClaudeJSON(path string) (*rawClaudeJSON, *ConnectorProblem) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, &ConnectorProblem{
+			Code:     "CC-CLAUDEJSON-READ",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to read %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	var raw rawClaudeJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-CLAUDEJSON-PARSE",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to parse %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	return &raw, nil
+}
+
+func readMCPJSON(path string) (*rawMCPJSON, *ConnectorProblem) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, &ConnectorProblem{
+			Code:     "CC-MCPJSON-READ",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to read %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	var raw rawMCPJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-MCPJSON-PARSE",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to parse %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	return &raw, nil
+}
+
+// readMCPFromSettings extracts the optional mcpServers map from a
+// Claude project settings file. Returns (nil, nil) when the file is
+// missing or has no mcpServers key.
+func readMCPFromSettings(path string) (map[string]rawMCPServer, *ConnectorProblem) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, &ConnectorProblem{
+			Code:     "CC-SETTINGS-READ",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to read %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	var shell struct {
+		MCPServers map[string]rawMCPServer `json:"mcpServers,omitempty"`
+	}
+	if err := json.Unmarshal(data, &shell); err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-SETTINGS-PARSE",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to parse %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	return shell.MCPServers, nil
+}
+
+func toMCPRef(name, scope, source string, raw rawMCPServer) MCPServerRef {
+	transport := raw.Transport
+	if transport == "" {
+		transport = raw.Type // some configs use "type" instead of "transport"
+	}
+	if transport == "" {
+		switch {
+		case raw.URL != "":
+			transport = "http"
+		case raw.Command != "":
+			transport = "stdio"
+		}
+	}
+	return MCPServerRef{
+		Name:      name,
+		Scope:     scope,
+		Source:    source,
+		Transport: transport,
+		Command:   raw.Command,
+		Args:      raw.Args,
+		URL:       raw.URL,
+		Env:       raw.Env,
+		IsOktsec:  isOktsecMCPServer(raw),
+	}
+}
+
+// isOktsecMCPServer flags entries that route through oktsec — either
+// the gateway HTTP URL or a wrapped stdio command. Conservative:
+// matches only the explicit oktsec command name and the "/mcp"
+// gateway endpoint to avoid claiming arbitrary HTTP MCP servers as
+// oktsec-managed.
+func isOktsecMCPServer(raw rawMCPServer) bool {
+	if raw.Command == "oktsec" {
+		return true
+	}
+	if raw.URL == "" {
+		return false
+	}
+	// Gateway URLs end in the configured endpoint_path (default "/mcp").
+	// We also accept "/mcp/" and any query string. Match only when the
+	// host is loopback or the URL clearly points at an oktsec gateway
+	// to avoid false positives.
+	lower := strings.ToLower(raw.URL)
+	if !strings.Contains(lower, "/mcp") {
+		return false
+	}
+	return strings.Contains(lower, "127.0.0.1") || strings.Contains(lower, "localhost") || strings.Contains(lower, "oktsec")
+}

--- a/internal/connectors/claudecode/settings.go
+++ b/internal/connectors/claudecode/settings.go
@@ -1,0 +1,79 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+)
+
+// rawSettings is just enough of the Claude Code settings.json shape
+// to extract hooks. Anything not modeled here is left as raw JSON in
+// the parent map and ignored, so unknown keys never cause Read to
+// fail. The shape mirrors the public docs at code.claude.com/docs/en/hooks.
+type rawSettings struct {
+	Hooks map[string]json.RawMessage `json:"hooks,omitempty"`
+}
+
+// rawHookEntry covers both shapes Claude Code accepts under one event:
+//   { "matcher": "*", "hooks": [ { "type": "command", "command": "..." } ] }
+//
+// The "hooks" inner array can also be a single object in some older
+// configs; we accept both via json.RawMessage and decode lazily.
+type rawHookEntry struct {
+	Matcher string            `json:"matcher,omitempty"`
+	Hooks   []rawHookHandler  `json:"hooks,omitempty"`
+}
+
+type rawHookHandler struct {
+	Type    string `json:"type,omitempty"`    // command | http | mcp_tool | prompt | agent
+	Command string `json:"command,omitempty"`
+	URL     string `json:"url,omitempty"`
+}
+
+// readSettings loads a single Claude settings file and unmarshals it
+// into rawSettings. Returns (nil, nil) when the file does not exist
+// — that is the normal "no project settings yet" case and not a
+// problem the operator needs to act on.
+func readSettings(path string) (*rawSettings, *ConnectorProblem) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, &ConnectorProblem{
+			Code:     "CC-SETTINGS-READ",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to read %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	if len(data) == 0 {
+		// An empty file is legal but parses as null; treat as "no settings".
+		return &rawSettings{}, nil
+	}
+	var s rawSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, &ConnectorProblem{
+			Code:     "CC-SETTINGS-PARSE",
+			Severity: "warning",
+			Title:    fmt.Sprintf("Unable to parse %s", path),
+			Detail:   err.Error(),
+		}
+	}
+	return &s, nil
+}
+
+// sortedKeys returns map keys in deterministic order so JSON output
+// from the doctor command does not jitter between runs. Centralized
+// here because every reader needs the same trick.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/dashboard/claude_code_health_test.go
+++ b/internal/dashboard/claude_code_health_test.go
@@ -1,0 +1,76 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity"
+)
+
+// TestClaudeCodeHealthEndpoint_NotInstalled verifies the dashboard
+// reports the right status string when no Claude state exists. The
+// dashboard pill code in Phase 4 will read this verbatim, so locking
+// it in here prevents accidental copy drift later.
+func TestClaudeCodeHealthEndpoint_NotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store, err := audit.NewStore(filepath.Join(dir, "test.db"), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Point HOME at an empty temp dir so the connector inspector sees
+	// a clean machine. PATH is cleared so the host's real `claude`
+	// binary (if any) does not flip Detected to true.
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("PATH", "")
+
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 0},
+		DBPath:  filepath.Join(dir, "test.db"),
+		Agents:  map[string]config.Agent{},
+	}
+	srv := NewServer(cfg, filepath.Join(dir, "oktsec.yaml"), store, identity.NewKeyStore(), sharedScanner, logger)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Use ?project=<empty-temp-dir> so the handler does not pick up
+	// this repo's project state by accident.
+	u := "/dashboard/api/connectors/claude-code/health?" + url.Values{"project": {emptyHome}}.Encode()
+	req := httptest.NewRequest("GET", u, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Health struct {
+			Status string `json:"status"`
+		} `json:"health"`
+		Inventory struct {
+			Detected bool `json:"detected"`
+		} `json:"inventory"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v; body=%s", err, w.Body.String())
+	}
+	if body.Health.Status != "not_installed" {
+		t.Errorf("status = %q, want not_installed (body=%s)", body.Health.Status, w.Body.String())
+	}
+	if body.Inventory.Detected {
+		t.Error("inventory.Detected should be false on an empty home")
+	}
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/auditcheck"
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
 	"github.com/oktsec/oktsec/internal/coverage"
 	"github.com/oktsec/oktsec/internal/discover"
 	"github.com/oktsec/oktsec/internal/graph"
@@ -4264,6 +4265,45 @@ func (s *Server) handleAPIGraph(w http.ResponseWriter, r *http.Request) {
 	since := parseSinceRange(rangeStr)
 	g := s.cachedBuildGraph(since)
 	s.renderJSON(w, g)
+}
+
+// handleClaudeCodeHealth wraps the Phase 1 Claude Code connector
+// inventory + health derivation into a JSON endpoint the dashboard
+// (and external tooling) can poll. Read-only: it never writes to
+// Claude Code state, never installs hooks, never modifies config.
+//
+// The endpoint returns both the raw inventory and the derived health
+// view so a single fetch is enough to render the Connection Health
+// card without a follow-up round-trip.
+func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) {
+	projectDir := r.URL.Query().Get("project")
+	if projectDir == "" {
+		// Default to the directory the config file lives in. That is
+		// the most useful "current project" for `oktsec run` users
+		// because the proxy is launched from there.
+		if s.cfgPath != "" {
+			projectDir = filepath.Dir(s.cfgPath)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	inv := claudecode.Read(ctx, claudecode.ReadOptions{
+		ProjectDir: projectDir,
+		// Skip the version probe in the dashboard path so a hung CLI
+		// can never stall the dashboard request.
+		SkipVersionProbe: true,
+	})
+
+	health := claudecode.DeriveHealth(inv, claudecode.HealthOptions{
+		LastEvent: claudecode.LookupLastEvent(s.audit),
+	})
+
+	s.renderJSON(w, map[string]any{
+		"inventory": inv,
+		"health":    health,
+	})
 }
 
 // handleEvidenceStatus returns a snapshot of the audit store's row

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -410,6 +410,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /dashboard/api/graph/edge", s.handleEdgeDetail)
 	s.mux.HandleFunc("POST /dashboard/api/audit/clear", s.handleAuditClear)
 	s.mux.HandleFunc("GET /dashboard/api/evidence/status", s.handleEvidenceStatus)
+	s.mux.HandleFunc("GET /dashboard/api/connectors/claude-code/health", s.handleClaudeCodeHealth)
 	s.mux.HandleFunc("POST /dashboard/api/audit/fix/{checkID}", s.handleAuditFix)
 	s.mux.HandleFunc("POST /dashboard/api/audit/fix-all", s.handleAuditFixAll)
 	s.mux.HandleFunc("POST /dashboard/api/audit/enrich", s.handleAuditEnrich)


### PR DESCRIPTION
## Summary

- `internal/connectors/claudecode/` package walks `~/.claude/settings.json`, project `.claude/settings(.local).json`, `~/.claude.json` (top-level + per-project mcpServers), `.mcp.json`, and `.claude/agents/*.md`. Returns `HookRef` / `SubagentRef` / `MCPServerRef` rows plus `ConnectorProblem` entries. Read-only by contract; never writes to any Claude state.
- `oktsec doctor claude-code` (with `--json` and `--project`) wraps the inventory and a new `ConnectorHealth` derivation (`not_installed` / `disconnected` / `partial` / `stale` / `ready`).
- `GET /dashboard/api/connectors/claude-code/health` returns the same `{inventory, health}` envelope so future Connection Health UI can render in a single fetch.
- `claudecode.PrincipalID` and `LookupLastEvent()` live in the connector package so the regression test that bans hard-coded client names in graph code stays satisfied.

## Review focus

Per the rollout plan, please concentrate review on:
- **Inventory read-only contract** -- `TestRead_NeverWritesToHome` snapshots `$HOME` before and after `Read()` and fails on any mutation.
- **Health states** -- the five status transitions and Reason strings (`TestDeriveHealth_StatusTransitions`).
- **Dashboard endpoint** -- envelope shape and that the connector handler does not leak literal client names into graph code.
- **`oktsec doctor claude-code --json`** -- output stable enough for future tooling (the Phase 5 fix assistant) to consume.
- **No writes to `~/.claude/`** anywhere in this slice -- hook installation is intentionally deferred.

## Test plan

- [x] `make build`
- [x] `make test` -- all packages green on the rebased branch
- [x] `make vet`
- [x] `make lint` -- 0 issues
- [x] Smoke: `./oktsec doctor claude-code --json` against a real install detects the CLI binary, version, hooks, and MCP entries