### PR TITLE
Install Claude Code hooks with backup + modern decision shape

### DIFF
--- a/cmd/oktsec/commands/doctor_claude_code.go
+++ b/cmd/oktsec/commands/doctor_claude_code.go
@@ -26,29 +26,68 @@ import (
 // state or oktsec config.
 func newDoctorClaudeCodeCmd() *cobra.Command {
 	var (
-		jsonOut    bool
-		projectDir string
+		jsonOut         bool
+		projectDir      string
+		installHooks    bool
+		uninstallHooks  bool
+		emitHeartbeat   bool
+		followSymlink   bool
+		dryRun          bool
 	)
 	cmd := &cobra.Command{
 		Use:   "claude-code",
-		Short: "Inspect Claude Code connector state (read-only)",
+		Short: "Inspect Claude Code connector state (read-only by default)",
 		Long: `Reports what oktsec sees about the local Claude Code install:
 the CLI binary, user/project settings paths, hooks installed in each
 scope, MCP server entries (~/.claude.json, .mcp.json, project
 settings.json), and static .claude/agents files.
 
-This is a read-only diagnostic. It never writes to ~/.claude.json,
-~/.claude/settings.json, or any project Claude state. Hook
-installation comes in a separate phase.`,
+The no-flag invocation is read-only and never writes to Claude state.
+The optional flags --install-hooks, --uninstall-hooks, and
+--emit-heartbeat write to disk or POST to the gateway, and are the
+only paths in this command that mutate state. Each respects
+--follow-symlink and --dry-run; install / uninstall always write a
+backup before any mutation.`,
 		Example: `  oktsec doctor claude-code
   oktsec doctor claude-code --json
-  oktsec doctor claude-code --project /path/to/project`,
+  oktsec doctor claude-code --project /path/to/project
+  oktsec doctor claude-code --install-hooks
+  oktsec doctor claude-code --uninstall-hooks
+  oktsec doctor claude-code --emit-heartbeat`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Mutually-exclusive guard: install / uninstall are
+			// opposites and emit-heartbeat is a separate one-shot.
+			modes := 0
+			if installHooks {
+				modes++
+			}
+			if uninstallHooks {
+				modes++
+			}
+			if emitHeartbeat {
+				modes++
+			}
+			if modes > 1 {
+				return fmt.Errorf("--install-hooks, --uninstall-hooks, and --emit-heartbeat are mutually exclusive")
+			}
+			switch {
+			case installHooks:
+				return runDoctorClaudeCodeInstall(jsonOut, followSymlink, dryRun)
+			case uninstallHooks:
+				return runDoctorClaudeCodeUninstall(jsonOut, followSymlink, dryRun)
+			case emitHeartbeat:
+				return runDoctorClaudeCodeHeartbeat(jsonOut)
+			}
 			return runDoctorClaudeCode(jsonOut, projectDir)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
 	cmd.Flags().StringVar(&projectDir, "project", "", "project directory to scope project/local settings to (defaults to cwd when reading project state)")
+	cmd.Flags().BoolVar(&installHooks, "install-hooks", false, "write the Phase 2 hook manifest into ~/.claude/settings.json (creates a timestamped backup first)")
+	cmd.Flags().BoolVar(&uninstallHooks, "uninstall-hooks", false, "remove every oktsec hook entry from ~/.claude/settings.json (creates a timestamped backup first)")
+	cmd.Flags().BoolVar(&emitHeartbeat, "emit-heartbeat", false, "post a synthetic SessionStart event to the local gateway and report round-trip latency")
+	cmd.Flags().BoolVar(&followSymlink, "follow-symlink", false, "write through ~/.claude/settings.json even when it is a symlink (default: refuse)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview install/uninstall actions without touching disk")
 	return cmd
 }
 
@@ -256,4 +295,144 @@ func truncate(s string, n int) string {
 		return s[:n]
 	}
 	return s[:n-3] + "..."
+}
+
+// runDoctorClaudeCodeInstall executes the Phase 2 installer with
+// the same gateway port the running config uses. It is the only
+// flag on this command (along with uninstall) that mutates Claude
+// state on disk; tests cover the refusal paths.
+func runDoctorClaudeCodeInstall(jsonOut, followSymlink, dryRun bool) error {
+	port := resolveGatewayPort()
+	exe, err := os.Executable()
+	if err != nil || exe == "" {
+		return fmt.Errorf("resolving oktsec binary path: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, instErr := claudecode.InstallV2(ctx, claudecode.InstallOptions{
+		BinaryPath:    exe,
+		GatewayPort:   port,
+		FollowSymlink: followSymlink,
+		DryRun:        dryRun,
+	})
+	if jsonOut {
+		out := map[string]any{"result": res}
+		if instErr != nil {
+			out["error"] = instErr.Error()
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return instErr
+	}
+	emitInstallHuman(res, instErr)
+	return instErr
+}
+
+func runDoctorClaudeCodeUninstall(jsonOut, followSymlink, dryRun bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, uninstErr := claudecode.UninstallV2(ctx, claudecode.UninstallOptions{
+		FollowSymlink:   followSymlink,
+		DryRun:          dryRun,
+		IncludeLegacyV1: true,
+	})
+	if jsonOut {
+		out := map[string]any{"result": res}
+		if uninstErr != nil {
+			out["error"] = uninstErr.Error()
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return uninstErr
+	}
+	emitUninstallHuman(res, uninstErr)
+	return uninstErr
+}
+
+func runDoctorClaudeCodeHeartbeat(jsonOut bool) error {
+	port := resolveGatewayPort()
+	id, latency, err := EmitHeartbeat(port)
+	if jsonOut {
+		out := map[string]any{
+			"event_id":    id,
+			"latency_ms":  latency.Milliseconds(),
+			"gateway_port": port,
+		}
+		if err != nil {
+			out["error"] = err.Error()
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		return err
+	}
+	if err != nil {
+		fmt.Printf("  heartbeat failed: %v\n", err)
+		return err
+	}
+	fmt.Printf("  heartbeat ok — event %s, %dms round-trip via gateway port %d\n",
+		id, latency.Milliseconds(), port)
+	return nil
+}
+
+// resolveGatewayPort honors the loaded config when present and
+// falls back to the gateway default. Centralised so install /
+// heartbeat / hook share one resolution rule.
+func resolveGatewayPort() int {
+	if cfg, err := config.Load(cfgFile); err == nil && cfg.Gateway.Port > 0 {
+		return cfg.Gateway.Port
+	}
+	return 9090
+}
+
+func emitInstallHuman(res claudecode.InstallResult, err error) {
+	bold := color.New(color.Bold).SprintFunc()
+	fmt.Println()
+	fmt.Printf("  %s\n", bold("oktsec doctor claude-code --install-hooks"))
+	fmt.Println("  ────────────────────────────────────────")
+	fmt.Printf("  Settings:   %s\n", res.SettingsPath)
+	if res.BackupPath != "" {
+		fmt.Printf("  Backup:     %s\n", res.BackupPath)
+	}
+	if err != nil {
+		fmt.Printf("  %s %v\n", color.RedString("error:"), err)
+		return
+	}
+	if res.Skipped != "" {
+		fmt.Printf("  %s %s\n", color.YellowString("skipped:"), res.Skipped)
+	}
+	if res.Wrote {
+		fmt.Printf("  %s %d planned hook(s) written\n", color.GreenString("ok:"), len(res.Plan))
+		if res.UpgradedV1 > 0 {
+			fmt.Printf("  upgraded %d legacy v1 hook(s) in place\n", res.UpgradedV1)
+		}
+	}
+	fmt.Println()
+}
+
+func emitUninstallHuman(res claudecode.UninstallResult, err error) {
+	bold := color.New(color.Bold).SprintFunc()
+	fmt.Println()
+	fmt.Printf("  %s\n", bold("oktsec doctor claude-code --uninstall-hooks"))
+	fmt.Println("  ────────────────────────────────────────")
+	fmt.Printf("  Settings:   %s\n", res.SettingsPath)
+	if res.BackupPath != "" {
+		fmt.Printf("  Backup:     %s\n", res.BackupPath)
+	}
+	if err != nil {
+		fmt.Printf("  %s %v\n", color.RedString("error:"), err)
+		return
+	}
+	if res.Skipped != "" {
+		fmt.Printf("  %s %s\n", color.YellowString("skipped:"), res.Skipped)
+	}
+	if res.Wrote {
+		fmt.Printf("  %s removed %d v2 + %d v1 hook(s)\n",
+			color.GreenString("ok:"), res.RemovedV2, res.RemovedV1)
+	}
+	fmt.Println()
 }

--- a/cmd/oktsec/commands/hook.go
+++ b/cmd/oktsec/commands/hook.go
@@ -7,25 +7,56 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/spf13/cobra"
 )
 
+// newHookCmd is the binary the Phase 2 manifest installs into Claude
+// Code's settings.json. It reads one hook event from stdin, forwards
+// it to the gateway's /hooks/event endpoint, and translates the
+// gateway response into the per-event Claude Code response shape.
+//
+// Phase 2 contract (see documentation/engineering/specs/2026-04-27-
+// phase2-hook-manifest-v2-spec.md section 4):
+//   - PreToolUse: emit hookSpecificOutput.permissionDecision: "deny"
+//     with permissionDecisionReason on a block.
+//   - PostToolUse / PostToolUseFailure / PostToolBatch / Stop /
+//     ConfigChange / SubagentStop: top-level decision: "block" with
+//     reason and hookSpecificOutput.additionalContext.
+//   - PermissionRequest: hookSpecificOutput.decision.behavior: "deny".
+//   - TaskCreated / TaskCompleted: stderr + exit 2.
+//   - All other events: stdout `{}`, exit 0 (observe-only).
+//
+// Exit code semantics follow the official Claude Code docs:
+// exit 2 is blocking, exit 1 is non-blocking, exit 0 is success.
+// We use exit 2 alongside the JSON shape as belt-and-suspenders.
 func newHookCmd() *cobra.Command {
-	var port int
+	var (
+		port       int
+		event      string
+		manifestID string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "hook",
-		Short: "Forward a tool-call event to the oktsec gateway",
-		Long: `Reads a hook event from stdin and forwards it to the oktsec gateway.
-Exits silently with code 0 if the gateway is not running.
-Designed for use as a Claude Code command hook.`,
+		Short: "Forward a Claude Code hook event to the oktsec gateway",
+		Long: `Reads a Claude Code hook event from stdin, forwards it to the
+oktsec gateway, and emits the response shape Claude expects for the
+given event. Exits silently with code 0 if the gateway is not running
+(observe mode failure-open posture; set OKTSEC_HOOK_FAIL_CLOSED=1 to
+fail closed instead).
+
+Designed for use as a Claude Code command hook installed by the
+Phase 2 manifest.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// If --port wasn't explicitly set, read from config
+			// If --port wasn't explicitly set, read from config so the
+			// hook still works when the gateway runs on a non-default port.
 			if !cmd.Flags().Changed("port") {
 				cfgPath, found := config.ResolveConfigPath("", false)
 				if found {
@@ -34,57 +65,258 @@ Designed for use as a Claude Code command hook.`,
 					}
 				}
 			}
-			return runHook(port)
+			return runHook(port, event)
 		},
 	}
 
 	cmd.Flags().IntVar(&port, "port", 9090, "gateway port")
+	cmd.Flags().StringVar(&event, "event", "", "Claude Code hook event name (e.g. PreToolUse); falls back to hook_event_name in stdin payload")
+	// --manifest is a marker the Phase 2 installer adds to every
+	// command it writes. We accept and ignore it here so the flag
+	// is invisible to Claude's parser; inventory + uninstall use the
+	// presence of "--manifest v2" in the command string to know
+	// which entries they own.
+	cmd.Flags().StringVar(&manifestID, "manifest", "", "internal manifest version marker; do not set manually")
+	_ = manifestID
+
 	return cmd
 }
 
