### PR TITLE
Surface Claude Code connection truth on Overview

### DIFF
--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -274,27 +274,34 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 			break
 		}
 		// Real-event promotion. Wins when the event is fresh
-		// enough by FreshEvent.
+		// enough by FreshEvent. Anything older drops to stale
+		// below — the connection-truth contract requires
+		// evidence fresh enough to trust, so a 2-hour-old event
+		// must NOT keep the tile reading "Connected and
+		// observed" or the posture grade visible.
 		if ev, ok := freshTimestamp(bestEvent, opts.Now(), opts.FreshEvent); ok {
 			h.Status = "ready"
 			h.Reason = "Claude Code connected. Last event observed " + humanizeAge(opts.Now().Sub(ev)) + " ago."
 			break
 		}
-		// Older event still counts as some evidence — surface as
-		// stale instead of falling back to partial.
+		// Past FreshEvent but parseable: stale. Stale never
+		// promotes back to ready in this branch — the only path
+		// to ready is the FreshEvent gate above. StaleAfter
+		// still distinguishes "we have recent-ish history" from
+		// "evidence so old it might as well not exist": past
+		// StaleAfter we drop to partial so the dashboard does not
+		// claim coverage from a row that may predate the current
+		// installation.
 		if ev, ok := parseTimestamp(bestEvent); ok {
 			age := opts.Now().Sub(ev)
-			if age > opts.StaleAfter {
+			if age <= opts.StaleAfter {
 				h.Status = "stale"
-				h.Reason = "Last Claude Code event observed " + humanizeAge(age) + " ago; coverage may be out of date."
-			} else {
-				h.Status = "ready"
-				h.Reason = "Claude Code connected. Last event observed " + humanizeAge(age) + " ago."
+				h.Reason = "Last Claude Code event observed " + humanizeAge(age) + " ago; connection is no longer fresh."
+				break
 			}
-			break
 		}
-		// No usable timestamp at all — installed but not yet
-		// observed.
+		// No usable timestamp, or so old we discard it —
+		// installed but not yet observed.
 		h.Status = "partial"
 		h.Reason = reasonPartial(h)
 	}

--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -240,12 +240,20 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 	}
 	h.Runtime = projectRuntimeEvidence(opts.Runtime)
 
