### PR TITLE
Harden Claude Code project directory validation

### DIFF
--- a/internal/dashboard/claude_code_health_test.go
+++ b/internal/dashboard/claude_code_health_test.go
@@ -235,3 +235,69 @@ func TestClaudeCodeHealth_DefaultsToConfigDirWhenProjectOmitted(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// TestClaudeCodeHealth_RejectsAbsoluteMissingPathOutsideRoot — an
+// absolute path that does NOT exist and is also outside every
+// allowed root must surface as "outside allowed roots", not as
+// "path not accessible". The earlier ordering (Stat first,
+// root-check after) leaked filesystem existence: missing-outside
+// returned the os error wording, existing-outside returned the
+// root-check wording. The lexical pre-check collapses both into
+// the same uniform refusal so an authenticated dashboard user
+// cannot use the endpoint to probe arbitrary filesystem paths.
+func TestClaudeCodeHealth_RejectsAbsoluteMissingPathOutsideRoot(t *testing.T) {
+	_, handler, cookie, _, _ := newProjectValidationServer(t)
+	missing := "/this-path-should-not-exist-anywhere/oktsec-test-12345"
+	w := projectHealthRequest(t, handler, cookie, missing)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "outside allowed roots") {
+		t.Errorf("400 body must say 'outside allowed roots' (no FS probe leak); got %q", body)
+	}
+	// Negative assertion: a leaky path would have surfaced as the
+	// stat error wording, which the helper used to forward as
+	// "path not accessible".
+	if strings.Contains(body, "path not accessible") {
+		t.Errorf("body leaked filesystem state: %q", body)
+	}
+}
+
+// TestClaudeCodeHealth_RejectsFileInsideAllowedRoot — a regular
+// file (not a directory) that lives inside an allowed root reaches
+// the IsDir check and is refused with the "not a directory"
+// message. Documents that the FS probes only run after the lexical
+// gate has accepted the path.
+func TestClaudeCodeHealth_RejectsFileInsideAllowedRoot(t *testing.T) {
+	_, handler, cookie, _, cfgDir := newProjectValidationServer(t)
+	f := filepath.Join(cfgDir, "not-a-dir.txt")
+	if err := os.WriteFile(f, []byte("oktsec"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	w := projectHealthRequest(t, handler, cookie, f)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "not a directory") {
+		t.Errorf("400 body should say 'not a directory'; got %q", w.Body.String())
+	}
+}
+
+// TestClaudeCodeHealth_AcceptsDoubleDotPrefixedDirectory — a
+// directory whose name happens to start with the two dot bytes
+// (e.g. "..project") is a perfectly valid POSIX name and must be
+// accepted when it lives inside an allowed root. A naive
+// HasPrefix(rel, "..") check would mis-classify it as traversal
+// and produce a false-positive 400.
+func TestClaudeCodeHealth_AcceptsDoubleDotPrefixedDirectory(t *testing.T) {
+	_, handler, cookie, _, cfgDir := newProjectValidationServer(t)
+	weird := filepath.Join(cfgDir, "..project")
+	if err := os.MkdirAll(weird, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	w := projectHealthRequest(t, handler, cookie, weird)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/dashboard/claude_code_health_test.go
+++ b/internal/dashboard/claude_code_health_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/audit"
@@ -72,5 +73,165 @@ func TestClaudeCodeHealthEndpoint_NotInstalled(t *testing.T) {
 	}
 	if body.Inventory.Detected {
 		t.Error("inventory.Detected should be false on an empty home")
+	}
+}
+
+// newProjectValidationServer builds a Server suitable for the
+// project-dir validation tests below. Each test owns its own home
+// tempdir + config tempdir so the allowed-root set is fully under
+// test control, with no leakage from the host's real HOME or this
+// repo's working tree.
+func newProjectValidationServer(t *testing.T) (*Server, http.Handler, *http.Cookie, string, string) {
+	t.Helper()
+	homeDir := t.TempDir()
+	cfgDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "")
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	dbDir := t.TempDir()
+	store, err := audit.NewStore(filepath.Join(dbDir, "test.db"), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 0},
+		DBPath:  filepath.Join(dbDir, "test.db"),
+		Agents:  map[string]config.Agent{},
+	}
+	srv := NewServer(cfg, filepath.Join(cfgDir, "oktsec.yaml"), store, identity.NewKeyStore(), sharedScanner, logger)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	return srv, handler, cookie, homeDir, cfgDir
+}
+
+// projectHealthRequest issues a GET against the Claude Code health
+// endpoint with a configurable ?project= value. Pass an empty
+// string to omit the query param entirely so the handler exercises
+// its blank-input fallback.
+func projectHealthRequest(t *testing.T, handler http.Handler, cookie *http.Cookie, project string) *httptest.ResponseRecorder {
+	t.Helper()
+	u := "/dashboard/api/connectors/claude-code/health"
+	if project != "" {
+		u += "?" + url.Values{"project": {project}}.Encode()
+	}
+	req := httptest.NewRequest("GET", u, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+// TestClaudeCodeHealth_RejectsTraversal — ?project=../../etc must
+// be rejected as relative input. Even a string that "looks
+// absolute after Clean" is not absolute up front, and the handler
+// must refuse it before any os.Stat / EvalSymlinks runs.
+func TestClaudeCodeHealth_RejectsTraversal(t *testing.T) {
+	_, handler, cookie, _, _ := newProjectValidationServer(t)
+	w := projectHealthRequest(t, handler, cookie, "../../etc")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "absolute") {
+		t.Errorf("400 body should explain the absolute-path rule; got %q", w.Body.String())
+	}
+}
+
+// TestClaudeCodeHealth_RejectsRelativeProject — a clearly
+// relative path with no traversal pieces is still rejected.
+// Relative input from HTTP is ambiguous; the operator must be
+// explicit.
+func TestClaudeCodeHealth_RejectsRelativeProject(t *testing.T) {
+	_, handler, cookie, _, _ := newProjectValidationServer(t)
+	w := projectHealthRequest(t, handler, cookie, "relative/project")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestClaudeCodeHealth_RejectsAbsoluteOutsideAllowedRoot — an
+// absolute, existing directory that lives outside both the home
+// tempdir and the config tempdir must be refused.
+func TestClaudeCodeHealth_RejectsAbsoluteOutsideAllowedRoot(t *testing.T) {
+	_, handler, cookie, _, _ := newProjectValidationServer(t)
+	outside := t.TempDir() // a fresh tempdir, not inside HOME or cfgDir
+	w := projectHealthRequest(t, handler, cookie, outside)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "outside allowed roots") {
+		t.Errorf("400 body should name the root-membership rule; got %q", w.Body.String())
+	}
+}
+
+// TestClaudeCodeHealth_RejectsSymlinkEscape — a symlink that
+// lives inside the config dir but resolves to a directory outside
+// every allowed root must be refused. The EvalSymlinks step is
+// what closes this gap; without it, HasPrefix-style checks would
+// pass because the input string starts inside cfgDir.
+func TestClaudeCodeHealth_RejectsSymlinkEscape(t *testing.T) {
+	_, handler, cookie, _, cfgDir := newProjectValidationServer(t)
+	outside := t.TempDir() // outside HOME and cfgDir
+	link := filepath.Join(cfgDir, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	w := projectHealthRequest(t, handler, cookie, link)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "outside allowed roots") {
+		t.Errorf("400 body should name the root-membership rule; got %q", w.Body.String())
+	}
+}
+
+// TestClaudeCodeHealth_AcceptsProjectInsideConfigDir — the happy
+// path: a real subdirectory of the loaded config dir is accepted,
+// and the inventory.current_project_path the connector returns is
+// the EvalSymlinks-resolved canonical form (NOT the raw input
+// string), so any downstream consumer that joins paths off it
+// keeps working from a stable base.
+func TestClaudeCodeHealth_AcceptsProjectInsideConfigDir(t *testing.T) {
+	_, handler, cookie, _, cfgDir := newProjectValidationServer(t)
+	subdir := filepath.Join(cfgDir, "myproject")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w := projectHealthRequest(t, handler, cookie, subdir)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Inventory struct {
+			CurrentProjectPath string `json:"current_project_path"`
+		} `json:"inventory"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	canonical, err := filepath.EvalSymlinks(subdir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if body.Inventory.CurrentProjectPath != canonical {
+		t.Errorf("current_project_path = %q, want canonical %q",
+			body.Inventory.CurrentProjectPath, canonical)
+	}
+}
+
+// TestClaudeCodeHealth_DefaultsToConfigDirWhenProjectOmitted — no
+// query param at all keeps the pre-existing behavior: the handler
+// uses filepath.Dir(s.cfgPath) as the implicit project. The
+// validation helper must NOT re-validate that operator-trusted
+// path, so this test asserts the endpoint still returns 200.
+func TestClaudeCodeHealth_DefaultsToConfigDirWhenProjectOmitted(t *testing.T) {
+	_, handler, cookie, _, _ := newProjectValidationServer(t)
+	w := projectHealthRequest(t, handler, cookie, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4420,37 +4420,39 @@ func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) 
 // dashboard-supplied project directory before it reaches the
 // Claude Code connector.
 //
-// Order matters here: the lexical root-membership check runs
-// BEFORE any filesystem call on the request path, so the helper
-// cannot be used as an existence/access probe for paths outside
-// the allowed roots. Stat / EvalSymlinks only run after the path
-// is provably inside an allowed root; a second post-symlink check
-// catches a symlink that lives inside a root but resolves outside.
+// The validation pattern is the documented Go sanitizer for
+// path-injection: derive a relative form from the request path
+// against an operator-trusted root, validate that relative form
+// with filepath.IsLocal (which rejects "..", absolute, and NUL
+// shapes), then rebuild the path that flows to the filesystem
+// from filepath.Join(trustedRoot, validatedRel). Because the
+// rebuilt path is constructed from a non-tainted root joined
+// with a stdlib-validated suffix, taint analysis sees a clean
+// value reaching os.Stat / EvalSymlinks instead of the original
+// query-string input.
+//
+// The check runs against allowed roots in two forms — raw
+// (filepath.Clean of the directory string) and canonical
+// (EvalSymlinks-resolved) — so an operator whose HOME advertises
+// either the symlink form (e.g. /var/home/x) or the resolved form
+// (/home/x) can pass the matching shape and have it accepted. A
+// symlink that lives inside a root but resolves outside is
+// refused at the post-symlink re-check, so the helper cannot be
+// used as a "follow this symlink for me" filesystem probe.
 //
 // Rules:
 //
 //   - blank input falls back to filepath.Dir(s.cfgPath) when the
-//     server has a config path, otherwise empty (the connector
-//     treats empty as "no project scope" and only reads HomeDir
-//     state). The default path is operator-trusted and not
-//     re-validated.
-//   - a non-blank input must contain no NUL byte, must be an
-//     absolute path, and its filepath.Clean form must lexically
-//     live inside one of the allowed roots. Allowed roots are
-//     gathered in two forms — the raw filepath.Clean of the
-//     directory and its EvalSymlinks canonical — so the operator
-//     can pass the literal path their environment advertises
-//     (e.g. /var/home/x) or its symlink-resolved form
-//     (/home/x), but not anything else.
-//   - only after the lexical check passes do we Stat the path
-//     (it must be a directory) and EvalSymlinks the result. A
-//     symlink that lives inside a root but points outside is
-//     refused at the post-symlink re-check.
-//
-// Failure mode is uniform: any non-blank input that does not
-// resolve to an allowed-root directory returns an error message
-// the caller maps to 400. Existence-vs-access distinctions for
-// outside paths are not reachable.
+//     server has a config path, otherwise empty. The default
+//     path is operator-trusted and not re-validated.
+//   - a non-blank input must contain no NUL byte and must be an
+//     absolute path. Anything else is rejected before the helper
+//     touches the filesystem.
+//   - the cleaned form must produce a relative path against at
+//     least one allowed root for which filepath.IsLocal returns
+//     true. Failure is uniform: "path is outside allowed roots".
+//   - Stat, EvalSymlinks, and the post-symlink canonical check
+//     only run on the rebuilt path, never the raw input.
 //
 // computeClaudeCodeConnectionHealth does NOT route through this
 // helper because it builds the project dir from s.cfgPath itself,
@@ -4472,46 +4474,70 @@ func (s *Server) resolveClaudeCodeProjectDir(raw string) (string, error) {
 	}
 	cleaned := filepath.Clean(raw)
 
-	// Allowed roots in two forms. Both resolve at most once per
-	// request and only touch operator-trusted paths (the home
-	// directory and the loaded config directory), never the
-	// request path. EvalSymlinks failures degrade silently — a
-	// missing canonical form just means the lexical check leans
-	// on the raw form, never on the request.
 	rawRoots, canonicalRoots := s.allowedClaudeCodeProjectRoots()
 	if len(rawRoots) == 0 && len(canonicalRoots) == 0 {
 		return "", fmt.Errorf("no allowed root configured")
 	}
 
-	// Lexical pre-check: the request path must already live
-	// inside an allowed root in either form. This is the line
-	// that prevents the helper from being a filesystem probe —
-	// outside paths never reach Stat or EvalSymlinks.
-	if !anyPathInside(cleaned, rawRoots) && !anyPathInside(cleaned, canonicalRoots) {
+	// Combine root forms; first match wins. The order does not
+	// matter for correctness because every root is operator-trusted;
+	// it only affects which equivalent shape the rebuilt path uses
+	// before EvalSymlinks runs.
+	candidateRoots := make([]string, 0, len(rawRoots)+len(canonicalRoots))
+	candidateRoots = append(candidateRoots, rawRoots...)
+	candidateRoots = append(candidateRoots, canonicalRoots...)
+
+	safePath, ok := safeJoinUnderRoots(candidateRoots, cleaned)
+	if !ok {
 		return "", fmt.Errorf("path is outside allowed roots")
 	}
 
-	info, err := os.Stat(cleaned)
+	info, err := os.Stat(safePath)
 	if err != nil {
 		return "", fmt.Errorf("path not accessible: %w", err)
 	}
 	if !info.IsDir() {
 		return "", fmt.Errorf("path is not a directory")
 	}
-	canonical, err := filepath.EvalSymlinks(cleaned)
+	canonical, err := filepath.EvalSymlinks(safePath)
 	if err != nil {
 		return "", fmt.Errorf("path resolution failed: %w", err)
 	}
 
-	// Post-symlink re-check. A symlink under cfgDir or HomeDir
-	// is allowed lexically because its name lives inside the
-	// root, but the target it resolves to may not. Only the
-	// canonical roots make sense for this comparison since the
-	// canonical form is what the connector will actually read.
+	// Post-symlink re-check. A symlink under cfgDir or HomeDir is
+	// allowed by the lexical step because its name lives inside
+	// the root, but the target it resolves to may not. Only the
+	// canonical roots are valid here because canonical compares
+	// against canonical.
 	if !anyPathInside(canonical, canonicalRoots) {
 		return "", fmt.Errorf("path is outside allowed roots")
 	}
 	return canonical, nil
+}
+
+// safeJoinUnderRoots walks the candidate roots and, for the first
+// one that lexically contains cleaned, returns a path rebuilt from
+// that root joined with the IsLocal-validated relative form. The
+// returned string is the value safe to hand to filesystem APIs:
+// the root half is operator-trusted (no taint), the relative half
+// passed filepath.IsLocal which is the recognized standard library
+// sanitizer for path-injection.
+//
+// IsLocal rejects ".."-segments, absolute paths, NUL bytes, and
+// (on Windows) reserved device names. A relative form of "." is
+// the input-equals-root case and is accepted directly.
+func safeJoinUnderRoots(roots []string, cleaned string) (string, bool) {
+	for _, root := range roots {
+		rel, err := filepath.Rel(root, cleaned)
+		if err != nil {
+			continue
+		}
+		if rel != "." && !filepath.IsLocal(rel) {
+			continue
+		}
+		return filepath.Join(root, rel), true
+	}
+	return "", false
 }
 
 // allowedClaudeCodeProjectRoots returns the operator-trusted roots

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4379,15 +4379,20 @@ func (s *Server) handleAPIGraph(w http.ResponseWriter, r *http.Request) {
 // The endpoint returns both the raw inventory and the derived health
 // view so a single fetch is enough to render the Connection Health
 // card without a follow-up round-trip.
+//
+// The optional ?project= query param goes through resolveClaudeCodeProjectDir
+// before the connector ever sees it: a non-blank value must be an
+// absolute, existing directory whose canonical (symlink-resolved)
+// form is inside the operator's home or the loaded config directory.
+// Anything else is a 400 — relative paths, NUL bytes, traversal,
+// and symlinks that escape the allowed roots all fail the same way
+// so an authenticated dashboard user cannot turn the connector into
+// a filesystem probe.
 func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) {
-	projectDir := r.URL.Query().Get("project")
-	if projectDir == "" {
-		// Default to the directory the config file lives in. That is
-		// the most useful "current project" for `oktsec run` users
-		// because the proxy is launched from there.
-		if s.cfgPath != "" {
-			projectDir = filepath.Dir(s.cfgPath)
-		}
+	projectDir, err := s.resolveClaudeCodeProjectDir(r.URL.Query().Get("project"))
+	if err != nil {
+		http.Error(w, "invalid project: "+err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
@@ -4409,6 +4414,116 @@ func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) 
 		"inventory": inv,
 		"health":    health,
 	})
+}
+
+// resolveClaudeCodeProjectDir validates and canonicalises a
+// dashboard-supplied project directory before it reaches the
+// Claude Code connector.
+//
+// Rules:
+//
+//   - blank input falls back to filepath.Dir(s.cfgPath) when the
+//     server has a config path, otherwise empty (the connector
+//     treats empty as "no project scope" and only reads HomeDir
+//     state). The default path is operator-trusted and not
+//     re-validated.
+//   - a non-blank input must contain no NUL byte, must be an
+//     absolute path, must point at an existing directory, and its
+//     EvalSymlinks-resolved form must live inside one of the
+//     allowed roots: the operator's home directory or the loaded
+//     config directory. The two roots are themselves resolved with
+//     EvalSymlinks so a system whose home is symlinked
+//     (e.g. /var/home/x → /home/x) compares correctly against the
+//     canonical input.
+//
+// The function returns either a path the caller can hand to
+// claudecode.Read or an error — never a partially cleaned value.
+// computeClaudeCodeConnectionHealth does NOT route through this
+// helper because it builds the project dir from s.cfgPath itself,
+// not from request input; the same is true for the CLI doctor
+// command, which is an explicit local invocation outside the HTTP
+// trust boundary.
+func (s *Server) resolveClaudeCodeProjectDir(raw string) (string, error) {
+	if raw == "" {
+		if s.cfgPath != "" {
+			return filepath.Dir(s.cfgPath), nil
+		}
+		return "", nil
+	}
+	if strings.ContainsRune(raw, 0) {
+		return "", fmt.Errorf("path contains NUL byte")
+	}
+	if !filepath.IsAbs(raw) {
+		return "", fmt.Errorf("path must be absolute")
+	}
+	cleaned := filepath.Clean(raw)
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("path not accessible: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory")
+	}
+	canonical, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("path resolution failed: %w", err)
+	}
+
+	roots := s.allowedClaudeCodeProjectRoots()
+	if len(roots) == 0 {
+		return "", fmt.Errorf("no allowed root configured")
+	}
+	for _, root := range roots {
+		if pathInside(canonical, root) {
+			return canonical, nil
+		}
+	}
+	return "", fmt.Errorf("path is outside allowed roots")
+}
+
+// allowedClaudeCodeProjectRoots returns the operator-trusted roots
+// a dashboard-supplied project dir is permitted to live inside.
+// Each root is canonicalised with EvalSymlinks so the membership
+// check against an EvalSymlinks-resolved input is a like-for-like
+// comparison. Roots that fail to resolve (missing dir, broken
+// symlink) are dropped silently — the helper degrades to the
+// roots that DID resolve, and rejects everything if none did.
+func (s *Server) allowedClaudeCodeProjectRoots() []string {
+	var roots []string
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if h, err := filepath.EvalSymlinks(home); err == nil {
+			roots = append(roots, h)
+		}
+	}
+	if s.cfgPath != "" {
+		cfgDir := filepath.Dir(s.cfgPath)
+		if c, err := filepath.EvalSymlinks(cfgDir); err == nil {
+			roots = append(roots, c)
+		}
+	}
+	return roots
+}
+
+// pathInside reports whether child is the same path as root or a
+// descendant of it. Uses filepath.Rel rather than HasPrefix so
+// /home/usera does not match /home/user as a prefix accident, and
+// rejects ".."-prefixed or absolute relative results so escaping
+// the root through resolved separators stays a hard NO.
+func pathInside(child, root string) bool {
+	rel, err := filepath.Rel(root, child)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if strings.HasPrefix(rel, "..") {
+		return false
+	}
+	if filepath.IsAbs(rel) {
+		return false
+	}
+	return true
 }
 
 // computeClaudeCodeConnectionHealth is the Overview's projection

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -4420,6 +4420,13 @@ func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) 
 // dashboard-supplied project directory before it reaches the
 // Claude Code connector.
 //
+// Order matters here: the lexical root-membership check runs
+// BEFORE any filesystem call on the request path, so the helper
+// cannot be used as an existence/access probe for paths outside
+// the allowed roots. Stat / EvalSymlinks only run after the path
+// is provably inside an allowed root; a second post-symlink check
+// catches a symlink that lives inside a root but resolves outside.
+//
 // Rules:
 //
 //   - blank input falls back to filepath.Dir(s.cfgPath) when the
@@ -4428,16 +4435,23 @@ func (s *Server) handleClaudeCodeHealth(w http.ResponseWriter, r *http.Request) 
 //     state). The default path is operator-trusted and not
 //     re-validated.
 //   - a non-blank input must contain no NUL byte, must be an
-//     absolute path, must point at an existing directory, and its
-//     EvalSymlinks-resolved form must live inside one of the
-//     allowed roots: the operator's home directory or the loaded
-//     config directory. The two roots are themselves resolved with
-//     EvalSymlinks so a system whose home is symlinked
-//     (e.g. /var/home/x → /home/x) compares correctly against the
-//     canonical input.
+//     absolute path, and its filepath.Clean form must lexically
+//     live inside one of the allowed roots. Allowed roots are
+//     gathered in two forms — the raw filepath.Clean of the
+//     directory and its EvalSymlinks canonical — so the operator
+//     can pass the literal path their environment advertises
+//     (e.g. /var/home/x) or its symlink-resolved form
+//     (/home/x), but not anything else.
+//   - only after the lexical check passes do we Stat the path
+//     (it must be a directory) and EvalSymlinks the result. A
+//     symlink that lives inside a root but points outside is
+//     refused at the post-symlink re-check.
 //
-// The function returns either a path the caller can hand to
-// claudecode.Read or an error — never a partially cleaned value.
+// Failure mode is uniform: any non-blank input that does not
+// resolve to an allowed-root directory returns an error message
+// the caller maps to 400. Existence-vs-access distinctions for
+// outside paths are not reachable.
+//
 // computeClaudeCodeConnectionHealth does NOT route through this
 // helper because it builds the project dir from s.cfgPath itself,
 // not from request input; the same is true for the CLI doctor
@@ -4457,6 +4471,26 @@ func (s *Server) resolveClaudeCodeProjectDir(raw string) (string, error) {
 		return "", fmt.Errorf("path must be absolute")
 	}
 	cleaned := filepath.Clean(raw)
+
+	// Allowed roots in two forms. Both resolve at most once per
+	// request and only touch operator-trusted paths (the home
+	// directory and the loaded config directory), never the
+	// request path. EvalSymlinks failures degrade silently — a
+	// missing canonical form just means the lexical check leans
+	// on the raw form, never on the request.
+	rawRoots, canonicalRoots := s.allowedClaudeCodeProjectRoots()
+	if len(rawRoots) == 0 && len(canonicalRoots) == 0 {
+		return "", fmt.Errorf("no allowed root configured")
+	}
+
+	// Lexical pre-check: the request path must already live
+	// inside an allowed root in either form. This is the line
+	// that prevents the helper from being a filesystem probe —
+	// outside paths never reach Stat or EvalSymlinks.
+	if !anyPathInside(cleaned, rawRoots) && !anyPathInside(cleaned, canonicalRoots) {
+		return "", fmt.Errorf("path is outside allowed roots")
+	}
+
 	info, err := os.Stat(cleaned)
 	if err != nil {
 		return "", fmt.Errorf("path not accessible: %w", err)
@@ -4469,46 +4503,73 @@ func (s *Server) resolveClaudeCodeProjectDir(raw string) (string, error) {
 		return "", fmt.Errorf("path resolution failed: %w", err)
 	}
 
-	roots := s.allowedClaudeCodeProjectRoots()
-	if len(roots) == 0 {
-		return "", fmt.Errorf("no allowed root configured")
+	// Post-symlink re-check. A symlink under cfgDir or HomeDir
+	// is allowed lexically because its name lives inside the
+	// root, but the target it resolves to may not. Only the
+	// canonical roots make sense for this comparison since the
+	// canonical form is what the connector will actually read.
+	if !anyPathInside(canonical, canonicalRoots) {
+		return "", fmt.Errorf("path is outside allowed roots")
 	}
-	for _, root := range roots {
-		if pathInside(canonical, root) {
-			return canonical, nil
-		}
-	}
-	return "", fmt.Errorf("path is outside allowed roots")
+	return canonical, nil
 }
 
 // allowedClaudeCodeProjectRoots returns the operator-trusted roots
-// a dashboard-supplied project dir is permitted to live inside.
-// Each root is canonicalised with EvalSymlinks so the membership
-// check against an EvalSymlinks-resolved input is a like-for-like
-// comparison. Roots that fail to resolve (missing dir, broken
-// symlink) are dropped silently — the helper degrades to the
-// roots that DID resolve, and rejects everything if none did.
-func (s *Server) allowedClaudeCodeProjectRoots() []string {
-	var roots []string
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		if h, err := filepath.EvalSymlinks(home); err == nil {
-			roots = append(roots, h)
+// a dashboard-supplied project dir is permitted to live inside,
+// in two forms:
+//
+//   - rawRoots: filepath.Clean of the directory string. Used for
+//     the lexical pre-check so the request path can match the
+//     literal root the operator's environment advertises (e.g.
+//     /var/home/x on a system whose HOME is the symlink form).
+//   - canonicalRoots: EvalSymlinks-resolved form. Used for the
+//     post-symlink re-check, and also accepted in the lexical
+//     pre-check so a request that already passes the canonical
+//     form is not rejected.
+//
+// Roots that fail to resolve (missing dir, broken symlink) drop
+// out of the canonical set silently; the helper degrades to the
+// surviving entries and rejects everything if both sets are
+// empty.
+func (s *Server) allowedClaudeCodeProjectRoots() (rawRoots, canonicalRoots []string) {
+	addRoot := func(p string) {
+		if p == "" {
+			return
 		}
+		rawRoots = append(rawRoots, filepath.Clean(p))
+		if c, err := filepath.EvalSymlinks(p); err == nil {
+			canonicalRoots = append(canonicalRoots, c)
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		addRoot(home)
 	}
 	if s.cfgPath != "" {
-		cfgDir := filepath.Dir(s.cfgPath)
-		if c, err := filepath.EvalSymlinks(cfgDir); err == nil {
-			roots = append(roots, c)
+		addRoot(filepath.Dir(s.cfgPath))
+	}
+	return rawRoots, canonicalRoots
+}
+
+// anyPathInside reports whether child sits inside any of the
+// provided roots. Empty roots slice returns false; pathInside is
+// called per-root so the directional comparison is consistent.
+func anyPathInside(child string, roots []string) bool {
+	for _, r := range roots {
+		if pathInside(child, r) {
+			return true
 		}
 	}
-	return roots
+	return false
 }
 
 // pathInside reports whether child is the same path as root or a
 // descendant of it. Uses filepath.Rel rather than HasPrefix so
-// /home/usera does not match /home/user as a prefix accident, and
-// rejects ".."-prefixed or absolute relative results so escaping
-// the root through resolved separators stays a hard NO.
+// /home/usera does not match /home/user as a prefix accident.
+// Rejects only the relative forms that escape the root: the
+// literal "..", a path that begins with the ".." element followed
+// by a separator, and absolute results. Names like "..project"
+// that simply happen to start with the two dot bytes are NOT
+// traversal and stay valid.
 func pathInside(child, root string) bool {
 	rel, err := filepath.Rel(root, child)
 	if err != nil {
@@ -4517,7 +4578,7 @@ func pathInside(child, root string) bool {
 	if rel == "." {
 		return true
 	}
-	if strings.HasPrefix(rel, "..") {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return false
 	}
 	if filepath.IsAbs(rel) {


### PR DESCRIPTION
## Summary

`handleClaudeCodeHealth` accepted `?project=<anything>` and handed the raw value to the Claude Code connector, which used it as the base for `os.ReadDir` / `os.ReadFile` calls under `.claude/agents`, `.claude/settings*.json`, and `.mcp.json`. An authenticated dashboard user could therefore turn the connector into a filesystem probe, asking for arbitrary paths and reading back any JSON file that happened to parse as a Claude config.

## Approach

A single-entry validation helper at the HTTP boundary:

- Blank input keeps the prior behavior: fall back to `filepath.Dir(s.cfgPath)`, which is operator-trusted.
- Non-blank input must contain no NUL byte, must be absolute, must point at an existing directory, and its `EvalSymlinks`-resolved form must live inside one of the allowed roots (the operator's home directory or the loaded config directory). Allowed roots are themselves resolved via `EvalSymlinks` so a system whose home is symlinked compares correctly against the canonical input.
- Any other shape returns `400 Bad Request` and never reaches the connector.
- Path-membership uses `filepath.Rel` so a sibling that shares a string prefix (`/home/usera` vs `/home/user`) cannot accidentally pass.

## Out of scope

- `internal/connectors/claudecode` is unchanged.
- `oktsec doctor claude-code --project` is unchanged: it is an explicit local invocation outside the HTTP trust boundary.

## Tests

Six new cases in `internal/dashboard/claude_code_health_test.go`:

- `TestClaudeCodeHealth_RejectsTraversal` (`../../etc` -> 400)
- `TestClaudeCodeHealth_RejectsRelativeProject` (`relative/project` -> 400)
- `TestClaudeCodeHealth_RejectsAbsoluteOutsideAllowedRoot` (absolute, exists, but not in HOME or cfgDir -> 400)
- `TestClaudeCodeHealth_RejectsSymlinkEscape` (symlink inside cfgDir resolving outside -> 400)
- `TestClaudeCodeHealth_AcceptsProjectInsideConfigDir` (200 with `inventory.current_project_path` returning the canonical form)
- `TestClaudeCodeHealth_DefaultsToConfigDirWhenProjectOmitted` (no `?project=` -> 200)

## Closes

CodeQL alerts in `internal/connectors/claudecode/{agents.go:52, agents.go:92, settings.go:82, mcp.go:142, mcp.go:170}` (`go/path-injection`).

## Test plan

- [x] `go test ./internal/dashboard -run 'ClaudeCodeHealth|Project' -count=1`
- [x] `go test ./internal/connectors/claudecode -count=1`
- [x] `go test ./internal/dashboard -count=1`
- [x] `make vet`
- [x] `make lint`