-func runHook(port int) error {
+func runHook(port int, eventOverride string) error {
 	body, err := io.ReadAll(os.Stdin)
 	if err != nil || len(body) == 0 {
 		return nil // nothing to send
 	}
 
-	url := fmt.Sprintf("http://127.0.0.1:%d/hooks/event", port)
+	// Detect event family. The --event flag the installer baked into
+	// the command is authoritative; falling back to hook_event_name
+	// in the stdin payload covers older Claude versions that may not
+	// echo the field consistently.
+	event := eventOverride
+	if event == "" {
+		var probe struct {
+			HookEventName string `json:"hook_event_name"`
+		}
+		if json.Unmarshal(body, &probe) == nil {
+			event = probe.HookEventName
+		}
+	}
 
+	url := fmt.Sprintf("http://127.0.0.1:%d/hooks/event", port)
 	client := &http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil // fail silently
+	req, reqErr := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if reqErr != nil {
+		return nil // fail-open on construction errors (e.g. malformed URL)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Oktsec-Agent", "claude-code")
 	req.Header.Set("X-Oktsec-Client", "claude-code")
+	// X-Oktsec-Agent kept for backwards compatibility with the
+	// pre-Phase-2 surface adapter contract; the gateway's identity
+	// resolver still honors it on loopback. Drop in Phase 4.
+	req.Header.Set("X-Oktsec-Agent", "claude-code")
 
-	// Forward session_id from the hook payload as a header.
-	var hookPayload struct {
+	// Forward session_id from the payload so the gateway can group
+	// events into runtime sessions (Phase 3).
+	var sessionProbe struct {
 		SessionID string `json:"session_id"`
 	}
-	if json.Unmarshal(body, &hookPayload) == nil && hookPayload.SessionID != "" {
-		req.Header.Set("X-Oktsec-Session", hookPayload.SessionID)
+	if json.Unmarshal(body, &sessionProbe) == nil && sessionProbe.SessionID != "" {
+		req.Header.Set("X-Oktsec-Session", sessionProbe.SessionID)
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		// Gateway not running — silently allow.
+	resp, doErr := client.Do(req)
+	if doErr != nil {
+		// Gateway unreachable. Record one diagnostic line so the
+		// dashboard can say "hooks installed but gateway unreachable"
+		// instead of silence; then honor the configured posture
+		// (fail-open by default).
+		writeHookDiag(event, fmt.Sprintf("gateway unreachable: %v", doErr))
+		if failClosed() {
+			emitFailClosed(event, "oktsec gateway unreachable")
+			os.Exit(2)
+		}
 		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Parse response to check for block decision.
-	var result struct {
-		Decision string `json:"decision"`
-		Reason   string `json:"reason"`
-	}
 	respBody, _ := io.ReadAll(resp.Body)
-	if json.Unmarshal(respBody, &result) == nil && result.Decision == "block" {
-		// Print reason to stderr so Claude Code shows it, then exit non-zero.
-		fmt.Fprintf(os.Stderr, "oktsec: blocked — %s\n", result.Reason)
-		os.Exit(2)
+	var result struct {
+		Decision          string `json:"decision"`
+		Reason            string `json:"reason"`
+		AdditionalContext string `json:"additional_context"`
+	}
+	_ = json.Unmarshal(respBody, &result)
+
+	if result.Decision != "block" {
+		// Allow path: explicit allow shape so tests can pin the
+		// envelope. Claude tolerates an empty stdout on observed
+		// events; we emit `{}` so a downstream parser never sees
+		// truncation.
+		fmt.Fprint(os.Stdout, "{}")
+		return nil
 	}
 
+	emitBlock(event, result.Reason, result.AdditionalContext)
+	os.Exit(2)
 	return nil
+}
+
+// emitBlock prints the per-event Claude Code response shape on
+// stdout. The Phase 2 spec section 4 enumerates every shape; this
+// switch is the single place to update when Claude evolves the
+// hook contract.
+func emitBlock(event, reason, additionalContext string) {
+	if reason == "" {
+		reason = "blocked by oktsec policy"
+	}
+	switch event {
+	case "PreToolUse":
+		// PreToolUse v2.0+ shape. The deprecated top-level
+		// {"decision":"block"} still works today but the spec
+		// explicitly migrates us to permissionDecision.
+		writeJSON(map[string]any{
+			"hookSpecificOutput": map[string]any{
+				"hookEventName":            "PreToolUse",
+				"permissionDecision":       "deny",
+				"permissionDecisionReason": reason,
+			},
+		})
+	case "PermissionRequest":
+		writeJSON(map[string]any{
+			"hookSpecificOutput": map[string]any{
+				"hookEventName": "PermissionRequest",
+				"decision": map[string]any{
+					"behavior": "deny",
+					"message":  reason,
+				},
+			},
+		})
+	case "PostToolUse", "PostToolUseFailure", "PostToolBatch",
+		"Stop", "ConfigChange", "SubagentStop":
+		// Top-level decision: "block" with hookSpecificOutput
+		// carrying additionalContext so Claude knows what the
+		// blocked output was about (e.g. "rotate the credential").
+		out := map[string]any{
+			"decision": "block",
+			"reason":   reason,
+		}
+		if additionalContext != "" {
+			out["hookSpecificOutput"] = map[string]any{
+				"hookEventName":     event,
+				"additionalContext": additionalContext,
+			}
+		}
+		writeJSON(out)
+	case "TaskCreated", "TaskCompleted":
+		// These events take exit-code-2 + stderr per docs; no
+		// JSON shape required.
+		fmt.Fprintf(os.Stderr, "oktsec: %s blocked — %s\n", event, reason)
+	default:
+		// Unknown / observe-only events should not normally reach
+		// this branch (the gateway should not return decision:block
+		// for them), but if they do we surface the reason on stderr
+		// and exit 2 so policy intent is honored.
+		fmt.Fprintf(os.Stderr, "oktsec: blocked — %s\n", reason)
+	}
+}
+
+// emitFailClosed is the fail-closed escape hatch when the gateway
+// is unreachable AND OKTSEC_HOOK_FAIL_CLOSED=1. Mirrors the block
+// shape so Claude Code refuses the action.
+func emitFailClosed(event, reason string) {
+	emitBlock(event, reason, "")
+}
+
+func writeJSON(payload map[string]any) {
+	enc := json.NewEncoder(os.Stdout)
+	_ = enc.Encode(payload)
+}
+
+func failClosed() bool {
+	return os.Getenv("OKTSEC_HOOK_FAIL_CLOSED") == "1"
+}
+
+// hookDiagMaxBytes caps the diagnostic file at 1 MiB. When the
+// limit is exceeded we rotate by truncating; an operator running
+// the doctor sees the most recent failures, not all of them.
+const hookDiagMaxBytes = 1 << 20
+
+// writeHookDiag appends a one-line JSON record to
+// ~/.oktsec/hook-diag.jsonl when the gateway is unreachable. Used
+// by the dashboard / doctor to say "hooks installed but gateway
+// unreachable" instead of just silence. Best-effort: any error
+// here is swallowed because we do not want to block the hook.
+func writeHookDiag(event, message string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	dir := filepath.Join(home, ".oktsec")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	path := filepath.Join(dir, "hook-diag.jsonl")
+
+	// Rotate when the file grows past the cap. Truncate is a
+	// pragmatic choice: a real ring buffer would be nicer but adds
+	// I/O cost on the hot path.
+	if info, err := os.Stat(path); err == nil && info.Size() > hookDiagMaxBytes {
+		_ = os.Truncate(path, 0)
+	}
+
+	rec := map[string]string{
+		"ts":      time.Now().UTC().Format(time.RFC3339),
+		"event":   event,
+		"message": message,
+	}
+	body, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	body = append(body, '\n')
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = f.Write(body)
+}
+
+// EmitHeartbeat is the synthetic event the doctor's --emit-heartbeat
+// flag posts to verify gateway round-trip. Exposed so the doctor
+// can call it without re-implementing the request plumbing. Returns
+// the event id the doctor displays alongside the latency measurement.
+func EmitHeartbeat(port int) (string, time.Duration, error) {
+	id := fmt.Sprintf("heartbeat-%s", time.Now().UTC().Format("20060102T150405.000Z"))
+	id = strings.ReplaceAll(id, ":", "")
+	body, err := json.Marshal(map[string]any{
+		"hook_event_name": "SessionStart",
+		"session_id":      id,
+		"source":          "oktsec-doctor",
+		"cwd":             "doctor-heartbeat",
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/hooks/event", port)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Oktsec-Client", "claude-code")
+	req.Header.Set("X-Oktsec-Agent", "claude-code")
+	req.Header.Set("X-Oktsec-Session", id)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return id, time.Since(start), fmt.Errorf("posting heartbeat: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return id, time.Since(start), fmt.Errorf("gateway returned HTTP %d", resp.StatusCode)
+	}
+	return id, time.Since(start), nil
 }

--- a/cmd/oktsec/commands/hook.go
+++ b/cmd/oktsec/commands/hook.go
@@ -126,26 +126,38 @@ func runHook(port int, eventOverride string) error {
 
 	resp, doErr := client.Do(req)
 	if doErr != nil {
-		// Gateway unreachable. Record one diagnostic line so the
-		// dashboard can say "hooks installed but gateway unreachable"
-		// instead of silence; then honor the configured posture
-		// (fail-open by default).
-		writeHookDiag(event, fmt.Sprintf("gateway unreachable: %v", doErr))
-		if failClosed() {
-			emitFailClosed(event, "oktsec gateway unreachable")
-			os.Exit(2)
-		}
+		handleGatewayFailure(event, fmt.Sprintf("gateway unreachable: %v", doErr))
 		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	// Treat any non-2xx, unreadable, or undecodable response as a
+	// gateway failure. Earlier the unmarshal error was swallowed,
+	// which let a 500 / empty body / HTML error page slip through
+	// as "no decision" → emit allow envelope, even when
+	// fail-closed was requested.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		handleGatewayFailure(event, fmt.Sprintf("gateway returned HTTP %d", resp.StatusCode))
+		return nil
+	}
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		handleGatewayFailure(event, fmt.Sprintf("reading gateway body: %v", readErr))
+		return nil
+	}
+	if len(bytes.TrimSpace(respBody)) == 0 {
+		handleGatewayFailure(event, "gateway returned empty body")
+		return nil
+	}
 	var result struct {
 		Decision          string `json:"decision"`
 		Reason            string `json:"reason"`
 		AdditionalContext string `json:"additional_context"`
 	}
-	_ = json.Unmarshal(respBody, &result)
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		handleGatewayFailure(event, fmt.Sprintf("decoding gateway response: %v", err))
+		return nil
+	}
 
 	if result.Decision != "block" {
 		// Allow path: explicit allow shape so tests can pin the
@@ -271,10 +283,36 @@ func emitBlock(event, reason, additionalContext string) {
 }
 
 // emitFailClosed is the fail-closed escape hatch when the gateway
-// is unreachable AND OKTSEC_HOOK_FAIL_CLOSED=1. Mirrors the block
-// shape so Claude Code refuses the action.
+// fails AND OKTSEC_HOOK_FAIL_CLOSED=1. Mirrors the block shape so
+// Claude Code refuses the action — but only on events Claude can
+// actually deny; observe-only events still fall through to the
+// allow envelope so a misconfigured fail-closed posture cannot
+// surface a deny that Claude would not honor anyway.
 func emitFailClosed(event, reason string) {
 	emitBlock(event, reason, "")
+}
+
+// handleGatewayFailure is the single chokepoint for every kind of
+// gateway-side problem: connection refused, non-2xx status,
+// unreadable body, undecodable JSON, empty body. It records one
+// diagnostic line so the dashboard can surface the failure, then
+// honors the configured posture:
+//
+//   - default: fail-open (allow envelope, exit 0)
+//   - OKTSEC_HOOK_FAIL_CLOSED=1: fail-closed for block-capable
+//     events (deny envelope, exit 2); observe-only events stay on
+//     the allow path because Claude does not honor a deny on them.
+//
+// Earlier this logic only fired on transport errors, so a 500 /
+// empty body / HTML error page silently produced an allow even
+// when fail-closed was set.
+func handleGatewayFailure(event, reason string) {
+	writeHookDiag(event, reason)
+	if failClosed() && isBlockCapableEvent(event) {
+		emitFailClosed(event, "oktsec gateway failure: "+reason)
+		os.Exit(2)
+	}
+	fmt.Fprint(os.Stdout, "{}")
 }
 
 func writeJSON(payload map[string]any) {

--- a/cmd/oktsec/commands/hook.go
+++ b/cmd/oktsec/commands/hook.go
@@ -156,9 +156,58 @@ func runHook(port int, eventOverride string) error {
 		return nil
 	}
 
+	// Observe-only events MUST NOT block even when the gateway
+	// returns decision:block — Claude Code does not honor a deny
+	// from these events anyway, and exiting 2 here would surface
+	// as a Claude error without preventing the action. The Phase 2
+	// installer wires us to events like SessionEnd, Notification,
+	// CwdChanged, etc. purely for audit; if the gateway accidentally
+	// returns block (e.g. a misconfigured rule), we record the
+	// gateway's intent in the diagnostic file and return the normal
+	// observe envelope so Claude proceeds.
+	if !isBlockCapableEvent(event) {
+		writeHookDiag(event, fmt.Sprintf("gateway returned block for observe-only event; honoring observe contract. reason=%s", result.Reason))
+		fmt.Fprint(os.Stdout, "{}")
+		return nil
+	}
+
 	emitBlock(event, result.Reason, result.AdditionalContext)
 	os.Exit(2)
 	return nil
+}
+
+// blockCapableEvents lists every event family where Claude Code
+// honors a block decision. Sourced from the official hook event
+// table in code.claude.com/docs/en/hooks; each entry is paired
+// with the response shape emitBlock uses.
+//
+// Observe-only events (SessionStart/SessionEnd/InstructionsLoaded/
+// SubagentStart/PermissionDenied/Notification/CwdChanged/
+// FileChanged/StopFailure) are deliberately absent — see the
+// gating in runHook above.
+var blockCapableEvents = map[string]bool{
+	"PreToolUse":         true,
+	"PermissionRequest":  true,
+	"PostToolUse":        true,
+	"PostToolUseFailure": true,
+	"PostToolBatch":      true,
+	"Stop":               true,
+	"SubagentStop":       true,
+	"ConfigChange":       true,
+	"TaskCreated":        true,
+	"TaskCompleted":      true,
+}
+
+// isBlockCapableEvent reports whether Claude Code will honor a
+// block from this event family. Empty event (gateway response did
+// not echo it back, no --event flag set) is treated as
+// non-blocking so we fail safe rather than send a deny shape that
+// Claude cannot apply.
+func isBlockCapableEvent(event string) bool {
+	if event == "" {
+		return false
+	}
+	return blockCapableEvents[event]
 }
 
 // emitBlock prints the per-event Claude Code response shape on
@@ -212,11 +261,12 @@ func emitBlock(event, reason, additionalContext string) {
 		// JSON shape required.
 		fmt.Fprintf(os.Stderr, "oktsec: %s blocked — %s\n", event, reason)
 	default:
-		// Unknown / observe-only events should not normally reach
-		// this branch (the gateway should not return decision:block
-		// for them), but if they do we surface the reason on stderr
-		// and exit 2 so policy intent is honored.
-		fmt.Fprintf(os.Stderr, "oktsec: blocked — %s\n", reason)
+		// Unreachable in normal operation: runHook gates emitBlock
+		// behind isBlockCapableEvent so observe-only events never
+		// reach this switch. Defensive fallback prints to stderr in
+		// case a future event addition forgets to update both
+		// blockCapableEvents and this switch.
+		fmt.Fprintf(os.Stderr, "oktsec: %s blocked — %s\n", event, reason)
 	}
 }
 

--- a/cmd/oktsec/commands/hook_shape_test.go
+++ b/cmd/oktsec/commands/hook_shape_test.go
@@ -187,6 +187,126 @@ func TestHook_AllowEmitsEnvelope(t *testing.T) {
 	}
 }
 
+// TestHook_FailClosedHonorsGatewayResponseFailures locks in the
+// P2.2 contract: OKTSEC_HOOK_FAIL_CLOSED=1 must cover every kind
+// of gateway-side failure, not just connection refused. A 500
+// status, empty body, or invalid JSON would previously slip
+// through as "no decision" → allow envelope, even with
+// fail-closed requested. Each scenario should now exit 2 with the
+// PreToolUse deny shape under fail-closed and exit 0 with the
+// allow envelope under the default fail-open posture.
+func TestHook_FailClosedHonorsGatewayResponseFailures(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "http_500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "invalid_json",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("{not json"))
+			},
+		},
+		{
+			name: "empty_body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name+"/fail_open", func(t *testing.T) {
+			stdout, _, exit := runHookBinaryWithEnv(t,
+				`{"hook_event_name":"PreToolUse"}`, "PreToolUse",
+				sc.handler, nil,
+			)
+			if exit != 0 {
+				t.Errorf("fail-open exit = %d, want 0", exit)
+			}
+			if strings.TrimSpace(stdout) != "{}" {
+				t.Errorf("fail-open stdout = %q, want {}", stdout)
+			}
+		})
+		t.Run(sc.name+"/fail_closed", func(t *testing.T) {
+			stdout, _, exit := runHookBinaryWithEnv(t,
+				`{"hook_event_name":"PreToolUse"}`, "PreToolUse",
+				sc.handler, []string{"OKTSEC_HOOK_FAIL_CLOSED=1"},
+			)
+			if exit != 2 {
+				t.Errorf("fail-closed exit = %d, want 2", exit)
+			}
+			if !strings.Contains(stdout, `"deny"`) {
+				t.Errorf("fail-closed stdout missing deny shape: %s", stdout)
+			}
+			if !strings.Contains(stdout, `"PreToolUse"`) {
+				t.Errorf("fail-closed stdout missing PreToolUse hookEventName: %s", stdout)
+			}
+		})
+	}
+}
+
+// TestHook_FailClosedSkipsObserveOnly verifies that even with
+// fail-closed enabled, observe-only events stay on the allow path
+// when the gateway fails. Emitting a deny on these would surface
+// as a Claude error without preventing anything (Claude does not
+// honor deny on observe-only events).
+func TestHook_FailClosedSkipsObserveOnly(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+	stdout, _, exit := runHookBinaryWithEnv(t,
+		`{"hook_event_name":"SessionEnd"}`, "SessionEnd",
+		handler, []string{"OKTSEC_HOOK_FAIL_CLOSED=1"},
+	)
+	if exit != 0 {
+		t.Errorf("observe-only fail-closed exit = %d, want 0", exit)
+	}
+	if strings.TrimSpace(stdout) != "{}" {
+		t.Errorf("observe-only fail-closed stdout = %q, want {}", stdout)
+	}
+}
+
+// runHookBinaryWithEnv is the configurable cousin of runHookBinary
+// used by the gateway-failure tests: caller supplies the gateway
+// handler and any extra env vars (e.g. OKTSEC_HOOK_FAIL_CLOSED=1).
+func runHookBinaryWithEnv(t *testing.T, payload, event string, gatewayHandler http.HandlerFunc, extraEnv []string) (string, string, int) {
+	t.Helper()
+	srv := httptest.NewServer(gatewayHandler)
+	t.Cleanup(srv.Close)
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	bin := buildHookBinaryOnce(t)
+	cmd := exec.Command(bin, "hook", "--port", iToStr(port), "--event", event, "--manifest", "v2")
+	cmd.Stdin = strings.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	exitCode := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("running hook binary: %v\nstderr=%s", err, stderr.String())
+		}
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
 // TestHook_ObserveOnlyEventsNeverBlock locks in the P3 contract:
 // even when the gateway returns decision:block for an
 // observe-only event family (SessionEnd, InstructionsLoaded,

--- a/cmd/oktsec/commands/hook_shape_test.go
+++ b/cmd/oktsec/commands/hook_shape_test.go
@@ -187,6 +187,38 @@ func TestHook_AllowEmitsEnvelope(t *testing.T) {
 	}
 }
 
+// TestHook_ObserveOnlyEventsNeverBlock locks in the P3 contract:
+// even when the gateway returns decision:block for an
+// observe-only event family (SessionEnd, InstructionsLoaded,
+// CwdChanged, Notification, etc.), the hook must exit 0 with the
+// allow envelope so Claude Code does not surface a deny it cannot
+// honor anyway. The gateway's intent is recorded in the
+// diagnostic file for the dashboard / doctor to surface.
+func TestHook_ObserveOnlyEventsNeverBlock(t *testing.T) {
+	for _, event := range []string{
+		"SessionEnd", "InstructionsLoaded", "CwdChanged",
+		"Notification", "PermissionDenied", "StopFailure",
+		"SubagentStart", "SessionStart",
+	} {
+		t.Run(event, func(t *testing.T) {
+			stdout, stderr, exit := runHookBinary(t,
+				`{"hook_event_name":"`+event+`"}`,
+				event,
+				map[string]any{"decision": "block", "reason": "rule misfire X-999"},
+			)
+			if exit != 0 {
+				t.Errorf("exit = %d, want 0 for observe-only event %s; stderr=%s", exit, event, stderr)
+			}
+			if strings.TrimSpace(stdout) != "{}" {
+				t.Errorf("stdout = %q, want {} for observe-only event %s", stdout, event)
+			}
+			if strings.Contains(stdout, `"deny"`) {
+				t.Errorf("observe-only event %s emitted deny shape; stdout=%s", event, stdout)
+			}
+		})
+	}
+}
+
 // TestHook_FailOpenWhenGatewayDown confirms the default
 // failure-open posture: gateway unreachable, no block emitted,
 // exit 0.

--- a/cmd/oktsec/commands/hook_shape_test.go
+++ b/cmd/oktsec/commands/hook_shape_test.go
@@ -1,0 +1,225 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runHookBinary builds the oktsec binary, points it at a fake
+// gateway via --port, pipes the given hook payload to stdin, and
+// returns stdout/stderr/exit. Used by every per-event response
+// shape test so we exercise the real binary path Claude Code would
+// invoke.
+func runHookBinary(t *testing.T, payload, event string, gatewayResponse map[string]any) (string, string, int) {
+	t.Helper()
+
+	// Spin up a fake gateway that records the inbound request and
+	// returns the supplied response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gatewayResponse)
+	}))
+	t.Cleanup(srv.Close)
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	bin := buildHookBinaryOnce(t)
+	cmd := exec.Command(bin, "hook", "--port", iToStr(port), "--event", event, "--manifest", "v2")
+	cmd.Stdin = strings.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Isolate $HOME so the hook diagnostic file lands in a tempdir
+	// instead of polluting the developer's real ~/.oktsec.
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+
+	exitCode := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("running hook binary: %v\nstderr=%s", err, stderr.String())
+		}
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
+// buildHookBinaryOnce compiles the oktsec binary once per test
+// process and caches the path in a tempdir that survives every
+// individual test's t.Cleanup (so tests after the first one still
+// find the binary). The dir is removed in cleanupHookBinary, called
+// from TestMain.
+var (
+	hookBinaryPath string
+	hookBinaryDir  string
+)
+
+func buildHookBinaryOnce(t *testing.T) string {
+	t.Helper()
+	if hookBinaryPath != "" {
+		return hookBinaryPath
+	}
+	dir, err := os.MkdirTemp("", "oktsec-hook-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "oktsec")
+	cmd := exec.Command("go", "build", "-o", out, "github.com/oktsec/oktsec/cmd/oktsec")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("go build: %v", err)
+	}
+	hookBinaryPath = out
+	hookBinaryDir = dir
+	return out
+}
+
+// hookBinaryDir is intentionally not registered for cleanup. The
+// directory lives under os.TempDir() and is reaped by the OS on
+// reboot; we trade a short-lived ~10 MB leak for a stable cached
+// path that survives every individual test's t.Cleanup.
+var _ = hookBinaryDir
+
+// TestHook_PreToolUseBlock_EmitsModernShape locks in the Phase 2
+// migration: a block on PreToolUse must come back as
+// hookSpecificOutput.permissionDecision: "deny" with a
+// permissionDecisionReason field. The deprecated top-level
+// {"decision":"block"} shape must NOT appear.
+func TestHook_PreToolUseBlock_EmitsModernShape(t *testing.T) {
+	stdout, _, exit := runHookBinary(t,
+		`{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`,
+		"PreToolUse",
+		map[string]any{"decision": "block", "reason": "rule TC-005: destructive command"},
+	)
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2 (blocking exit code)", exit)
+	}
+	var out struct {
+		Decision           string `json:"decision"`
+		HookSpecificOutput struct {
+			HookEventName            string `json:"hookEventName"`
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout=%s", err, stdout)
+	}
+	if out.Decision != "" {
+		t.Errorf("top-level decision should be empty for PreToolUse v2 shape; got %q", out.Decision)
+	}
+	if out.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Errorf("hookEventName = %q, want PreToolUse", out.HookSpecificOutput.HookEventName)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "TC-005") {
+		t.Errorf("permissionDecisionReason should contain rule id, got %q",
+			out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+// TestHook_PostToolUseBlock_TopLevelWithContext locks in the
+// post-action shape: top-level decision: "block" with
+// hookSpecificOutput.additionalContext when provided.
+func TestHook_PostToolUseBlock_TopLevelWithContext(t *testing.T) {
+	stdout, _, exit := runHookBinary(t,
+		`{"hook_event_name":"PostToolUse","tool_name":"Read","tool_response":"AKIA..."}`,
+		"PostToolUse",
+		map[string]any{
+			"decision":           "block",
+			"reason":             "credential leaked in tool output",
+			"additional_context": "Rotate the exposed key before re-running.",
+		},
+	)
+	if exit != 2 {
+		t.Errorf("exit = %d, want 2", exit)
+	}
+	var out struct {
+		Decision           string `json:"decision"`
+		Reason             string `json:"reason"`
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout=%s", err, stdout)
+	}
+	if out.Decision != "block" {
+		t.Errorf("decision = %q, want block", out.Decision)
+	}
+	if out.HookSpecificOutput.HookEventName != "PostToolUse" {
+		t.Errorf("hookEventName = %q, want PostToolUse", out.HookSpecificOutput.HookEventName)
+	}
+	if out.HookSpecificOutput.AdditionalContext == "" {
+		t.Error("additionalContext should be populated when gateway returns it")
+	}
+}
+
+// TestHook_AllowEmitsEnvelope confirms the no-block path returns
+// `{}` instead of empty stdout. Empty stdout is legal but a
+// concrete envelope makes downstream parsers easier to test.
+func TestHook_AllowEmitsEnvelope(t *testing.T) {
+	stdout, _, exit := runHookBinary(t,
+		`{"hook_event_name":"PreToolUse","tool_name":"Read"}`,
+		"PreToolUse",
+		map[string]any{"decision": "allow"},
+	)
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if strings.TrimSpace(stdout) != "{}" {
+		t.Errorf("stdout = %q, want {}", stdout)
+	}
+}
+
+// TestHook_FailOpenWhenGatewayDown confirms the default
+// failure-open posture: gateway unreachable, no block emitted,
+// exit 0.
+func TestHook_FailOpenWhenGatewayDown(t *testing.T) {
+	bin := buildHookBinaryOnce(t)
+	// Use port 1 (privileged, almost certainly unreachable from
+	// userspace) so the hook hits a connect error.
+	cmd := exec.Command(bin, "hook", "--port", "1", "--event", "PreToolUse", "--manifest", "v2")
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse"}`)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("hook should fail-open (exit 0); got %v\nstderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), `"deny"`) {
+		t.Errorf("fail-open should not emit deny; stdout=%s", stdout.String())
+	}
+}
+
+func iToStr(n int) string {
+	const digits = "0123456789"
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = digits[n%10]
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/connectors/claudecode/hooks.go
+++ b/internal/connectors/claudecode/hooks.go
@@ -6,30 +6,16 @@ import (
 	"strings"
 )
 
-// expectedEventFamilies is the Phase 2 hook manifest the spec calls for
-// (section 2). Phase 1 only reports which of these are missing; it
-// never installs them. Kept as a sorted slice so HookRef.Expected
-// renders the same on every run.
-var expectedEventFamilies = []string{
-	"PreToolUse",         // pre-action / blocking
-	"PostToolUse",        // observed / feedback
-	"PostToolUseFailure", // observed / failure surface
-	"PostToolBatch",      // observed / batched failures
-	"SubagentStart",      // observed actor lifecycle
-	"SubagentStop",
-	"SessionStart", // observed session lifecycle
-	"SessionEnd",
-	"InstructionsLoaded", // observed config-change surface
-	"CwdChanged",
-	"FileChanged",
-	"PermissionRequest", // pre-action / blocking
-	"PermissionDenied",
-	"Stop",
-	"StopFailure",
-	"TaskCreated",
-	"TaskCompleted",
-	"ConfigChange",
-}
+// expectedEventFamilies is derived from the canonical Phase 2
+// install plan in install.go (Phase2EventNames). Phase 1 reports
+// the same set as "missing when not installed" so a successful
+// install brings MissingExpectedEvents to empty and the doctor /
+// health view can reach `ready`. The previous standalone slice
+// drifted from buildPlan and made the gap report unreliable.
+//
+// Initialized via init() so the install.go table is the only place
+// new event families are added.
+var expectedEventFamilies = Phase2EventNames()
 
 // blockingEventFamilies is the subset of hooks that can deny an
 // action before Claude executes it. Used to populate

--- a/internal/connectors/claudecode/hooks.go
+++ b/internal/connectors/claudecode/hooks.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -70,12 +71,69 @@ func readHooks(opts ReadOptions) ([]HookRef, []ConnectorProblem) {
 		if prob != nil {
 			problems = append(problems, *prob)
 		}
-		if settings == nil || settings.Hooks == nil {
+		if settings == nil {
 			continue
 		}
-		hooks = append(hooks, parseHookEntries(s.scope, s.path, settings.Hooks)...)
+		// Surface disable / restrict knobs so the Phase 2 installer
+		// can refuse to write hooks the operator (or a managed
+		// policy) has globally neutered.
+		problems = append(problems, disableKnobProblems(s.scope, s.path, settings)...)
+		if settings.Hooks != nil {
+			hooks = append(hooks, parseHookEntries(s.scope, s.path, settings.Hooks)...)
+		}
 	}
 	return hooks, problems
+}
+
+// disableKnobProblems converts the three Claude Code "silently
+// neuter every hook" flags into ConnectorProblem rows. The installer
+// reads the codes, not the raw bools, so a future config-shape
+// change only needs to update the parser in settings.go.
+func disableKnobProblems(scope, path string, s *rawSettings) []ConnectorProblem {
+	var ps []ConnectorProblem
+	if s.DisableAllHooks != nil && *s.DisableAllHooks {
+		ps = append(ps, ConnectorProblem{
+			Code:     "CC-HOOKS-GLOBALLY-DISABLED",
+			Severity: "risk",
+			Title:    fmt.Sprintf("Claude Code hooks are globally disabled in %s settings", scope),
+			Detail:   fmt.Sprintf("disableAllHooks: true at %s. Until this is removed, no oktsec hook will fire.", path),
+			FixKind:  "manual",
+		})
+	}
+	if s.AllowManagedHooksOnly != nil && *s.AllowManagedHooksOnly {
+		ps = append(ps, ConnectorProblem{
+			Code:     "CC-HOOKS-MANAGED-ONLY",
+			Severity: "risk",
+			Title:    fmt.Sprintf("Claude Code restricts hooks to managed scope in %s settings", scope),
+			Detail:   fmt.Sprintf("allowManagedHooksOnly: true at %s. User and project hooks are blocked, including any oktsec install at non-managed scope.", path),
+			FixKind:  "manual",
+		})
+	}
+	if s.AllowedHTTPHookURLs != nil && len(*s.AllowedHTTPHookURLs) == 0 {
+		ps = append(ps, ConnectorProblem{
+			Code:     "CC-HOOKS-HTTP-URLS-RESTRICTED",
+			Severity: "warning",
+			Title:    fmt.Sprintf("HTTP hooks are blocked by an empty allowlist in %s settings", scope),
+			Detail:   fmt.Sprintf("allowedHttpHookUrls is set to [] at %s. Command hooks (oktsec's default) still work, but any future HTTP variant would be silently dropped.", path),
+			FixKind:  "manual",
+		})
+	}
+	return ps
+}
+
+// HookInstallBlockedReasons returns the inventory problems that must
+// be cleared before the Phase 2 installer can safely write a new
+// manifest. Empty slice means "safe to install". Centralised so the
+// doctor and the installer agree on the refusal contract.
+func HookInstallBlockedReasons(inv Inventory) []ConnectorProblem {
+	var blockers []ConnectorProblem
+	for _, p := range inv.Problems {
+		switch p.Code {
+		case "CC-HOOKS-GLOBALLY-DISABLED", "CC-HOOKS-MANAGED-ONLY":
+			blockers = append(blockers, p)
+		}
+	}
+	return blockers
 }
 
 // parseHookEntries flattens the {event: [{matcher, hooks: [handler]}]}
@@ -138,6 +196,34 @@ func isOktsecHookHandler(h rawHookHandler) bool {
 		return true
 	}
 	return false
+}
+
+// ManifestV2Marker is the literal flag the Phase 2 installer adds to
+// every command it writes. Inventory and uninstall both look for it
+// to know which entries are theirs to manage. The flag is parsed
+// (and ignored beyond its tagging role) by oktsec hook so Claude
+// Code never sees a foreign key in the JSON.
+const ManifestV2Marker = "--manifest v2"
+
+// isManifestV2Handler returns true when the handler is an oktsec
+// hook entry written by the Phase 2 installer. Used by the merge
+// algorithm to decide which entries it owns and may safely
+// rewrite/remove.
+func isManifestV2Handler(h rawHookHandler) bool {
+	if h.Type != "command" {
+		return false
+	}
+	if !isOktsecHookHandler(h) {
+		return false
+	}
+	return strings.Contains(h.Command, ManifestV2Marker)
+}
+
+// isLegacyOktsecHandler returns true for a v1 oktsec hook that
+// predates the manifest marker. The installer upgrades these
+// in-place without leaving duplicates.
+func isLegacyOktsecHandler(h rawHookHandler) bool {
+	return isOktsecHookHandler(h) && !isManifestV2Handler(h)
 }
 
 // isExpectedEvent reports whether the named event family is part of