-	// Pick the most recent timestamp the caller can offer. Runtime
-	// signals win because they are the durable per-event row Phase
-	// 3B writes; LastEvent is the audit-store fallback for callers
-	// without a runtime store wired in.
-	bestEvent := h.Runtime.LastEventAt
-	if bestEvent == "" {
+	// Pick the most recent timestamp the caller can offer. The
+	// presence of opts.Runtime — not its content — switches the
+	// signal source: when the dashboard wires a runtime store it
+	// is the authoritative source, and an empty runtime means
+	// "installed but not yet observed". Falling back to the
+	// audit-store LastEvent in that case would let a legacy
+	// audit row from before runtime was wired flip the tile to
+	// ready, masking the real setup state. opts.LastEvent is
+	// only honored when the caller (the doctor command) has no
+	// runtime store at all.
+	bestEvent := ""
+	if opts.Runtime != nil {
+		bestEvent = h.Runtime.LastEventAt
+	} else {
 		bestEvent = opts.LastEvent
 	}
 

--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -20,6 +20,25 @@ const (
 	SurfaceMCPHTTP = "mcp_http"
 )
 
+// Default freshness windows. Exported so callers (the
+// dashboard's runtime-evidence projection, the doctor command)
+// can apply the same cutoffs DeriveHealth uses internally
+// without re-deriving the numbers and silently drifting from
+// the canonical contract.
+//
+// DefaultStaleAfter is the boundary between "stale" (we have
+// real evidence within this window) and "partial" (the row is
+// so old it might predate the current install). Any cell that
+// represents "usable evidence right now" — coverage,
+// observed-recently, last-event freshness — should drop to
+// empty past this cutoff so the UI never paints a badge the
+// status field already disowned.
+const (
+	DefaultStaleAfter     = 24 * time.Hour
+	DefaultFreshHeartbeat = 10 * time.Minute
+	DefaultFreshEvent     = 30 * time.Minute
+)
+
 // LastSeenLookup is the narrow projection of audit.Store the
 // connector needs to derive freshness. Defined locally so the
 // dashboard handler does not have to thread the whole AuditStore
@@ -231,13 +250,13 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 		opts.Now = time.Now
 	}
 	if opts.StaleAfter <= 0 {
-		opts.StaleAfter = 24 * time.Hour
+		opts.StaleAfter = DefaultStaleAfter
 	}
 	if opts.FreshHeartbeat <= 0 {
-		opts.FreshHeartbeat = 10 * time.Minute
+		opts.FreshHeartbeat = DefaultFreshHeartbeat
 	}
 	if opts.FreshEvent <= 0 {
-		opts.FreshEvent = 30 * time.Minute
+		opts.FreshEvent = DefaultFreshEvent
 	}
 
 	h := ConnectorHealth{

--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -118,11 +118,23 @@ type RuntimeEvidence struct {
 
 	// HasEvidence is true when runtime tables have at least one
 	// row attributable to Claude Code (heartbeat or real event).
-	// The Overview tile uses it to switch between "no evidence
-	// yet" copy and the observed view, and the dashboard's
-	// posture handler uses it to decide whether to suppress the
-	// hard grade.
+	// Answers "did anything ever land", not "is the cell badge
+	// true right now". The Overview tile uses HasFreshHeartbeat /
+	// HasFreshRealEvent below for cell badges; HasEvidence is for
+	// "first time vs not first time" prompts only.
 	HasEvidence bool `json:"has_evidence"`
+
+	// HasFreshHeartbeat / HasFreshRealEvent split the evidence
+	// timestamps into fresh (within FreshHeartbeat / FreshEvent)
+	// and stale buckets so the tile never paints a green
+	// "received" / "observed" badge while the same tile's title
+	// reads "Installed, waiting for first observed event". The
+	// status field already encodes this rule for the headline;
+	// these booleans surface the same rule per-cell so the
+	// template does not have to re-derive freshness from raw
+	// timestamps.
+	HasFreshHeartbeat bool `json:"has_fresh_heartbeat"`
+	HasFreshRealEvent bool `json:"has_fresh_real_event"`
 
 	// CoverageStage is the strongest stage the runtime has
 	// observed in the rollup window. One of "protected",
@@ -239,6 +251,18 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 		MissingExpectedEvents: MissingExpectedEvents(inv.Hooks),
 	}
 	h.Runtime = projectRuntimeEvidence(opts.Runtime)
+	// Per-cell freshness flags. Computed here so the template
+	// reads them directly instead of re-checking timestamps and
+	// drifting from the headline status. A non-empty timestamp
+	// past the fresh window means "we observed it but it does
+	// not back the current connection state" — the cell renders
+	// "none recent" rather than the green badge.
+	if _, ok := freshTimestamp(h.Runtime.LastHeartbeatAt, opts.Now(), opts.FreshHeartbeat); ok {
+		h.Runtime.HasFreshHeartbeat = true
+	}
+	if _, ok := freshTimestamp(h.Runtime.LastEventAt, opts.Now(), opts.FreshEvent); ok {
+		h.Runtime.HasFreshRealEvent = true
+	}
 
 	// Pick the most recent timestamp the caller can offer. The
 	// presence of opts.Runtime — not its content — switches the

--- a/internal/connectors/claudecode/health.go
+++ b/internal/connectors/claudecode/health.go
@@ -89,34 +89,143 @@ type ConnectorHealth struct {
 	// next to the status pill. Composed from inventory + last-seen so
 	// the UI never has to guess at "why partial?".
 	Reason string `json:"reason"`
+
+	// Runtime is the Phase 3C-0 evidence projection that turns
+	// "hooks installed" into "hooks observed". When the runtime
+	// store has no rows yet the block is empty; when there are
+	// rows the dashboard reads RuntimeReady to decide whether the
+	// Overview tile says "observed" vs "installed, not yet observed".
+	Runtime RuntimeEvidence `json:"runtime"`
+}
+
+// RuntimeEvidence is the durable runtime signal the Connection
+// Health tile and the doctor consume to tell "we have evidence
+// the hooks are firing" apart from "we believe they are
+// installed". Empty timestamps mean "never observed"; the UI
+// renders the explicit empty state instead of inventing a value.
+//
+// Computed once in DeriveHealth from a HealthOptions.Runtime
+// snapshot the caller fills from runtime.Store. Pure
+// projection — no I/O here.
+type RuntimeEvidence struct {
+	LastHeartbeatAt          string   `json:"last_heartbeat_at,omitempty"`
+	LastEventAt              string   `json:"last_event_at,omitempty"`
+	LastEventFamily          string   `json:"last_event_family,omitempty"`
+	ObservedFamilies         []string `json:"observed_families,omitempty"`
+	MissingInstalledFamilies []string `json:"missing_installed_families,omitempty"`
+	SubagentsObserved        int      `json:"subagents_observed"`
+	SessionsObserved         int      `json:"sessions_observed"`
+
+	// HasEvidence is true when runtime tables have at least one
+	// row attributable to Claude Code (heartbeat or real event).
+	// The Overview tile uses it to switch between "no evidence
+	// yet" copy and the observed view, and the dashboard's
+	// posture handler uses it to decide whether to suppress the
+	// hard grade.
+	HasEvidence bool `json:"has_evidence"`
+
+	// CoverageStage is the strongest stage the runtime has
+	// observed in the rollup window. One of "protected",
+	// "observed", "blind", or "" (no evidence). Lets the tile
+	// render Protected/Observed without joining back to the
+	// activity row for every render.
+	CoverageStage string `json:"coverage_stage,omitempty"`
 }
 
 // HealthOptions controls staleness thresholds and lets callers inject
 // the last-seen signal without depending on the audit store directly.
-// Phase 1 keeps both fields optional so the doctor can compute a
-// useful health snapshot even when no audit store is reachable.
+// Phase 1 keeps the audit-derived fields optional so the doctor can
+// compute a useful health snapshot even when no store is reachable;
+// Phase 3C-0 adds Runtime so the dashboard can lift the status to
+// "ready" only when there is real runtime evidence.
 type HealthOptions struct {
-	// LastEvent is the most recent timestamp (RFC3339) attributable
-	// to claude-code, or "" when none. Callers typically derive this
-	// from audit.Store.LastSeenByPrincipalSurface(principalID, surface).
+	// LastEvent is the most recent audit-store timestamp
+	// (RFC3339) attributable to claude-code, or "" when none.
+	// Kept for backwards compatibility with the doctor command;
+	// the new Runtime block carries the same signal but with
+	// finer detail when available.
 	LastEvent string
+
+	// Runtime is the optional projection from the Phase 3
+	// runtime store. When provided it takes precedence over
+	// LastEvent for the freshness check because the runtime row
+	// is the durable evidence Phase 3B writes per hook event.
+	Runtime *RuntimeEvidenceInput
 
 	// StaleAfter is the cutoff between "ready" and "stale". Defaults
 	// to 24h when zero, matching the spec's section 5 thresholds.
 	StaleAfter time.Duration
 
+	// FreshHeartbeat is the cutoff for "heartbeat is recent enough
+	// to count toward ready". Defaults to 10 minutes per spec
+	// section "Health rules" — a heartbeat older than this stops
+	// promoting the status by itself.
+	FreshHeartbeat time.Duration
+
+	// FreshEvent is the cutoff for "real event is recent enough
+	// to count toward ready". Defaults to 30 minutes per spec
+	// section "Health rules".
+	FreshEvent time.Duration
+
 	// Now is the clock seam for tests. Defaults to time.Now().
 	Now func() time.Time
 }
 
-// DeriveHealth maps an Inventory + observed signal to a ConnectorHealth.
-// Pure function: no I/O, no side effects, deterministic given inputs.
+// RuntimeEvidenceInput is the dashboard-supplied snapshot of the
+// runtime store. Defined as a separate input type from
+// RuntimeEvidence (the JSON projection) so the package boundary
+// stays one-way: callers feed in raw signals, DeriveHealth
+// computes the derived view.
+//
+// Empty fields mean "no evidence on this dimension". The
+// derivation tolerates partial inputs — e.g. a heartbeat without
+// real events still moves the status off "partial" because it
+// proves the hook command can reach the gateway.
+type RuntimeEvidenceInput struct {
+	LastHeartbeatAt          string
+	LastEventAt              string
+	LastEventFamily          string
+	ObservedFamilies         []string
+	MissingInstalledFamilies []string
+	SubagentsObserved        int
+	SessionsObserved         int
+
+	// CoverageStage is the strongest stage observed in the
+	// recent window: "protected" (PreToolUse with token auth),
+	// "observed" (any non-blocking auth or post-action), "blind"
+	// (no evidence). Empty means no evidence yet.
+	CoverageStage string
+}
+
+// DeriveHealth maps an Inventory + observed signals to a
+// ConnectorHealth. Pure function: no I/O, no side effects,
+// deterministic given inputs.
+//
+// Phase 3C-0 rules (per spec section "Health rules"):
+//
+//   - inventory says not installed → not_installed
+//   - installed but no oktsec hook AND no gateway → disconnected
+//   - hook installed + heartbeat in last FreshHeartbeat → ready (heartbeat)
+//   - hook installed + real event in last FreshEvent → ready (event)
+//   - hook installed + last event older than StaleAfter → stale
+//   - hook installed + nothing observed → partial ("installed,
+//     not yet observed")
+//
+// The runtime block on HealthOptions takes precedence over the
+// legacy LastEvent string; LastEvent is still honored when the
+// caller has no runtime store (the doctor command).
 func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
 	if opts.StaleAfter <= 0 {
 		opts.StaleAfter = 24 * time.Hour
+	}
+	if opts.FreshHeartbeat <= 0 {
+		opts.FreshHeartbeat = 10 * time.Minute
+	}
+	if opts.FreshEvent <= 0 {
+		opts.FreshEvent = 30 * time.Minute
 	}
 
 	h := ConnectorHealth{
@@ -129,6 +238,16 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 		LastEvent:             opts.LastEvent,
 		MissingExpectedEvents: MissingExpectedEvents(inv.Hooks),
 	}
+	h.Runtime = projectRuntimeEvidence(opts.Runtime)
+
+	// Pick the most recent timestamp the caller can offer. Runtime
+	// signals win because they are the durable per-event row Phase
+	// 3B writes; LastEvent is the audit-store fallback for callers
+	// without a runtime store wired in.
+	bestEvent := h.Runtime.LastEventAt
+	if bestEvent == "" {
+		bestEvent = opts.LastEvent
+	}
 
 	switch {
 	case !inv.Detected:
@@ -137,29 +256,96 @@ func DeriveHealth(inv Inventory, opts HealthOptions) ConnectorHealth {
 	case !h.HookInstalled && !h.GatewayConfigured:
 		h.Status = "disconnected"
 		h.Reason = "Claude Code is installed, but no oktsec hook or gateway MCP entry was found in user/project settings."
-	case opts.LastEvent == "":
-		h.Status = "partial"
-		h.Reason = reasonPartial(h)
 	default:
-		ts, err := time.Parse(time.RFC3339, opts.LastEvent)
-		if err != nil {
-			// Unparseable timestamp is a data bug, not the operator's
-			// fault — surface it as partial so the dashboard does not
-			// claim "ready" on garbled input.
-			h.Status = "partial"
-			h.Reason = "An event was reported but its timestamp could not be parsed; treating as partial."
+		// Heartbeat-driven promotion. A heartbeat alone is not
+		// "real activity" but it does prove the hook command can
+		// reach the gateway, which is the connection-truth signal.
+		if hb, ok := freshTimestamp(h.Runtime.LastHeartbeatAt, opts.Now(), opts.FreshHeartbeat); ok {
+			h.Status = "ready"
+			h.Reason = "Claude Code connected. Heartbeat received " + humanizeAge(opts.Now().Sub(hb)) + " ago."
 			break
 		}
-		age := opts.Now().Sub(ts)
-		if age > opts.StaleAfter {
-			h.Status = "stale"
-			h.Reason = "Last Claude Code event observed " + humanizeAge(age) + " ago; coverage may be out of date."
-		} else {
+		// Real-event promotion. Wins when the event is fresh
+		// enough by FreshEvent.
+		if ev, ok := freshTimestamp(bestEvent, opts.Now(), opts.FreshEvent); ok {
 			h.Status = "ready"
-			h.Reason = "Claude Code connected. Last event observed " + humanizeAge(age) + " ago."
+			h.Reason = "Claude Code connected. Last event observed " + humanizeAge(opts.Now().Sub(ev)) + " ago."
+			break
 		}
+		// Older event still counts as some evidence — surface as
+		// stale instead of falling back to partial.
+		if ev, ok := parseTimestamp(bestEvent); ok {
+			age := opts.Now().Sub(ev)
+			if age > opts.StaleAfter {
+				h.Status = "stale"
+				h.Reason = "Last Claude Code event observed " + humanizeAge(age) + " ago; coverage may be out of date."
+			} else {
+				h.Status = "ready"
+				h.Reason = "Claude Code connected. Last event observed " + humanizeAge(age) + " ago."
+			}
+			break
+		}
+		// No usable timestamp at all — installed but not yet
+		// observed.
+		h.Status = "partial"
+		h.Reason = reasonPartial(h)
 	}
 	return h
+}
+
+// projectRuntimeEvidence converts the dashboard-supplied input
+// into the JSON projection. Centralised so the input shape and
+// the wire shape can evolve independently without callers having
+// to know which fields drive the UI.
+func projectRuntimeEvidence(in *RuntimeEvidenceInput) RuntimeEvidence {
+	if in == nil {
+		return RuntimeEvidence{}
+	}
+	out := RuntimeEvidence{
+		LastHeartbeatAt:          in.LastHeartbeatAt,
+		LastEventAt:              in.LastEventAt,
+		LastEventFamily:          in.LastEventFamily,
+		ObservedFamilies:         append([]string(nil), in.ObservedFamilies...),
+		MissingInstalledFamilies: append([]string(nil), in.MissingInstalledFamilies...),
+		SubagentsObserved:        in.SubagentsObserved,
+		SessionsObserved:         in.SessionsObserved,
+		CoverageStage:            in.CoverageStage,
+	}
+	out.HasEvidence = in.LastHeartbeatAt != "" || in.LastEventAt != "" ||
+		in.SessionsObserved > 0 || in.SubagentsObserved > 0 ||
+		len(in.ObservedFamilies) > 0
+	return out
+}
+
+// freshTimestamp parses ts and returns (time, true) when it is
+// at most fresh ago. Empty / unparseable timestamps return
+// (zero, false) so callers fall through to the next rule.
+func freshTimestamp(ts string, now time.Time, fresh time.Duration) (time.Time, bool) {
+	t, ok := parseTimestamp(ts)
+	if !ok {
+		return time.Time{}, false
+	}
+	if now.Sub(t) > fresh {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// parseTimestamp tolerates both RFC3339 and the nanosecond-
+// resolution form runtime tables use. Returns (zero, false) on
+// any parse failure so the caller can downgrade to partial /
+// stale instead of claiming a false "ready".
+func parseTimestamp(ts string) (time.Time, bool) {
+	if ts == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
 }
 
 func reasonPartial(h ConnectorHealth) string {

--- a/internal/connectors/claudecode/health_runtime_test.go
+++ b/internal/connectors/claudecode/health_runtime_test.go
@@ -122,6 +122,35 @@ func TestDeriveHealth_RuntimeEvidenceTrumpsAuditLastEvent(t *testing.T) {
 	}
 }
 
+// TestDeriveHealth_EmptyRuntimeIgnoresAuditLastEvent locks in
+// the contract that a non-nil but empty Runtime block means
+// "installed, not yet observed" — not "installed, partially
+// observed via audit". A legacy audit row from before runtime
+// was wired must NOT flip the dashboard tile to ready, because
+// that would mask the true setup state and re-enable the
+// posture grade prematurely.
+func TestDeriveHealth_EmptyRuntimeIgnoresAuditLastEvent(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	// Audit reports a fresh event; runtime store is wired but
+	// empty. Phase 3C-0 expects partial.
+	h := DeriveHealth(inv, HealthOptions{
+		LastEvent: now.Add(-3 * time.Minute).Format(time.RFC3339),
+		Runtime:   &RuntimeEvidenceInput{},
+		Now:       clock,
+	})
+	if h.Status != "partial" {
+		t.Errorf("status = %q, want partial (empty runtime must override audit fallback)", h.Status)
+	}
+	if h.Runtime.HasEvidence {
+		t.Error("Runtime.HasEvidence = true on empty input")
+	}
+}
+
 // TestDeriveHealth_AuditLastEventStillWorksForLegacyCallers
 // verifies the doctor command path: when no Runtime block is
 // passed (the doctor opens audit read-only and has no runtime

--- a/internal/connectors/claudecode/health_runtime_test.go
+++ b/internal/connectors/claudecode/health_runtime_test.go
@@ -122,6 +122,57 @@ func TestDeriveHealth_RuntimeEvidenceTrumpsAuditLastEvent(t *testing.T) {
 	}
 }
 
+// TestDeriveHealth_NonFreshRuntimeEventIsStaleNotReady pins the
+// connection-truth contract that "ready" requires evidence
+// fresh enough to trust (FreshEvent, default 30m). A real
+// event from 31 minutes ago must drop to stale, not stay at
+// ready under the old StaleAfter (24h) window.
+func TestDeriveHealth_NonFreshRuntimeEventIsStaleNotReady(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{
+			LastEventAt:     now.Add(-31 * time.Minute).Format(time.RFC3339Nano),
+			LastEventFamily: "PreToolUse",
+		},
+		Now: clock,
+	})
+	if h.Status == "ready" {
+		t.Errorf("status = ready, want stale (event 31m ago is past FreshEvent default 30m)")
+	}
+	if h.Status != "stale" {
+		t.Errorf("status = %q, want stale", h.Status)
+	}
+}
+
+// TestDeriveHealth_VeryOldRuntimeEventIsPartial covers the far
+// edge: an event past StaleAfter (default 24h) is so old we
+// treat the connection as having no usable evidence and drop
+// back to partial. Without this the dashboard would keep
+// "stale" visible forever for installations that fired one hook
+// long ago and never again.
+func TestDeriveHealth_VeryOldRuntimeEventIsPartial(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{
+			LastEventAt: now.Add(-25 * time.Hour).Format(time.RFC3339Nano),
+		},
+		Now: clock,
+	})
+	if h.Status != "partial" {
+		t.Errorf("status = %q, want partial (event 25h ago is past StaleAfter)", h.Status)
+	}
+}
+
 // TestDeriveHealth_EmptyRuntimeIgnoresAuditLastEvent locks in
 // the contract that a non-nil but empty Runtime block means
 // "installed, not yet observed" — not "installed, partially

