### PR TITLE
Render runtime actors on the graph (root, subagents, tools)

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -3979,7 +3979,34 @@ func (s *Server) buildAgentRemap() map[string]string {
 	return remap
 }
 
+// buildGraph is the public entrypoint the dashboard handlers
+// call. Phase 3D adds a runtime-driven path on top of the
+// long-standing audit-driven legacy path; the decision tree is:
+//
+//   - runtime store wired AND has at least one row in the window:
+//     use the runtime graph, even if it projects to empty edges
+//     after the heartbeat filter. The dashboard explicitly
+//     prefers an empty runtime graph over an old audit row —
+//     a heartbeat-only state legitimately shows no traffic, and
+//     falling back to legacy would let phantom audit rows from
+//     before runtime existed resurrect a local-codex node.
+//   - runtime store unavailable, query failed, or no rows at
+//     all in the window: fall back to the legacy audit-driven
+//     graph so freshly upgraded installs and the existing test
+//     suite keep rendering.
 func (s *Server) buildGraph(since string) *graph.AgentGraph {
+	if g, ok := s.buildRuntimeGraph(since); ok {
+		return g
+	}
+	return s.buildLegacyGraph(since)
+}
+
+// buildLegacyGraph is the audit-driven graph that has been here
+// since v1. Renamed from the old buildGraph so the runtime path
+// can sit above it without changing its body. Preserves the
+// forward-proxy UnrepresentedRoutes projection and the gateway/
+// tool-name collapsing rules.
+func (s *Server) buildLegacyGraph(since string) *graph.AgentGraph {
 	edgeStats, _ := s.audit.QueryEdgeStats(since)
 
 	// Build a remap table: slugified agent names → config agent names.
@@ -4201,6 +4228,19 @@ func (s *Server) cachedBuildGraph(since string) *graph.AgentGraph {
 	s.graphCacheRange = since
 	s.graphCacheTime = time.Now()
 	return g
+}
+
+// invalidateGraphCache drops the cached graph so the next call
+// rebuilds. Tests reuse a single Server across multiple writes
+// + reads inside one second; without invalidating they would see
+// the same stale snapshot. Production callers do not need this
+// — the 10s window is short enough for live use.
+func (s *Server) invalidateGraphCache() {
+	s.graphMu.Lock()
+	defer s.graphMu.Unlock()
+	s.graphCache = nil
+	s.graphCacheRange = ""
+	s.graphCacheTime = time.Time{}
 }
 
 // dateOnly extracts the YYYY-MM-DD portion from an RFC3339 timestamp

--- a/internal/dashboard/regression_test.go
+++ b/internal/dashboard/regression_test.go
@@ -275,12 +275,27 @@ func TestRegression_SettingsToggleNoStaleSavedOnRedirect(t *testing.T) {
 // explicit role/client model that supersedes them.
 
 // TestRegression_GraphCodeIsClientAgnostic fails if a specific client display
-// name appears as a literal in the graph builder or template. Replace with a
-// capability lookup once the activity layer ships.
+// name OR a Claude-shaped event family literal appears in the graph builder,
+// the runtime-graph adapter, or the graph template. Replace with a capability
+// lookup once the activity layer ships.
+//
+// Phase 3D adds runtime_graph.go to the watched set and broadens the banned
+// substrings beyond "claude-code" to the per-event names ("PreToolUse",
+// "SubagentStart", etc.) — those belong in the runtime normalizer, not in
+// any code path that builds or renders the graph.
 func TestRegression_GraphCodeIsClientAgnostic(t *testing.T) {
 	files := []string{
 		"handlers.go",
 		"tmpl_graph.go",
+		"runtime_graph.go",
+	}
+	bannedLiterals := []string{
+		`"claude-code"`,
+		`'claude-code'`,
+		`"Claude Code"`,
+		`"SubagentStart"`,
+		`"PreToolUse"`,
+		`"PostToolUse"`,
 	}
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
@@ -290,18 +305,17 @@ func TestRegression_GraphCodeIsClientAgnostic(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read %s: %v", f, err)
 			}
-			// Graph code paths must remain client-agnostic: client identification
-			// belongs in the activity layer (Phase 1+), not in literal node names.
-			// Comments are exempt; only non-comment code lines are checked.
 			lines := strings.Split(data, "\n")
 			for i, line := range lines {
 				trimmed := strings.TrimSpace(line)
 				if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
 					continue
 				}
-				if strings.Contains(line, `"claude-code"`) || strings.Contains(line, `'claude-code'`) {
-					t.Errorf("%s:%d references a specific client name in non-comment code: %s",
-						f, i+1, strings.TrimSpace(line))
+				for _, lit := range bannedLiterals {
+					if strings.Contains(line, lit) {
+						t.Errorf("%s:%d references %s in non-comment code: %s",
+							f, i+1, lit, strings.TrimSpace(line))
+					}
 				}
 			}
 		})

--- a/internal/dashboard/runtime_graph.go
+++ b/internal/dashboard/runtime_graph.go
@@ -1,0 +1,399 @@
+package dashboard
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/graph"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtimeGraphTopTools caps the tool-node list the dashboard
+// renders. Mirrors the legacy buildGraph cap so the runtime
+// path does not flood the page with rare tools.
+const runtimeGraphTopTools = 5
+
+// buildRuntimeGraph projects the Phase 3 runtime tables into a
+// generic graph the dashboard can render. The graph package stays
+// client-agnostic; this file is the only place that knows about
+// runtime concepts (sessions, actors, hook events, lifecycle,
+// stage).
+//
+// Two distinct booleans are returned so the caller can pick the
+// right fallback policy:
+//
+//   - usable: true when the runtime store is wired AND has at
+//     least one row (real or heartbeat) in the window. The
+//     dashboard MUST trust this graph even when it is empty —
+//     a heartbeat-only state legitimately renders no edges, and
+//     falling back to legacy here would let an old audit row
+//     resurrect a phantom node the user explicitly does not
+//     want to see.
+//   - false: store unavailable, query failed, OR no rows at all
+//     in the window. The caller falls back to the legacy
+//     audit-driven graph so brand-new installs and the existing
+//     audit-only test suite keep rendering.
+//
+// Range filter is the same RFC3339 timestamp parseSinceRange
+// produces; passing "" means "all time".
+func (s *Server) buildRuntimeGraph(since string) (*graph.AgentGraph, bool) {
+	store := s.runtimeStore()
+	if store == nil {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sinceTime, _ := time.Parse(time.RFC3339, since)
+
+	events, err := store.QueryEvents(ctx, runtime.EventQuery{
+		Since: sinceTime,
+		Limit: 5000,
+	})
+	if err != nil {
+		s.logger.Warn("runtime graph: QueryEvents failed; falling back to legacy", "error", err)
+		return nil, false
+	}
+	if len(events) == 0 {
+		// No runtime evidence at all in the window. Caller
+		// falls back to legacy so pre-3B installs and existing
+		// fixtures keep rendering.
+		return nil, false
+	}
+
+	// Drop heartbeat-session rows from the projection. They are
+	// diagnostic and must never inflate the graph. The presence
+	// of heartbeat rows DID flip the usable=true return above,
+	// so a heartbeat-only window correctly produces an empty
+	// runtime graph (no fallback to legacy).
+	realEvents := events[:0]
+	for _, ev := range events {
+		if runtime.IsHeartbeatSession(ev.SessionID) {
+			continue
+		}
+		realEvents = append(realEvents, ev)
+	}
+
+	actors, err := store.QueryActors(ctx, runtime.ActorQuery{Limit: 5000})
+	if err != nil {
+		s.logger.Warn("runtime graph: QueryActors failed; falling back to legacy", "error", err)
+		return nil, false
+	}
+
+	return projectRuntimeGraph(realEvents, actors), true
+}
+
+// projectRuntimeGraph is the pure projection from runtime rows
+// into graph inputs. Pulled out of buildRuntimeGraph so tests can
+// exercise it without spinning up a Store.
+func projectRuntimeGraph(events []runtime.HookEvent, actors []runtime.Actor) *graph.AgentGraph {
+	actorByID := indexActors(actors)
+	agents, edgeStats, toolNodes, toolEdges := rollupRuntime(events, actorByID)
+	g := graph.BuildObserved(agents, edgeStats)
+	g.ToolNodes = toolNodes
+	g.ToolEdges = toolEdges
+	return g
+}
+
+// indexActors gives O(1) lookup by runtime actor id so the
+// edge/projection loops below do not pay an O(n^2) scan.
+func indexActors(actors []runtime.Actor) map[string]runtime.Actor {
+	out := make(map[string]runtime.Actor, len(actors))
+	for _, a := range actors {
+		out[a.ID] = a
+	}
+	return out
+}
+
+// rollupRuntime walks the events slice once and produces:
+//
+//   - agent metadata for every actor that sourced or received an event;
+//   - actor->actor edges (parent->child) keyed by event activity;
+//   - tool nodes + actor->tool edges deduped by (session, actor, use_id);
+//
+// The dedupe key handles Pre/Post pairs that share a tool_use_id;
+// when no use_id exists the helper falls back to counting only
+// pre-action events (or the first event in the bucket if no
+// pre-action exists) so the same call never doubles in the count.
+func rollupRuntime(events []runtime.HookEvent, actorByID map[string]runtime.Actor) ([]graph.AgentMeta, []graph.EdgeInput, []graph.ToolNode, []graph.ToolEdge) {
+	type edgeKey struct{ from, to string }
+	type toolEdgeKey struct{ agent, tool string }
+	type dedupeKey struct{ session, actor, useID string }
+
+	agentMeta := make(map[string]graph.AgentMeta)
+	edgeAgg := make(map[edgeKey]*graph.EdgeInput)
+	toolEdgeAgg := make(map[toolEdgeKey]int)
+	toolTotals := make(map[string]int)
+	dedupe := make(map[dedupeKey]bool)
+
+	displayLabel := func(actorID string) string {
+		a, ok := actorByID[actorID]
+		if !ok {
+			return fallbackActorLabel(actorID)
+		}
+		return runtimeActorDisplayName(a)
+	}
+	registerAgent := func(actorID string) {
+		name := displayLabel(actorID)
+		if _, ok := agentMeta[name]; ok {
+			return
+		}
+		kind := actorKind(actorID, actorByID)
+		agentMeta[name] = graph.AgentMeta{
+			Name:       name,
+			Kind:       kind,
+			CanMessage: []string{"*"}, // observed actors carry no ACL; wildcard avoids phantom shadow
+		}
+	}
+
+	for _, ev := range events {
+		if ev.ActorID == "" {
+			continue
+		}
+		registerAgent(ev.ActorID)
+		actorName := displayLabel(ev.ActorID)
+
+		// Actor->actor edge when the row points at a parent
+		// distinct from the actor itself. Missing parent rows
+		// fall back to the parent id so we never drop the edge.
+		if ev.ParentActorID != "" && ev.ParentActorID != ev.ActorID {
+			parentName := displayLabel(ev.ParentActorID)
+			registerAgent(ev.ParentActorID)
+			k := edgeKey{from: parentName, to: actorName}
+			if e, ok := edgeAgg[k]; ok {
+				e.Total++
+				accumulateOutcome(e, ev)
+			} else {
+				e := &graph.EdgeInput{From: parentName, To: actorName, Total: 1}
+				accumulateOutcome(e, ev)
+				edgeAgg[k] = e
+			}
+		}
+
+		// Tool node + tool edge. Dedupe so a Pre/Post pair never
+		// counts the same call twice. The dedupe scope is the
+		// (session, actor, use_id) tuple; without a use_id we fall
+		// back to counting only pre-action events so post-action
+		// alone or both stages never inflate.
+		if ev.ToolName == "" {
+			continue
+		}
+		stage := ev.Stage
+		if ev.ToolUseID != "" {
+			k := dedupeKey{session: ev.SessionID, actor: ev.ActorID, useID: ev.ToolUseID}
+			if dedupe[k] {
+				continue
+			}
+			dedupe[k] = true
+		} else if stage != runtime.StagePreAction {
+			// No use_id and post-action: skip so the matching
+			// pre-action (if any) is the row we count.
+			continue
+		}
+
+		toolName := stripGatewayNamespace(ev.ToolName)
+		toolEdgeAgg[toolEdgeKey{agent: actorName, tool: toolName}]++
+		toolTotals[toolName]++
+	}
+
+	// Materialise agents in deterministic order.
+	agents := make([]graph.AgentMeta, 0, len(agentMeta))
+	for _, a := range agentMeta {
+		agents = append(agents, a)
+	}
+	sort.Slice(agents, func(i, j int) bool { return agents[i].Name < agents[j].Name })
+
+	// Materialise edges.
+	edges := make([]graph.EdgeInput, 0, len(edgeAgg))
+	for _, e := range edgeAgg {
+		edges = append(edges, *e)
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		return edges[i].To < edges[j].To
+	})
+
+	// Top tools by total invocations (same cap as legacy graph).
+	type toolRank struct {
+		name  string
+		total int
+	}
+	ranked := make([]toolRank, 0, len(toolTotals))
+	for name, total := range toolTotals {
+		ranked = append(ranked, toolRank{name, total})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].total != ranked[j].total {
+			return ranked[i].total > ranked[j].total
+		}
+		return ranked[i].name < ranked[j].name
+	})
+	topTools := make(map[string]bool)
+	toolNodes := make([]graph.ToolNode, 0, runtimeGraphTopTools)
+	for _, r := range ranked {
+		if len(toolNodes) >= runtimeGraphTopTools {
+			break
+		}
+		topTools[r.name] = true
+		toolNodes = append(toolNodes, graph.ToolNode{Name: r.name, Total: r.total})
+	}
+
+	toolEdges := make([]graph.ToolEdge, 0, len(toolEdgeAgg))
+	for k, total := range toolEdgeAgg {
+		if !topTools[k.tool] {
+			continue
+		}
+		toolEdges = append(toolEdges, graph.ToolEdge{Agent: k.agent, Tool: k.tool, Total: total})
+	}
+	sort.Slice(toolEdges, func(i, j int) bool {
+		if toolEdges[i].Agent != toolEdges[j].Agent {
+			return toolEdges[i].Agent < toolEdges[j].Agent
+		}
+		return toolEdges[i].Tool < toolEdges[j].Tool
+	})
+
+	return agents, edges, toolNodes, toolEdges
+}
+
+// accumulateOutcome maps the per-event policy decision and status
+// onto the EdgeInput counters. Generic rule:
+//
+//   - status=blocked OR policy_decision in {block, deny} → Blocked
+//   - status=quarantined → Quarantined
+//   - status=rejected → Rejected
+//   - everything else (allow, delivered, empty) → Delivered
+//
+// Total is bumped by the caller; this helper only fills the
+// per-status buckets so the final HealthScore reflects the mix.
+func accumulateOutcome(e *graph.EdgeInput, ev runtime.HookEvent) {
+	switch strings.ToLower(ev.Status) {
+	case "blocked":
+		e.Blocked++
+		return
+	case "quarantined":
+		e.Quarantined++
+		return
+	case "rejected":
+		e.Rejected++
+		return
+	}
+	switch strings.ToLower(ev.PolicyDecision) {
+	case "block", "deny":
+		e.Blocked++
+		return
+	}
+	e.Delivered++
+}
+
+// runtimeActorDisplayName picks the operator-visible name for one
+// runtime actor. Generic rule:
+//
+//   - root: actor.PrincipalID (the resolved client identity),
+//     falling back to actor.Label only when no principal is set.
+//     The Phase 3A normalizer wrote a "root (clientID)" wrapper
+//     label that is too long for a graph node; the principal
+//     id is the canonical short form.
+//   - subagent: subagent/<label-or-id-tail>
+//   - task: task/<label-or-id-tail>
+//   - other: actor/<id-tail>
+//
+// PrincipalID is only used as the root node label here. Subagent
+// and task nodes never reuse the principal — actor metadata
+// drives those names so the policy identity (one per session)
+// stays distinct from the runtime actor (many per session).
+func runtimeActorDisplayName(a runtime.Actor) string {
+	switch a.Kind {
+	case runtime.ActorKindRoot:
+		if a.PrincipalID != "" {
+			return a.PrincipalID
+		}
+		if a.Label != "" {
+			return a.Label
+		}
+		return fallbackActorLabel(a.ID)
+	case runtime.ActorKindSubagent:
+		return "subagent/" + nonEmpty(a.Label, actorIDTail(a.ID))
+	case runtime.ActorKindTask:
+		return "task/" + nonEmpty(a.Label, actorIDTail(a.ID))
+	default:
+		return "actor/" + actorIDTail(a.ID)
+	}
+}
+
+// fallbackActorLabel handles the edge case where rollupRuntime
+// references an actor row that QueryActors did not return (e.g. a
+// timing window or a row trimmed by the limit). The fallback
+// keeps the node in a reasonable bucket so the parent edge does
+// not vanish; for a root id we keep the literal "root" because
+// no principal id is available in this branch (the actor row
+// itself is what would have carried it).
+func fallbackActorLabel(actorID string) string {
+	if actorID == "" {
+		return "unknown"
+	}
+	if strings.HasSuffix(actorID, ":root") {
+		return "root"
+	}
+	if strings.Contains(actorID, ":subagent:") || strings.Contains(actorID, ":subagent-type:") {
+		return "subagent/" + actorIDTail(actorID)
+	}
+	if strings.Contains(actorID, ":task:") {
+		return "task/" + actorIDTail(actorID)
+	}
+	return "actor/" + actorIDTail(actorID)
+}
+
+// actorKind reads the Kind from the indexed actor when present,
+// otherwise infers from the id pattern. Used by registerAgent to
+// stamp the AgentMeta.Kind that ends up on graph.Node.
+func actorKind(actorID string, actors map[string]runtime.Actor) string {
+	if a, ok := actors[actorID]; ok && a.Kind != "" {
+		return a.Kind
+	}
+	switch {
+	case strings.HasSuffix(actorID, ":root"):
+		return runtime.ActorKindRoot
+	case strings.Contains(actorID, ":subagent:"), strings.Contains(actorID, ":subagent-type:"):
+		return runtime.ActorKindSubagent
+	case strings.Contains(actorID, ":task:"):
+		return runtime.ActorKindTask
+	}
+	return runtime.ActorKindUnknown
+}
+
+// actorIDTail returns the trailing component of a structured
+// actor id (everything after the last colon). Used so subagent
+// labels read "subagent/sa-1" instead of leaking the full
+// session-prefixed id.
+func actorIDTail(id string) string {
+	if id == "" {
+		return ""
+	}
+	if i := strings.LastIndex(id, ":"); i >= 0 && i < len(id)-1 {
+		return id[i+1:]
+	}
+	return id
+}
+
+// nonEmpty picks the first non-empty argument. Local helper to
+// keep the display-name switches readable.
+func nonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// stripGatewayNamespace mirrors the legacy graph behavior: tool
+// names like "mcp__oktsec-gateway__Read" render as "Read" so the
+// runtime and audit paths display the same node name.
+func stripGatewayNamespace(name string) string {
+	if i := strings.LastIndex(name, "__"); i >= 0 && i < len(name)-2 {
+		return name[i+2:]
+	}
+	return name
+}