--- a/internal/connectors/claudecode/install.go
+++ b/internal/connectors/claudecode/install.go
@@ -1,0 +1,542 @@
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PlannedHookEntry is one event family + handler the installer would
+// write. Exposed so callers (the doctor command, future dashboard
+// preview) can render the planned manifest before it touches disk.
+type PlannedHookEntry struct {
+	Event       string  `json:"event"`
+	Matcher     string  `json:"matcher,omitempty"`
+	Type        string  `json:"type"`
+	Command     string  `json:"command"`
+	TimeoutSecs int     `json:"timeout,omitempty"`
+	Status      string  `json:"statusMessage,omitempty"`
+}
+
+// InstallOptions controls where and how the Phase 2 manifest is
+// written. Defaults match the conservative posture the spec calls
+// for: user scope only, refuse symlinks, refuse when global disable
+// knobs are present.
+type InstallOptions struct {
+	HomeDir        string // override $HOME for tests; "" => os.UserHomeDir
+	BinaryPath     string // absolute path to the oktsec binary; "" => auto-detect
+	GatewayPort    int    // gateway port the hook will POST to; required (>0)
+	FollowSymlink  bool   // when true, write through symlinks instead of refusing
+	DryRun         bool   // when true, return the planned actions without writing
+}
+
+// InstallResult summarises what InstallV2 did (or would do, in dry-run).
+// Designed for both the human doctor output and structured JSON.
+type InstallResult struct {
+	SettingsPath string             `json:"settings_path"`
+	BackupPath   string             `json:"backup_path,omitempty"`
+	Plan         []PlannedHookEntry `json:"plan"`
+	Wrote        bool               `json:"wrote"`
+	UpgradedV1   int                `json:"upgraded_v1"`
+	Skipped      string             `json:"skipped,omitempty"` // reason when wrote=false
+}
+
+// installerVersion is the schema tag baked into every entry's
+// command line via ManifestV2Marker. Bumping this constant is the
+// signal that future installers should treat older entries as
+// upgrade candidates.
+const installerVersion = "v2"
+
+// InstallV2 writes the Phase 2 hook manifest into the user-scope
+// Claude Code settings file. Read-by-default, write-only-when-needed:
+//
+//   - Refuses when an inventory blocker exists (disableAllHooks /
+//     allowManagedHooksOnly). Operators must clear those first.
+//   - Refuses when the settings file is a symlink, unless
+//     opts.FollowSymlink is set.
+//   - Backs up the existing file to <path>.oktsec-pre-<UTCstamp>.bak
+//     with the original mode bits before any rewrite.
+//   - Writes through a sibling tempfile + fsync + rename for
+//     POSIX-atomic replacement.
+//   - Skips the rewrite entirely when the planned content is
+//     byte-identical to the current file (idempotency exit).
+//
+// InstallV2 never touches keys other than `hooks`. Operator entries
+// inside the same event family are preserved; only entries the
+// installer owns (carrying ManifestV2Marker, or legacy v1 oktsec
+// hooks pending upgrade) are removed before the new entry is
+// appended.
+func InstallV2(ctx context.Context, opts InstallOptions) (InstallResult, error) {
+	if opts.GatewayPort <= 0 {
+		return InstallResult{}, fmt.Errorf("gateway port required (got %d)", opts.GatewayPort)
+	}
+	if opts.HomeDir == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return InstallResult{}, fmt.Errorf("resolving home dir: %w", err)
+		}
+		opts.HomeDir = h
+	}
+	if opts.BinaryPath == "" {
+		exe, err := os.Executable()
+		if err != nil || exe == "" {
+			return InstallResult{}, fmt.Errorf("resolving oktsec binary path: %w", err)
+		}
+		opts.BinaryPath = exe
+	}
+
+	settingsPath := filepath.Join(opts.HomeDir, ".claude", "settings.json")
+	result := InstallResult{
+		SettingsPath: settingsPath,
+		Plan:         buildPlan(opts.BinaryPath, opts.GatewayPort),
+	}
+
+	// Pre-flight via inventory. Only the disable-knob blockers stop
+	// the install; missing-hooks problems are exactly what we are
+	// here to fix.
+	inv := Read(ctx, ReadOptions{
+		HomeDir:          opts.HomeDir,
+		SkipVersionProbe: true,
+	})
+	if blockers := HookInstallBlockedReasons(inv); len(blockers) > 0 {
+		return result, &InstallBlockedError{Reasons: blockers}
+	}
+
+	// Symlink handling: refuse by default so dotfiles repos are not
+	// silently rewritten. With --follow-symlink, resolve to the real
+	// target so the atomic rename writes through the link instead of
+	// replacing the link with a regular file.
+	writePath := settingsPath
+	if info, lerr := os.Lstat(settingsPath); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+		if !opts.FollowSymlink {
+			return result, &SymlinkRefusedError{Path: settingsPath}
+		}
+		resolved, err := filepath.EvalSymlinks(settingsPath)
+		if err != nil {
+			return result, fmt.Errorf("resolving symlink %s: %w", settingsPath, err)
+		}
+		writePath = resolved
+	}
+
+	// Read existing settings as raw JSON so unknown keys round-trip
+	// untouched. Decoding into a typed struct would silently drop
+	// any operator-added top-level field on rewrite.
+	existing, mode, err := readRawSettings(writePath)
+	if err != nil {
+		return result, err
+	}
+
+	// Ensure the directory containing the write target exists. When
+	// we resolved a symlink the target's parent might not be ~/.claude,
+	// so we use writePath, not settingsPath.
+	if err := os.MkdirAll(filepath.Dir(writePath), 0o700); err != nil {
+		return result, fmt.Errorf("creating settings directory: %w", err)
+	}
+
+	// Apply the manifest to the parsed settings tree.
+	upgraded, mutated, err := applyManifest(existing, result.Plan)
+	if err != nil {
+		return result, err
+	}
+	result.UpgradedV1 = upgraded
+
+	// Encode the mutated tree. Stable indentation = stable diffs.
+	planned, err := encodeSettings(mutated)
+	if err != nil {
+		return result, err
+	}
+
+	// Idempotency exit: if the current file equals the planned
+	// content (after our canonical encoding), skip the rewrite.
+	current, _ := os.ReadFile(writePath)
+	if bytesEqual(current, planned) {
+		result.Skipped = "byte-identical to current file"
+		return result, nil
+	}
+
+	if opts.DryRun {
+		result.Skipped = "dry-run"
+		return result, nil
+	}
+
+	// Backup before any write. The backup carries the original mode
+	// so a restore preserves the file's permission posture. We
+	// always back up next to the symlink (settingsPath) so the
+	// operator can find it from the canonical path even when the
+	// real file lives in a dotfiles repo.
+	backupPath, err := writeBackup(settingsPath, current, mode)
+	if err != nil {
+		return result, err
+	}
+	result.BackupPath = backupPath
+
+	// Atomic write to the resolved write path so a symlink at
+	// settingsPath keeps pointing at the same on-disk file.
+	if err := atomicWrite(writePath, planned, mode); err != nil {
+		return result, err
+	}
+	result.Wrote = true
+	return result, nil
+}
+
+// InstallBlockedError signals that an inventory problem must be
+// cleared before the installer will proceed. The doctor formats the
+// reasons; tests assert on errors.As.
+type InstallBlockedError struct {
+	Reasons []ConnectorProblem
+}
+
+func (e *InstallBlockedError) Error() string {
+	codes := make([]string, len(e.Reasons))
+	for i, p := range e.Reasons {
+		codes[i] = p.Code
+	}
+	return fmt.Sprintf("hook install refused: %s", strings.Join(codes, ", "))
+}
+
+// SymlinkRefusedError signals the settings file is a symlink and the
+// caller did not opt in to following it. Surfaces in the doctor as a
+// clear "pass --follow-symlink to override" message.
+type SymlinkRefusedError struct {
+	Path string
+}
+
+func (e *SymlinkRefusedError) Error() string {
+	return fmt.Sprintf("refusing to follow symlink %s; pass --follow-symlink to override", e.Path)
+}
+
+// readRawSettings reads the settings file into a generic map so
+// unknown keys round-trip untouched. Returns (empty map, default
+// mode, nil) when the file does not exist — that is a valid
+// "first-time install" path.
+func readRawSettings(path string) (map[string]json.RawMessage, os.FileMode, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]json.RawMessage{}, 0o600, nil
+		}
+		return nil, 0, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var raw map[string]json.RawMessage
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, 0, fmt.Errorf("parsing %s: %w (refusing to overwrite a malformed file)", path, err)
+		}
+	}
+	if raw == nil {
+		raw = map[string]json.RawMessage{}
+	}
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	return raw, mode, nil
+}
+
+// buildPlan composes the per-event entries the installer will
+// write. Centralised so tests can read the canonical plan without
+// touching disk and so future event additions are one-table swap.
+func buildPlan(binary string, port int) []PlannedHookEntry {
+	cmdFor := func(event string) string {
+		return fmt.Sprintf("%q hook --port %d --event %s --manifest %s",
+			binary, port, event, installerVersion)
+	}
+	statusFor := func(event string) string {
+		return fmt.Sprintf("oktsec checking %s", event)
+	}
+
+	type spec struct {
+		event   string
+		matcher string
+	}
+	specs := []spec{
+		// Pre-action / blocking
+		{"PreToolUse", "*"},
+		{"PermissionRequest", "*"},
+
+		// Post-action / observed
+		{"PostToolUse", "*"},
+		{"PostToolUseFailure", "*"},
+		{"PostToolBatch", ""},
+		{"Stop", ""},
+		{"StopFailure", ""},
+		{"PermissionDenied", ""},
+
+		// Subagent + task lifecycle
+		{"SubagentStart", "*"},
+		{"SubagentStop", "*"},
+		{"TaskCreated", ""},
+		{"TaskCompleted", ""},
+
+		// Session + config
+		{"SessionStart", ""},
+		{"SessionEnd", ""},
+		{"InstructionsLoaded", ""},
+		{"CwdChanged", ""},
+		{"ConfigChange", ""},
+		{"Notification", ""},
+	}
+	plan := make([]PlannedHookEntry, 0, len(specs))
+	for _, s := range specs {
+		plan = append(plan, PlannedHookEntry{
+			Event:       s.event,
+			Matcher:     s.matcher,
+			Type:        "command",
+			Command:     cmdFor(s.event),
+			TimeoutSecs: 30,
+			Status:      statusFor(s.event),
+		})
+	}
+	return plan
+}
+
+// applyManifest rewrites the "hooks" subtree of the parsed settings
+// map: filters out our own entries (v2 + legacy v1) per event,
+// preserves operator entries, and appends one fresh v2 entry per
+// planned event. Returns the count of v1 entries upgraded, the
+// mutated settings map, and any encode/decode error.
+func applyManifest(settings map[string]json.RawMessage, plan []PlannedHookEntry) (int, map[string]json.RawMessage, error) {
+	// Decode the current hooks subtree into a typed map so we can
+	// filter cleanly. Unknown event keys round-trip via raw JSON
+	// untouched.
+	current := map[string][]rawHookEntry{}
+	if rawHooks, ok := settings["hooks"]; ok && len(rawHooks) > 0 {
+		var perEvent map[string]json.RawMessage
+		if err := json.Unmarshal(rawHooks, &perEvent); err != nil {
+			return 0, nil, fmt.Errorf("parsing hooks subtree: %w", err)
+		}
+		for event, raw := range perEvent {
+			var entries []rawHookEntry
+			if err := json.Unmarshal(raw, &entries); err != nil {
+				// Tolerate single-object form that some older
+				// configs use. Fall through to a single-element slice.
+				var single rawHookEntry
+				if err2 := json.Unmarshal(raw, &single); err2 == nil {
+					entries = []rawHookEntry{single}
+				} else {
+					return 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, err)
+				}
+			}
+			current[event] = entries
+		}
+	}
+
+	// Build planned-event lookup for fast membership tests.
+	plannedByEvent := map[string]PlannedHookEntry{}
+	for _, p := range plan {
+		plannedByEvent[p.Event] = p
+	}
+
+	upgradedV1 := 0
+	out := map[string][]rawHookEntry{}
+
+	// 1) Pass through events not in our plan untouched.
+	for event, entries := range current {
+		if _, planned := plannedByEvent[event]; planned {
+			continue
+		}
+		out[event] = entries
+	}
+
+	// 2) For each planned event, filter operator entries through
+	// our ownership predicate, count v1 upgrades, then append the
+	// fresh v2 entry.
+	for _, p := range plan {
+		var preserved []rawHookEntry
+		for _, entry := range current[p.Event] {
+			kept := []rawHookHandler{}
+			for _, h := range entry.Hooks {
+				switch {
+				case isManifestV2Handler(h):
+					// Drop our own previous v2 entry — we are about to write a fresh one.
+					continue
+				case isLegacyOktsecHandler(h):
+					upgradedV1++
+					continue
+				default:
+					kept = append(kept, h)
+				}
+			}
+			if len(kept) > 0 {
+				preserved = append(preserved, rawHookEntry{
+					Matcher: entry.Matcher,
+					Hooks:   kept,
+				})
+			}
+		}
+		preserved = append(preserved, rawHookEntry{
+			Matcher: p.Matcher,
+			Hooks: []rawHookHandler{{
+				Type:    p.Type,
+				Command: p.Command,
+			}},
+		})
+		out[p.Event] = preserved
+	}
+
+	// Re-encode hooks subtree with stable key order.
+	encoded := map[string]json.RawMessage{}
+	for _, event := range sortedKeys(out) {
+		entries := out[event]
+		// Drop empty event keys to avoid leaving "PreToolUse": [].
+		if len(entries) == 0 {
+			continue
+		}
+		body, err := json.Marshal(entries)
+		if err != nil {
+			return 0, nil, fmt.Errorf("encoding hooks[%s]: %w", event, err)
+		}
+		encoded[event] = body
+	}
+	if len(encoded) > 0 {
+		body, err := json.Marshal(encoded)
+		if err != nil {
+			return 0, nil, fmt.Errorf("encoding hooks subtree: %w", err)
+		}
+		settings["hooks"] = body
+	} else {
+		delete(settings, "hooks")
+	}
+	return upgradedV1, settings, nil
+}
+
+// encodeSettings serialises the raw settings map into the canonical
+// on-disk form: 2-space indent, sorted top-level keys, trailing
+// newline. Stable encoding is what makes the byte-equal idempotency
+// check possible.
+func encodeSettings(settings map[string]json.RawMessage) ([]byte, error) {
+	keys := make([]string, 0, len(settings))
+	for k := range settings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build an ordered key sequence by marshalling as a
+	// json.RawMessage stream. encoding/json does not preserve key
+	// order from a map, so we assemble by hand.
+	var buf strings.Builder
+	buf.WriteString("{\n")
+	for i, k := range keys {
+		keyBytes, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		valueBytes, err := indentValue(settings[k], "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encoding key %q: %w", k, err)
+		}
+		buf.WriteString("  ")
+		buf.Write(keyBytes)
+		buf.WriteString(": ")
+		buf.Write(valueBytes)
+		if i < len(keys)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("}\n")
+	return []byte(buf.String()), nil
+}
+
+// indentValue re-marshals a single JSON value with a leading-line
+// prefix of `prefix` so the assembled object reads consistently.
+func indentValue(raw json.RawMessage, prefix string) ([]byte, error) {
+	// Round-trip through Indent so map values reformat consistently
+	// regardless of how the operator wrote them.
+	var any interface{}
+	if err := json.Unmarshal(raw, &any); err != nil {
+		// Could not decode — return the raw value verbatim so we do
+		// not lose data. This only happens on values we round-trip
+		// from disk that were already valid JSON.
+		return raw, nil
+	}
+	pretty, err := json.MarshalIndent(any, prefix, "  ")
+	if err != nil {
+		return nil, err
+	}
+	return pretty, nil
+}
+
+// writeBackup copies the current settings file to a sibling named
+// settings.json.oktsec-pre-<UTCstamp>.bak, preserving the source
+// file's mode bits. Returns the backup path.
+//
+// The timestamp includes nanoseconds because back-to-back operations
+// (e.g. install followed by uninstall in the same test) can land
+// inside the same UTC second; second-resolution collisions would
+// abort the second backup with "already exists".
+func writeBackup(path string, content []byte, mode os.FileMode) (string, error) {
+	if len(content) == 0 {
+		// First-time install: nothing to back up.
+		return "", nil
+	}
+	stamp := strings.ReplaceAll(time.Now().UTC().Format("20060102T150405.000000000Z"), ".", "")
+	backup := fmt.Sprintf("%s.oktsec-pre-%s.bak", path, stamp)
+	if _, err := os.Stat(backup); err == nil {
+		return "", fmt.Errorf("backup %s already exists; refusing to overwrite", backup)
+	}
+	if err := os.WriteFile(backup, content, mode); err != nil {
+		return "", fmt.Errorf("writing backup %s: %w", backup, err)
+	}
+	return backup, nil
+}
+
+// atomicWrite writes data to path via a tempfile + fsync + rename
+// + parent dir fsync. Mode is preserved through the rename.
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".oktsec-settings-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("writing tempfile: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("fsync tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("closing tempfile: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return fmt.Errorf("chmod tempfile: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename tempfile to %s: %w", path, err)
+	}
+	// Parent fsync ensures the rename is durable across crashes.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/connectors/claudecode/install.go
+++ b/internal/connectors/claudecode/install.go
@@ -451,13 +451,24 @@ func decodePreservedEntries(raw json.RawMessage) ([]preservedHookEntry, error) {
 }
 
 // encodeOwnHandler produces the raw JSON shape for one oktsec hook
