### PR TITLE
Wire runtime.Store into the hooks handler

### DIFF
--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -350,36 +350,45 @@ func principalIDOrUnknown(id string) string {
 	return id
 }
 
+// hookCoverage returns the stage-aware coverage mode + confidence
+// for one hook event. Centralised so the activity row, the runtime
+// row, and any future projection share one canonical value instead
+// of recomputing it from scratch and risking drift.
+//
+// Hook coverage is stage-aware: post_tool_use evidence cannot
+// block (the action already ran) so even token-authenticated
+// post-action hooks are Observed/60, not Protected/100. See
+// activity.CoverageFromHookEvent.
+func hookCoverage(authResult resolve.Result, eventName string) (activity.CoverageMode, int) {
+	return activity.CoverageFromHookEvent(string(authResult.Principal.AuthMethod), eventName)
+}
+
 // emitHookActivity writes one activity event correlated to the audit
 // row just logged. Runs in a fresh background context with a bounded
 // timeout so a slow DB cannot delay the request handler. Insert errors
 // are logged at warn — they never affect the policy decision or the
 // audit row.
 //
-// The activity event id is pre-computed by the caller and passed in
-// so the runtime hook event can carry it as a cross-reference even
-// before the async insert lands. msgID is the audit row id, kept as
-// AuditEntryID for correlation. ResourceLabel carries the tool name
-// so the dashboard drill-down can show which tool the hook reported.
+// The activity event id, coverage mode, and confidence are all
+// computed in ServeHTTP and passed in so the runtime hook event
+// carries the same values as cross-references. msgID is the audit
+// row id, kept as AuditEntryID for correlation. ResourceLabel
+// carries the tool name so the dashboard drill-down can show which
+// tool the hook reported.
 //