--- a/internal/dashboard/runtime_graph_test.go
+++ b/internal/dashboard/runtime_graph_test.go
@@ -1,0 +1,373 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// newRuntimeGraphTestServer wires a Server backed by a real
+// audit + runtime store so the buildGraph decision tree picks
+// the runtime path. Returns the server, the runtime store, the
+// audit store (so the test can Flush between writes), and a
+// helper closure that posts a hook-event JSON directly into
+// runtime via Normalize+RecordHook (bypasses the hook handler
+// for hermetic seeding).
+func newRuntimeGraphTestServer(t *testing.T) (*Server, *runtime.Store, *audit.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	auditStore, err := audit.NewStore(filepath.Join(dir, "test.db"), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = auditStore.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 0},
+		DBPath:  filepath.Join(dir, "test.db"),
+		Agents:  map[string]config.Agent{},
+	}
+	srv := NewServer(cfg, filepath.Join(dir, "oktsec.yaml"), auditStore, identity.NewKeyStore(), sharedScanner, logger)
+	rs := srv.runtimeStore()
+	if rs == nil {
+		t.Fatal("expected runtime store to auto-build")
+	}
+	return srv, rs, auditStore
+}
+
+// seedRuntimeEvent posts one normalized event into the runtime
+// store. Tests use this instead of the hook handler so the
+// seeded payload directly drives the runtime tables without
+// audit + activity contention.
+func seedRuntimeEvent(t *testing.T, rs *runtime.Store, body string, sessionID string, principalID string, ts time.Time, outcome runtime.OutcomeRefs) {
+	t.Helper()
+	env, err := runtime.Normalize([]byte(body), runtime.IdentityResolution{
+		PrincipalID: principalID,
+		ClientID:    "local-codex",
+		SessionID:   sessionID,
+	}, ts)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if err := rs.RecordHook(context.Background(), env, outcome); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+}
+
+func graphResponse(t *testing.T, srv *Server, cookie *http.Cookie, handler http.Handler, rng string) map[string]any {
+	t.Helper()
+	url := "/dashboard/api/graph"
+	if rng != "" {
+		url += "?range=" + rng
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	return out
+}
+
+func nodeNames(g map[string]any) []string {
+	out := []string{}
+	if nodes, ok := g["nodes"].([]any); ok {
+		for _, n := range nodes {
+			if m, ok := n.(map[string]any); ok {
+				if name, _ := m["name"].(string); name != "" {
+					out = append(out, name)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func edgeKeys(g map[string]any) []string {
+	out := []string{}
+	if edges, ok := g["edges"].([]any); ok {
+		for _, e := range edges {
+			if m, ok := e.(map[string]any); ok {
+				from, _ := m["from"].(string)
+				to, _ := m["to"].(string)
+				out = append(out, from+"->"+to)
+			}
+		}
+	}
+	return out
+}
+
+func toolEdgeKeys(g map[string]any) []string {
+	out := []string{}
+	if edges, ok := g["tool_edges"].([]any); ok {
+		for _, e := range edges {
+			if m, ok := e.(map[string]any); ok {
+				agent, _ := m["agent"].(string)
+				tool, _ := m["tool"].(string)
+				total := 0
+				if t, ok := m["total"].(float64); ok {
+					total = int(t)
+				}
+				out = append(out, agent+"->"+tool+":"+strItoa(total))
+			}
+		}
+	}
+	return out
+}
+
+func strItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + strItoa(-n)
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// TestRuntimeGraph_RootToolCall — root-only tool call shows
+// local-codex -> Read in the runtime graph.
+func TestRuntimeGraph_RootToolCall(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-root"}`,
+		"sess-root", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-root","tool_name":"Read","tool_use_id":"u1"}`,
+		"sess-root", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	nodes := strings.Join(nodeNames(g), ",")
+	if !strings.Contains(nodes, "local-codex") {
+		t.Errorf("expected local-codex node; got %s", nodes)
+	}
+	tools := strings.Join(toolEdgeKeys(g), ",")
+	if !strings.Contains(tools, "local-codex->Read:1") {
+		t.Errorf("expected tool edge local-codex->Read:1; got %s", tools)
+	}
+}
+
+// TestRuntimeGraph_SubagentToolCall — root + subagent + tool
+// chain renders as root -> subagent/research -> Read.
+func TestRuntimeGraph_SubagentToolCall(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-sub"}`,
+		"sess-sub", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-sub","agent_id":"sa-1","agent_type":"research"}`,
+		"sess-sub", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-sub","agent_id":"sa-1","agent_type":"research","tool_name":"Read","tool_use_id":"u2"}`,
+		"sess-sub", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	edges := strings.Join(edgeKeys(g), ",")
+	tools := strings.Join(toolEdgeKeys(g), ",")
+	if !strings.Contains(edges, "local-codex->subagent/research") {
+		t.Errorf("expected actor edge local-codex->subagent/research; got edges=%s", edges)
+	}
+	if !strings.Contains(tools, "subagent/research->Read:1") {
+		t.Errorf("expected tool edge subagent/research->Read:1; got tools=%s", tools)
+	}
+}
+
+// TestRuntimeGraph_LazySubagentKeepsParent — even when the only
+// event is a tool call from a subagent (no SubagentStart), the
+// inferred root + subagent + tool render.
+func TestRuntimeGraph_LazySubagentKeepsParent(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-lazy","agent_id":"sa-late","agent_type":"investigator","tool_name":"Bash","tool_use_id":"u3"}`,
+		"sess-lazy", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	edges := strings.Join(edgeKeys(g), ",")
+	tools := strings.Join(toolEdgeKeys(g), ",")
+	if !strings.Contains(edges, "->subagent/investigator") {
+		t.Errorf("expected actor edge ending in subagent/investigator; got edges=%s", edges)
+	}
+	if !strings.Contains(tools, "subagent/investigator->Bash:1") {
+		t.Errorf("expected tool edge subagent/investigator->Bash:1; got tools=%s", tools)
+	}
+}
+
+// TestRuntimeGraph_HeartbeatOnlyDoesNotFallbackToLegacy seeds a
+// heartbeat in runtime AND a legacy audit row that would render
+// as local-codex -> list_agents under the audit-driven graph.
+// The runtime path must short-circuit the legacy fallback so the
+// audit-side phantom never resurfaces.
+func TestRuntimeGraph_HeartbeatOnlyDoesNotFallbackToLegacy(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Heartbeat event in runtime — filtered before projection.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-graph"}`,
+		"heartbeat-2026-graph", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{})
+	// Legacy audit row that the old graph would surface.
+	auditStore.Log(audit.Entry{
+		ID:             "legacy-1",
+		Timestamp:      now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent:      "local-codex",
+		ToAgent:        "list_agents",
+		Status:         "delivered",
+		PolicyDecision: "allow",
+	})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	for _, key := range edgeKeys(g) {
+		if key == "local-codex->list_agents" {
+			t.Errorf("legacy audit edge resurfaced under heartbeat-only runtime: %v", edgeKeys(g))
+		}
+	}
+}
+
+// TestRuntimeGraph_DedupesPreAndPostToolUse — Pre+Post events
+// sharing a tool_use_id must produce one tool edge with total 1.
+func TestRuntimeGraph_DedupesPreAndPostToolUse(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-dedupe","tool_name":"Read","tool_use_id":"shared-1"}`,
+		"sess-dedupe", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PostToolUse","session_id":"sess-dedupe","tool_name":"Read","tool_use_id":"shared-1","tool_response":"ok"}`,
+		"sess-dedupe", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	tools := toolEdgeKeys(g)
+	for _, key := range tools {
+		if strings.HasPrefix(key, "local-codex->Read:") && key != "local-codex->Read:1" {
+			t.Errorf("tool edge total != 1 for deduped Pre/Post pair: %s", key)
+		}
+	}
+}
+
+// TestRuntimeGraph_DoesNotCreateShadowEdgesForActorHierarchy —
+// observed root->subagent must NOT appear in shadow_edges.
+// Actor hierarchy is not policy ACL.
+func TestRuntimeGraph_DoesNotCreateShadowEdgesForActorHierarchy(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-shadow"}`,
+		"sess-shadow", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-shadow","agent_id":"sa-2","agent_type":"explorer"}`,
+		"sess-shadow", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	if shadow, ok := g["shadow_edges"].([]any); ok && len(shadow) > 0 {
+		t.Errorf("ShadowEdges non-empty for runtime actor hierarchy: %v", shadow)
+	}
+}
+
+// TestRuntimeGraph_RangeFilter — an event 2h ago must NOT
+// appear in the 1h window but MUST appear in the 6h window.
+func TestRuntimeGraph_RangeFilter(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-range","tool_name":"Read","tool_use_id":"r1"}`,
+		"sess-range", "local-codex", now.Add(-2*time.Hour), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g1h := graphResponse(t, srv, cookie, handler, "1h")
+	if strings.Contains(strings.Join(toolEdgeKeys(g1h), ","), "local-codex->Read") {
+		t.Errorf("event from 2h ago leaked into 1h window: %v", toolEdgeKeys(g1h))
+	}
+
+	srv.invalidateGraphCache()
+	g6h := graphResponse(t, srv, cookie, handler, "6h")
+	if !strings.Contains(strings.Join(toolEdgeKeys(g6h), ","), "local-codex->Read") {
+		t.Errorf("event from 2h ago missing from 6h window: %v", toolEdgeKeys(g6h))
+	}
+}
+
+// TestRuntimeGraph_NoRawPayloadInJSON — the JSON response must
+// not contain raw tool input/output strings; only hashes are
+// allowed off the persisted runtime row.
+func TestRuntimeGraph_NoRawPayloadInJSON(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-redact","tool_name":"Bash","tool_use_id":"r2","tool_input":{"command":"echo SUPER_SECRET"}}`,
+		"sess-redact", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	req := httptest.NewRequest("GET", "/dashboard/api/graph?range=1h", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	body := w.Body.String()
+	if strings.Contains(body, "SUPER_SECRET") {
+		t.Errorf("graph JSON leaks raw tool input: %s", body)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -8,12 +8,20 @@ import (
 )
 
 // AgentMeta describes an agent from config (decoupled from config.Agent).
+//
+// Kind is a generic node-shape hint: "root", "subagent", "task", or
+// empty for the legacy agent-from-config case. The graph package
+// stays client-agnostic — Kind values are descriptive labels the
+// dashboard maps to display styles, not policy categories. Adding
+// a new Kind here must NOT introduce knowledge of any specific
+// client (e.g. "claude-code").
 type AgentMeta struct {
 	Name        string
 	Description string
 	Location    string
 	Tags        []string
 	CanMessage  []string
+	Kind        string
 }
 
 // EdgeInput describes observed traffic on a single from→to edge.
@@ -29,11 +37,16 @@ type EdgeInput struct {
 }
 
 // Node is a computed graph node with metrics.
+//
+// Kind mirrors AgentMeta.Kind so the dashboard can pick a render
+// style ("subagent" gets a different shape from "root") without
+// re-deriving the kind from name patterns.
 type Node struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description,omitempty"`
 	Location    string   `json:"location,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
+	Kind        string   `json:"kind,omitempty"`
 	InDegree    int      `json:"in_degree"`
 	OutDegree   int      `json:"out_degree"`
 	Betweenness float64  `json:"betweenness"`
@@ -111,33 +124,65 @@ type AgentGraph struct {
 	TotalEdges          int                  `json:"total_edges"`
 }
 
-// Build constructs the full agent interaction graph from config agents and observed edges.
+// BuildOptions controls how Build assembles the graph. CompareACL
+// gates the ACL/shadow/unused projection: callers that hand in
+// observed runtime evidence (actor hierarchy, tool calls) must
+// turn it off because actor parent-child relationships are not
+// authorization edges and treating them as such produces phantom
+// shadow edges and "unused ACL" rows in the dashboard.
+type BuildOptions struct {
+	CompareACL bool
+}
+
+// Build constructs the full agent interaction graph from config
+// agents and observed edges. Equivalent to BuildWithOptions with
+// CompareACL=true; kept as the legacy convenience entrypoint for
+// the audit-driven path.
 func Build(agents []AgentMeta, edges []EdgeInput) *AgentGraph {
+	return BuildWithOptions(agents, edges, BuildOptions{CompareACL: true})
+}
+
+// BuildObserved is the runtime-evidence entrypoint: it assembles
+// the same node/edge metrics but skips the ACL comparison so
+// observed actor hierarchy never lands in ShadowEdges or
+// UnusedACL. Use it whenever the input edges describe runtime
+// behavior (actor parent links, tool calls) rather than a policy
+// graph.
+func BuildObserved(agents []AgentMeta, edges []EdgeInput) *AgentGraph {
+	return BuildWithOptions(agents, edges, BuildOptions{CompareACL: false})
+}
+
+// BuildWithOptions is the explicit constructor. The two named
+// variants above route to it so the option-bearing path is the
+// single place to evolve the build pipeline.
+func BuildWithOptions(agents []AgentMeta, edges []EdgeInput, opts BuildOptions) *AgentGraph {
 	nodeMap := buildNodeSet(agents, edges)
 	computed := buildEdges(edges)
 	computeDegrees(nodeMap, computed)
 	computeBetweenness(nodeMap, computed)
 	computeThreatScores(nodeMap, edges)
-	aclEdges, shadowEdges, unusedACL := compareACL(agents, edges)
+
+	g := &AgentGraph{
+		Edges:      computed,
+		TotalEdges: len(computed),
+	}
+	if opts.CompareACL {
+		g.ACLEdges, g.ShadowEdges, g.UnusedACL = compareACL(agents, edges)
+	}
 
 	nodes := make([]Node, 0, len(nodeMap))
 	for _, n := range nodeMap {
 		nodes = append(nodes, *n)
 	}
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
-
-	return &AgentGraph{
-		Nodes:       nodes,
-		Edges:       computed,
-		ACLEdges:    aclEdges,
-		ShadowEdges: shadowEdges,
-		UnusedACL:   unusedACL,
-		TotalNodes:  len(nodes),
-		TotalEdges:  len(computed),
-	}
+	g.Nodes = nodes
+	g.TotalNodes = len(nodes)
+	return g
 }
 
 // buildNodeSet merges config agents with agents seen in edges.
+// Nodes from edges that did not appear in agents inherit no
+// Kind; the dashboard renders them as the default agent style.
 func buildNodeSet(agents []AgentMeta, edges []EdgeInput) map[string]*Node {
 	nodeMap := make(map[string]*Node)
 	for _, a := range agents {
@@ -146,6 +191,7 @@ func buildNodeSet(agents []AgentMeta, edges []EdgeInput) map[string]*Node {
 			Description: a.Description,
 			Location:    a.Location,
 			Tags:        a.Tags,
+			Kind:        a.Kind,
 			Betweenness: -1,
 		}
 	}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -2,6 +2,63 @@ package graph
 
 import "testing"
 
+// TestBuildObserved_SkipsACLProjection locks in the runtime
+// path's contract: BuildObserved must not produce ACLEdges,
+// ShadowEdges, or UnusedACL. Actor hierarchy is not authorization
+// — passing parent->child runtime edges through compareACL would
+// fabricate phantom shadow rows and "unused ACL" entries that
+// confuse the dashboard's Unmonitored Routes view.
+func TestBuildObserved_SkipsACLProjection(t *testing.T) {
+	agents := []AgentMeta{
+		{Name: "root", Kind: "root"},
+		{Name: "subagent/research", Kind: "subagent"},
+	}
+	edges := []EdgeInput{
+		{From: "root", To: "subagent/research", Delivered: 3, Total: 3},
+	}
+	g := BuildObserved(agents, edges)
+	if len(g.ACLEdges) != 0 {
+		t.Errorf("ACLEdges = %d, want 0 for BuildObserved", len(g.ACLEdges))
+	}
+	if len(g.ShadowEdges) != 0 {
+		t.Errorf("ShadowEdges = %d, want 0 for BuildObserved (root->subagent must not phantom-shadow)", len(g.ShadowEdges))
+	}
+	if len(g.UnusedACL) != 0 {
+		t.Errorf("UnusedACL = %d, want 0 for BuildObserved", len(g.UnusedACL))
+	}
+	// Sanity: nodes + edges + Kind passthrough still work.
+	if g.TotalNodes != 2 || g.TotalEdges != 1 {
+		t.Errorf("nodes=%d edges=%d, want 2 + 1", g.TotalNodes, g.TotalEdges)
+	}
+	for _, n := range g.Nodes {
+		if n.Name == "subagent/research" && n.Kind != "subagent" {
+			t.Errorf("subagent node Kind = %q, want subagent", n.Kind)
+		}
+	}
+}
+
+// TestBuild_LegacyStillRunsACLProjection guards the audit-side
+// path: the original Build entrypoint must keep running compareACL
+// so existing dashboard rendering of UnusedACL and ShadowEdges
+// stays intact.
+func TestBuild_LegacyStillRunsACLProjection(t *testing.T) {
+	agents := []AgentMeta{
+		{Name: "alice", CanMessage: []string{"bob"}},
+		{Name: "bob"},
+		{Name: "eve"},
+	}
+	edges := []EdgeInput{
+		{From: "alice", To: "eve", Delivered: 2, Total: 2}, // not in ACL
+	}
+	g := Build(agents, edges)
+	if len(g.ACLEdges) == 0 {
+		t.Error("ACLEdges empty under legacy Build")
+	}
+	if len(g.ShadowEdges) == 0 {
+		t.Error("ShadowEdges empty under legacy Build (alice->eve must shadow)")
+	}
+}
+
 func TestBuild_BasicGraph(t *testing.T) {
 	agents := []AgentMeta{
 		{Name: "a", Description: "Agent A", CanMessage: []string{"b", "c"}},


### PR DESCRIPTION
## Summary

Closes the original Phase 3 bug: `/dashboard/graph` collapsed every session into one `local-codex` node and one tool edge. The runtime tables already carry the actor hierarchy; this slice adds the projection that turns them into the graph nodes and edges the dashboard renders.

The graph package stays client-agnostic. `internal/dashboard/runtime_graph.go` is the only place that knows about runtime concepts (sessions, actors, hook events, lifecycle, stage). The regression test that bans client-name literals in graph code now also covers `runtime_graph.go` and broadens its banned list to include Claude-shaped event family names.

## Changes

**`internal/graph`** — additive, backwards-compatible:

- `AgentMeta.Kind` and `Node.Kind` (descriptive node-shape hints, never client-specific).
- `BuildOptions{ CompareACL bool }`, `BuildWithOptions(...)`, `BuildObserved(...)`. `Build(...)` keeps the legacy `CompareACL: true` semantics. The runtime path uses `BuildObserved` so observed root->subagent edges never land in `ShadowEdges` or `UnusedACL` — actor hierarchy is not authorization.

**`internal/dashboard/runtime_graph.go`** (new):

- `buildRuntimeGraph(since)` queries `QueryActors` + `QueryEvents`, drops heartbeat sessions, projects actors to `AgentMeta` with the right `Kind`, rolls events into actor->actor edges plus actor->tool edges. Returns `(graph, usable bool)` — `usable=true` means runtime is wired AND has at least one row in the window, so a heartbeat-only state correctly renders no edges instead of falling back to a stale audit row.
- `projectRuntimeGraph` is the pure projection (no I/O) so tests can exercise the rollup directly.
- Display name rules: root = `PrincipalID` (fallback `Label`); subagent = `subagent/<label-or-id-tail>`; task = `task/<label-or-id-tail>`. Principal id is never reused for child actors.
- Tool edges dedupe Pre/Post pairs by `tool_use_id`. Events without a use_id fall back to counting only pre-action so post-action alone or mixed pairs still produce one edge.
- `accumulateOutcome` maps `status` / `policy_decision` to the existing delivered/blocked/quarantined/rejected counters generically.

**`internal/dashboard/handlers.go`** — `buildGraph` splits in two:

- `buildGraph(since)` — decision tree. If runtime is `usable`, return runtime graph. Else legacy.
- `buildLegacyGraph(since)` — long-standing audit-driven path, renamed and otherwise unchanged. Forward-proxy `UnrepresentedRoutes`, gateway/ tool-name collapsing, and tool-stat ranking are all preserved.

`invalidateGraphCache()` exposed for tests so seeded writes between graph queries skip the 10s render cache.

## What this slice does NOT touch

- No Sessions page changes.
- No Coverage drill-down changes.
- No graph template / UI redesign — the existing nodes/edges/tool_nodes/tool_edges keys are reused.
- No Phase 4 Security Posture changes.
- No `~/.claude/settings.json` edits.

## Tests

Acceptance gates from the spec, all in `internal/dashboard/runtime_graph_test.go`:

- `TestRuntimeGraph_RootToolCall` — root-only tool call shows `local-codex -> Read`.
- `TestRuntimeGraph_SubagentToolCall` — root + subagent + tool chain renders as `local-codex -> subagent/research -> Read`.
- `TestRuntimeGraph_LazySubagentKeepsParent` — only event is a tool call from a subagent; inferred root + subagent + tool all render.
- `TestRuntimeGraph_HeartbeatOnlyDoesNotFallbackToLegacy` — heartbeat in runtime + legacy audit row; runtime path short-circuits the legacy fallback.
- `TestRuntimeGraph_DedupesPreAndPostToolUse` — tool edge total is 1 for a Pre/Post pair sharing `tool_use_id`.
- `TestRuntimeGraph_DoesNotCreateShadowEdgesForActorHierarchy` — observed root->subagent never lands in `ShadowEdges`.
- `TestRuntimeGraph_RangeFilter` — event 2h ago absent from 1h window, present in 6h.
- `TestRuntimeGraph_NoRawPayloadInJSON` — graph response carries no raw tool input / output strings.

Plus at the graph package:

- `TestBuildObserved_SkipsACLProjection` — `BuildObserved` produces no `ACLEdges` / `ShadowEdges` / `UnusedACL`.
- `TestBuild_LegacyStillRunsACLProjection` — `Build` keeps the audit-side ACL projection intact.

`TestRegression_GraphCodeIsClientAgnostic` extended to cover `runtime_graph.go` and to ban `"Claude Code"`, `"PreToolUse"`, `"PostToolUse"`, `"SubagentStart"` literals in graph-related files.

## Test plan

- [x] `make build`
- [x] `make test` — all packages green
- [x] `make vet`
- [x] `make lint` — 0 issues