-// handler. Centralised so the manifest's wire format is one
-// function the test suite can pin.
+// handler. The output must match every field PlannedHookEntry
+// advertises (timeout, statusMessage) so that --install-hooks
+// --dry-run --json describes the same manifest the installer
+// actually writes to disk. Earlier the timeout / status fields
+// were dropped here while buildPlan kept them, leaving the dry-run
+// preview lying about the on-disk state.
 func encodeOwnHandler(p PlannedHookEntry) (json.RawMessage, error) {
-	body, err := json.Marshal(map[string]any{
+	handler := map[string]any{
 		"type":    p.Type,
 		"command": p.Command,
-	})
+	}
+	if p.TimeoutSecs > 0 {
+		handler["timeout"] = p.TimeoutSecs
+	}
+	if p.Status != "" {
+		handler["statusMessage"] = p.Status
+	}
+	body, err := json.Marshal(handler)
 	if err != nil {
 		return nil, fmt.Errorf("encoding own handler for %s: %w", p.Event, err)
 	}

--- a/internal/connectors/claudecode/install.go
+++ b/internal/connectors/claudecode/install.go
@@ -240,9 +240,72 @@ func readRawSettings(path string) (map[string]json.RawMessage, os.FileMode, erro
 	return raw, mode, nil
 }
 
+// phase2EventSpec is one (event, matcher) pair the installer
+// writes. Centralised so the install plan, the inventory's
+// "missing events" report, and the runtime block-capability map
+// all derive from one table. Adding an event family is a
+// one-line change here.
+type phase2EventSpec struct {
+	event   string
+	matcher string
+}
+
+// phase2EventSpecs is the canonical Phase 2 hook manifest. The
+// inventory derives expectedEventFamilies from this list so the
+// "missing events" report always matches what the installer
+// writes; previously the two lists drifted (FileChanged was
+// expected but never installed, Notification was installed but
+// not expected) and the doctor never reached `ready` after a
+// successful install.
+//
+// FileChanged is intentionally absent: the docs require literal
+// filename matchers and the spec defers it to Phase 3. Adding it
+// here without a watch-list would create silent matcher drift.
+var phase2EventSpecs = []phase2EventSpec{
+	// Pre-action / blocking
+	{"PreToolUse", "*"},
+	{"PermissionRequest", "*"},
+
+	// Post-action / observed
+	{"PostToolUse", "*"},
+	{"PostToolUseFailure", "*"},
+	{"PostToolBatch", ""},
+	{"Stop", ""},
+	{"StopFailure", ""},
+	{"PermissionDenied", ""},
+
+	// Subagent + task lifecycle
+	{"SubagentStart", "*"},
+	{"SubagentStop", "*"},
+	{"TaskCreated", ""},
+	{"TaskCompleted", ""},
+
+	// Session + config
+	{"SessionStart", ""},
+	{"SessionEnd", ""},
+	{"InstructionsLoaded", ""},
+	{"CwdChanged", ""},
+	{"ConfigChange", ""},
+	{"Notification", ""},
+}
+
+// Phase2EventNames returns the event-family names the installer
+// writes, in stable order. Used by the inventory to compute the
+// "missing events" gap report so the inventory and installer never
+// drift again. Exported so external tooling (the dashboard's
+// future Setup Health card) can render the same list.
+func Phase2EventNames() []string {
+	names := make([]string, len(phase2EventSpecs))
+	for i, s := range phase2EventSpecs {
+		names[i] = s.event
+	}
+	return names
+}
+
 // buildPlan composes the per-event entries the installer will
-// write. Centralised so tests can read the canonical plan without
-// touching disk and so future event additions are one-table swap.
+// write. Pure projection of phase2EventSpecs through the binary
+// path + port, so a contract change to the command line is one
+// edit.
 func buildPlan(binary string, port int) []PlannedHookEntry {
 	cmdFor := func(event string) string {
 		return fmt.Sprintf("%q hook --port %d --event %s --manifest %s",
@@ -251,40 +314,8 @@ func buildPlan(binary string, port int) []PlannedHookEntry {
 	statusFor := func(event string) string {
 		return fmt.Sprintf("oktsec checking %s", event)
 	}
-
-	type spec struct {
-		event   string
-		matcher string
-	}
-	specs := []spec{
-		// Pre-action / blocking
-		{"PreToolUse", "*"},
-		{"PermissionRequest", "*"},
-
-		// Post-action / observed
-		{"PostToolUse", "*"},
-		{"PostToolUseFailure", "*"},
-		{"PostToolBatch", ""},
-		{"Stop", ""},
-		{"StopFailure", ""},
-		{"PermissionDenied", ""},
-
-		// Subagent + task lifecycle
-		{"SubagentStart", "*"},
-		{"SubagentStop", "*"},
-		{"TaskCreated", ""},
-		{"TaskCompleted", ""},
-
-		// Session + config
-		{"SessionStart", ""},
-		{"SessionEnd", ""},
-		{"InstructionsLoaded", ""},
-		{"CwdChanged", ""},
-		{"ConfigChange", ""},
-		{"Notification", ""},
-	}
-	plan := make([]PlannedHookEntry, 0, len(specs))
-	for _, s := range specs {
+	plan := make([]PlannedHookEntry, 0, len(phase2EventSpecs))
+	for _, s := range phase2EventSpecs {
 		plan = append(plan, PlannedHookEntry{
 			Event:       s.event,
 			Matcher:     s.matcher,
@@ -299,45 +330,42 @@ func buildPlan(binary string, port int) []PlannedHookEntry {
 
 // applyManifest rewrites the "hooks" subtree of the parsed settings
 // map: filters out our own entries (v2 + legacy v1) per event,
-// preserves operator entries, and appends one fresh v2 entry per
+// preserves operator entries verbatim (handler payloads stay as
+// raw JSON so unknown fields like timeout / statusMessage / env
+// survive the round-trip), and appends one fresh v2 entry per
 // planned event. Returns the count of v1 entries upgraded, the
 // mutated settings map, and any encode/decode error.
 func applyManifest(settings map[string]json.RawMessage, plan []PlannedHookEntry) (int, map[string]json.RawMessage, error) {
-	// Decode the current hooks subtree into a typed map so we can
-	// filter cleanly. Unknown event keys round-trip via raw JSON
-	// untouched.
-	current := map[string][]rawHookEntry{}
+	// Decode the current hooks subtree using the preservation
+	// shape so handlers round-trip as raw JSON. The lossy rawHookEntry
+	// type would silently drop any handler field we do not model
+	// (timeout, statusMessage, env, headers, allowedEnvVars, future
+	// Claude additions) on rewrite.
+	current := map[string][]preservedHookEntry{}
 	if rawHooks, ok := settings["hooks"]; ok && len(rawHooks) > 0 {
 		var perEvent map[string]json.RawMessage
 		if err := json.Unmarshal(rawHooks, &perEvent); err != nil {
 			return 0, nil, fmt.Errorf("parsing hooks subtree: %w", err)
 		}
 		for event, raw := range perEvent {
-			var entries []rawHookEntry
-			if err := json.Unmarshal(raw, &entries); err != nil {
-				// Tolerate single-object form that some older
-				// configs use. Fall through to a single-element slice.
-				var single rawHookEntry
-				if err2 := json.Unmarshal(raw, &single); err2 == nil {
-					entries = []rawHookEntry{single}
-				} else {
-					return 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, err)
-				}
+			entries, perr := decodePreservedEntries(raw)
+			if perr != nil {
+				return 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, perr)
 			}
 			current[event] = entries
 		}
 	}
 
-	// Build planned-event lookup for fast membership tests.
 	plannedByEvent := map[string]PlannedHookEntry{}
 	for _, p := range plan {
 		plannedByEvent[p.Event] = p
 	}
 
 	upgradedV1 := 0
-	out := map[string][]rawHookEntry{}
+	out := map[string][]preservedHookEntry{}
 
-	// 1) Pass through events not in our plan untouched.
+	// 1) Pass through events not in our plan untouched. The raw
+	// JSON handler payloads stay verbatim.
 	for event, entries := range current {
 		if _, planned := plannedByEvent[event]; planned {
 			continue
@@ -345,47 +373,46 @@ func applyManifest(settings map[string]json.RawMessage, plan []PlannedHookEntry)
 		out[event] = entries
 	}
 
-	// 2) For each planned event, filter operator entries through
-	// our ownership predicate, count v1 upgrades, then append the
-	// fresh v2 entry.
+	// 2) For each planned event, filter operator handlers through
+	// the ownership predicate, count v1 upgrades, then append the
+	// fresh v2 entry. Operator handlers retain their raw JSON
+	// payload so unknown fields are preserved.
 	for _, p := range plan {
-		var preserved []rawHookEntry
+		var preserved []preservedHookEntry
 		for _, entry := range current[p.Event] {
-			kept := []rawHookHandler{}
-			for _, h := range entry.Hooks {
+			kept := []json.RawMessage{}
+			for _, raw := range entry.Hooks {
+				isV2, isLegacy := handlerOwnership(raw)
 				switch {
-				case isManifestV2Handler(h):
-					// Drop our own previous v2 entry — we are about to write a fresh one.
-					continue
-				case isLegacyOktsecHandler(h):
+				case isV2:
+					// Drop our previous v2 entry — about to write fresh.
+				case isLegacy:
 					upgradedV1++
-					continue
 				default:
-					kept = append(kept, h)
+					kept = append(kept, raw)
 				}
 			}
 			if len(kept) > 0 {
-				preserved = append(preserved, rawHookEntry{
+				preserved = append(preserved, preservedHookEntry{
 					Matcher: entry.Matcher,
 					Hooks:   kept,
 				})
 			}
 		}
-		preserved = append(preserved, rawHookEntry{
+		ownHandler, err := encodeOwnHandler(p)
+		if err != nil {
+			return 0, nil, err
+		}
+		preserved = append(preserved, preservedHookEntry{
 			Matcher: p.Matcher,
-			Hooks: []rawHookHandler{{
-				Type:    p.Type,
-				Command: p.Command,
-			}},
+			Hooks:   []json.RawMessage{ownHandler},
 		})
 		out[p.Event] = preserved
 	}
 
-	// Re-encode hooks subtree with stable key order.
 	encoded := map[string]json.RawMessage{}
 	for _, event := range sortedKeys(out) {
 		entries := out[event]
-		// Drop empty event keys to avoid leaving "PreToolUse": [].
 		if len(entries) == 0 {
 			continue
 		}
@@ -405,6 +432,36 @@ func applyManifest(settings map[string]json.RawMessage, plan []PlannedHookEntry)
 		delete(settings, "hooks")
 	}
 	return upgradedV1, settings, nil
+}
+
+// decodePreservedEntries parses one event's raw JSON value into the
+// preservation shape. Tolerates the older single-object form some
+// configs use; either way the returned entries carry handler
+// payloads as raw JSON for verbatim round-trip.
+func decodePreservedEntries(raw json.RawMessage) ([]preservedHookEntry, error) {
+	var entries []preservedHookEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		var single preservedHookEntry
+		if err2 := json.Unmarshal(raw, &single); err2 != nil {
+			return nil, err
+		}
+		entries = []preservedHookEntry{single}
+	}
+	return entries, nil
+}
+
+// encodeOwnHandler produces the raw JSON shape for one oktsec hook
+// handler. Centralised so the manifest's wire format is one
+// function the test suite can pin.
+func encodeOwnHandler(p PlannedHookEntry) (json.RawMessage, error) {
+	body, err := json.Marshal(map[string]any{
+		"type":    p.Type,
+		"command": p.Command,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding own handler for %s: %w", p.Event, err)
+	}
+	return body, nil
 }
 
 // encodeSettings serialises the raw settings map into the canonical

--- a/internal/connectors/claudecode/install_test.go
+++ b/internal/connectors/claudecode/install_test.go
@@ -340,6 +340,72 @@ func TestUninstallV2_RemovesOnlyOurEntries(t *testing.T) {
 	}
 }
 
+// TestInstallV2_OnDiskHandlerCarriesPlannedFields locks in the
+// promise that --install-hooks --dry-run --json advertises the
+// same manifest the installer actually writes. Previously the
+// dry-run plan listed timeout + statusMessage, but encodeOwnHandler
+// dropped them on the way to disk; an operator inspecting the
+// installed file saw a sparser entry than the dry-run claimed.
+//
+// The test installs against a fixture home, then reads
+// settings.json off disk and walks every oktsec entry asserting
+// the planned fields are present.
+func TestInstallV2_OnDiskHandlerCarriesPlannedFields(t *testing.T) {
+	home := installFixtureHome(t, "")
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	planned := buildPlan("/usr/local/bin/oktsec", 9090)
+	plannedByEvent := map[string]PlannedHookEntry{}
+	for _, p := range planned {
+		plannedByEvent[p.Event] = p
+	}
+
+	settings := readSettingsFile(t, home)
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks key missing or wrong type: %#v", settings["hooks"])
+	}
+	for event, want := range plannedByEvent {
+		entries, ok := hooks[event].([]any)
+		if !ok {
+			t.Errorf("event %s missing from installed hooks", event)
+			continue
+		}
+		// Walk every entry and find the oktsec one. Operator
+		// entries are ignored — this test pins our own handler.
+		var ownHandler map[string]any
+		for _, raw := range entries {
+			entry, _ := raw.(map[string]any)
+			handlers, _ := entry["hooks"].([]any)
+			for _, h := range handlers {
+				cmd, _ := h.(map[string]any)["command"].(string)
+				if strings.Contains(cmd, ManifestV2Marker) {
+					ownHandler = h.(map[string]any)
+					break
+				}
+			}
+			if ownHandler != nil {
+				break
+			}
+		}
+		if ownHandler == nil {
+			t.Errorf("no oktsec handler installed for event %s", event)
+			continue
+		}
+		if got, _ := ownHandler["timeout"].(float64); int(got) != want.TimeoutSecs {
+			t.Errorf("event %s: installed timeout = %v, want %d", event, ownHandler["timeout"], want.TimeoutSecs)
+		}
+		if got, _ := ownHandler["statusMessage"].(string); got != want.Status {
+			t.Errorf("event %s: installed statusMessage = %q, want %q", event, got, want.Status)
+		}
+	}
+}
+
 // TestPhase2EventNames_MatchesInstalledPlan locks in the P1
 // invariant: the inventory's "missing events" report and the
 // installer's plan derive from the same source. A drift here

--- a/internal/connectors/claudecode/install_test.go
+++ b/internal/connectors/claudecode/install_test.go
@@ -340,6 +340,163 @@ func TestUninstallV2_RemovesOnlyOurEntries(t *testing.T) {
 	}
 }
 
+// TestPhase2EventNames_MatchesInstalledPlan locks in the P1
+// invariant: the inventory's "missing events" report and the
+// installer's plan derive from the same source. A drift here
+// would mean the doctor never reaches `ready` after a clean
+// install (or, in the other direction, would mark events
+// "missing" that we silently never install).
+func TestPhase2EventNames_MatchesInstalledPlan(t *testing.T) {
+	plan := buildPlan("/usr/local/bin/oktsec", 9090)
+	planEvents := map[string]bool{}
+	for _, p := range plan {
+		planEvents[p.Event] = true
+	}
+	for _, name := range Phase2EventNames() {
+		if !planEvents[name] {
+			t.Errorf("Phase2EventNames lists %q but buildPlan does not install it", name)
+		}
+	}
+	for event := range planEvents {
+		var found bool
+		for _, name := range Phase2EventNames() {
+			if name == event {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("buildPlan installs %q but Phase2EventNames does not list it (missing-events report would be wrong)", event)
+		}
+	}
+}
+
+// TestMissingExpectedEvents_EmptyAfterInstall is the operator-
+// visible guarantee that the doctor's "missing manifest events"
+// list is empty once the installer has run.
+func TestMissingExpectedEvents_EmptyAfterInstall(t *testing.T) {
+	home := installFixtureHome(t, "")
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	inv := Read(context.Background(), ReadOptions{
+		HomeDir:          home,
+		SkipVersionProbe: true,
+	})
+	if missing := MissingExpectedEvents(inv.Hooks); len(missing) > 0 {
+		t.Errorf("MissingExpectedEvents non-empty after fresh install: %v", missing)
+	}
+}
+
+// TestInstallV2_PreservesUnknownHandlerFields locks in the P2
+// merge contract: an operator hook with `timeout` and
+// `statusMessage` fields (or any other Claude-supported field
+// the inventory does not model) must round-trip verbatim across
+// install. The previous typed-struct decode silently dropped them.
+func TestInstallV2_PreservesUnknownHandlerFields(t *testing.T) {
+	existing := `{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash(git *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/operator/audit.sh",
+            "timeout": 600,
+            "statusMessage": "operator audit running",
+            "if": "Bash(git push *)",
+            "allowedEnvVars": ["GIT_AUTHOR"],
+            "shell": "bash"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+	home := installFixtureHome(t, existing)
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	for _, expected := range []string{
+		`"timeout"`,
+		`"statusMessage"`,
+		`"if"`,
+		`"allowedEnvVars"`,
+		`"shell"`,
+		`"operator audit running"`,
+		`"GIT_AUTHOR"`,
+		`"Bash(git push *)"`,
+		`"/opt/operator/audit.sh"`,
+	} {
+		if !strings.Contains(string(body), expected) {
+			t.Errorf("operator field %s lost on install round-trip; body=%s", expected, body)
+		}
+	}
+	// And the oktsec entry must still be present.
+	if !strings.Contains(string(body), ManifestV2Marker) {
+		t.Errorf("oktsec entry missing after preserve-fields install; body=%s", body)
+	}
+}
+
+// TestUninstallV2_PreservesUnknownHandlerFields confirms the
+// symmetric guarantee on the uninstall path.
+func TestUninstallV2_PreservesUnknownHandlerFields(t *testing.T) {
+	existing := `{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash(git *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/operator/audit.sh",
+            "timeout": 600,
+            "statusMessage": "operator audit running"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+	home := installFixtureHome(t, existing)
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UninstallV2(context.Background(), UninstallOptions{
+		HomeDir:         home,
+		IncludeLegacyV1: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	for _, expected := range []string{
+		`"timeout"`,
+		`"statusMessage"`,
+		`"operator audit running"`,
+		`"/opt/operator/audit.sh"`,
+	} {
+		if !strings.Contains(string(body), expected) {
+			t.Errorf("operator field %s lost on uninstall round-trip; body=%s", expected, body)
+		}
+	}
+}
+
 // TestInstallV2_DryRunMakesNoMutation locks in the dry-run contract.
 func TestInstallV2_DryRunMakesNoMutation(t *testing.T) {
 	home := installFixtureHome(t, "")

--- a/internal/connectors/claudecode/install_test.go
+++ b/internal/connectors/claudecode/install_test.go
@@ -1,0 +1,394 @@
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFixtureHome assembles a fake $HOME with optional initial
+// settings.json content, returning the home dir path so tests can
+// pass it as InstallOptions.HomeDir. Centralized to avoid scattering
+// MkdirAll boilerplate across cases.
+func installFixtureHome(t *testing.T, settings string) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if settings != "" {
+		path := filepath.Join(home, ".claude", "settings.json")
+		if err := os.WriteFile(path, []byte(settings), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+func readSettingsFile(t *testing.T, home string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal post-install settings: %v\nbody=%s", err, data)
+	}
+	return out
+}
+
+// TestInstallV2_FreshHomeWritesManifest exercises the happy path:
+// no settings file exists, install creates one with every Phase 2
+// event, no backup is needed (nothing to back up), and the manifest
+// marker is present in the command string.
+func TestInstallV2_FreshHomeWritesManifest(t *testing.T) {
+	home := installFixtureHome(t, "")
+
+	res, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !res.Wrote {
+		t.Errorf("expected Wrote=true, got skipped=%q", res.Skipped)
+	}
+	if res.BackupPath != "" {
+		t.Errorf("first-time install should not back up: %q", res.BackupPath)
+	}
+
+	settings := readSettingsFile(t, home)
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks key missing or wrong type: %#v", settings["hooks"])
+	}
+	for _, must := range []string{"PreToolUse", "PostToolUse", "SubagentStart", "SessionStart"} {
+		if _, ok := hooks[must]; !ok {
+			t.Errorf("expected event %q in installed hooks", must)
+		}
+	}
+	// Marker must be present in at least one command.
+	if !strings.Contains(string(mustMarshal(t, settings)), ManifestV2Marker) {
+		t.Error("ManifestV2Marker not found in any installed command")
+	}
+}
+
+// TestInstallV2_RefusesWhenDisableAllHooks proves the disable-knob
+// gate fires before any disk write. The settings file must be
+// untouched after the refusal.
+func TestInstallV2_RefusesWhenDisableAllHooks(t *testing.T) {
+	home := installFixtureHome(t, `{"disableAllHooks": true}`)
+	before, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+
+	_, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	var blocked *InstallBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected InstallBlockedError, got %v", err)
+	}
+	codes := make([]string, len(blocked.Reasons))
+	for i, r := range blocked.Reasons {
+		codes[i] = r.Code
+	}
+	if want := "CC-HOOKS-GLOBALLY-DISABLED"; !contains(codes, want) {
+		t.Errorf("blocked reasons = %v, want to contain %q", codes, want)
+	}
+
+	after, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if string(before) != string(after) {
+		t.Error("settings file mutated despite refusal")
+	}
+}
+
+// TestInstallV2_RefusesSymlink default-refuses to follow a symlinked
+// settings.json so dotfiles repos are not silently rewritten.
+func TestInstallV2_RefusesSymlink(t *testing.T) {
+	home := installFixtureHome(t, "")
+	target := t.TempDir()
+	realPath := filepath.Join(target, "settings-real.json")
+	if err := os.WriteFile(realPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(home, ".claude", "settings.json")
+	_ = os.Remove(link) // installFixtureHome did not create one
+	if err := os.Symlink(realPath, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	var sym *SymlinkRefusedError
+	if !errors.As(err, &sym) {
+		t.Fatalf("expected SymlinkRefusedError, got %v", err)
+	}
+
+	// FollowSymlink=true should succeed and write through the symlink.
+	res, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:       home,
+		BinaryPath:    "/usr/local/bin/oktsec",
+		GatewayPort:   9090,
+		FollowSymlink: true,
+	})
+	if err != nil {
+		t.Fatalf("FollowSymlink install: %v", err)
+	}
+	if !res.Wrote {
+		t.Errorf("FollowSymlink install should have written; skipped=%q", res.Skipped)
+	}
+	// The real target file should now contain hooks; the symlink in
+	// home should still resolve to it.
+	body, _ := os.ReadFile(realPath)
+	if !strings.Contains(string(body), "PreToolUse") {
+		t.Error("symlinked target was not updated by FollowSymlink install")
+	}
+}
+
+// TestInstallV2_PreservesOperatorEntries asserts the merge-no-replace
+// contract: an operator's existing SessionStart hook survives an
+// oktsec install.
+func TestInstallV2_PreservesOperatorEntries(t *testing.T) {
+	existing := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "echo hello" }
+        ]
+      }
+    ]
+  }
+}
+`
+	home := installFixtureHome(t, existing)
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if !strings.Contains(string(body), "echo hello") {
+		t.Errorf("operator SessionStart hook lost on install; body=%s", body)
+	}
+	if !strings.Contains(string(body), ManifestV2Marker) {
+		t.Errorf("oktsec entry not added; body=%s", body)
+	}
+}
+
+// TestInstallV2_UpgradesLegacyV1 confirms an existing v1 oktsec hook
+// is replaced (not duplicated) by the v2 manifest.
+func TestInstallV2_UpgradesLegacyV1(t *testing.T) {
+	v1 := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/oktsec hook --port 9090" }
+        ]
+      }
+    ]
+  }
+}
+`
+	home := installFixtureHome(t, v1)
+	res, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if res.UpgradedV1 == 0 {
+		t.Error("expected UpgradedV1 > 0")
+	}
+
+	settings := readSettingsFile(t, home)
+	hooks := settings["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	if len(pre) != 1 {
+		t.Fatalf("PreToolUse should have exactly one entry after upgrade, got %d", len(pre))
+	}
+	cmd := mustExtractCommand(t, pre[0])
+	if !strings.Contains(cmd, ManifestV2Marker) {
+		t.Errorf("upgraded entry missing marker; cmd=%s", cmd)
+	}
+	if strings.Contains(cmd, "oktsec hook --port 9090\"") {
+		t.Errorf("legacy v1 command still present alongside v2: cmd=%s", cmd)
+	}
+}
+
+// TestInstallV2_IsIdempotent guarantees a second install produces a
+// byte-identical file (and skips the rewrite).
+func TestInstallV2_IsIdempotent(t *testing.T) {
+	home := installFixtureHome(t, "")
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+
+	res2, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.Wrote {
+		t.Error("second install should be idempotent (skipped)")
+	}
+	if res2.Skipped == "" {
+		t.Error("expected Skipped reason on idempotent re-run")
+	}
+	body2, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if string(body1) != string(body2) {
+		t.Error("settings file changed across idempotent runs")
+	}
+}
+
+// TestInstallV2_BackupCarriesOriginalMode proves the backup file
+// preserves the source file's permission bits so a manual restore
+// keeps the operator's posture.
+func TestInstallV2_BackupCarriesOriginalMode(t *testing.T) {
+	home := installFixtureHome(t, `{"hooks":{}}`)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.Chmod(settingsPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.BackupPath == "" {
+		t.Fatal("expected backup path")
+	}
+	info, err := os.Stat(res.BackupPath)
+	if err != nil {
+		t.Fatalf("stat backup: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("backup mode = %o, want 644", info.Mode().Perm())
+	}
+}
+
+// TestUninstallV2_RemovesOnlyOurEntries confirms operator entries
+// survive uninstall and oktsec footprints are gone.
+func TestUninstallV2_RemovesOnlyOurEntries(t *testing.T) {
+	existing := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "echo hello" }
+        ]
+      }
+    ]
+  }
+}
+`
+	home := installFixtureHome(t, existing)
+	// Install first so there is something to remove.
+	if _, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := UninstallV2(context.Background(), UninstallOptions{
+		HomeDir:         home,
+		IncludeLegacyV1: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedV2 == 0 {
+		t.Error("expected RemovedV2 > 0")
+	}
+
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if !strings.Contains(string(body), "echo hello") {
+		t.Errorf("operator hook removed by uninstall; body=%s", body)
+	}
+	if strings.Contains(string(body), ManifestV2Marker) {
+		t.Errorf("oktsec marker survived uninstall; body=%s", body)
+	}
+}
+
+// TestInstallV2_DryRunMakesNoMutation locks in the dry-run contract.
+func TestInstallV2_DryRunMakesNoMutation(t *testing.T) {
+	home := installFixtureHome(t, "")
+	res, err := InstallV2(context.Background(), InstallOptions{
+		HomeDir:     home,
+		BinaryPath:  "/usr/local/bin/oktsec",
+		GatewayPort: 9090,
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Wrote {
+		t.Error("dry-run install should not write")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err == nil {
+		t.Error("dry-run install created settings file")
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func mustExtractCommand(t *testing.T, entry any) string {
+	t.Helper()
+	m, ok := entry.(map[string]any)
+	if !ok {
+		t.Fatalf("entry is not a map: %#v", entry)
+	}
+	hooks, ok := m["hooks"].([]any)
+	if !ok || len(hooks) == 0 {
+		t.Fatalf("entry has no hooks slice: %#v", entry)
+	}
+	h := hooks[0].(map[string]any)
+	cmd, _ := h["command"].(string)
+	return cmd
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/connectors/claudecode/settings.go
+++ b/internal/connectors/claudecode/settings.go
@@ -13,8 +13,16 @@ import (
 // to extract hooks. Anything not modeled here is left as raw JSON in
 // the parent map and ignored, so unknown keys never cause Read to
 // fail. The shape mirrors the public docs at code.claude.com/docs/en/hooks.
+//
+// Disable / restrict knobs are surfaced because the Phase 2 installer
+// must refuse to write hooks the operator (or a managed policy) has
+// globally disabled. The inventory reports them as ConnectorProblem
+// rows so the doctor can explain the situation before any write.
 type rawSettings struct {
-	Hooks map[string]json.RawMessage `json:"hooks,omitempty"`
+	Hooks                 map[string]json.RawMessage `json:"hooks,omitempty"`
+	DisableAllHooks       *bool                      `json:"disableAllHooks,omitempty"`
+	AllowManagedHooksOnly *bool                      `json:"allowManagedHooksOnly,omitempty"`
+	AllowedHTTPHookURLs   *[]string                  `json:"allowedHttpHookUrls,omitempty"`
 }
 
 // rawHookEntry covers both shapes Claude Code accepts under one event:

--- a/internal/connectors/claudecode/settings.go
+++ b/internal/connectors/claudecode/settings.go
@@ -25,20 +25,53 @@ type rawSettings struct {
 	AllowedHTTPHookURLs   *[]string                  `json:"allowedHttpHookUrls,omitempty"`
 }
 
-// rawHookEntry covers both shapes Claude Code accepts under one event:
-//   { "matcher": "*", "hooks": [ { "type": "command", "command": "..." } ] }
-//
-// The "hooks" inner array can also be a single object in some older
-// configs; we accept both via json.RawMessage and decode lazily.
+// rawHookEntry is the lossy projection used by the inventory's
+// HookRef rendering path (read-only). It only models the fields the
+// dashboard / doctor surface display, so unknown handler fields
+// (timeout, statusMessage, env, headers, allowedEnvVars, etc.) are
+// dropped. NEVER use rawHookEntry for the write round-trip — see
+// preservedHookEntry instead.
 type rawHookEntry struct {
-	Matcher string            `json:"matcher,omitempty"`
-	Hooks   []rawHookHandler  `json:"hooks,omitempty"`
+	Matcher string           `json:"matcher,omitempty"`
+	Hooks   []rawHookHandler `json:"hooks,omitempty"`
 }
 
 type rawHookHandler struct {
 	Type    string `json:"type,omitempty"`    // command | http | mcp_tool | prompt | agent
 	Command string `json:"command,omitempty"`
 	URL     string `json:"url,omitempty"`
+}
+
+// preservedHookEntry is the install/uninstall round-trip shape:
+// the matcher is decoded so we can split entries by matcher, but
+// each handler is kept as raw JSON so unknown fields the operator
+// added (timeout, statusMessage, env, headers, allowedEnvVars,
+// future Claude additions) round-trip verbatim. Inventory HookRef
+// rendering does NOT need this preservation; it stays on
+// rawHookEntry.
+type preservedHookEntry struct {
+	Matcher string            `json:"matcher,omitempty"`
+	Hooks   []json.RawMessage `json:"hooks,omitempty"`
+}
+
+// handlerOwnership decodes just enough of a raw handler payload to
+// classify it as oktsec-owned (v2), legacy oktsec (v1), or operator
+// content. Used by applyManifest / stripManifest so the round-trip
+// path never has to fully decode a handler whose unknown fields
+// must be preserved.
+func handlerOwnership(raw json.RawMessage) (isV2, isLegacy bool) {
+	var probe rawHookHandler
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false, false
+	}
+	switch {
+	case isManifestV2Handler(probe):
+		return true, false
+	case isLegacyOktsecHandler(probe):
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // readSettings loads a single Claude settings file and unmarshals it

--- a/internal/connectors/claudecode/uninstall.go
+++ b/internal/connectors/claudecode/uninstall.go
@@ -119,8 +119,11 @@ func UninstallV2(ctx context.Context, opts UninstallOptions) (UninstallResult, e
 
 // stripManifest mirrors the install-side filter loop but removes
 // every oktsec-owned handler instead of substituting a fresh one.
-// Empty event arrays are dropped so uninstall is fully reversible
-// — a follow-up install regenerates the keys cleanly.
+// Operator handlers retain their raw JSON payload so unknown
+// fields (timeout, statusMessage, env, headers, future Claude
+// additions) survive uninstall verbatim. Empty event arrays are
+// dropped so uninstall is fully reversible — a follow-up install
+// regenerates the keys cleanly.
 func stripManifest(settings map[string]json.RawMessage, includeLegacyV1 bool) (int, int, map[string]json.RawMessage, error) {
 	rawHooks, ok := settings["hooks"]
 	if !ok || len(rawHooks) == 0 {
@@ -132,34 +135,28 @@ func stripManifest(settings map[string]json.RawMessage, includeLegacyV1 bool) (i
 	}
 
 	removedV2, removedV1 := 0, 0
-	out := map[string][]rawHookEntry{}
+	out := map[string][]preservedHookEntry{}
 	for event, raw := range perEvent {
-		var entries []rawHookEntry
-		if err := json.Unmarshal(raw, &entries); err != nil {
-			var single rawHookEntry
-			if err2 := json.Unmarshal(raw, &single); err2 == nil {
-				entries = []rawHookEntry{single}
-			} else {
-				return 0, 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, err)
-			}
+		entries, perr := decodePreservedEntries(raw)
+		if perr != nil {
+			return 0, 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, perr)
 		}
-		var keptEntries []rawHookEntry
+		var keptEntries []preservedHookEntry
 		for _, entry := range entries {
-			var keptHandlers []rawHookHandler
+			var keptHandlers []json.RawMessage
 			for _, h := range entry.Hooks {
+				isV2, isLegacy := handlerOwnership(h)
 				switch {
-				case isManifestV2Handler(h):
+				case isV2:
 					removedV2++
-					continue
-				case includeLegacyV1 && isLegacyOktsecHandler(h):
+				case includeLegacyV1 && isLegacy:
 					removedV1++
-					continue
 				default:
 					keptHandlers = append(keptHandlers, h)
 				}
 			}
 			if len(keptHandlers) > 0 {
-				keptEntries = append(keptEntries, rawHookEntry{
+				keptEntries = append(keptEntries, preservedHookEntry{
 					Matcher: entry.Matcher,
 					Hooks:   keptHandlers,
 				})

--- a/internal/connectors/claudecode/uninstall.go
+++ b/internal/connectors/claudecode/uninstall.go
@@ -1,0 +1,191 @@
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// UninstallOptions mirrors InstallOptions for the symmetric removal
+// path. The same symlink and dry-run guards apply; backups are
+// always written so the operator can recover if uninstall removed
+// more than they expected.
+type UninstallOptions struct {
+	HomeDir       string
+	FollowSymlink bool
+	DryRun        bool
+	// IncludeLegacyV1 controls whether older oktsec hooks (no
+	// --manifest v2 marker) are also removed. Default true:
+	// uninstall is meant to clear all of oktsec's footprints,
+	// not just the V2 ones.
+	IncludeLegacyV1 bool
+}
+
+// UninstallResult reports what the symmetric removal did. Counts
+// are split between v2 and legacy v1 so the doctor can show the
+// operator exactly what footprint was cleared.
+type UninstallResult struct {
+	SettingsPath string `json:"settings_path"`
+	BackupPath   string `json:"backup_path,omitempty"`
+	Wrote        bool   `json:"wrote"`
+	RemovedV2    int    `json:"removed_v2"`
+	RemovedV1    int    `json:"removed_v1"`
+	Skipped      string `json:"skipped,omitempty"`
+}
+
+// UninstallV2 removes every hook entry the installer owns from the
+// user-scope Claude Code settings file. Uses the same atomic write
+// + backup contract as InstallV2 so a botched uninstall never
+// leaves the file in a torn state.
+//
+// Operator-added entries inside the same event family are
+// preserved verbatim; only handlers that match
+// isManifestV2Handler (and, when IncludeLegacyV1 is true, legacy
+// oktsec entries) are dropped. Empty event arrays are removed
+// entirely so the file does not gain "PreToolUse": [] cruft.
+func UninstallV2(ctx context.Context, opts UninstallOptions) (UninstallResult, error) {
+	if opts.HomeDir == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return UninstallResult{}, fmt.Errorf("resolving home dir: %w", err)
+		}
+		opts.HomeDir = h
+	}
+
+	settingsPath := filepath.Join(opts.HomeDir, ".claude", "settings.json")
+	result := UninstallResult{SettingsPath: settingsPath}
+
+	writePath := settingsPath
+	if info, lerr := os.Lstat(settingsPath); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+		if !opts.FollowSymlink {
+			return result, &SymlinkRefusedError{Path: settingsPath}
+		}
+		resolved, err := filepath.EvalSymlinks(settingsPath)
+		if err != nil {
+			return result, fmt.Errorf("resolving symlink %s: %w", settingsPath, err)
+		}
+		writePath = resolved
+	}
+
+	existing, mode, err := readRawSettings(writePath)
+	if err != nil {
+		return result, err
+	}
+	if len(existing) == 0 {
+		result.Skipped = "settings file is empty or missing"
+		return result, nil
+	}
+
+	removedV2, removedV1, mutated, err := stripManifest(existing, opts.IncludeLegacyV1)
+	if err != nil {
+		return result, err
+	}
+	result.RemovedV2 = removedV2
+	result.RemovedV1 = removedV1
+
+	if removedV2+removedV1 == 0 {
+		result.Skipped = "no oktsec entries found"
+		return result, nil
+	}
+
+	planned, err := encodeSettings(mutated)
+	if err != nil {
+		return result, err
+	}
+	current, _ := os.ReadFile(writePath)
+	if bytesEqual(current, planned) {
+		result.Skipped = "byte-identical to current file"
+		return result, nil
+	}
+	if opts.DryRun {
+		result.Skipped = "dry-run"
+		return result, nil
+	}
+
+	backupPath, err := writeBackup(settingsPath, current, mode)
+	if err != nil {
+		return result, err
+	}
+	result.BackupPath = backupPath
+
+	if err := atomicWrite(writePath, planned, mode); err != nil {
+		return result, err
+	}
+	result.Wrote = true
+	return result, nil
+}
+
+// stripManifest mirrors the install-side filter loop but removes
+// every oktsec-owned handler instead of substituting a fresh one.
+// Empty event arrays are dropped so uninstall is fully reversible
+// — a follow-up install regenerates the keys cleanly.
+func stripManifest(settings map[string]json.RawMessage, includeLegacyV1 bool) (int, int, map[string]json.RawMessage, error) {
+	rawHooks, ok := settings["hooks"]
+	if !ok || len(rawHooks) == 0 {
+		return 0, 0, settings, nil
+	}
+	var perEvent map[string]json.RawMessage
+	if err := json.Unmarshal(rawHooks, &perEvent); err != nil {
+		return 0, 0, nil, fmt.Errorf("parsing hooks subtree: %w", err)
+	}
+
+	removedV2, removedV1 := 0, 0
+	out := map[string][]rawHookEntry{}
+	for event, raw := range perEvent {
+		var entries []rawHookEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			var single rawHookEntry
+			if err2 := json.Unmarshal(raw, &single); err2 == nil {
+				entries = []rawHookEntry{single}
+			} else {
+				return 0, 0, nil, fmt.Errorf("parsing hooks[%s]: %w", event, err)
+			}
+		}
+		var keptEntries []rawHookEntry
+		for _, entry := range entries {
+			var keptHandlers []rawHookHandler
+			for _, h := range entry.Hooks {
+				switch {
+				case isManifestV2Handler(h):
+					removedV2++
+					continue
+				case includeLegacyV1 && isLegacyOktsecHandler(h):
+					removedV1++
+					continue
+				default:
+					keptHandlers = append(keptHandlers, h)
+				}
+			}
+			if len(keptHandlers) > 0 {
+				keptEntries = append(keptEntries, rawHookEntry{
+					Matcher: entry.Matcher,
+					Hooks:   keptHandlers,
+				})
+			}
+		}
+		if len(keptEntries) > 0 {
+			out[event] = keptEntries
+		}
+	}
+
+	encoded := map[string]json.RawMessage{}
+	for _, event := range sortedKeys(out) {
+		body, err := json.Marshal(out[event])
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("encoding hooks[%s]: %w", event, err)
+		}
+		encoded[event] = body
+	}
+	if len(encoded) > 0 {
+		body, err := json.Marshal(encoded)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("encoding hooks subtree: %w", err)
+		}
+		settings["hooks"] = body
+	} else {
+		delete(settings, "hooks")
+	}
+	return removedV2, removedV1, settings, nil
+}

--- a/internal/connectors/claudecode/uninstall.go
+++ b/internal/connectors/claudecode/uninstall.go
@@ -17,9 +17,12 @@ type UninstallOptions struct {
 	FollowSymlink bool
 	DryRun        bool
 	// IncludeLegacyV1 controls whether older oktsec hooks (no
-	// --manifest v2 marker) are also removed. Default true:
-	// uninstall is meant to clear all of oktsec's footprints,
-	// not just the V2 ones.
+	// --manifest v2 marker) are also removed. Zero value is false
+	// because the Go zero-value contract wins; the doctor command
+	// passes true so a `oktsec doctor claude-code --uninstall-hooks`
+	// invocation clears every oktsec footprint, not just the V2
+	// entries. Library callers that want narrower scope can leave
+	// the field at its default.
 	IncludeLegacyV1 bool
 }
 


### PR DESCRIPTION
## Summary

- Adds `internal/connectors/claudecode/install.go` and `uninstall.go`. The installer writes the Phase 2 hook manifest (18 event families) into `~/.claude/settings.json` with three guarantees: operator entries are preserved, a timestamped backup is written before any mutation, and the swap is atomic (temp + fsync + rename + parent fsync). A re-run that produces byte-identical content skips the rewrite entirely.
- Refuses to install when `disableAllHooks: true` or `allowManagedHooksOnly: true` is set in any inspected scope; refuses to follow a symlinked settings file unless `--follow-symlink` is passed. Three new inventory problem codes surface the conditions in `oktsec doctor claude-code`.
- Rewrites `oktsec hook` to emit Claude Code's modern per-event response shapes. `PreToolUse` blocks now return `hookSpecificOutput.permissionDecision: "deny"` with `permissionDecisionReason`; post-action events use the top-level `decision: "block"` shape with `hookSpecificOutput.additionalContext` when the gateway returns it. Adds `--event` and `--manifest` flags the installer uses to mark its own entries.
- New doctor flags: `--install-hooks`, `--uninstall-hooks`, `--emit-heartbeat`, `--follow-symlink`, `--dry-run`. The no-flag invocation stays read-only.

## Review focus

- **Merge-no-replace contract:** the installer must never destroy an operator-added hook in the same event family. `TestInstallV2_PreservesOperatorEntries` pins this.
- **Atomic + backup protocol:** `writeBackup` + `atomicWrite` in `install.go`. Backup carries the original file mode (`TestInstallV2_BackupCarriesOriginalMode`); rename is performed against the symlink target, not the symlink itself, when `--follow-symlink` is set.
- **Modern decision shape:** `TestHook_PreToolUseBlock_EmitsModernShape` and `TestHook_PostToolUseBlock_TopLevelWithContext` lock in the response envelopes Claude Code expects today.
- **V1 -> V2 upgrade:** legacy `oktsec hook --port N` entries (no `--manifest v2` flag) are upgraded in place without duplication. `TestInstallV2_UpgradesLegacyV1` pins this.
- **Disable-knob refusal:** `TestInstallV2_RefusesWhenDisableAllHooks` confirms the installer aborts before any disk write when the operator has globally disabled hooks.

## Out of scope (intentional, deferred to later phases)

- Plugin / managed hook discovery
- Dashboard redesign / Security Posture changes
- Subagent graph expansion beyond what the existing runtime contract already supports

## Test plan

- [x] `make build`
- [x] `make test` -- all packages green on the rebased branch
- [x] `make vet`
- [x] `make lint` -- 0 issues
- [x] Smoke: `./oktsec doctor claude-code --install-hooks --dry-run --json` against the developer machine renders the full plan without touching disk
- [x] Smoke: `./oktsec doctor claude-code --emit-heartbeat --json` returns a clear `connection refused` error when the gateway is offline