--- a/internal/connectors/claudecode/health_runtime_test.go
+++ b/internal/connectors/claudecode/health_runtime_test.go
@@ -1,0 +1,143 @@
+package claudecode
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDeriveHealth_HeartbeatPromotesToReady locks in the
+// Phase 3C-0 acceptance: a fresh heartbeat (under FreshHeartbeat,
+// 10m default) is enough to lift the connection to "ready" even
+// before any real event lands. This is the path
+// `oktsec doctor claude-code --emit-heartbeat` exercises.
+func TestDeriveHealth_HeartbeatPromotesToReady(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{
+			LastHeartbeatAt: now.Add(-2 * time.Minute).Format(time.RFC3339Nano),
+		},
+		Now: clock,
+	})
+	if h.Status != "ready" {
+		t.Errorf("status = %q, want ready (heartbeat 2m ago should promote)", h.Status)
+	}
+	if !h.Runtime.HasEvidence {
+		t.Errorf("runtime.HasEvidence = false, want true")
+	}
+}
+
+// TestDeriveHealth_StaleHeartbeatDoesNotPromote covers the other
+// half of the heartbeat rule: an old heartbeat should not falsely
+// claim "ready". 11 minutes is just past the default 10m window.
+func TestDeriveHealth_StaleHeartbeatDoesNotPromote(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{
+			LastHeartbeatAt: now.Add(-11 * time.Minute).Format(time.RFC3339Nano),
+		},
+		Now: clock,
+	})
+	if h.Status == "ready" {
+		t.Errorf("status = ready, want partial/stale (heartbeat 11m ago is past FreshHeartbeat)")
+	}
+}
+
+// TestDeriveHealth_RealEventPromotesToReady covers the second
+// path to ready: a real hook event under FreshEvent (30m
+// default) wins regardless of heartbeat presence.
+func TestDeriveHealth_RealEventPromotesToReady(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{
+			LastEventAt:     now.Add(-5 * time.Minute).Format(time.RFC3339Nano),
+			LastEventFamily: "PreToolUse",
+			CoverageStage:   "observed",
+		},
+		Now: clock,
+	})
+	if h.Status != "ready" {
+		t.Errorf("status = %q, want ready", h.Status)
+	}
+	if h.Runtime.CoverageStage != "observed" {
+		t.Errorf("runtime.CoverageStage = %q, want observed", h.Runtime.CoverageStage)
+	}
+}
+
+// TestDeriveHealth_InstalledNoEvidenceStaysPartial pins the
+// Overview tile's "installed, waiting for first observed event"
+// state. The user emphasised that this must not look like a
+// security gap, so the test asserts the status string the tile
+// renders off.
+func TestDeriveHealth_InstalledNoEvidenceStaysPartial(t *testing.T) {
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		Runtime: &RuntimeEvidenceInput{}, // empty: no heartbeat, no event
+	})
+	if h.Status != "partial" {
+		t.Errorf("status = %q, want partial", h.Status)
+	}
+	if h.Runtime.HasEvidence {
+		t.Errorf("runtime.HasEvidence = true, want false (empty input)")
+	}
+}
+
+// TestDeriveHealth_RuntimeEvidenceTrumpsAuditLastEvent confirms
+// the precedence rule: when both are present, the runtime
+// timestamp wins because runtime is the durable per-event row.
+func TestDeriveHealth_RuntimeEvidenceTrumpsAuditLastEvent(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	// Audit says it's old; runtime says it's fresh. Runtime wins.
+	h := DeriveHealth(inv, HealthOptions{
+		LastEvent: now.Add(-2 * time.Hour).Format(time.RFC3339),
+		Runtime: &RuntimeEvidenceInput{
+			LastEventAt: now.Add(-3 * time.Minute).Format(time.RFC3339Nano),
+		},
+		Now: clock,
+	})
+	if h.Status != "ready" {
+		t.Errorf("status = %q, want ready (runtime fresh trumps audit stale)", h.Status)
+	}
+}
+
+// TestDeriveHealth_AuditLastEventStillWorksForLegacyCallers
+// verifies the doctor command path: when no Runtime block is
+// passed (the doctor opens audit read-only and has no runtime
+// store), DeriveHealth still uses the audit-supplied LastEvent.
+func TestDeriveHealth_AuditLastEventStillWorksForLegacyCallers(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	inv := Inventory{
+		Detected: true,
+		Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
+	}
+	h := DeriveHealth(inv, HealthOptions{
+		LastEvent: now.Add(-2 * time.Minute).Format(time.RFC3339),
+		Now:       clock,
+	})
+	if h.Status != "ready" {
+		t.Errorf("status = %q, want ready (legacy LastEvent path)", h.Status)
+	}
+}

