### PR TITLE
Anchor Overview sparkline test on time.Now() instead of a fixed date

### DIFF
--- a/internal/dashboard/overview_sparkline_test.go
+++ b/internal/dashboard/overview_sparkline_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
@@ -39,10 +40,14 @@ func TestOverviewSparkline_LabelledCardWhenDataExists(t *testing.T) {
 	srv := newTestServer(t)
 	srv.cfg.Agents["smoke-agent"] = config.Agent{}
 
-	// Log one real audit entry so QueryHourlyStats has data.
+	// Log one real audit entry so QueryHourlyStats has data. The
+	// timestamp must fall inside the Overview's 24h sparkline
+	// window; using a hardcoded calendar date drifts out of range
+	// the moment the wall clock crosses midnight, so anchor on
+	// time.Now() instead.
 	srv.audit.Log(audit.Entry{
 		ID:             "smoke-1",
-		Timestamp:      "2026-04-27T10:00:00Z",
+		Timestamp:      time.Now().UTC().Add(-time.Hour).Format(time.RFC3339),
 		FromAgent:      "smoke-agent",
 		ToAgent:        "echo",
 		ContentHash:    "h",


### PR DESCRIPTION
## Summary

Test-only fix. `TestOverviewSparkline_LabelledCardWhenDataExists` seeded an audit row at a hardcoded `2026-04-27T10:00:00Z`. The Overview sparkline only renders rows from the last 24h, so once the wall clock crossed into 2026-04-28 the seeded row fell outside the window and the template suppressed the card — flipping the test red without any product change.

Anchor the timestamp on `time.Now().UTC().Add(-time.Hour)` so the seed always lands inside the window.

Sparkline behavior unchanged: the test still proves "real traffic in at least one hour bucket renders the labelled card".

## Changes

- `internal/dashboard/overview_sparkline_test.go`: import `time`, replace fixed timestamp.
- No template / handler / production change.

## Test plan

- [x] `go test ./internal/dashboard -run TestOverviewSparkline -count=1`
- [x] `go test ./internal/dashboard -count=1`
- [x] `make vet`
- [x] `make lint`