-// Returns the activity event id so callers (which precomputed it) can
-// use the same identifier on the runtime row without re-derivation.
-func (h *Handler) emitHookActivity(activityID, msgID string, authResult resolve.Result, reportedActor string, ev *ToolEvent, status, decision string) string {
+// Returns the activity event id so callers (which precomputed it)
+// can use the same identifier on the runtime row without
+// re-derivation.
+func (h *Handler) emitHookActivity(activityID, msgID string, authResult resolve.Result, reportedActor string, ev *ToolEvent, status, decision string, coverage activity.CoverageMode, confidence int) string {
 	if h.activity == nil {
 		return activityID
 	}
-	authMethod := string(authResult.Principal.AuthMethod)
-	// Hook coverage is stage-aware: post_tool_use evidence cannot
-	// block (the action already ran) so even token-authenticated
-	// post-action hooks are Observed/60, not Protected/100. See
-	// activity.CoverageFromHookEvent.
-	coverage, confidence := activity.CoverageFromHookEvent(authMethod, ev.Event)
 	event := activity.Event{
 		ID:                  activityID,
 		Timestamp:           time.Now().UTC(),
 		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
 		ReportedActor:       reportedActor,
-		AuthMethod:          authMethod,
+		AuthMethod:          string(authResult.Principal.AuthMethod),
 		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
 		Surface:             activity.SurfaceHooks,
 		EventType:           activity.EventHookEvent,
@@ -667,17 +676,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// reportedActor passed here is the same value the audit row
 	// carries, so the two stay in lock-step.
 	//
-	// Phase 3B: the activity event id is pre-computed here so the
-	// runtime row below can carry it as a cross-reference even
-	// before the async insert lands.
+	// Phase 3B: the activity event id, coverage mode, and
+	// confidence are all computed once here so the runtime row
+	// below can carry the same cross-reference and coverage state
+	// even before the async activity insert lands. Without this,
+	// 3C would have to re-derive coverage from the runtime row by
+	// joining back to the activity table.
 	activityEventID := uuid.New().String()
-	h.emitHookActivity(activityEventID, msgID, authResult, reportedActor, &ev, status, decision)
+	coverage, confidence := hookCoverage(authResult, ev.Event)
+	h.emitHookActivity(activityEventID, msgID, authResult, reportedActor, &ev, status, decision, coverage, confidence)
 
 	// Phase 3B: persist the durable runtime row. The security
 	// decision is already committed in the audit row above, so a
 	// runtime write failure here logs at warn but never changes
 	// the response.
-	h.recordRuntime(r.Context(), body, authResult, ev.Client, ev.SessionID, msgID, activityEventID, status, decision, time.Since(start).Milliseconds())
+	h.recordRuntime(r.Context(), body, authResult, ev.Client, ev.SessionID, msgID, activityEventID, status, decision, string(coverage), confidence, time.Since(start).Milliseconds())
 
 	// Update agent hierarchy table
 	if ev.SessionID != "" {
@@ -783,7 +796,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // actor metadata only. ClientID falls back through the X-Oktsec-
 // Client header so a client that did not set the resolver-friendly
 // header still lands a runtime row tagged with the right client.
-func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult resolve.Result, clientID, sessionID, auditID, activityID, status, decision string, latencyMs int64) {
+func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult resolve.Result, clientID, sessionID, auditID, activityID, status, decision, coverage string, confidence int, latencyMs int64) {
 	_ = ctx // kept for future per-request cancellation; the inner call uses a detached deadline
 	if h.runtime == nil {
 		return
@@ -805,6 +818,8 @@ func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult 
 		ActivityEventID: activityID,
 		Status:          status,
 		PolicyDecision:  decision,
+		CoverageMode:    coverage,
+		Confidence:      confidence,
 		LatencyMs:       latencyMs,
 	}
 	// Detached context with a bounded deadline so a stalled DB
@@ -820,10 +835,15 @@ func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult 
 }
 
 // runtimeRecordTimeout bounds the runtime write so a stalled DB
-// cannot pin the hook hot path. Mirrors activityInsertTimeout for
-// the same reason — the runtime store is on the same DB and so
-// shares its failure modes.
-const runtimeRecordTimeout = 2 * time.Second
+// cannot pin the hook hot path. The deadline is set to 15s so the
+// runtime store's busy retry loop has room to complete: each
+// retry can wait up to the SQLite busy_timeout (5s) the audit
+// dialect configures, and a shorter context would cancel
+// mid-retry and silently drop the runtime row.
+// activityInsertTimeout stays at 2s because the activity insert
+// is async and a missed row is recovered on the next event; the
+// runtime row is the durable substrate and must not be dropped.
+const runtimeRecordTimeout = 15 * time.Second
 
 func formatBlockReason(outcome *engine.ScanOutcome) string {
 	if outcome == nil || len(outcome.Findings) == 0 {

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -20,10 +20,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/identity/resolve"
+	"github.com/oktsec/oktsec/internal/runtime"
 	"github.com/oktsec/oktsec/internal/verdict"
-	"github.com/oktsec/oktsec/internal/config"
 )
 
 // buildHooksIdentity wires the hooks endpoint into the same identity
@@ -228,6 +229,14 @@ type Handler struct {
 	// implementation (e.g., test mocks that do not expose a *sql.DB) or
 	// when activity migration failed at startup.
 	activity activityWriter
+
+	// runtime captures the durable session/actor/event substrate added
+	// in Phase 3A. Same nil-safety contract as activity: a missing
+	// store means the dashboard's runtime APIs (added in 3C) read from
+	// audit alone. A runtime write failure here is logged at warn but
+	// never changes the security decision the audit row already
+	// committed — runtime is evidence projection, not policy.
+	runtime *runtime.Store
 }
 
 // NewHandler creates a hooks handler wired to the security pipeline.
@@ -242,6 +251,7 @@ func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, lo
 		resolverConfig: resolverCfg,
 		requireAuth:    requireAuth,
 		activity:       buildHooksActivity(store, logger),
+		runtime:        buildHooksRuntime(store, logger),
 	}
 	// Periodic cleanup of old session states to prevent memory leaks.
 	go func() {
@@ -260,6 +270,41 @@ func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, lo
 // mid-flight.
 func (h *Handler) SetActivityStore(w activityWriter) {
 	h.activity = w
+}
+
+// SetRuntimeStore lets callers inject a custom runtime.Store (e.g.,
+// a fixture-backed instance in tests). Pass nil to disable runtime
+// writes entirely. Same swap rules as SetActivityStore: call before
+// the handler starts serving.
+func (h *Handler) SetRuntimeStore(s *runtime.Store) {
+	h.runtime = s
+}
+
+// buildHooksRuntime mirrors buildHooksActivity: the runtime store
+// only comes online when the underlying HookStore exposes the
+// *sql.DB it needs. Returns nil for in-memory test mocks; a nil
+// store turns runtime writes into a no-op without breaking the
+// hook hot path.
+func buildHooksRuntime(store HookStore, logger *slog.Logger) *runtime.Store {
+	dbs, ok := store.(dbBackedAuditStore)
+	if !ok {
+		return nil
+	}
+	db := dbs.DB()
+	if db == nil {
+		return nil
+	}
+	dialect := runtime.Dialect(dbs.DialectName())
+	if dialect == "" {
+		logger.Warn("runtime store skipped: audit store reports unknown dialect", "surface", "hooks")
+		return nil
+	}
+	rs, err := runtime.Open(context.Background(), db, dialect)
+	if err != nil {
+		logger.Warn("runtime store skipped: open failed", "surface", "hooks", "error", err)
+		return nil
+	}
+	return rs
 }
 
 // buildHooksActivity returns an activityWriter when the underlying
@@ -311,12 +356,17 @@ func principalIDOrUnknown(id string) string {
 // are logged at warn — they never affect the policy decision or the
 // audit row.
 //
-// The activity event uses a fresh UUID for ID and stores msgID as
-// AuditEntryID for correlation. ResourceLabel carries the tool name so
-// the dashboard drill-down can show which tool the hook reported.
-func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, reportedActor string, ev *ToolEvent, status, decision string) {
+// The activity event id is pre-computed by the caller and passed in
+// so the runtime hook event can carry it as a cross-reference even
+// before the async insert lands. msgID is the audit row id, kept as
+// AuditEntryID for correlation. ResourceLabel carries the tool name
+// so the dashboard drill-down can show which tool the hook reported.
+//
+// Returns the activity event id so callers (which precomputed it) can
+// use the same identifier on the runtime row without re-derivation.
+func (h *Handler) emitHookActivity(activityID, msgID string, authResult resolve.Result, reportedActor string, ev *ToolEvent, status, decision string) string {
 	if h.activity == nil {
-		return
+		return activityID
 	}
 	authMethod := string(authResult.Principal.AuthMethod)
 	// Hook coverage is stage-aware: post_tool_use evidence cannot
@@ -325,7 +375,7 @@ func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, repo
 	// activity.CoverageFromHookEvent.
 	coverage, confidence := activity.CoverageFromHookEvent(authMethod, ev.Event)
 	event := activity.Event{
-		ID:                  uuid.New().String(),
+		ID:                  activityID,
 		Timestamp:           time.Now().UTC(),
 		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
 		ReportedActor:       reportedActor,
@@ -354,6 +404,7 @@ func (h *Handler) emitHookActivity(msgID string, authResult resolve.Result, repo
 			h.logger.Warn("activity insert failed", "error", err, "msg_id", msgID, "surface", "hooks")
 		}
 	}()
+	return activityID
 }
 
 // getSessionState returns or creates the session state for tracking agent hierarchy.
@@ -615,7 +666,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Async with a 2s timeout — never blocks the response. The
 	// reportedActor passed here is the same value the audit row
 	// carries, so the two stay in lock-step.
-	h.emitHookActivity(msgID, authResult, reportedActor, &ev, status, decision)
+	//
+	// Phase 3B: the activity event id is pre-computed here so the
+	// runtime row below can carry it as a cross-reference even
+	// before the async insert lands.
+	activityEventID := uuid.New().String()
+	h.emitHookActivity(activityEventID, msgID, authResult, reportedActor, &ev, status, decision)
+
+	// Phase 3B: persist the durable runtime row. The security
+	// decision is already committed in the audit row above, so a
+	// runtime write failure here logs at warn but never changes
+	// the response.
+	h.recordRuntime(r.Context(), body, authResult, ev.Client, ev.SessionID, msgID, activityEventID, status, decision, time.Since(start).Milliseconds())
 
 	// Update agent hierarchy table
 	if ev.SessionID != "" {
@@ -701,6 +763,67 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"decision": "allow",
 	})
 }
+
+// recordRuntime normalizes the inbound hook body into the Phase 3
+// runtime envelope and persists it via runtime.Store.RecordHook.
+// Wraps the runtime call in two safety guards:
+//
+//  1. The runtime store may be nil (in-memory test mocks, missing
+//     SQLite migration). In that case the call is a no-op and the
+//     response is unchanged.
+//  2. RecordHook errors are logged at warn but never propagated to
+//     the caller. The audit row already carried the policy
+//     decision; runtime is evidence projection. Failing the hook
+//     here would turn a runtime DB hiccup into a blocked tool call,
+//     which violates the spec's "runtime write failure must never
+//     change a security decision" invariant.
+//
+// Identity comes from the resolver (PrincipalID, AuthMethod,
+// TrustLevel). The payload's agent / agent_type fields stay as
+// actor metadata only. ClientID falls back through the X-Oktsec-
+// Client header so a client that did not set the resolver-friendly
+// header still lands a runtime row tagged with the right client.
+func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult resolve.Result, clientID, sessionID, auditID, activityID, status, decision string, latencyMs int64) {
+	_ = ctx // kept for future per-request cancellation; the inner call uses a detached deadline
+	if h.runtime == nil {
+		return
+	}
+	identity := runtime.IdentityResolution{
+		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
+		PrincipalTrustLevel: string(authResult.Principal.TrustLevel),
+		AuthMethod:          string(authResult.Principal.AuthMethod),
+		ClientID:            clientID,
+		SessionID:           sessionID,
+	}
+	env, err := runtime.Normalize(rawBody, identity, time.Now().UTC())
+	if err != nil {
+		h.logger.Warn("runtime normalize failed", "error", err, "msg_id", auditID, "surface", "hooks")
+		return
+	}
+	outcome := runtime.OutcomeRefs{
+		AuditEntryID:    auditID,
+		ActivityEventID: activityID,
+		Status:          status,
+		PolicyDecision:  decision,
+		LatencyMs:       latencyMs,
+	}
+	// Detached context with a bounded deadline so a stalled DB
+	// cannot pin the request goroutine. RecordHook is sync within
+	// the hook hot path on purpose: runtime is the durable
+	// substrate the dashboard reads back, and the spec wants its
+	// write to be atomic with the request.
+	rtCtx, cancel := context.WithTimeout(context.Background(), runtimeRecordTimeout)
+	defer cancel()
+	if err := h.runtime.RecordHook(rtCtx, env, outcome); err != nil {
+		h.logger.Warn("runtime record failed", "error", err, "msg_id", auditID, "surface", "hooks", "event", env.HookEventName)
+	}
+}
+
+// runtimeRecordTimeout bounds the runtime write so a stalled DB
+// cannot pin the hook hot path. Mirrors activityInsertTimeout for
+// the same reason — the runtime store is on the same DB and so
+// shares its failure modes.
+const runtimeRecordTimeout = 2 * time.Second
 
 func formatBlockReason(outcome *engine.ScanOutcome) string {
 	if outcome == nil || len(outcome.Findings) == 0 {

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -690,7 +690,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// decision is already committed in the audit row above, so a
 	// runtime write failure here logs at warn but never changes
 	// the response.
-	h.recordRuntime(r.Context(), body, authResult, ev.Client, ev.SessionID, msgID, activityEventID, status, decision, string(coverage), confidence, time.Since(start).Milliseconds())
+	h.recordRuntime(r.Context(), body, authResult, ev.Client, ev.SessionID, &ev, msgID, activityEventID, status, decision, string(coverage), confidence, time.Since(start).Milliseconds())
 
 	// Update agent hierarchy table
 	if ev.SessionID != "" {
@@ -796,10 +796,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // actor metadata only. ClientID falls back through the X-Oktsec-
 // Client header so a client that did not set the resolver-friendly
 // header still lands a runtime row tagged with the right client.
-func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult resolve.Result, clientID, sessionID, auditID, activityID, status, decision, coverage string, confidence int, latencyMs int64) {
+func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult resolve.Result, clientID, sessionID string, ev *ToolEvent, auditID, activityID, status, decision, coverage string, confidence int, latencyMs int64) {
 	_ = ctx // kept for future per-request cancellation; the inner call uses a detached deadline
 	if h.runtime == nil {
 		return
+	}
+	// Hints the runtime normalizer cannot derive from the raw body
+	// alone: ToolEvent.normalize defaults Event to "pre_tool_use"
+	// when both fields are missing, and generic clients put the
+	// post-tool string under "tool_output" while the runtime
+	// payload models Claude's "tool_response". Pass the
+	// already-normalized values so the runtime row is never empty
+	// for these fields.
+	hintEvent := ev.HookEventName
+	if hintEvent == "" {
+		hintEvent = runtime.CanonicalEventName(ev.Event)
 	}
 	identity := runtime.IdentityResolution{
 		PrincipalID:         principalIDOrUnknown(authResult.Principal.ID),
@@ -807,6 +818,8 @@ func (h *Handler) recordRuntime(ctx context.Context, rawBody []byte, authResult 
 		AuthMethod:          string(authResult.Principal.AuthMethod),
 		ClientID:            clientID,
 		SessionID:           sessionID,
+		HookEventName:       hintEvent,
+		ToolOutput:          ev.ToolOutput,
 	}
 	env, err := runtime.Normalize(rawBody, identity, time.Now().UTC())
 	if err != nil {

--- a/internal/hooks/runtime_integration_test.go
+++ b/internal/hooks/runtime_integration_test.go
@@ -364,6 +364,62 @@ func TestServeHTTP_RuntimeRowCarriesCoverage(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_BodyWithoutAnyEventFieldStillLandsRuntimeRow
+// covers the corner case of generic clients: a payload that
+// omits BOTH hook_event_name AND event. The handler's
+// ToolEvent.normalize defaults the in-memory event to
+// "pre_tool_use" so audit + activity write under that name; the
+// runtime path used to lose this entirely because the raw body
+// it parsed had nothing to canonicalize. The handler now passes
+// its normalized value as a hint via IdentityResolution.HookEventName
+// so the runtime row lands too.
+func TestServeHTTP_BodyWithoutAnyEventFieldStillLandsRuntimeRow(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"tool_name":"Read","session_id":"sess-noevent"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-noevent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1 (handler default must reach runtime)", len(events))
+	}
+	if events[0].HookEventName != "PreToolUse" {
+		t.Errorf("HookEventName = %q, want PreToolUse (handler default)", events[0].HookEventName)
+	}
+}
+
+// TestServeHTTP_GenericPostToolUseCarriesOutputHash covers the
+// other half of the generic-client contract: a post_tool_use
+// payload that uses the generic `tool_output` field (a string,
+// the shape ToolEvent models) must produce a non-empty
+// tool_output_hash on the runtime row. Without the handler hint,
+// runtime.Normalize was looking for Claude's `tool_response`
+// json.RawMessage and saw nothing.
+func TestServeHTTP_GenericPostToolUseCarriesOutputHash(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"event":"post_tool_use","session_id":"sess-out","tool_name":"Read","tool_output":"contents of /etc/hosts"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-out"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+	if events[0].ToolOutputHash == "" {
+		t.Errorf("ToolOutputHash empty for generic post_tool_use; handler hint did not reach runtime")
+	}
+}
+
 // TestServeHTTP_GenericEventFormatLandsRuntimeRow covers the P2
 // contract: a payload using the client-agnostic `event:
 // "pre_tool_use"` field (and no hook_event_name) must still

--- a/internal/hooks/runtime_integration_test.go
+++ b/internal/hooks/runtime_integration_test.go
@@ -1,0 +1,295 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// newRuntimeWiredHandler builds a Handler against a real audit
+// store so the auto-built runtime store has a *sql.DB to attach
+// to. Returns the handler, the runtime store handle (for
+// queryback), the *sql.DB so tests can inspect runtime tables
+// directly, and a cleanup func.
+func newRuntimeWiredHandler(t *testing.T) (*Handler, *runtime.Store, *sql.DB, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	auditStore := mustCreateAuditStore(t, dbPath, logger)
+	scanner := engine.NewScanner("")
+	cfg := config.Defaults()
+	h := NewHandler(scanner, auditStore, cfg, logger)
+	if h.runtime == nil {
+		t.Fatal("expected NewHandler to auto-build runtime store from audit *sql.DB")
+	}
+	cleanup := func() {
+		scanner.Close()
+		_ = auditStore.Close()
+	}
+	return h, h.runtime, auditStore.DB(), cleanup
+}
+
+// post helper sends a hook event and returns the response body.
+func post(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Oktsec-Client", "claude-code")
+	req.Header.Set("X-Oktsec-Agent", "claude-code")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+// TestServeHTTP_WritesRuntimeRowForToolEvent locks in the Phase 3B
+// integration: a single PreToolUse landing on /hooks/event must
+// produce both the audit row (already covered by the existing
+// suite) AND a runtime hook event row joined back through the
+// audit_entry_id cross-reference.
+func TestServeHTTP_WritesRuntimeRowForToolEvent(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"hook_event_name":"PreToolUse","session_id":"sess-3b-tool","tool_name":"Read","tool_input":{"path":"/etc/hosts"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-3b-tool"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("runtime event count = %d, want 1", len(events))
+	}
+	got := events[0]
+	if got.HookEventName != "PreToolUse" {
+		t.Errorf("hook_event_name = %q, want PreToolUse", got.HookEventName)
+	}
+	if got.PrincipalID == "" {
+		t.Error("principal_id empty — resolver hand-off broke")
+	}
+	if got.AuditEntryID == "" {
+		t.Error("audit_entry_id missing on runtime row — cross-reference broken")
+	}
+	if got.ActivityEventID == "" {
+		t.Error("activity_event_id missing on runtime row — precomputed id was lost")
+	}
+	if got.ToolInputHash == "" {
+		t.Error("tool_input_hash missing on runtime row")
+	}
+}
+
+// TestServeHTTP_FullSessionRunRoundTrip walks the canonical sequence
+// the Phase 3 spec calls out: SessionStart → SubagentStart →
+// PreToolUse → PostToolUse → SessionEnd. After all five, the
+// runtime tables should carry one session, two actors (root +
+// subagent linked by parent), and five hook events.
+func TestServeHTTP_FullSessionRunRoundTrip(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	for _, body := range []string{
+		`{"hook_event_name":"SessionStart","session_id":"sess-3b-full","cwd":"/Users/dev/proj"}`,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-3b-full","agent_id":"sa-1","agent_type":"code-reviewer"}`,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-3b-full","agent_id":"sa-1","tool_name":"Read","tool_input":{"path":"/etc/hosts"}}`,
+		`{"hook_event_name":"PostToolUse","session_id":"sess-3b-full","agent_id":"sa-1","tool_name":"Read","tool_response":"ok"}`,
+		`{"hook_event_name":"SessionEnd","session_id":"sess-3b-full"}`,
+	} {
+		w := post(t, h, body)
+		if w.Code != http.StatusOK {
+			t.Fatalf("step body=%s -> status %d, body=%s", body, w.Code, w.Body.String())
+		}
+	}
+
+	sessions, err := store.QuerySessions(context.Background(), runtime.SessionQuery{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != "sess-3b-full" {
+		t.Fatalf("sessions = %+v", sessions)
+	}
+	if sessions[0].EventCount != 5 {
+		t.Errorf("event_count = %d, want 5", sessions[0].EventCount)
+	}
+	if sessions[0].SubagentCount != 1 {
+		t.Errorf("subagent_count = %d, want 1", sessions[0].SubagentCount)
+	}
+	if sessions[0].Status != runtime.SessionStatusEnded {
+		t.Errorf("status = %q, want ended", sessions[0].Status)
+	}
+
+	actors, err := store.QueryActors(context.Background(), runtime.ActorQuery{SessionID: "sess-3b-full"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actors) != 2 {
+		t.Fatalf("actor count = %d, want 2 (root + subagent); got %+v", len(actors), actors)
+	}
+	var root, sub runtime.Actor
+	for _, a := range actors {
+		switch a.Kind {
+		case runtime.ActorKindRoot:
+			root = a
+		case runtime.ActorKindSubagent:
+			sub = a
+		}
+	}
+	if sub.ParentActorID != root.ID {
+		t.Errorf("subagent.parent_actor_id = %q, want root id %q", sub.ParentActorID, root.ID)
+	}
+	if sub.ClaudeAgentID != "sa-1" || sub.ClaudeAgentType != "code-reviewer" {
+		t.Errorf("subagent claude refs = (%q, %q)", sub.ClaudeAgentID, sub.ClaudeAgentType)
+	}
+}
+
+// TestServeHTTP_HeartbeatLandsAsRuntimeRow confirms the spec's
+// promise that `oktsec doctor claude-code --emit-heartbeat` (which
+// posts a SessionStart with a heartbeat-* session id) produces a
+// runtime session row tagged as heartbeat. The handler does not
+// need any heartbeat-specific code path for this to work — the
+// normalizer detects the session id pattern.
+func TestServeHTTP_HeartbeatLandsAsRuntimeRow(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"hook_event_name":"SessionStart","session_id":"heartbeat-20260427T120000Z","source":"oktsec-doctor"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	hb, err := store.LastHeartbeat(context.Background(), "unknown", "claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hb == nil {
+		// principal_id is "unknown" because the test harness has no
+		// configured principals; the heartbeat still lands but keyed
+		// to the unknown principal. That is the intended local-mode
+		// behavior — the dashboard's connector health card scopes to
+		// the configured principal in production.
+		t.Fatal("LastHeartbeat returned nil for the principal the resolver fell back to")
+	}
+	if hb.SessionID != "heartbeat-20260427T120000Z" {
+		t.Errorf("heartbeat session id = %q", hb.SessionID)
+	}
+	if hb.ClientID != "claude-code" {
+		t.Errorf("heartbeat client_id = %q, want claude-code", hb.ClientID)
+	}
+}
+
+// TestServeHTTP_RuntimeFailureDoesNotChangeResponse pins the spec
+// invariant: a runtime write failure must never turn an allow
+// into a deny. We swap in a recording stub that always errors and
+// confirm the HTTP response stays "allow".
+func TestServeHTTP_RuntimeFailureDoesNotChangeResponse(t *testing.T) {
+	h, _, db, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	// Replace the working runtime store with a closed-DB-backed one
+	// so every RecordHook call fails. We can't use SetRuntimeStore
+	// with nil (that disables runtime entirely); instead we close the
+	// underlying DB so all writes return an error.
+	failingStore, err := runtime.Open(context.Background(), db, runtime.DialectSQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.SetRuntimeStore(failingStore)
+	if err := db.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
+		t.Fatal(err)
+	}
+
+	// Even with the runtime store guaranteed to fail, the response
+	// must still be 200 OK with decision=allow.
+	w := post(t, h, `{"hook_event_name":"PreToolUse","session_id":"sess-fail","tool_name":"Read"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["decision"] != "allow" {
+		t.Errorf("decision = %v, want allow (runtime failure must not change security decision)", resp["decision"])
+	}
+}
+
+// TestServeHTTP_NilRuntimeStoreIsNoOp confirms an injected nil
+// runtime store turns the runtime path into a no-op without
+// breaking the response. Useful for callers that want to disable
+// runtime writes (legacy mocks, future feature flag if ever
+// reintroduced).
+func TestServeHTTP_NilRuntimeStoreIsNoOp(t *testing.T) {
+	h, _, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+	h.SetRuntimeStore(nil)
+
+	w := post(t, h, `{"hook_event_name":"PreToolUse","session_id":"sess-nil","tool_name":"Read"}`)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+// TestServeHTTP_ActivityIDMatchesRuntimeRow verifies the
+// pre-computed activity_event_id pattern: the same id is on both
+// the activity row and the runtime row. Without precomputation
+// the runtime row would carry a useless empty string and the
+// future joined timeline would lose the cross-reference.
+func TestServeHTTP_ActivityIDMatchesRuntimeRow(t *testing.T) {
+	h, store, db, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"hook_event_name":"PostToolUse","session_id":"sess-3b-xref","tool_name":"Read","tool_response":"ok"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-3b-xref"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("runtime event count = %d, want 1", len(events))
+	}
+	runtimeActivityID := events[0].ActivityEventID
+
+	// Wait for the async activity insert to land. The activity
+	// insert is bounded by activityInsertTimeout (2s) but the race
+	// detector under a full-suite run can push the goroutine past
+	// that window; 5s is the slack we give the test before
+	// declaring the cross-reference broken.
+	deadline := time.Now().Add(5 * time.Second)
+	var activityRowID string
+	for time.Now().Before(deadline) {
+		row := db.QueryRow(`SELECT id FROM activity_events WHERE session_id = ?`, "sess-3b-xref")
+		if err := row.Scan(&activityRowID); err == nil && activityRowID != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if activityRowID == "" {
+		t.Fatal("activity_events row never landed within 5s")
+	}
+	if activityRowID != runtimeActivityID {
+		t.Errorf("activity_events.id = %q, runtime row's activity_event_id = %q (must match)", activityRowID, runtimeActivityID)
+	}
+}
+
+// silence unused complaint when the test set is built without audit
+// import side effects.
+var _ = audit.Entry{}

--- a/internal/hooks/runtime_integration_test.go
+++ b/internal/hooks/runtime_integration_test.go
@@ -14,17 +14,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/runtime"
+
+	_ "modernc.org/sqlite"
 )
 
 // newRuntimeWiredHandler builds a Handler against a real audit
 // store so the auto-built runtime store has a *sql.DB to attach
 // to. Returns the handler, the runtime store handle (for
 // queryback), the *sql.DB so tests can inspect runtime tables
-// directly, and a cleanup func.
+// directly, and a no-op flush callback (the real audit close
+// runs via t.Cleanup so callers do not have to remember it).
 func newRuntimeWiredHandler(t *testing.T) (*Handler, *runtime.Store, *sql.DB, func()) {
 	t.Helper()
 	dir := t.TempDir()
@@ -38,14 +42,25 @@ func newRuntimeWiredHandler(t *testing.T) (*Handler, *runtime.Store, *sql.DB, fu
 	if h.runtime == nil {
 		t.Fatal("expected NewHandler to auto-build runtime store from audit *sql.DB")
 	}
-	cleanup := func() {
+	// Stash the audit store on the handler via a closure so post()
+	// can drain its batch loop before the test queries any
+	// downstream table. Without this the audit writeLoop, the
+	// runtime tx, and the activity insert can race for the same
+	// SQLite writer and burst posts lose rows under contention.
+	t.Cleanup(func() {
 		scanner.Close()
 		_ = auditStore.Close()
+	})
+	return h, h.runtime, auditStore.DB(), func() {
+		auditStore.Flush()
 	}
-	return h, h.runtime, auditStore.DB(), cleanup
 }
 
-// post helper sends a hook event and returns the response body.
+// post helper sends a hook event, drains the audit batch, and
+// returns the response body. Drains are necessary because the
+// runtime store + audit batch + activity insert all write to one
+// SQLite file; without serialising on Flush() between posts a
+// burst can lose runtime/audit rows to SQLITE_BUSY contention.
 func post(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader([]byte(body)))
@@ -54,6 +69,9 @@ func post(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
 	req.Header.Set("X-Oktsec-Agent", "claude-code")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	if dbs, ok := h.store.(interface{ Flush() }); ok {
+		dbs.Flush()
+	}
 	return w
 }
 
@@ -195,22 +213,33 @@ func TestServeHTTP_HeartbeatLandsAsRuntimeRow(t *testing.T) {
 
 // TestServeHTTP_RuntimeFailureDoesNotChangeResponse pins the spec
 // invariant: a runtime write failure must never turn an allow
-// into a deny. We swap in a recording stub that always errors and
-// confirm the HTTP response stays "allow".
+// into a deny.
+//
+// We isolate the failure to the runtime store by swapping in a
+// store whose own DB handle is closed. Previously the test closed
+// the SHARED audit DB, which left the audit batch goroutine
+// reading from a closed handle and polluted later tests in the
+// same package. The current setup uses a separate, dedicated DB
+// for the failing runtime store so the audit + activity writes
+// continue normally and only the runtime path errors out.
 func TestServeHTTP_RuntimeFailureDoesNotChangeResponse(t *testing.T) {
-	h, _, db, cleanup := newRuntimeWiredHandler(t)
+	h, _, _, cleanup := newRuntimeWiredHandler(t)
 	defer cleanup()
 
-	// Replace the working runtime store with a closed-DB-backed one
-	// so every RecordHook call fails. We can't use SetRuntimeStore
-	// with nil (that disables runtime entirely); instead we close the
-	// underlying DB so all writes return an error.
-	failingStore, err := runtime.Open(context.Background(), db, runtime.DialectSQLite)
+	// Build a runtime store on a separate DB, then close that DB
+	// so every RecordHook call returns an error. The audit + activity
+	// path keep using the shared DB the helper opened.
+	failDir := t.TempDir()
+	failDB, err := sql.Open("sqlite", filepath.Join(failDir, "fail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failingStore, err := runtime.Open(context.Background(), failDB, runtime.DialectSQLite)
 	if err != nil {
 		t.Fatal(err)
 	}
 	h.SetRuntimeStore(failingStore)
-	if err := db.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
+	if err := failDB.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
 		t.Fatal(err)
 	}
 
@@ -271,9 +300,11 @@ func TestServeHTTP_ActivityIDMatchesRuntimeRow(t *testing.T) {
 	// Wait for the async activity insert to land. The activity
 	// insert is bounded by activityInsertTimeout (2s) but the race
 	// detector under a full-suite run can push the goroutine past
-	// that window; 5s is the slack we give the test before
-	// declaring the cross-reference broken.
-	deadline := time.Now().Add(5 * time.Second)
+	// that window; SQLite write lock contention with the runtime
+	// tx and the audit batch loop can stretch the wait to ~5-8s
+	// under load. 10s gives generous slack before declaring the
+	// cross-reference broken.
+	deadline := time.Now().Add(10 * time.Second)
 	var activityRowID string
 	for time.Now().Before(deadline) {
 		row := db.QueryRow(`SELECT id FROM activity_events WHERE session_id = ?`, "sess-3b-xref")
@@ -287,6 +318,74 @@ func TestServeHTTP_ActivityIDMatchesRuntimeRow(t *testing.T) {
 	}
 	if activityRowID != runtimeActivityID {
 		t.Errorf("activity_events.id = %q, runtime row's activity_event_id = %q (must match)", activityRowID, runtimeActivityID)
+	}
+}
+
+// TestServeHTTP_RuntimeRowCarriesCoverage locks in the P1
+// invariant: the durable runtime row carries coverage_mode +
+// confidence so Phase 3C can render Protected/Observed without
+// joining back to the async activity row.
+//
+// The contract is "runtime row gets the same coverage state the
+// activity row got". For a PreToolUse from an unauthenticated
+// loopback request that means CoverageMode = "Observed" and
+// Confidence = 0 today (the spec deliberately marks anonymous
+// telemetry as diagnostic-quality). The test pins
+// non-empty CoverageMode and an exact match against
+// activity.CoverageFromHookEvent so a future spec tweak there
+// flows through without silently breaking the runtime read path.
+func TestServeHTTP_RuntimeRowCarriesCoverage(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"hook_event_name":"PreToolUse","session_id":"sess-cov","tool_name":"Read","tool_input":{"path":"/etc/hosts"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-cov"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+	if events[0].CoverageMode == "" {
+		t.Errorf("runtime row CoverageMode empty — Phase 3C cannot render Protected/Observed without it")
+	}
+	// Cross-check: the runtime row must agree with the activity
+	// helper. Without this assertion, a future drift between the
+	// two would silently surface as inconsistent dashboard cells.
+	wantCoverage, wantConfidence := activity.CoverageFromHookEvent("", "pre_tool_use")
+	if events[0].CoverageMode != string(wantCoverage) {
+		t.Errorf("runtime row CoverageMode = %q, want %q (must match activity helper)", events[0].CoverageMode, wantCoverage)
+	}
+	if events[0].Confidence != wantConfidence {
+		t.Errorf("runtime row Confidence = %d, want %d (must match activity helper)", events[0].Confidence, wantConfidence)
+	}
+}
+
+// TestServeHTTP_GenericEventFormatLandsRuntimeRow covers the P2
+// contract: a payload using the client-agnostic `event:
+// "pre_tool_use"` field (and no hook_event_name) must still
+// produce a runtime row. Without the normalizer fallback,
+// generic clients would silently skip every runtime write.
+func TestServeHTTP_GenericEventFormatLandsRuntimeRow(t *testing.T) {
+	h, store, _, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	w := post(t, h, `{"event":"pre_tool_use","session_id":"sess-generic","tool_name":"Read"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: "sess-generic"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1 (generic event must still produce a runtime row)", len(events))
+	}
+	if events[0].HookEventName != "PreToolUse" {
+		t.Errorf("HookEventName = %q, want PreToolUse (canonicalized from pre_tool_use)", events[0].HookEventName)
 	}
 }
 

--- a/internal/runtime/normalize.go
+++ b/internal/runtime/normalize.go
@@ -16,12 +16,40 @@ import (
 // locally so the runtime package does not import
 // internal/identity/resolve directly — the hook handler does the
 // resolver call and feeds us a flat struct.
+//
+// HookEventName and ToolOutput are handler-supplied hints that
+// fill in for fields the raw body cannot expose. The handler's
+// ToolEvent normalization defaults Event to "pre_tool_use" when
+// the body omits it, but that defaulting only mutates the
+// in-memory ToolEvent; the body the runtime parses still has no
+// event field. ToolOutput is the same story: generic clients put
+// the post-tool string under "tool_output", which the Claude-
+// shaped runtime payload does not model.
+//
+// Both fields are fallbacks: payload values win when present so
+// runtime.Normalize stays a self-contained body-to-envelope
+// converter for callers that have no handler to feed it.
 type IdentityResolution struct {
 	PrincipalID         string
 	PrincipalTrustLevel string
 	AuthMethod          string
 	ClientID            string // X-Oktsec-Client
 	SessionID           string // X-Oktsec-Session header (may differ from payload)
+
+	// HookEventName is the canonical PascalCase event name the
+	// handler resolved (Claude-style hook_event_name, or the
+	// generic event field after canonicalization). Used as the
+	// final fallback when neither hook_event_name nor event
+	// appear in the payload body — the case where the handler
+	// defaulted ev.Event to "pre_tool_use" in memory.
+	HookEventName string
+
+	// ToolOutput is the generic-client post-tool string the
+	// handler extracted (ToolEvent.ToolOutput). Used to compute
+	// tool_output_hash when the body's "tool_response" field is
+	// empty. Without this hint a generic post_tool_use event
+	// would land a runtime row with an empty output hash.
+	ToolOutput string
 }
 
 // rawClaudePayload is the slice of the inbound JSON the
@@ -34,6 +62,11 @@ type IdentityResolution struct {
 // this, generic clients would land an audit + activity row but
 // silently skip the runtime row because RecordHook requires a
 // canonical event name.
+//
+// `ToolOutput` is the generic-client post-tool string (ToolEvent
+// uses "tool_output"; Claude uses "tool_response"). Modeled here
+// as a JSON string so a generic post_tool_use lands a non-empty
+// tool_output_hash on the runtime row.
 type rawClaudePayload struct {
 	HookEventName  string          `json:"hook_event_name"`
 	Event          string          `json:"event"`
@@ -49,6 +82,7 @@ type rawClaudePayload struct {
 	ToolUseID      string          `json:"tool_use_id"`
 	ToolInput      json.RawMessage `json:"tool_input"`
 	ToolResponse   json.RawMessage `json:"tool_response"`
+	ToolOutput     string          `json:"tool_output"`
 	TaskID         string          `json:"task_id"`
 	TaskSubject    string          `json:"task_subject"`
 	TaskDescription string         `json:"task_description"`
@@ -80,16 +114,19 @@ func Normalize(rawBody []byte, identity IdentityResolution, receivedAt time.Time
 		}
 	}
 
-	// Resolve the canonical hook event name. Claude Code clients
-	// always send hook_event_name; the client-agnostic surface
-	// (the existing ToolEvent path in internal/hooks) sends only
-	// the lower_snake `event` field. We accept either and
-	// canonicalize the latter so the runtime row always carries
-	// the Claude-style PascalCase name the rest of the package
-	// keys off.
+	// Resolve the canonical hook event name. Claude clients send
+	// hook_event_name; generic clients send the lower_snake event
+	// field. When neither appears in the body, the handler's
+	// in-memory ToolEvent normalization may have defaulted Event
+	// to "pre_tool_use" — that defaulting can only reach us via
+	// identity.HookEventName (the body the runtime parses still
+	// has no event field).
 	canonicalEvent := payload.HookEventName
 	if canonicalEvent == "" {
-		canonicalEvent = canonicalEventName(payload.Event)
+		canonicalEvent = CanonicalEventName(payload.Event)
+	}
+	if canonicalEvent == "" {
+		canonicalEvent = identity.HookEventName
 	}
 
 	env := HookEnvelope{
@@ -135,12 +172,24 @@ func Normalize(rawBody []byte, identity IdentityResolution, receivedAt time.Time
 	env.Stage = mapping.stage
 	env.BlockCapable = mapping.blockCapable
 
-	// Resource refs.
+	// Resource refs. Output hash falls back to the handler's
+	// hint (generic clients put the post-tool string under
+	// "tool_output", which the Claude-shaped payload does not
+	// model) and finally to the body's tool_output field for
+	// callers with no handler in front.
+	outputHash := hashJSON(payload.ToolResponse)
+	if outputHash == "" {
+		if payload.ToolOutput != "" {
+			outputHash = shortHash(payload.ToolOutput)
+		} else if identity.ToolOutput != "" {
+			outputHash = shortHash(identity.ToolOutput)
+		}
+	}
 	env.Tool = ToolRef{
 		Name:       payload.ToolName,
 		UseID:      payload.ToolUseID,
 		InputHash:  hashJSON(payload.ToolInput),
-		OutputHash: hashJSON(payload.ToolResponse),
+		OutputHash: outputHash,
 	}
 	env.Task = TaskRef{
 		ID:          payload.TaskID,
@@ -393,7 +442,7 @@ func hashJSON(raw json.RawMessage) string {
 	return shortHash(trimmed)
 }
 
-// canonicalEventName converts the client-agnostic lower_snake
+// CanonicalEventName converts the client-agnostic lower_snake
 // event field (e.g. "pre_tool_use") into the Claude-style
 // PascalCase name the rest of the package keys off (e.g.
 // "PreToolUse"). Used as a fallback when the payload omits
@@ -401,10 +450,15 @@ func hashJSON(raw json.RawMessage) string {
 // skip the runtime row because RecordHook requires a non-empty
 // canonical event name.
 //
+// Exported so the hook handler can canonicalize the value it
+// already normalized (ToolEvent.Event) before passing it to
+// runtime.IdentityResolution.HookEventName as a fallback for
+// payloads that omit both event fields entirely.
+//
 // Pure string transform: every "_" splits a part, the first rune
 // of each part uppercases, parts join with no separator. Already-
 // PascalCase input ("PreToolUse") is preserved verbatim.
-func canonicalEventName(generic string) string {
+func CanonicalEventName(generic string) string {
 	if generic == "" {
 		return ""
 	}

--- a/internal/runtime/normalize.go
+++ b/internal/runtime/normalize.go
@@ -27,8 +27,16 @@ type IdentityResolution struct {
 // rawClaudePayload is the slice of the inbound JSON the
 // normalizer needs. Anything not modeled is left untouched in the
 // raw evidence blob (which is then redacted before persistence).
+//
+// `Event` is the client-agnostic lower_snake form (e.g.
+// "pre_tool_use") that non-Claude clients send. It is the fallback
+// the normalizer uses when `hook_event_name` is missing — without
+// this, generic clients would land an audit + activity row but
+// silently skip the runtime row because RecordHook requires a
+// canonical event name.
 type rawClaudePayload struct {
 	HookEventName  string          `json:"hook_event_name"`
+	Event          string          `json:"event"`
 	SessionID      string          `json:"session_id"`
 	TranscriptPath string          `json:"transcript_path"`
 	AgentTranscriptPath string     `json:"agent_transcript_path"`
@@ -72,6 +80,18 @@ func Normalize(rawBody []byte, identity IdentityResolution, receivedAt time.Time
 		}
 	}
 
+	// Resolve the canonical hook event name. Claude Code clients
+	// always send hook_event_name; the client-agnostic surface
+	// (the existing ToolEvent path in internal/hooks) sends only
+	// the lower_snake `event` field. We accept either and
+	// canonicalize the latter so the runtime row always carries
+	// the Claude-style PascalCase name the rest of the package
+	// keys off.
+	canonicalEvent := payload.HookEventName
+	if canonicalEvent == "" {
+		canonicalEvent = canonicalEventName(payload.Event)
+	}
+
 	env := HookEnvelope{
 		ID:                  newEventID(),
 		ReceivedAt:          receivedAt.UTC(),
@@ -81,7 +101,7 @@ func Normalize(rawBody []byte, identity IdentityResolution, receivedAt time.Time
 		PrincipalID:         identity.PrincipalID,
 		PrincipalTrustLevel: identity.PrincipalTrustLevel,
 		AuthMethod:          identity.AuthMethod,
-		HookEventName:       payload.HookEventName,
+		HookEventName:       canonicalEvent,
 		CWD:                 PathTail(payload.CWD),
 		CWDHash:             HashPath(payload.CWD),
 	}
@@ -106,8 +126,11 @@ func Normalize(rawBody []byte, identity IdentityResolution, receivedAt time.Time
 	}
 
 	// Lifecycle, stage, and block-capability come from one table
-	// so a future Claude addition is one entry to update.
-	mapping := lookupEventMapping(payload.HookEventName)
+	// so a future Claude addition is one entry to update. We pass
+	// the canonical (already PascalCase) name so the lookup hits
+	// the same row whether the payload arrived in Claude shape or
+	// generic shape.
+	mapping := lookupEventMapping(canonicalEvent)
 	env.Lifecycle = mapping.lifecycle
 	env.Stage = mapping.stage
 	env.BlockCapable = mapping.blockCapable
@@ -368,6 +391,38 @@ func hashJSON(raw json.RawMessage) string {
 		return ""
 	}
 	return shortHash(trimmed)
+}
+
+// canonicalEventName converts the client-agnostic lower_snake
+// event field (e.g. "pre_tool_use") into the Claude-style
+// PascalCase name the rest of the package keys off (e.g.
+// "PreToolUse"). Used as a fallback when the payload omits
+// hook_event_name; without it, generic clients would silently
+// skip the runtime row because RecordHook requires a non-empty
+// canonical event name.
+//
+// Pure string transform: every "_" splits a part, the first rune
+// of each part uppercases, parts join with no separator. Already-
+// PascalCase input ("PreToolUse") is preserved verbatim.
+func canonicalEventName(generic string) string {
+	if generic == "" {
+		return ""
+	}
+	parts := strings.Split(generic, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		// ASCII uppercase the first rune. Hook event names are all
+		// ASCII per Claude docs so a Unicode-aware path would be
+		// over-engineering.
+		first := p[0]
+		if first >= 'a' && first <= 'z' {
+			first -= 'a' - 'A'
+		}
+		parts[i] = string(first) + p[1:]
+	}
+	return strings.Join(parts, "")
 }
 
 // newEventID generates a 16-byte random id for a runtime hook

--- a/internal/runtime/normalize_test.go
+++ b/internal/runtime/normalize_test.go
@@ -253,6 +253,89 @@ func TestNormalize_UnknownEventDefaultsToObserved(t *testing.T) {
 	}
 }
 
+// TestNormalize_GenericEventFieldFallsBackToCanonicalName covers
+// the P2 contract: a payload that uses the client-agnostic
+// `event: "pre_tool_use"` field (and omits hook_event_name) must
+// still produce a runtime envelope keyed off the canonical
+// PascalCase name. Without this, generic clients would silently
+// skip every runtime row even though their audit + activity rows
+// land normally.
+func TestNormalize_GenericEventFieldFallsBackToCanonicalName(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    string
+		wantLC  string // expected lifecycle to confirm the mapping table hit
+		wantStg string // expected stage
+	}{
+		{
+			name:    "pre_tool_use_lower",
+			body:    `{"event":"pre_tool_use","session_id":"sess-test","tool_name":"Read"}`,
+			want:    "PreToolUse",
+			wantLC:  LifecycleTool,
+			wantStg: StagePreAction,
+		},
+		{
+			name:    "post_tool_use_lower",
+			body:    `{"event":"post_tool_use","session_id":"sess-test","tool_name":"Read"}`,
+			want:    "PostToolUse",
+			wantLC:  LifecycleTool,
+			wantStg: StagePostAction,
+		},
+		{
+			name:    "subagent_start_lower",
+			body:    `{"event":"subagent_start","session_id":"sess-test","agent_id":"sa-1"}`,
+			want:    "SubagentStart",
+			wantLC:  LifecycleSubagent,
+			wantStg: StageObserved,
+		},
+		{
+			name:    "claude_form_wins_when_both_set",
+			body:    `{"hook_event_name":"PreToolUse","event":"post_tool_use","session_id":"sess-test"}`,
+			want:    "PreToolUse",
+			wantLC:  LifecycleTool,
+			wantStg: StagePreAction,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := Normalize([]byte(tc.body), baseIdentity, time.Now())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if env.HookEventName != tc.want {
+				t.Errorf("HookEventName = %q, want %q", env.HookEventName, tc.want)
+			}
+			if env.Lifecycle != tc.wantLC {
+				t.Errorf("Lifecycle = %q, want %q (mapping must hit canonical row)", env.Lifecycle, tc.wantLC)
+			}
+			if env.Stage != tc.wantStg {
+				t.Errorf("Stage = %q, want %q", env.Stage, tc.wantStg)
+			}
+		})
+	}
+}
+
+// TestCanonicalEventName_PureTransform pins the snake -> Pascal
+// helper so a future addition to the mapping table can rely on it.
+func TestCanonicalEventName_PureTransform(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"pre_tool_use", "PreToolUse"},
+		{"post_tool_use", "PostToolUse"},
+		{"session_start", "SessionStart"},
+		{"PreToolUse", "PreToolUse"}, // already canonical
+		{"a", "A"},
+		{"single", "Single"},
+	} {
+		if got := canonicalEventName(tc.in); got != tc.want {
+			t.Errorf("canonicalEventName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestNormalize_MalformedJSONErrors makes sure the normalizer
 // surfaces a parse error so the hook handler can choose how to
 // handle it, instead of silently returning an empty envelope.

--- a/internal/runtime/normalize_test.go
+++ b/internal/runtime/normalize_test.go
@@ -330,8 +330,8 @@ func TestCanonicalEventName_PureTransform(t *testing.T) {
 		{"a", "A"},
 		{"single", "Single"},
 	} {
-		if got := canonicalEventName(tc.in); got != tc.want {
-			t.Errorf("canonicalEventName(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := CanonicalEventName(tc.in); got != tc.want {
+			t.Errorf("CanonicalEventName(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -4,8 +4,35 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
+
+// runtimeBusyRetries + runtimeBusyBackoff bound the retry loop on
+// SQLITE_BUSY. The audit store's batch loop and the runtime tx
+// share one *sql.DB; under burst load (or under race-detector
+// overhead in CI) the audit batch can hold the writer past the
+// SQLite busy_timeout (5s) and the BEGIN here returns
+// SQLITE_BUSY. Eight attempts with a small backoff cleared every
+// flake observed in the full-suite run; the caller's runtime
+// context still bounds the total wall time so a stalled DB cannot
+// pin the request goroutine indefinitely.
+const (
+	runtimeBusyRetries = 8
+	runtimeBusyBackoff = 100 * time.Millisecond
+)
+
+// isBusyError detects SQLite's SQLITE_BUSY (5) without taking a
+// dependency on the driver's typed error. modernc.org/sqlite
+// formats the message as "database is locked (5) (SQLITE_BUSY)";
+// matching on substring is cheap and survives a driver swap.
+func isBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") || strings.Contains(msg, "database is locked")
+}
 
 // Store is the runtime tables' read+write surface. Phase 3A
 // exposes the API only; Phase 3B wires the hook handler to call
@@ -79,6 +106,39 @@ func (s *Store) RecordHook(ctx context.Context, env HookEnvelope, outcome Outcom
 		now = time.Now().UTC()
 	}
 
+	// Retry the whole tx (BEGIN, the upserts, the insert, and the
+	// COMMIT) on SQLITE_BUSY. The audit store's batch loop and the
+	// runtime tx share one *sql.DB, so under burst load any of
+	// these statements can collide with the audit batch's open
+	// transaction and the driver returns SQLITE_BUSY (5). The
+	// audit store already sets busy_timeout=5s; the loop here adds
+	// a small backoff between retries so a transient lock does
+	// not drop the runtime row entirely. The caller's runtime
+	// context bounds the total wall time so a stalled DB cannot
+	// pin the request goroutine indefinitely.
+	var lastErr error
+	for attempt := 0; attempt < runtimeBusyRetries; attempt++ {
+		err := s.recordHookOnce(ctx, env, outcome, now)
+		if err == nil {
+			return nil
+		}
+		if !isBusyError(err) {
+			return err
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("runtime: %w (last busy error: %v)", ctx.Err(), err)
+		case <-time.After(runtimeBusyBackoff):
+		}
+	}
+	return fmt.Errorf("runtime: gave up after %d busy retries: %w", runtimeBusyRetries, lastErr)
+}
+
+// recordHookOnce is one attempt at the RecordHook transaction.
+// Wrapped in a retry loop above so SQLITE_BUSY at any statement —
+// not just BEGIN — gives us a fresh shot at the writer lock.
+func (s *Store) recordHookOnce(ctx context.Context, env HookEnvelope, outcome OutcomeRefs, now time.Time) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("runtime: begin tx: %w", err)


### PR DESCRIPTION
## Summary

Phase 3B of the runtime event model. Every POST to `/hooks/event` now produces a durable runtime row alongside the existing audit and activity writes.

- Runtime store is auto-built from the audit store's `*sql.DB` so proxy and gateway share one DB and one writer — same pattern Phase 0 used for `archive_dir` and Phase 2B.1 used for activity. Production callers (`cmd/oktsec/commands/run.go`, `cmd/oktsec/commands/gateway.go`) do not change. Tests can override via `SetRuntimeStore`.
- `emitHookActivity` now accepts a precomputed activity event id. `ServeHTTP` generates it once and passes the same value to both the async activity insert AND the sync `runtime.RecordHook`, so the runtime row carries the activity_event_id as a cross-reference even before the async insert lands.
- `recordRuntime` runs under a detached 15s context. The deadline exceeds the SQLite `busy_timeout` (5s) so the runtime tx's busy-retry loop has room to complete; a shorter context would cancel mid-retry and silently drop the row. A failure logs at warn and never changes the security decision the audit row already committed — the spec's "runtime write failure must never change a security decision" invariant.
- Identity comes from the resolver only: `PrincipalID`, `AuthMethod`, `TrustLevel` are sourced from `authResult.Principal`, never from payload's `agent` / `agent_type`. Those payload fields stay as actor metadata for `runtime.Normalize`.
- Coverage state (`CoverageMode` + `Confidence`) is computed once via `hookCoverage` and passed to both the activity row and the runtime row, so Phase 3C can read Protected/Observed off the durable runtime row without joining back to the async activity insert.
- Generic-client compatibility: handler-supplied hints (`HookEventName`, `ToolOutput`) on `runtime.IdentityResolution` cover the cases where `ToolEvent.normalize` defaults the in-memory event or where a generic post-tool string lives under `tool_output` instead of Claude's `tool_response`. Payload values still win when present so `runtime.Normalize` stays self-contained for callers without a handler in front.

## What this slice does NOT touch

Per the rollout plan:

- No UI changes (Phase 3C).
- No `~/.claude/settings.json` edits.
- No Phase 2 installer event-set change.
- No graph package changes (Phase 3D).
- No new endpoints; the existing `/hooks/event` path is the only writer.

## Heartbeat

Heartbeat works through the same code path. `oktsec doctor claude-code --emit-heartbeat` posts a `SessionStart` with a `heartbeat-*` session id; the normalizer detects the prefix and the store sets `status=heartbeat` + `last_heartbeat_at`. No special-case code in the handler.

## Tests

- `TestServeHTTP_WritesRuntimeRowForToolEvent` — single `PreToolUse` produces a runtime row with audit + activity cross-references and the tool input hash populated.
- `TestServeHTTP_FullSessionRunRoundTrip` — `SessionStart` -> `SubagentStart` -> `PreToolUse` -> `PostToolUse` -> `SessionEnd`; one session, root + subagent actors with the parent edge, five hook events, ended status.
- `TestServeHTTP_HeartbeatLandsAsRuntimeRow` — heartbeat session id lands as `status=heartbeat` and `LastHeartbeat` returns it.
- `TestServeHTTP_RuntimeFailureDoesNotChangeResponse` — closed-DB runtime store on a separate DB; HTTP response stays `200 OK` with `decision=allow`.
- `TestServeHTTP_NilRuntimeStoreIsNoOp` — explicit `SetRuntimeStore(nil)` still serves cleanly.
- `TestServeHTTP_ActivityIDMatchesRuntimeRow` — precomputed activity event id is the same value on both rows (cross-reference invariant).
- `TestServeHTTP_RuntimeRowCarriesCoverage` — runtime row's CoverageMode + Confidence equal what `activity.CoverageFromHookEvent` returns for the same auth method + event family.
- `TestServeHTTP_GenericEventFormatLandsRuntimeRow` — `event:"pre_tool_use"` (no `hook_event_name`) lands a runtime row with canonical `PreToolUse`.
- `TestServeHTTP_BodyWithoutAnyEventFieldStillLandsRuntimeRow` — body with neither event field lands a runtime row using the handler's defaulted `PreToolUse` hint.
- `TestServeHTTP_GenericPostToolUseCarriesOutputHash` — generic `tool_output` (string) produces a non-empty `tool_output_hash`.

## Operational notes

- Runtime writes are sync inside `ServeHTTP`. `runtime.RecordHook` retries the entire transaction (not just `BEGIN`) on `SQLITE_BUSY` with 8 attempts and 100ms backoff so the audit batch loop and the runtime tx never silently lose a row when they share the same `*sql.DB`. Latency on the hook hot path is bounded by `runtimeRecordTimeout` (15s).

## Test plan

- [x] `make build`
- [x] `make test` -- all packages green; full-suite stable across multiple consecutive runs
- [x] `make vet`
- [x] `make lint` -- 0 issues