--- a/internal/connectors/claudecode/inventory_test.go
+++ b/internal/connectors/claudecode/inventory_test.go
@@ -291,12 +291,17 @@ func TestDeriveHealth_StatusTransitions(t *testing.T) {
 			want:      "ready",
 		},
 		{
-			name: "stale when last event is older than threshold",
+			// Past FreshEvent (30m default) but within
+			// StaleAfter (24h default) — Phase 3C-0 keeps the
+			// stale label here. Beyond 24h the row drops to
+			// partial; that boundary is exercised by
+			// TestDeriveHealth_VeryOldRuntimeEventIsPartial.
+			name: "stale when last event is past fresh window",
 			inv: Inventory{
 				Detected: true,
 				Hooks:    []HookRef{{IsOktsec: true, Event: "PreToolUse"}},
 			},
-			lastEvent: now.Add(-48 * time.Hour).Format(time.RFC3339),
+			lastEvent: now.Add(-2 * time.Hour).Format(time.RFC3339),
 			want:      "stale",
 		},
 		{

--- a/internal/dashboard/connection_health_overview_test.go
+++ b/internal/dashboard/connection_health_overview_test.go
@@ -1,0 +1,234 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+	"github.com/oktsec/oktsec/internal/identity"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// newOverviewTestServer wires a Server backed by a real audit
+// store + DB so the runtime auto-build path actually fires. The
+// overview handler reads from these stores directly so an
+// in-memory mock would not exercise the new tile code.
+func newOverviewTestServer(t *testing.T) (*Server, *audit.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	store, err := audit.NewStore(filepath.Join(dir, "test.db"), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 0},
+		DBPath:  filepath.Join(dir, "test.db"),
+		Agents:  map[string]config.Agent{"agent-a": {CanMessage: []string{"agent-b"}}},
+	}
+	srv := NewServer(cfg, filepath.Join(dir, "oktsec.yaml"), store, identity.NewKeyStore(), sharedScanner, logger)
+	return srv, store
+}
+
+func renderOverview(t *testing.T, srv *Server, cookie *http.Cookie, handler http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+// TestOverview_NotInstalledShowsSetupPending pins the
+// Phase 3C-0 acceptance: with no Claude install at all the tile
+// shows "Claude Code not detected" and the posture grade is
+// suppressed (no hard score during install). Empty $HOME is
+// configured so the connector inspector reports not_installed.
+func TestOverview_NotInstalledShowsSetupPending(t *testing.T) {
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("PATH", "")
+
+	srv, _ := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	body := renderOverview(t, srv, cookie, handler)
+
+	if !strings.Contains(body, "Claude Code not detected") {
+		t.Errorf("Overview tile missing not_installed copy; body excerpt: %s", excerpt(body, "Claude Code"))
+	}
+	if !strings.Contains(body, "Posture grade not yet computed") {
+		t.Error("Posture suppression banner not rendered for not_installed")
+	}
+	if !strings.Contains(body, "Posture (setup pending)") {
+		t.Error("Hero score should fall back to 'setup pending' label, not show a number")
+	}
+}
+
+// TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture
+// covers the heartbeat-promotes-to-ready path AND the
+// suppression rule that "ready" is the threshold for showing
+// the hard grade again.
+func TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture(t *testing.T) {
+	// Build an inventory that looks installed so DeriveHealth
+	// proceeds past the not_installed / disconnected branches.
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	// Seed a runtime heartbeat row directly via the runtime store
+	// so the test does not depend on the hook handler being wired.
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store to auto-build off audit DB")
+	}
+	now := time.Now().UTC()
+	hbEnv, _ := runtime.Normalize([]byte(`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "heartbeat-2026",
+		}, now)
+	if err := rs.RecordHook(context.Background(), hbEnv, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed heartbeat: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	if !strings.Contains(body, "Connected and observed") {
+		t.Errorf("Overview tile missing 'Connected and observed' copy; excerpt: %s", excerpt(body, "Claude Code connection"))
+	}
+	if strings.Contains(body, "Posture grade not yet computed") {
+		t.Error("Posture grade should not be suppressed once status=ready (heartbeat received)")
+	}
+}
+
+// TestOverview_HooksInstalledNoEventsShowsWaiting locks in the
+// "installed, waiting for first observed event" empty state.
+// The tile must read as setup pending, not as a security alert.
+func TestOverview_HooksInstalledNoEventsShowsWaiting(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, _ := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	body := renderOverview(t, srv, cookie, handler)
+	if !strings.Contains(body, "Installed, waiting for first observed event") {
+		t.Errorf("Overview tile missing 'Installed, waiting for first observed event'; excerpt: %s",
+			excerpt(body, "Claude Code connection"))
+	}
+	if strings.Contains(body, "Critical security gaps detected") {
+		t.Error("alarmist 'Critical security gaps detected' copy should NOT appear during install")
+	}
+	if strings.Contains(body, "Deployment needs attention") {
+		t.Error("alarmist 'Deployment needs attention' copy should NOT appear during install")
+	}
+}
+
+// TestOverview_RealEventLiftsToProtectedCoverage exercises the
+// final acceptance: a PreToolUse with Protected coverage in the
+// runtime row is reflected in the tile's coverage badge.
+func TestOverview_RealEventLiftsToProtectedCoverage(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	now := time.Now().UTC()
+	env, _ := runtime.Normalize([]byte(`{"hook_event_name":"PreToolUse","session_id":"sess-real","tool_name":"Read"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "sess-real",
+		}, now)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{
+		CoverageMode: "Protected",
+		Confidence:   100,
+	}); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	if !strings.Contains(body, "Connected and observed") {
+		t.Errorf("Overview tile should show Connected and observed; excerpt: %s",
+			excerpt(body, "Claude Code connection"))
+	}
+	if !strings.Contains(body, "Protected") {
+		t.Error("Coverage stage 'Protected' should be rendered when runtime row carries it")
+	}
+}
+
+// stageClaudeFixture writes the minimum settings file to make
+// the connector inspector report Detected=true and (when
+// withOktsecHook) HookInstalled=true. Returns the temp home dir
+// the test should set $HOME to.
+func stageClaudeFixture(t *testing.T, withOktsecHook bool) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := `{}`
+	if withOktsecHook {
+		body = `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"*","hooks":[{"type":"command","command":"/usr/local/bin/oktsec hook --port 9090 --event PreToolUse --manifest v2"}]}
+    ]
+  }
+}`
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// excerpt returns a short window around the first occurrence of
+// needle so failure messages stay readable. Empty when not found.
+func excerpt(haystack, needle string) string {
+	idx := strings.Index(haystack, needle)
+	if idx < 0 {
+		return "(needle not found)"
+	}
+	start := idx - 80
+	if start < 0 {
+		start = 0
+	}
+	end := idx + len(needle) + 200
+	if end > len(haystack) {
+		end = len(haystack)
+	}
+	return haystack[start:end]
+}

--- a/internal/dashboard/connection_health_overview_test.go
+++ b/internal/dashboard/connection_health_overview_test.go
@@ -123,6 +123,54 @@ func TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture(t *testing.T) {
 	}
 }
 
