### PR TITLE
Align graph stats and auto-widen with runtime projection

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1172,9 +1172,11 @@ func (s *Server) handleAPIRecent(w http.ResponseWriter, r *http.Request) {
 // range query param mirrors handleGraph so a 1h canvas reads 1h
 // stats.
 //
-// blocks is intentionally summed only over Edges + UnrepresentedRoutes:
-// ToolEdge has no block counter today, so reporting tool blocks
-// would require inventing data the runtime does not carry.
+// messages and blocks come from g.ActivityEvents / g.ActivityBlocks,
+// the projection-level unique counters. Summing g.Edges + g.ToolEdges
+// would double-count any source row that drives both an actor->actor
+// edge and an actor->tool edge in the same projection (e.g. a
+// PreToolUse from a subagent: one event, two edge layers).
 func (s *Server) handleAPIGraphStats(w http.ResponseWriter, r *http.Request) {
 	rangeStr := r.URL.Query().Get("range")
 	if rangeStr == "" {
@@ -1187,17 +1189,8 @@ func (s *Server) handleAPIGraphStats(w http.ResponseWriter, r *http.Request) {
 	if g != nil {
 		agents = len(g.Nodes)
 		tools = len(g.ToolNodes)
-		for _, e := range g.Edges {
-			messages += e.Total
-			blocks += e.Blocked
-		}
-		for _, te := range g.ToolEdges {
-			messages += te.Total
-		}
-		for _, u := range g.UnrepresentedRoutes {
-			messages += u.Total
-			blocks += u.Blocked
-		}
+		messages = g.ActivityEvents
+		blocks = g.ActivityBlocks
 	}
 	s.renderJSON(w, map[string]int{
 		"agents":   agents,
@@ -4248,6 +4241,21 @@ func (s *Server) buildLegacyGraph(since string) *graph.AgentGraph {
 		if topTools[k.tool] {
 			g.ToolEdges = append(g.ToolEdges, graph.ToolEdge{Agent: k.agent, Tool: k.tool, Total: total})
 		}
+	}
+
+	// Activity counters for the legacy path. Each audit row already
+	// lands in exactly one of {Edge, UnrepresentedRoute}; tool stats
+	// are a separate aggregation over the same rows, so summing tool
+	// edges here would double-count. Self-message rows the legacy
+	// builder drops (from == to) are intentionally not counted —
+	// they would not appear in the canvas either.
+	for _, e := range g.Edges {
+		g.ActivityEvents += e.Total
+		g.ActivityBlocks += e.Blocked
+	}
+	for _, u := range g.UnrepresentedRoutes {
+		g.ActivityEvents += u.Total
+		g.ActivityBlocks += u.Blocked
 	}
 
 	return g

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1164,24 +1164,62 @@ func (s *Server) handleAPIRecent(w http.ResponseWriter, r *http.Request) {
 	s.renderTemplate(w, recentPartialTmpl, recent)
 }
 
+// handleAPIGraphStats derives the four hero counters from the same
+// graph the canvas renders. Reading from cfg.Agents / cfg.MCPServers
+// or audit.QueryStats() would let the cards diverge from the canvas
+// (e.g. runtime is heartbeat-only but cards still show legacy audit
+// totals, or agents=0/tools=0 while the canvas paints nodes). The
+// range query param mirrors handleGraph so a 1h canvas reads 1h
+// stats.
+//
+// blocks is intentionally summed only over Edges + UnrepresentedRoutes:
+// ToolEdge has no block counter today, so reporting tool blocks
+// would require inventing data the runtime does not carry.
 func (s *Server) handleAPIGraphStats(w http.ResponseWriter, r *http.Request) {
-	sc, _ := s.audit.QueryStats()
-	agentCount := len(s.cfg.Agents)
-	toolCount := 0
-	for range s.cfg.MCPServers {
-		toolCount++
+	rangeStr := r.URL.Query().Get("range")
+	if rangeStr == "" {
+		rangeStr = "24h"
 	}
-	total, blocked := 0, 0
-	if sc != nil {
-		total = sc.Total
-		blocked = sc.Blocked
+	since := parseSinceRange(rangeStr)
+	g := s.cachedBuildGraph(since)
+
+	agents, tools, messages, blocks := 0, 0, 0, 0
+	if g != nil {
+		agents = len(g.Nodes)
+		tools = len(g.ToolNodes)
+		for _, e := range g.Edges {
+			messages += e.Total
+			blocks += e.Blocked
+		}
+		for _, te := range g.ToolEdges {
+			messages += te.Total
+		}
+		for _, u := range g.UnrepresentedRoutes {
+			messages += u.Total
+			blocks += u.Blocked
+		}
 	}
 	s.renderJSON(w, map[string]int{
-		"agents":   agentCount,
-		"tools":    toolCount,
-		"messages": total,
-		"blocks":   blocked,
+		"agents":   agents,
+		"tools":    tools,
+		"messages": messages,
+		"blocks":   blocks,
 	})
+}
+
+// graphHasTraffic returns true when the graph carries any observed
+// activity in the current window. TotalEdges only measures
+// actor-to-actor edges, so a root-only tool call (no actor edge,
+// just a ToolEdge) registers TotalEdges == 0 even though the
+// dashboard has real traffic to render. UnrepresentedRoutes covers
+// forward-proxy / non-agent endpoints the legacy graph captures.
+func graphHasTraffic(g *graph.AgentGraph) bool {
+	if g == nil {
+		return false
+	}
+	return len(g.Edges) > 0 ||
+		len(g.ToolEdges) > 0 ||
+		len(g.UnrepresentedRoutes) > 0
 }
 
 func (s *Server) handleAPIGraphTables(w http.ResponseWriter, r *http.Request) {
@@ -4280,13 +4318,16 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 	since := parseSinceRange(rangeStr)
 	g := s.cachedBuildGraph(since)
 	// When the user did not pin a window, auto-widen so a quiet day does not
-	// render as an empty graph — walk up to 7d, then 30d if needed.
-	if !explicit && g != nil && g.TotalEdges == 0 {
+	// render as an empty graph — walk up to 7d, then 30d if needed. Use
+	// graphHasTraffic instead of TotalEdges so a window with only tool calls
+	// (e.g. a root issuing a single Read with no actor->actor edge) is treated
+	// as populated, not empty.
+	if !explicit && !graphHasTraffic(g) {
 		for _, fallback := range []string{"7d", "30d"} {
 			since = parseSinceRange(fallback)
 			g = s.cachedBuildGraph(since)
 			rangeStr = fallback
-			if g != nil && g.TotalEdges > 0 {
+			if graphHasTraffic(g) {
 				break
 			}
 		}

--- a/internal/dashboard/runtime_graph.go
+++ b/internal/dashboard/runtime_graph.go
@@ -111,22 +111,37 @@ func indexActors(actors []runtime.Actor) map[string]runtime.Actor {
 //
 //   - agent metadata for every actor that sourced or received an event;
 //   - actor->actor edges (parent->child) keyed by event activity;
-//   - tool nodes + actor->tool edges deduped by (session, actor, use_id);
+//   - tool nodes + actor->tool edges deduped per call.
 //
-// The dedupe key handles Pre/Post pairs that share a tool_use_id;
-// when no use_id exists the helper falls back to counting only
-// pre-action events (or the first event in the bucket if no
-// pre-action exists) so the same call never doubles in the count.
+// Tool dedupe rule:
+//
+//   - With ToolUseID: scope by (session, actor, tool_use_id). Pre+Post
+//     pairs collapse to one count; the first event observed wins.
+//   - Without ToolUseID: scope by (session, actor, tool_name). Some
+//     hook payloads emit only PostToolUse and never carry a use_id,
+//     so we cannot rely on stage filtering — counting only
+//     pre-action would silently drop those calls. Instead we bucket
+//     by (session, actor, tool) and count once: prefer a pre-action
+//     row when present so the count lines up with "calls initiated",
+//     but if the bucket is post-only we still record exactly one
+//     edge so post-only evidence does not vanish from the graph.
+//
+// The bucket pass is a two-pass walk to keep the result stable
+// regardless of event order (QueryEvents returns DESC, but the
+// rule must hold for any input order).
 func rollupRuntime(events []runtime.HookEvent, actorByID map[string]runtime.Actor) ([]graph.AgentMeta, []graph.EdgeInput, []graph.ToolNode, []graph.ToolEdge) {
 	type edgeKey struct{ from, to string }
 	type toolEdgeKey struct{ agent, tool string }
-	type dedupeKey struct{ session, actor, useID string }
+	type useIDKey struct{ session, actor, useID string }
+	type noUseKey struct{ session, actor, tool string }
 
 	agentMeta := make(map[string]graph.AgentMeta)
 	edgeAgg := make(map[edgeKey]*graph.EdgeInput)
 	toolEdgeAgg := make(map[toolEdgeKey]int)
 	toolTotals := make(map[string]int)
-	dedupe := make(map[dedupeKey]bool)
+	useIDSeen := make(map[useIDKey]bool)
+	noUseHasPre := make(map[noUseKey]bool)
+	noUseAny := make(map[noUseKey]runtime.HookEvent)
 
 	displayLabel := func(actorID string) string {
 		a, ok := actorByID[actorID]
@@ -146,6 +161,12 @@ func rollupRuntime(events []runtime.HookEvent, actorByID map[string]runtime.Acto
 			Kind:       kind,
 			CanMessage: []string{"*"}, // observed actors carry no ACL; wildcard avoids phantom shadow
 		}
+	}
+	recordToolEdge := func(actorID, toolName string) {
+		actorName := displayLabel(actorID)
+		clean := stripGatewayNamespace(toolName)
+		toolEdgeAgg[toolEdgeKey{agent: actorName, tool: clean}]++
+		toolTotals[clean]++
 	}
 
 	for _, ev := range events {
@@ -172,30 +193,46 @@ func rollupRuntime(events []runtime.HookEvent, actorByID map[string]runtime.Acto
 			}
 		}
 
-		// Tool node + tool edge. Dedupe so a Pre/Post pair never
-		// counts the same call twice. The dedupe scope is the
-		// (session, actor, use_id) tuple; without a use_id we fall
-		// back to counting only pre-action events so post-action
-		// alone or both stages never inflate.
 		if ev.ToolName == "" {
 			continue
 		}
-		stage := ev.Stage
+
 		if ev.ToolUseID != "" {
-			k := dedupeKey{session: ev.SessionID, actor: ev.ActorID, useID: ev.ToolUseID}
-			if dedupe[k] {
+			k := useIDKey{session: ev.SessionID, actor: ev.ActorID, useID: ev.ToolUseID}
+			if useIDSeen[k] {
 				continue
 			}
-			dedupe[k] = true
-		} else if stage != runtime.StagePreAction {
-			// No use_id and post-action: skip so the matching
-			// pre-action (if any) is the row we count.
+			useIDSeen[k] = true
+			recordToolEdge(ev.ActorID, ev.ToolName)
 			continue
 		}
 
-		toolName := stripGatewayNamespace(ev.ToolName)
-		toolEdgeAgg[toolEdgeKey{agent: actorName, tool: toolName}]++
-		toolTotals[toolName]++
+		// No use_id: defer to second pass so the count is
+		// independent of event order (QueryEvents is DESC).
+		bucket := noUseKey{session: ev.SessionID, actor: ev.ActorID, tool: ev.ToolName}
+		if ev.Stage == runtime.StagePreAction {
+			if !noUseHasPre[bucket] {
+				noUseHasPre[bucket] = true
+				recordToolEdge(ev.ActorID, ev.ToolName)
+			}
+			continue
+		}
+		// Post-action / observed-only / unknown stage. Stash the
+		// first one we see; a pre-action row in the same bucket
+		// will take precedence when materialised.
+		if _, ok := noUseAny[bucket]; !ok {
+			noUseAny[bucket] = ev
+		}
+	}
+
+	// Second pass: emit one tool edge per no-use_id bucket that
+	// never saw a pre-action. Pre-action buckets already counted
+	// above; visiting them again would double the edge.
+	for bucket, ev := range noUseAny {
+		if noUseHasPre[bucket] {
+			continue
+		}
+		recordToolEdge(ev.ActorID, ev.ToolName)
 	}
 
 	// Materialise agents in deterministic order.

--- a/internal/dashboard/runtime_graph.go
+++ b/internal/dashboard/runtime_graph.go
@@ -94,7 +94,43 @@ func projectRuntimeGraph(events []runtime.HookEvent, actors []runtime.Actor) *gr
 	g := graph.BuildObserved(agents, edgeStats)
 	g.ToolNodes = toolNodes
 	g.ToolEdges = toolEdges
+	countRuntimeActivity(events, g)
 	return g
+}
+
+// countRuntimeActivity tallies the unique source rows the
+// projection consumed. One event in, one count out — even if that
+// event drove both an actor->actor edge (parent edge) and an
+// actor->tool edge. Heartbeat sessions are filtered upstream of
+// projectRuntimeGraph, so every row reaching this loop is real
+// activity. Events that never registered an actor are ignored:
+// they are out of scope for the graph and should not inflate
+// "scanned-rows" totals the dashboard surfaces.
+func countRuntimeActivity(events []runtime.HookEvent, g *graph.AgentGraph) {
+	for _, ev := range events {
+		if ev.ActorID == "" {
+			continue
+		}
+		g.ActivityEvents++
+		if isEventBlocked(ev) {
+			g.ActivityBlocks++
+		}
+	}
+}
+
+// isEventBlocked applies the same outcome rules accumulateOutcome
+// uses, but at the event level: status=blocked or policy_decision
+// in {block, deny} → blocked. Pulled out so the activity counter
+// and the per-edge bucket agree on what "blocked" means.
+func isEventBlocked(ev runtime.HookEvent) bool {
+	if strings.EqualFold(ev.Status, "blocked") {
+		return true
+	}
+	switch strings.ToLower(ev.PolicyDecision) {
+	case "block", "deny":
+		return true
+	}
+	return false
 }
 
 // indexActors gives O(1) lookup by runtime actor id so the

--- a/internal/dashboard/runtime_graph_test.go
+++ b/internal/dashboard/runtime_graph_test.go
@@ -541,6 +541,92 @@ func TestRuntimeGraph_PostOnlyToolWithoutUseIDRendersOneEdge(t *testing.T) {
 	}
 }
 
+// TestRuntimeGraphStats_DoesNotDoubleCountAcrossEdgeAndToolLayers —
+// a single PreToolUse from a subagent contributes to both an
+// actor->actor edge (parent->child) and an actor->tool edge. Pre-fix,
+// the stats endpoint summed sum(Edge.Total) + sum(ToolEdge.Total),
+// so one row got counted twice (once per layer). The fix exposes
+// AgentGraph.ActivityEvents — a unique-row counter the projection
+// fills directly — so the messages card matches the rows actually
+// scanned, not the rendered-edge total.
+func TestRuntimeGraphStats_DoesNotDoubleCountAcrossEdgeAndToolLayers(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// SubagentStart drives only the actor edge. PreToolUse drives
+	// both the actor edge AND the tool edge — that is the layer
+	// overlap the stats endpoint must collapse.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-double","agent_id":"sa-d","agent_type":"research"}`,
+		"sess-double", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-double","agent_id":"sa-d","agent_type":"research","tool_name":"Read","tool_use_id":"d1"}`,
+		"sess-double", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+
+	sumEdges := 0
+	if edges, ok := g["edges"].([]any); ok {
+		for _, e := range edges {
+			if m, ok := e.(map[string]any); ok {
+				if v, ok := m["total"].(float64); ok {
+					sumEdges += int(v)
+				}
+			}
+		}
+	}
+	sumToolEdges := 0
+	if edges, ok := g["tool_edges"].([]any); ok {
+		for _, e := range edges {
+			if m, ok := e.(map[string]any); ok {
+				if v, ok := m["total"].(float64); ok {
+					sumToolEdges += int(v)
+				}
+			}
+		}
+	}
+	if sumEdges == 0 || sumToolEdges == 0 {
+		t.Fatalf("test setup expected both an actor edge and a tool edge; sumEdges=%d sumToolEdges=%d (edges=%v tool_edges=%v)",
+			sumEdges, sumToolEdges, edgeKeys(g), toolEdgeKeys(g))
+	}
+
+	stats := statsResponse(t, srv, cookie, handler, "1h")
+	if stats["messages"] == 0 {
+		t.Fatalf("messages = 0 with active runtime evidence; stats=%v", stats)
+	}
+	// The pre-fix bug would surface as messages == sumEdges + sumToolEdges.
+	if stats["messages"] == sumEdges+sumToolEdges {
+		t.Errorf("stats double-counted across actor and tool edges: messages=%d == sumEdges(%d)+sumToolEdges(%d); stats=%v",
+			stats["messages"], sumEdges, sumToolEdges, stats)
+	}
+	// And the unique counter the projection exposes must match what
+	// the endpoint reports — the canvas and the cards reading the
+	// same number is the whole point of the fix.
+	if v, ok := g["activity_events"].(float64); ok {
+		if stats["messages"] != int(v) {
+			t.Errorf("messages = %d, want activity_events = %d (stats and canvas projection diverged)",
+				stats["messages"], int(v))
+		}
+	} else {
+		t.Errorf("graph JSON missing activity_events; got keys: %v", graphKeys(g))
+	}
+}
+
+// graphKeys returns the top-level keys of the decoded graph JSON.
+// Used in the double-count regression to surface a clear error if
+// the activity_events field is missing from the response.
+func graphKeys(g map[string]any) []string {
+	keys := make([]string, 0, len(g))
+	for k := range g {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // TestRuntimeGraph_PreAndPostWithoutUseIDCountOne — when both Pre
 // and Post events lack a tool_use_id, the rollup must still collapse
 // them to one edge per (session, actor, tool). The bucket dedupe

--- a/internal/dashboard/runtime_graph_test.go
+++ b/internal/dashboard/runtime_graph_test.go
@@ -371,3 +371,203 @@ func TestRuntimeGraph_NoRawPayloadInJSON(t *testing.T) {
 		t.Errorf("graph JSON leaks raw tool input: %s", body)
 	}
 }
+
+// statsResponse fetches /dashboard/api/graph/stats and decodes the
+// integer counters. Tests that exercise the runtime path use this
+// to assert the stats endpoint reads from the same graph the canvas
+// renders.
+func statsResponse(t *testing.T, srv *Server, cookie *http.Cookie, handler http.Handler, rng string) map[string]int {
+	t.Helper()
+	url := "/dashboard/api/graph/stats"
+	if rng != "" {
+		url += "?range=" + rng
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	// Decode through json.Number so non-int payload shows up loudly.
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	out := make(map[string]int, len(raw))
+	for k, v := range raw {
+		switch n := v.(type) {
+		case float64:
+			out[k] = int(n)
+		default:
+			t.Fatalf("stats key %q has non-numeric value %T", k, v)
+		}
+	}
+	return out
+}
+
+// TestRuntimeGraphStats_UsesRuntimeGraphCounts — the stats endpoint
+// must derive from the same runtime-projected graph the canvas reads.
+// cfg.Agents and cfg.MCPServers are empty here, so a stats endpoint
+// that fell back to config (the pre-fix shape) would return
+// agents=0/tools=0 even though the canvas paints the local-codex
+// node + Read tool.
+func TestRuntimeGraphStats_UsesRuntimeGraphCounts(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-stats"}`,
+		"sess-stats", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-stats","agent_id":"sa-stats","agent_type":"research"}`,
+		"sess-stats", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-stats","agent_id":"sa-stats","agent_type":"research","tool_name":"Read","tool_use_id":"stats-1"}`,
+		"sess-stats", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	stats := statsResponse(t, srv, cookie, handler, "1h")
+	if stats["agents"] < 2 {
+		t.Errorf("agents = %d, want >= 2 (root + subagent); stats=%v", stats["agents"], stats)
+	}
+	if stats["tools"] != 1 {
+		t.Errorf("tools = %d, want 1 (Read); stats=%v", stats["tools"], stats)
+	}
+	if stats["messages"] < 1 {
+		t.Errorf("messages = %d, want >= 1; stats=%v", stats["messages"], stats)
+	}
+}
+
+// TestRuntimeGraphStats_HeartbeatOnlyDoesNotFallbackToAuditStats —
+// when runtime is heartbeat-only the canvas renders empty, and the
+// stats cards must agree. Pre-fix, the stats endpoint summed
+// audit.QueryStats(), so a stale legacy row would resurrect a
+// phantom message count. The runtime-graph projection drops the
+// heartbeat session, leaving the graph empty; stats must mirror.
+func TestRuntimeGraphStats_HeartbeatOnlyDoesNotFallbackToAuditStats(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-stats"}`,
+		"heartbeat-2026-stats", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{})
+	auditStore.Log(audit.Entry{
+		ID:             "legacy-stats",
+		Timestamp:      now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent:      "local-codex",
+		ToAgent:        "list_agents",
+		Status:         "delivered",
+		PolicyDecision: "allow",
+	})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	stats := statsResponse(t, srv, cookie, handler, "1h")
+	if stats["agents"] != 0 || stats["tools"] != 0 || stats["messages"] != 0 || stats["blocks"] != 0 {
+		t.Errorf("heartbeat-only stats leaked legacy audit totals: %v", stats)
+	}
+}
+
+// TestGraphDefaultRange_DoesNotWidenWhenOnlyToolTrafficExists — a
+// root-only tool call inside the default 24h window has no
+// actor-to-actor edge (TotalEdges == 0) but real ToolEdge traffic.
+// The auto-widen must treat the window as populated, otherwise the
+// page silently snaps to 7d/30d and surfaces an older event the
+// user did not ask for.
+func TestGraphDefaultRange_DoesNotWidenWhenOnlyToolTrafficExists(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Root-only tool call inside the 24h window.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-recent","tool_name":"Read","tool_use_id":"recent-1"}`,
+		"sess-recent", "local-codex", now.Add(-30*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	// Older event well outside 24h to make widening tempting.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-old","tool_name":"Bash","tool_use_id":"old-1"}`,
+		"sess-old", "local-codex", now.Add(-5*24*time.Hour), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	// No range query param: handleGraph should pick the default
+	// 24h window and stay there.
+	req := httptest.NewRequest("GET", "/dashboard/graph", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	// The active range button has the active class. A 7d or 30d
+	// active button means auto-widen kicked in.
+	if strings.Contains(body, `range=7d" class="btn btn-sm active`) ||
+		strings.Contains(body, `range=30d" class="btn btn-sm active`) {
+		t.Errorf("auto-widen widened past 24h despite tool traffic in window")
+	}
+	if !strings.Contains(body, `range=24h" class="btn btn-sm active`) {
+		t.Errorf("expected 24h to remain active range; body suggests otherwise")
+	}
+}
+
+// TestRuntimeGraph_PostOnlyToolWithoutUseIDRendersOneEdge — a
+// PostToolUse without tool_use_id must still surface as a tool
+// edge. Pre-fix, the rollup skipped non-pre-action events lacking
+// a use_id, so post-only evidence vanished from the graph.
+func TestRuntimeGraph_PostOnlyToolWithoutUseIDRendersOneEdge(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PostToolUse","session_id":"sess-postonly","tool_name":"Read","tool_response":"ok"}`,
+		"sess-postonly", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	tools := strings.Join(toolEdgeKeys(g), ",")
+	if !strings.Contains(tools, "local-codex->Read:1") {
+		t.Errorf("expected tool edge local-codex->Read:1 from post-only event; got %s", tools)
+	}
+}
+
+// TestRuntimeGraph_PreAndPostWithoutUseIDCountOne — when both Pre
+// and Post events lack a tool_use_id, the rollup must still collapse
+// them to one edge per (session, actor, tool). The bucket dedupe
+// runs in two passes so input order does not matter.
+func TestRuntimeGraph_PreAndPostWithoutUseIDCountOne(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-noid","tool_name":"Read"}`,
+		"sess-noid", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PostToolUse","session_id":"sess-noid","tool_name":"Read","tool_response":"ok"}`,
+		"sess-noid", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+	auditStore.Flush()
+	srv.invalidateGraphCache()
+
+	g := graphResponse(t, srv, cookie, handler, "1h")
+	tools := toolEdgeKeys(g)
+	for _, key := range tools {
+		if strings.HasPrefix(key, "local-codex->Read:") && key != "local-codex->Read:1" {
+			t.Errorf("Pre+Post without use_id counted more than once: %s", key)
+		}
+	}
+	if !strings.Contains(strings.Join(tools, ","), "local-codex->Read:1") {
+		t.Errorf("expected local-codex->Read:1; got %v", tools)
+	}
+}

--- a/internal/dashboard/tmpl_graph.go
+++ b/internal/dashboard/tmpl_graph.go
@@ -746,7 +746,7 @@ function toggleGraphSidebar() {
   var _prevEv='',_prevTb='';
   function _nc(){return '_t='+Date.now();}
   function pollGraph(){
-    fetch('/dashboard/api/graph/stats?'+_nc(),{credentials:'same-origin',cache:'no-store'}).then(function(r){return r.json()}).then(function(d){
+    fetch('/dashboard/api/graph/stats?range={{.Range}}&'+_nc(),{credentials:'same-origin',cache:'no-store'}).then(function(r){return r.json()}).then(function(d){
       var g=function(id){return document.getElementById(id)};
       if(g('gs-agents'))g('gs-agents').textContent=d.agents;
       if(g('gs-tools'))g('gs-tools').textContent=d.tools;

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -122,6 +122,23 @@ type AgentGraph struct {
 	UnrepresentedRoutes []UnrepresentedRoute `json:"unrepresented_routes,omitempty"`
 	TotalNodes          int                  `json:"total_nodes"`
 	TotalEdges          int                  `json:"total_edges"`
+	// ActivityEvents is the unique number of source rows the
+	// projection consumed. Distinct from
+	// sum(Edge.Total) + sum(ToolEdge.Total) because a single
+	// source row can drive both an actor->actor edge (a child
+	// actor pointing at its parent) and an actor->tool edge (the
+	// tool that row invoked); collapsing the layer overlap here
+	// lets the dashboard report a unique scanned-row total
+	// without mixing two representations of the same row.
+	// Callers that build a graph fill this directly — Build /
+	// BuildObserved leave it at zero so the field stays generic
+	// to graph backends.
+	ActivityEvents int `json:"activity_events"`
+	// ActivityBlocks is the matching block counter: source rows
+	// the projection treated as blocked (status=blocked or
+	// policy_decision in {block, deny}). Same caller-fills-it
+	// contract as ActivityEvents.
+	ActivityBlocks int `json:"activity_blocks"`
 }
 
 // BuildOptions controls how Build assembles the graph. CompareACL


### PR DESCRIPTION
## Summary

Follow-up to Phase 3D runtime graph projection.

This closes three runtime-truth gaps left after #161:
- Graph stat cards now derive from the same graph projection as the canvas.
- Default range auto-widen treats tool-only runtime traffic as real traffic.
- Post-only tool events without `tool_use_id` no longer disappear from the graph.

## Changes

- `/dashboard/api/graph/stats` now reads `cachedBuildGraph(parseSinceRange(range))` instead of config/audit legacy counters.
- `tmpl_graph.go` passes `range={{.Range}}` to the stats poller so cards and canvas stay in the same window.
- `graphHasTraffic` treats actor edges, tool edges, and unrepresented routes as real graph activity.
- Runtime tool rollup now dedupes in two passes:
  - with `tool_use_id`: `(session, actor, use_id)`
  - without `tool_use_id`: `(session, actor, tool_name)`, preferring pre-action but preserving post-only evidence.

## Tests

- `TestRuntimeGraphStats_UsesRuntimeGraphCounts`
- `TestGraphDefaultRange_DoesNotWidenWhenOnlyToolTrafficExists`
- `TestRuntimeGraph_PostOnlyToolWithoutUseIDRendersOneEdge`
- `TestRuntimeGraph_PreAndPostWithoutUseIDCountOne`
- `TestRuntimeGraphStats_HeartbeatOnlyDoesNotFallbackToAuditStats`

## Test plan

- [x] `make build`
- [x] `make vet`
- [x] `make lint`
- [x] `go test ./internal/graph`
- [x] `go test ./internal/dashboard` except pre-existing time-locked `TestOverviewSparkline_LabelledCardWhenDataExists`, which also fails on main because its hardcoded 2026-04-27 timestamp is now outside the 24h window.

## Known pre-existing failure

`TestOverviewSparkline_LabelledCardWhenDataExists` is date-locked to `2026-04-27T10:00:00Z` and fails on 2026-04-28 because the Overview uses a 24h window. This branch does not touch sparkline code.