+// TestOverview_HeartbeatOnlyDoesNotCountAsRealEvent locks in
+// the P2 contract: a heartbeat row writes a SessionStart event
+// to runtime_hook_events, but the Overview must keep its
+// "Real events: none yet" badge until a non-heartbeat event
+// lands. Otherwise `oktsec doctor claude-code --emit-heartbeat`
+// would silently inflate the connection-truth view to "real
+// activity observed" and mark SessionStart as an observed family.
+func TestOverview_HeartbeatOnlyDoesNotCountAsRealEvent(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	now := time.Now().UTC()
+	hbEnv, _ := runtime.Normalize([]byte(`{"hook_event_name":"SessionStart","session_id":"heartbeat-only-2026"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "heartbeat-only-2026",
+		}, now)
+	if err := rs.RecordHook(context.Background(), hbEnv, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed heartbeat: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	// Heartbeat tile cell must show "received".
+	if !strings.Contains(body, ">received<") {
+		t.Errorf("Heartbeat cell missing 'received' value; excerpt: %s", excerpt(body, "Heartbeat"))
+	}
+	// Real events tile cell must still show "none yet".
+	idx := strings.Index(body, "Real events")
+	if idx < 0 {
+		t.Fatal("Real events cell not rendered")
+	}
+	tail := body[idx:]
+	if !strings.Contains(tail[:200], ">none yet<") {
+		t.Errorf("Real events cell should show 'none yet' for heartbeat-only state; excerpt: %s", tail[:200])
+	}
+}
+
 // TestOverview_HooksInstalledNoEventsShowsWaiting locks in the
 // "installed, waiting for first observed event" empty state.
 // The tile must read as setup pending, not as a security alert.

--- a/internal/dashboard/connection_health_overview_test.go
+++ b/internal/dashboard/connection_health_overview_test.go
@@ -123,6 +123,63 @@ func TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture(t *testing.T) {
 	}
 }
 
+// TestOverview_VeryOldProtectedEventHidesCoverageCell pins the
+// per-cell coverage rule: an event past StaleAfter must NOT
+// keep the green Coverage badge visible even when its
+// CoverageMode was Protected. Past the connection-truth window
+// the status field drops to partial; the coverage cell must
+// follow so the tile cannot say "Coverage: Protected" while
+// the headline says "Installed, waiting for first observed
+// event".
+func TestOverview_VeryOldProtectedEventHidesCoverageCell(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	old := time.Now().UTC().Add(-25 * time.Hour)
+	env, _ := runtime.Normalize(
+		[]byte(`{"hook_event_name":"PreToolUse","session_id":"sess-old-cov","tool_name":"Read"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "sess-old-cov",
+		}, old)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{
+		CoverageMode: "Protected",
+		Confidence:   100,
+	}); err != nil {
+		t.Fatalf("seed old protected event: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	// The Coverage badge text in the tile is rendered by a
+	// `{{if .Runtime.CoverageStage}}` block, so a hidden cell
+	// has no "Coverage" header at all near the connection
+	// tile. Search the tile region only to avoid false positives
+	// from the coverage matrix elsewhere on the page.
+	tileStart := strings.Index(body, "Claude Code connection")
+	if tileStart < 0 {
+		t.Fatal("Claude Code connection tile not rendered")
+	}
+	tile := body[tileStart : tileStart+1500]
+	if strings.Contains(tile, "Protected") {
+		t.Errorf("Coverage badge says 'Protected' for 25h event; tile excerpt: %s", tile)
+	}
+	// Sanity: the headline should be in the partial state.
+	if !strings.Contains(tile, "Installed, waiting for first observed event") {
+		t.Errorf("expected partial headline; tile excerpt: %s", tile)
+	}
+}
+
 // TestOverview_VeryOldEventCellDoesNotSayObserved pins the
 // per-cell freshness contract: a 25-hour-old runtime event
 // drops the connection to partial AND the Real events cell

--- a/internal/dashboard/connection_health_overview_test.go
+++ b/internal/dashboard/connection_health_overview_test.go
@@ -123,6 +123,103 @@ func TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture(t *testing.T) {
 	}
 }
 
+// TestOverview_VeryOldEventCellDoesNotSayObserved pins the
+// per-cell freshness contract: a 25-hour-old runtime event
+// drops the connection to partial AND the Real events cell
+// must NOT render its green "observed" badge. Otherwise the
+// tile contradicts itself — title/reason say "Installed,
+// waiting for first observed event" while the cell flashes
+// green because LastEventAt is non-empty.
+func TestOverview_VeryOldEventCellDoesNotSayObserved(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	old := time.Now().UTC().Add(-25 * time.Hour)
+	env, _ := runtime.Normalize(
+		[]byte(`{"hook_event_name":"PreToolUse","session_id":"sess-old-cell","tool_name":"Read"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "sess-old-cell",
+		}, old)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed old event: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+
+	// Locate the Real events cell. It must NOT say "observed"
+	// (the green badge) because no event landed inside the
+	// freshness window. "none recent" is the expected value
+	// because LastEventAt is non-empty.
+	idx := strings.Index(body, "Real events")
+	if idx < 0 {
+		t.Fatal("Real events cell not rendered")
+	}
+	cell := body[idx:idx+200]
+	if strings.Contains(cell, ">observed<") {
+		t.Errorf("Real events cell says 'observed' for 25h-old event; expected 'none recent'. excerpt: %s", cell)
+	}
+	if !strings.Contains(cell, ">none recent<") {
+		t.Errorf("Real events cell missing 'none recent' badge; excerpt: %s", cell)
+	}
+}
+
+// TestOverview_StaleHeartbeatCellDoesNotSayReceived covers the
+// symmetric heartbeat case: a 30-minute-old heartbeat past
+// FreshHeartbeat must NOT keep the cell on the green "received"
+// badge. The badge belongs only to fresh heartbeats; stale ones
+// render "none recent".
+func TestOverview_StaleHeartbeatCellDoesNotSayReceived(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	old := time.Now().UTC().Add(-30 * time.Minute)
+	env, _ := runtime.Normalize(
+		[]byte(`{"hook_event_name":"SessionStart","session_id":"heartbeat-stale-cell"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "heartbeat-stale-cell",
+		}, old)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed stale heartbeat: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	idx := strings.Index(body, "Heartbeat")
+	if idx < 0 {
+		t.Fatal("Heartbeat cell not rendered")
+	}
+	cell := body[idx:idx+200]
+	if strings.Contains(cell, ">received<") {
+		t.Errorf("Heartbeat cell says 'received' for 30m-old heartbeat; expected 'none recent'. excerpt: %s", cell)
+	}
+	if !strings.Contains(cell, ">none recent<") {
+		t.Errorf("Heartbeat cell missing 'none recent' badge; excerpt: %s", cell)
+	}
+}
+
 // TestOverview_VeryOldEventSuppressesPostureGrade pins the
 // updated suppression rule: an event past StaleAfter (default
 // 24h) drops the connection to partial, and partial must

--- a/internal/dashboard/connection_health_overview_test.go
+++ b/internal/dashboard/connection_health_overview_test.go
@@ -123,6 +123,99 @@ func TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture(t *testing.T) {
 	}
 }
 
+// TestOverview_VeryOldEventSuppressesPostureGrade pins the
+// updated suppression rule: an event past StaleAfter (default
+// 24h) drops the connection to partial, and partial must
+// suppress the posture grade even though Runtime.HasEvidence is
+// still true (the row landed at some point). Otherwise the
+// Overview would say "installed, waiting for first observed
+// event" while still showing a hard grade — exactly the
+// historical-evidence-inflates-current-state smell Phase 3C-0
+// is meant to close.
+func TestOverview_VeryOldEventSuppressesPostureGrade(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	// 25 hours back-dates the runtime row past the default
+	// StaleAfter (24h) so DeriveHealth drops to partial. The
+	// runtime tables still carry a row, so HasEvidence is true —
+	// without the suppression tightening, the Overview would
+	// keep the grade visible.
+	old := time.Now().UTC().Add(-25 * time.Hour)
+	env, _ := runtime.Normalize(
+		[]byte(`{"hook_event_name":"PreToolUse","session_id":"sess-old","tool_name":"Read"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "sess-old",
+		}, old)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed old event: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	if !strings.Contains(body, "Posture grade not yet computed") {
+		t.Errorf("posture suppression banner missing for partial state with stale historical evidence; excerpt: %s",
+			excerpt(body, "Posture"))
+	}
+	if !strings.Contains(body, "Installed, waiting for first observed event") {
+		t.Errorf("expected 'Installed, waiting for first observed event' (partial state); excerpt: %s",
+			excerpt(body, "Claude Code connection"))
+	}
+}
+
+// TestOverview_StaleHeartbeatOnlySuppressesPostureGrade locks
+// in the symmetrical rule for diagnostic-only evidence: a
+// heartbeat past the FreshHeartbeat window (10m default) with
+// no real event leaves DeriveHealth in partial. The Overview
+// must suppress the posture grade in that state too —
+// HasEvidence is true (the heartbeat row exists) but it does
+// not back a hardening grade.
+func TestOverview_StaleHeartbeatOnlySuppressesPostureGrade(t *testing.T) {
+	stagedHome := stageClaudeFixture(t, true)
+	t.Setenv("HOME", stagedHome)
+	t.Setenv("PATH", "")
+
+	srv, auditStore := newOverviewTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store")
+	}
+	// 30 minutes back-dates the heartbeat past FreshHeartbeat
+	// (10m default). No real event ever lands.
+	old := time.Now().UTC().Add(-30 * time.Minute)
+	env, _ := runtime.Normalize(
+		[]byte(`{"hook_event_name":"SessionStart","session_id":"heartbeat-stale-2026"}`),
+		runtime.IdentityResolution{
+			PrincipalID: claudecode.PrincipalID,
+			ClientID:    claudecode.PrincipalID,
+			SessionID:   "heartbeat-stale-2026",
+		}, old)
+	if err := rs.RecordHook(context.Background(), env, runtime.OutcomeRefs{}); err != nil {
+		t.Fatalf("seed stale heartbeat: %v", err)
+	}
+	auditStore.Flush()
+
+	body := renderOverview(t, srv, cookie, handler)
+	if !strings.Contains(body, "Posture grade not yet computed") {
+		t.Errorf("posture suppression banner missing for partial state with stale heartbeat; excerpt: %s",
+			excerpt(body, "Posture"))
+	}
+}
+
 // TestOverview_HeartbeatOnlyDoesNotCountAsRealEvent locks in
 // the P2 contract: a heartbeat row writes a SessionStart event
 // to runtime_hook_events, but the Overview must keep its

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4347,27 +4347,33 @@ func (s *Server) computeClaudeCodeConnectionHealth(parent context.Context) claud
 
 // suppressPostureGrade returns true when the Phase 4 redesign's
 // "no hard score during install" rule applies: until the
-// connection is verified, the audit-driven posture grade
-// describes a system the operator has not yet wired up. Showing
-// "grade C" here looks like a security alert when in fact it is
-// just an unconfigured surface.
+// connection has fresh enough evidence to back a grade, the
+// audit-driven posture score describes a system the operator
+// has not yet wired up. Showing "grade C" here looks like a
+// security alert when in fact it is just an unconfigured surface.
 //
 // Rules (per spec section "Target Product Model" + the
 // Phase 3C-0 acceptance):
 //
 //   - not_installed → suppress
 //   - disconnected → suppress
-//   - partial without runtime evidence → suppress (installed but
-//     never observed)
-//   - partial with runtime evidence (heartbeat-only) → keep
-//   - stale → keep (we have history; the score still applies)
-//   - ready → keep
+//   - partial → suppress, regardless of historical evidence.
+//     ConnectorHealth.Runtime.HasEvidence answers "did anything
+//     ever land", not "is there fresh evidence to grade
+//     against". A partial state means DeriveHealth could not
+//     find usable fresh evidence (no fresh heartbeat, no fresh
+//     event, anything older was demoted by the freshness rules)
+//     — grading hardening on top of that would tell the
+//     operator their posture is bad when really we just lost the
+//     connection signal.
+//   - stale → keep. We have parseable evidence within the
+//     StaleAfter window; the score still applies even though
+//     the connection went quiet.
+//   - ready → keep.
 func suppressPostureGrade(h claudecode.ConnectorHealth) bool {
 	switch h.Status {
-	case "not_installed", "disconnected":
+	case "not_installed", "disconnected", "partial":
 		return true
-	case "partial":
-		return !h.Runtime.HasEvidence
 	}
 	return false
 }
@@ -4384,9 +4390,10 @@ func postureSuppressionReason(h claudecode.ConnectorHealth) string {
 		return "Setup pending — Claude Code is not installed yet."
 	case "disconnected":
 		return "Setup pending — install oktsec hooks before grading hardening."
-	default:
+	case "partial":
 		return "Setup pending — installed, waiting for the first observed event."
 	}
+	return ""
 }
 
 // claudeCodeRuntimeEvidence builds the RuntimeEvidenceInput

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oktsec/oktsec/internal/coverage"
 	"github.com/oktsec/oktsec/internal/discover"
 	"github.com/oktsec/oktsec/internal/graph"
+	"github.com/oktsec/oktsec/internal/runtime"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/llm"
 	"gopkg.in/yaml.v3"
@@ -230,6 +231,17 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 	// surface column shows the corresponding cell's badge + limitation.
 	coverageRows := buildCoverageRows(coverage.Compute(s.cfg, s.coverageReader()))
 
+	// Phase 3C-0 connection truth. Cheap to compute (the underlying
+	// inventory + runtime queries cap at 100 rows each), and the
+	// posture grade/grade-suppression decision below depends on it.
+	connHealth := s.computeClaudeCodeConnectionHealth(r.Context())
+	postureSuppressed := suppressPostureGrade(connHealth)
+	postureSuppressedReason := postureSuppressionReason(connHealth)
+	if postureSuppressed {
+		score = 0
+		grade = ""
+	}
+
 	data := map[string]any{
 		"Active":        "overview",
 		"Stats":         stats,
@@ -256,6 +268,9 @@ func (s *Server) handleOverview(w http.ResponseWriter, r *http.Request) {
 		"GuardEnabled":    s.cfg.Guard.Enabled,
 		"GuardAlerts":     guardEventCount,
 		"CoverageRows":    coverageRows,
+		"ConnHealth":      connHealth,
+		"PostureSuppressed":       postureSuppressed,
+		"PostureSuppressedReason": postureSuppressedReason,
 	}
 
 	s.populateLLMStats(data)
@@ -4298,12 +4313,216 @@ func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) 
 
 	health := claudecode.DeriveHealth(inv, claudecode.HealthOptions{
 		LastEvent: claudecode.LookupLastEvent(s.audit),
+		Runtime:   s.claudeCodeRuntimeEvidence(ctx, inv),
 	})
 
 	s.renderJSON(w, map[string]any{
 		"inventory": inv,
 		"health":    health,
 	})
+}
+
+// computeClaudeCodeConnectionHealth is the Overview's projection
+// of the connector health endpoint. Same inputs (inventory +
+// runtime evidence + audit fallback), same DeriveHealth call —
+// rendered inline so the Overview does not require a second
+// fetch from the browser. Bounded to a 3s deadline so a stalled
+// inventory read cannot stall the page.
+func (s *Server) computeClaudeCodeConnectionHealth(parent context.Context) claudecode.ConnectorHealth {
+	ctx, cancel := context.WithTimeout(parent, 3*time.Second)
+	defer cancel()
+	projectDir := ""
+	if s.cfgPath != "" {
+		projectDir = filepath.Dir(s.cfgPath)
+	}
+	inv := claudecode.Read(ctx, claudecode.ReadOptions{
+		ProjectDir:       projectDir,
+		SkipVersionProbe: true,
+	})
+	return claudecode.DeriveHealth(inv, claudecode.HealthOptions{
+		LastEvent: claudecode.LookupLastEvent(s.audit),
+		Runtime:   s.claudeCodeRuntimeEvidence(ctx, inv),
+	})
+}
+
+// suppressPostureGrade returns true when the Phase 4 redesign's
+// "no hard score during install" rule applies: until the
+// connection is verified, the audit-driven posture grade
+// describes a system the operator has not yet wired up. Showing
+// "grade C" here looks like a security alert when in fact it is
+// just an unconfigured surface.
+//
+// Rules (per spec section "Target Product Model" + the
+// Phase 3C-0 acceptance):
+//
+//   - not_installed → suppress
+//   - disconnected → suppress
+//   - partial without runtime evidence → suppress (installed but
+//     never observed)
+//   - partial with runtime evidence (heartbeat-only) → keep
+//   - stale → keep (we have history; the score still applies)
+//   - ready → keep
+func suppressPostureGrade(h claudecode.ConnectorHealth) bool {
+	switch h.Status {
+	case "not_installed", "disconnected":
+		return true
+	case "partial":
+		return !h.Runtime.HasEvidence
+	}
+	return false
+}
+
+// postureSuppressionReason returns the operator-facing copy the
+// Overview tile shows in place of a hard grade. Empty string
+// when the grade is not suppressed.
+func postureSuppressionReason(h claudecode.ConnectorHealth) string {
+	if !suppressPostureGrade(h) {
+		return ""
+	}
+	switch h.Status {
+	case "not_installed":
+		return "Setup pending — Claude Code is not installed yet."
+	case "disconnected":
+		return "Setup pending — install oktsec hooks before grading hardening."
+	default:
+		return "Setup pending — installed, waiting for the first observed event."
+	}
+}
+
+// claudeCodeRuntimeEvidence builds the RuntimeEvidenceInput
+// snapshot DeriveHealth needs from the Phase 3 runtime store.
+// Returns nil when the runtime store is not available so callers
+// can fall back to the legacy LastEvent path without changing
+// rules. Bounded to a 2s context so a stalled DB cannot stretch
+// the dashboard render.
+func (s *Server) claudeCodeRuntimeEvidence(parent context.Context, inv claudecode.Inventory) *claudecode.RuntimeEvidenceInput {
+	store := s.runtimeStore()
+	if store == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+
+	in := &claudecode.RuntimeEvidenceInput{}
+
+	if hb, err := store.LastHeartbeat(ctx, claudecode.PrincipalID, claudecode.PrincipalID); err == nil && hb != nil {
+		in.LastHeartbeatAt = hb.ReceivedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	// Latest non-heartbeat event (and the family) for the principal.
+	// Capped to a small window so the query stays cheap; older
+	// activity surfaces via QuerySessions/QueryEvents in 3C.
+	events, err := store.QueryEvents(ctx, runtime.EventQuery{
+		PrincipalID: claudecode.PrincipalID,
+		Limit:       100,
+	})
+	if err == nil {
+		latestPerFamily := map[string]bool{}
+		var latestEvent *runtime.HookEvent
+		for i := range events {
+			ev := events[i]
+			latestPerFamily[ev.HookEventName] = true
+			if latestEvent == nil || ev.Timestamp.After(latestEvent.Timestamp) {
+				latestEvent = &ev
+			}
+		}
+		if latestEvent != nil {
+			in.LastEventAt = latestEvent.Timestamp.UTC().Format(time.RFC3339Nano)
+			in.LastEventFamily = latestEvent.HookEventName
+			in.CoverageStage = strongestCoverage(events)
+		}
+		in.ObservedFamilies = sortedStringSet(latestPerFamily)
+	}
+
+	// Sessions + subagents counts. Sessions list is already capped
+	// in the store; subagents come from the runtime_actors view.
+	if sessions, err := store.QuerySessions(ctx, runtime.SessionQuery{
+		PrincipalID: claudecode.PrincipalID,
+		Limit:       100,
+	}); err == nil {
+		in.SessionsObserved = len(sessions)
+	}
+	if actors, err := store.QueryActors(ctx, runtime.ActorQuery{
+		PrincipalID: claudecode.PrincipalID,
+		Kind:        runtime.ActorKindSubagent,
+		Limit:       100,
+	}); err == nil {
+		in.SubagentsObserved = len(actors)
+	}
+
+	// Cross-check: which Phase 2 manifest events the inventory
+	// expects but the runtime has never seen. The dashboard tile
+	// surfaces this so the operator knows whether a missing event
+	// family is expected (not yet installed) or a regression
+	// (installed but never fired).
+	in.MissingInstalledFamilies = installedButUnobservedFamilies(inv.Hooks, in.ObservedFamilies)
+	return in
+}
+
+// strongestCoverage rolls up the per-event coverage_mode column
+// to a single label the tile can render. "protected" wins over
+// "observed" wins over "blind" wins over empty. Operating on the
+// already-fetched events slice avoids a second round-trip.
+func strongestCoverage(events []runtime.HookEvent) string {
+	rank := func(mode string) int {
+		switch strings.ToLower(mode) {
+		case "protected":
+			return 3
+		case "observed":
+			return 2
+		case "blind":
+			return 1
+		default:
+			return 0
+		}
+	}
+	best := ""
+	bestRank := 0
+	for _, ev := range events {
+		if r := rank(ev.CoverageMode); r > bestRank {
+			best = strings.ToLower(ev.CoverageMode)
+			bestRank = r
+		}
+	}
+	return best
+}
+
+// installedButUnobservedFamilies returns the Phase 2 manifest
+// event families the inventory says are installed (oktsec hook
+// present) but the runtime has not seen yet. Used by the
+// connection-health tile to nudge the operator toward triggering
+// the missing event family — heartbeat covers SessionStart, but
+// the rest only fire on real activity.
+func installedButUnobservedFamilies(hooks []claudecode.HookRef, observed []string) []string {
+	observedSet := map[string]bool{}
+	for _, e := range observed {
+		observedSet[e] = true
+	}
+	installed := map[string]bool{}
+	for _, h := range hooks {
+		if h.IsOktsec {
+			installed[h.Event] = true
+		}
+	}
+	var out []string
+	for _, name := range claudecode.Phase2EventNames() {
+		if installed[name] && !observedSet[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// sortedStringSet collapses a presence-only map to a sorted
+// slice. The handler renders the list verbatim, so deterministic
+// order keeps JSON diffs stable across renders.
+func sortedStringSet(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // handleEvidenceStatus returns a snapshot of the audit store's row

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4409,7 +4409,15 @@ func (s *Server) claudeCodeRuntimeEvidence(parent context.Context, inv claudecod
 		in.LastHeartbeatAt = hb.ReceivedAt.UTC().Format(time.RFC3339Nano)
 	}
 
-	// Latest non-heartbeat event (and the family) for the principal.
+	// Latest real (non-heartbeat) event and family for the
+	// principal. Heartbeat sessions write SessionStart rows to
+	// runtime_hook_events too, but they are diagnostic — counting
+	// them here would let `oktsec doctor claude-code
+	// --emit-heartbeat` flip the Overview tile to "Real events:
+	// observed" + "SessionStart family seen" without any actual
+	// Claude Code activity having happened. Heartbeat evidence
+	// belongs only to LastHeartbeatAt.
+	//
 	// Capped to a small window so the query stays cheap; older
 	// activity surfaces via QuerySessions/QueryEvents in 3C.
 	events, err := store.QueryEvents(ctx, runtime.EventQuery{
@@ -4417,10 +4425,17 @@ func (s *Server) claudeCodeRuntimeEvidence(parent context.Context, inv claudecod
 		Limit:       100,
 	})
 	if err == nil {
+		realEvents := events[:0]
+		for _, ev := range events {
+			if runtime.IsHeartbeatSession(ev.SessionID) {
+				continue
+			}
+			realEvents = append(realEvents, ev)
+		}
 		latestPerFamily := map[string]bool{}
 		var latestEvent *runtime.HookEvent
-		for i := range events {
-			ev := events[i]
+		for i := range realEvents {
+			ev := realEvents[i]
 			latestPerFamily[ev.HookEventName] = true
 			if latestEvent == nil || ev.Timestamp.After(latestEvent.Timestamp) {
 				latestEvent = &ev
@@ -4429,7 +4444,7 @@ func (s *Server) claudeCodeRuntimeEvidence(parent context.Context, inv claudecod
 		if latestEvent != nil {
 			in.LastEventAt = latestEvent.Timestamp.UTC().Format(time.RFC3339Nano)
 			in.LastEventFamily = latestEvent.HookEventName
-			in.CoverageStage = strongestCoverage(events)
+			in.CoverageStage = strongestCoverage(realEvents)
 		}
 		in.ObservedFamilies = sortedStringSet(latestPerFamily)
 	}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4448,10 +4448,26 @@ func (s *Server) claudeCodeRuntimeEvidence(parent context.Context, inv claudecod
 				latestEvent = &ev
 			}
 		}
+		// Coverage badge represents "usable evidence right now",
+		// not "ever observed". Past the StaleAfter window the
+		// status field already drops to partial and disowns the
+		// row; CoverageStage must follow the same rule or the
+		// tile contradicts itself (status=partial but
+		// Coverage=Protected). ObservedFamilies stays unfiltered
+		// because it answers the orthogonal "did this family
+		// ever fire" question for the missing-installed gap
+		// report.
+		coverageCutoff := time.Now().UTC().Add(-claudecode.DefaultStaleAfter)
+		usableForCoverage := make([]runtime.HookEvent, 0, len(realEvents))
+		for _, ev := range realEvents {
+			if !ev.Timestamp.Before(coverageCutoff) {
+				usableForCoverage = append(usableForCoverage, ev)
+			}
+		}
 		if latestEvent != nil {
 			in.LastEventAt = latestEvent.Timestamp.UTC().Format(time.RFC3339Nano)
 			in.LastEventFamily = latestEvent.HookEventName
-			in.CoverageStage = strongestCoverage(realEvents)
+			in.CoverageStage = strongestCoverage(usableForCoverage)
 		}
 		in.ObservedFamilies = sortedStringSet(latestPerFamily)
 	}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oktsec/oktsec/internal/graph"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/llm"
+	"github.com/oktsec/oktsec/internal/runtime"
 )
 
 // Version is set by the CLI command at startup for use in exports (e.g., SARIF).
@@ -83,6 +84,17 @@ type Server struct {
 	// stall cannot permanently disable activity attribution.
 	coverageActivityOnce sync.Once
 	coverageActivityVal  activity.Store
+
+	// runtimeStoreOnce + runtimeStoreVal lazily build the Phase 3
+	// runtime store off the audit DB. Same idempotency contract as
+	// coverageActivityStore: Open is safe to call repeatedly under
+	// both SQLite and Postgres, but Migrate has a non-zero cost so
+	// we cache the result. nil when the audit store does not
+	// expose a *sql.DB (test mocks) or when the migration failed
+	// at startup; in either case the connection-health endpoint
+	// falls back to audit-only signals.
+	runtimeStoreOnce sync.Once
+	runtimeStoreVal  *runtime.Store
 }
 
 // NewServer creates a dashboard server with access-code authentication.
@@ -190,6 +202,44 @@ func (s *Server) coverageActivityStore() activity.Store {
 		s.coverageActivityVal = s.buildActivityStoreForCoverage()
 	})
 	return s.coverageActivityVal
+}
+
+// runtimeStore returns the cached Phase 3 runtime.Store handle,
+// building it lazily off the audit DB on first call. nil when the
+// audit store does not expose a *sql.DB (test mocks) or when the
+// migration failed at startup. Callers treat nil as "no runtime
+// evidence available" and fall back to audit-only signals.
+func (s *Server) runtimeStore() *runtime.Store {
+	s.runtimeStoreOnce.Do(func() {
+		s.runtimeStoreVal = s.buildRuntimeStore()
+	})
+	return s.runtimeStoreVal
+}
+
+func (s *Server) buildRuntimeStore() *runtime.Store {
+	type dbBackedAuditStore interface {
+		DB() *sql.DB
+		DialectName() string
+	}
+	dbs, ok := s.audit.(dbBackedAuditStore)
+	if !ok {
+		return nil
+	}
+	db := dbs.DB()
+	if db == nil {
+		return nil
+	}
+	dialect := runtime.Dialect(dbs.DialectName())
+	if dialect == "" {
+		s.logger.Warn("connection health: audit store reports unknown dialect; runtime evidence disabled")
+		return nil
+	}
+	rs, err := runtime.Open(context.Background(), db, dialect)
+	if err != nil {
+		s.logger.Warn("connection health: runtime store open failed; falling back to audit-only signals", "error", err)
+		return nil
+	}
+	return rs
 }
 
 func (s *Server) buildActivityStoreForCoverage() activity.Store {

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -111,6 +111,10 @@ a.ov-metric:hover{background:var(--surface2)}
     <div class="lbl">Agents Observed</div>
   </a>
   <a href="/dashboard/audit" class="hero-stat">
+    {{if .PostureSuppressed}}
+    <div class="num" style="color:var(--text3);font-weight:500;font-size:1.4rem">—</div>
+    <div class="lbl">Posture (setup pending)</div>
+    {{else}}
     <div class="score-ring" id="score-ring">
       <svg viewBox="0 0 48 48" width="48" height="48">
         <circle cx="24" cy="24" r="20" fill="none" stroke="var(--border)" stroke-width="3"/>
@@ -125,6 +129,7 @@ a.ov-metric:hover{background:var(--surface2)}
     (function(){var arc=document.getElementById('score-ring-arc');if(!arc)return;var score={{.Score}};var offset=125.66*(1-score/100);setTimeout(function(){arc.style.strokeDashoffset=offset},50)})();
     </script>
     <div class="lbl">Posture Score</div>
+    {{end}}
   </a>
 </div>
 
@@ -133,6 +138,68 @@ a.ov-metric:hover{background:var(--surface2)}
   <strong>{{.PendingReview}} message{{if gt .PendingReview 1}}s{{end}} pending review</strong>
   <span style="color:var(--text2);font-size:var(--text-sm)">Quarantined content awaiting human decision</span>
   <a href="/dashboard/events?tab=quarantine" class="btn btn-sm" style="background:var(--warn);color:#000">Review Now</a>
+</div>
+{{end}}
+
+{{with .ConnHealth}}
+<!--
+  Connection Health tile (Phase 3C-0). Answers the four questions
+  the operator asks during install:
+    - is Claude Code installed?
+    - are oktsec hooks installed?
+    - have we received a heartbeat / real event?
+    - what coverage stage do we have evidence for?
+  Empty states are deliberately non-alarmist: "installed, waiting
+  for first observed event" reads as setup pending, not as a
+  security gap.
+-->
+<div class="ov-card" style="margin-bottom:var(--sp-4);border-left:3px solid {{if eq .Status "ready"}}var(--success){{else if or (eq .Status "partial") (eq .Status "stale")}}var(--warn){{else}}var(--text3){{end}}">
+  <div style="display:flex;align-items:baseline;justify-content:space-between;gap:var(--sp-3);flex-wrap:wrap">
+    <div>
+      <div style="font-size:var(--text-xs);color:var(--text3);text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Claude Code connection</div>
+      <div style="font-size:var(--text-lg);font-weight:600;margin-top:4px">
+        {{if eq .Status "ready"}}Connected and observed{{end}}
+        {{if eq .Status "partial"}}Installed, waiting for first observed event{{end}}
+        {{if eq .Status "stale"}}Last event is stale{{end}}
+        {{if eq .Status "disconnected"}}Installed, hooks not connected{{end}}
+        {{if eq .Status "not_installed"}}Claude Code not detected{{end}}
+      </div>
+      <div style="font-size:var(--text-sm);color:var(--text2);margin-top:4px;max-width:60ch">{{.Reason}}</div>
+    </div>
+    <div style="display:flex;gap:var(--sp-3);font-size:var(--text-xs);color:var(--text3);flex-wrap:wrap;align-items:flex-end">
+      <div>
+        <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Hooks</div>
+        <div style="color:{{if .HookInstalled}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .HookInstalled}}installed{{else}}not installed{{end}}</div>
+      </div>
+      <div>
+        <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Heartbeat</div>
+        <div style="color:{{if .Runtime.LastHeartbeatAt}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.LastHeartbeatAt}}received{{else}}none yet{{end}}</div>
+      </div>
+      <div>
+        <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Real events</div>
+        <div style="color:{{if .Runtime.LastEventAt}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.LastEventAt}}observed{{else}}none yet{{end}}</div>
+      </div>
+      {{if .Runtime.CoverageStage}}
+      <div>
+        <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Coverage</div>
+        <div style="font-weight:600;margin-top:2px;text-transform:capitalize">{{.Runtime.CoverageStage}}</div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
+{{if .PostureSuppressed}}
+<!--
+  Posture grade is suppressed during install (Phase 3C-0). The
+  hero score above shows 0/empty in this state; the inline note
+  explains why the grade is N/A so the operator does not read it
+  as a security alert.
+-->
+<div class="ov-card" style="margin-bottom:var(--sp-4);background:var(--surface2);font-size:var(--text-sm);color:var(--text2)">
+  <strong style="color:var(--text)">Posture grade not yet computed.</strong>
+  <span>{{.PostureSuppressedReason}}</span>
 </div>
 {{end}}
 

--- a/internal/dashboard/tmpl_overview.go
+++ b/internal/dashboard/tmpl_overview.go
@@ -173,11 +173,11 @@ a.ov-metric:hover{background:var(--surface2)}
       </div>
       <div>
         <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Heartbeat</div>
-        <div style="color:{{if .Runtime.LastHeartbeatAt}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.LastHeartbeatAt}}received{{else}}none yet{{end}}</div>
+        <div style="color:{{if .Runtime.HasFreshHeartbeat}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.HasFreshHeartbeat}}received{{else if .Runtime.LastHeartbeatAt}}none recent{{else}}none yet{{end}}</div>
       </div>
       <div>
         <div style="text-transform:uppercase;letter-spacing:var(--ls-caps);font-weight:500">Real events</div>
-        <div style="color:{{if .Runtime.LastEventAt}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.LastEventAt}}observed{{else}}none yet{{end}}</div>
+        <div style="color:{{if .Runtime.HasFreshRealEvent}}var(--success){{else}}var(--text3){{end}};font-weight:600;margin-top:2px">{{if .Runtime.HasFreshRealEvent}}observed{{else if .Runtime.LastEventAt}}none recent{{else}}none yet{{end}}</div>
       </div>
       {{if .Runtime.CoverageStage}}
       <div>


### PR DESCRIPTION
## Summary

Phase 3C-0 connection-truth slice. The Overview now answers the four install-time questions before showing any hardening grade:

1. Is Claude Code installed?
2. Are oktsec hooks installed?
3. Has the gateway received a heartbeat?
4. Has it observed a real hook event?

Empty states read as "setup pending", never "deployment at risk". Posture grade is withheld whenever the connection is `not_installed`, `disconnected`, or `partial` so the operator never sees a hardening grade backed by stale or diagnostic-only evidence. Per-cell badges follow the same freshness rule as the headline status — a stale timestamp renders "none recent", never the green "observed" / "received" badge.

## Changes

- `claudecode.HealthOptions` gains a `Runtime` block (`RuntimeEvidenceInput`) carrying the durable signals Phase 3B writes per hook event. `DeriveHealth` applies the spec's "Health rules": fresh heartbeat (10m default) or fresh real event (30m default) lifts to `ready`; older events fall through to `stale`; events past `StaleAfter` (24h default) are treated as noise and drop to `partial`. Empty `Runtime` block ALWAYS means "installed, not yet observed" — the legacy audit `LastEvent` is only honored when the caller has no runtime store at all (the doctor command).
- `RuntimeEvidence` exposes `HasFreshHeartbeat` and `HasFreshRealEvent` derived booleans so the Overview tile cells render freshness, not raw timestamps. `HasEvidence` remains as the "did anything ever land" flag for first-time-vs-not prompts only.
- Dashboard `Server` gains a lazy `runtime.Store` handle, built off the audit DB the same way activity already is. `runtime.Open` is idempotent; nil-safe so test mocks without a `*sql.DB` still serve cleanly.
- `handleClaudeCodeHealth` now reads runtime evidence (last heartbeat, last real event + family, observed families, sessions and subagents observed, strongest coverage stage, missing installed families). Heartbeat sessions are excluded from the real-event rollup so `--emit-heartbeat` does not silently inflate the connection-truth view.
- Overview computes the same connection health inline so the page renders in one request. New tile sits between the hero numbers and Pipeline Health, color-coded by status. Copy reads "Installed, waiting for first observed event" / "Connected and observed" / "Last event is stale" — no alarmist language during install.
- Posture grade is suppressed in the hero ring AND on the Overview drill whenever the connection is `not_installed`, `disconnected`, or `partial`. Hero falls back to a "Posture (setup pending)" label and an inline note explains why a hard score is not shown yet. `ready` and `stale` keep the grade visible (`stale` represents real evidence within the StaleAfter window).

## What this slice does NOT touch

Per the rollout plan:

- No Sessions page changes (Phase 3C full).
- No Coverage drill-down changes (Phase 3C full).
- No Graph changes (Phase 3D).
- No Phase 4 Security Posture redesign — only the suppression rule gets touched.
- No `~/.claude/settings.json` edits.

## Tests

Acceptance criteria pinned by `internal/dashboard/connection_health_overview_test.go`:

- `TestOverview_NotInstalledShowsSetupPending` — empty $HOME, empty PATH; tile says "not detected", posture grade is suppressed.
- `TestOverview_HeartbeatFlipsTileToConnectedAndKeepsPosture` — runtime heartbeat row; tile says "Connected and observed"; posture grade visible.
- `TestOverview_HooksInstalledNoEventsShowsWaiting` — hook-installed fixture with no runtime rows; tile reads "Installed, waiting for first observed event"; "Critical security gaps detected" / "Deployment needs attention" copy is absent.
- `TestOverview_RealEventLiftsToProtectedCoverage` — runtime event with `CoverageMode: Protected`; tile shows Protected stage.
- `TestOverview_HeartbeatOnlyDoesNotCountAsRealEvent` — heartbeat row alone; tile shows `Heartbeat: received` plus `Real events: none yet` (heartbeat sessions excluded from the rollup).
- `TestOverview_VeryOldEventSuppressesPostureGrade` — 25h-old runtime event; status drops to `partial` past `StaleAfter`; posture grade suppressed even though `HasEvidence` is true.
- `TestOverview_StaleHeartbeatOnlySuppressesPostureGrade` — 30m-old heartbeat alone; status `partial`; posture grade suppressed.
- `TestOverview_VeryOldEventCellDoesNotSayObserved` — 25h-old runtime event; Real events cell reads "none recent", not "observed".
- `TestOverview_StaleHeartbeatCellDoesNotSayReceived` — 30m-old heartbeat; Heartbeat cell reads "none recent", not "received".
- `TestOverview_VeryOldProtectedEventHidesCoverageCell` — 25h-old PreToolUse with `CoverageMode: Protected`; Coverage cell is hidden entirely (no Protected badge in the tile region).

Pure-unit tests on `DeriveHealth` (`internal/connectors/claudecode/health_runtime_test.go`):

- `TestDeriveHealth_HeartbeatPromotesToReady` — heartbeat under 10m → ready.
- `TestDeriveHealth_StaleHeartbeatDoesNotPromote` — heartbeat over 10m → not ready.
- `TestDeriveHealth_RealEventPromotesToReady` — real event under 30m → ready.
- `TestDeriveHealth_InstalledNoEvidenceStaysPartial` — empty runtime → partial.
- `TestDeriveHealth_RuntimeEvidenceTrumpsAuditLastEvent` — runtime fresh trumps audit stale.
- `TestDeriveHealth_AuditLastEventStillWorksForLegacyCallers` — doctor path keeps audit fallback.
- `TestDeriveHealth_EmptyRuntimeIgnoresAuditLastEvent` — non-nil empty runtime overrides audit fallback.
- `TestDeriveHealth_NonFreshRuntimeEventIsStaleNotReady` — 31m-old event drops to stale, never ready.
- `TestDeriveHealth_VeryOldRuntimeEventIsPartial` — 25h-old event drops to partial.

## Test plan

- [x] `make build`
- [x] `make test` -- all packages green
- [x] `make vet`
- [x] `make lint` -- 0 issues
