### PR TITLE
Sanitise custom rule id before joining onto CustomRulesDir

### DIFF
--- a/internal/dashboard/coverage_test.go
+++ b/internal/dashboard/coverage_test.go
@@ -92,6 +92,18 @@ func TestNormalizeCustomRuleID(t *testing.T) {
 		{"", "test 123", "CUSTOM-TEST-123"},
 		{"CUSTOM-EXISTING", "ignored", "CUSTOM-EXISTING"},
 		{"raw-id", "ignored", "CUSTOM-RAW-ID"},
+
+		// Path-traversal payloads collapse to a safe id: the byte
+		// filter strips "/", ".", and any other non-[A-Z0-9-] byte
+		// so the result is a valid filename component under
+		// cfg.CustomRulesDir.
+		{"../../etc/cron.d/pwn", "ignored", "CUSTOM-ETCCRONDPWN"},
+		{"CUSTOM-../../etc", "ignored", "CUSTOM-ETC"},
+		{"CUSTOM-hello/world", "ignored", "CUSTOM-HELLOWORLD"},
+		// All-special input collapses to the bare prefix; the
+		// handler is responsible for refusing this shape with 400.
+		{"../", "ignored", "CUSTOM-"},
+		{"...", "ignored", "CUSTOM-"},
 	}
 	for _, tc := range tests {
 		got := normalizeCustomRuleID(tc.ruleID, tc.name)

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2383,6 +2383,28 @@ func (s *Server) handleCreateCustomRule(w http.ResponseWriter, r *http.Request) 
 	}
 
 	ruleID := normalizeCustomRuleID(strings.TrimSpace(r.FormValue("rule_id")), name)
+	// Reject ids that survived normalisation but carry no useful
+	// payload beyond the CUSTOM- prefix. This happens when the
+	// user-supplied rule_id is built entirely of bytes the
+	// normaliser drops (path separators, "..", control bytes), so
+	// the result collapses to the bare prefix.
+	if strings.TrimPrefix(ruleID, "CUSTOM-") == "" {
+		http.Error(w, "rule id must contain at least one alphanumeric character", http.StatusBadRequest)
+		return
+	}
+	// safeRuleIDRe is the existing rule-id contract enforced by the
+	// DELETE handler. Reusing it here keeps the create/delete
+	// surface in lock-step. filepath.IsLocal is the static-analysis
+	// barrier on the path that filepath.Join below builds: it
+	// rejects "..", absolute paths, and NUL bytes, and it is the
+	// pattern CodeQL recognises as sanitised input for
+	// go/path-injection.
+	ruleFilename := ruleID + ".yaml"
+	if !safeRuleIDRe.MatchString(ruleID) || !filepath.IsLocal(ruleFilename) {
+		http.Error(w, "invalid rule id", http.StatusBadRequest)
+		return
+	}
+
 	yamlContent := buildCustomRuleYAML(ruleID, name, r.FormValue("severity"), strings.TrimSpace(r.FormValue("category")), patterns)
 
 	// Validate the generated YAML before writing
@@ -2398,8 +2420,8 @@ func (s *Server) handleCreateCustomRule(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	filename := filepath.Join(s.cfg.CustomRulesDir, ruleID+".yaml")
-	if err := os.WriteFile(filename, []byte(yamlContent), 0o644); err != nil {
+	rulePath := filepath.Join(s.cfg.CustomRulesDir, ruleFilename)
+	if err := os.WriteFile(rulePath, []byte(yamlContent), 0o644); err != nil {
 		s.logger.Error("write failed", "error", err)
 		http.Error(w, "write failed", http.StatusInternalServerError)
 		return
@@ -2416,21 +2438,32 @@ func (s *Server) handleCreateCustomRule(w http.ResponseWriter, r *http.Request) 
 	http.Redirect(w, r, "/dashboard/rules?tab=custom", http.StatusFound)
 }
 
+// normalizeCustomRuleID maps free-form user input to a safe rule
+// id used as a filename component under cfg.CustomRulesDir. The
+// byte filter is applied to the FINAL id (not only the
+// auto-derived form) so a non-empty rule_id from the form cannot
+// smuggle path separators, "..", or NUL into the file write that
+// follows. The CUSTOM- prefix is always present on output.
+//
+// The handler still validates the result against safeRuleIDRe and
+// filepath.IsLocal as belt-and-braces; this helper just guarantees
+// the input shape every caller can rely on.
 func normalizeCustomRuleID(ruleID, name string) string {
-	if ruleID == "" {
-		slug := strings.ToUpper(strings.ReplaceAll(name, " ", "-"))
-		var clean []byte
-		for _, b := range []byte(slug) {
-			if (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' {
-				clean = append(clean, b)
-			}
+	candidate := ruleID
+	if candidate == "" {
+		candidate = strings.ToUpper(strings.ReplaceAll(name, " ", "-"))
+	}
+	if !strings.HasPrefix(strings.ToUpper(candidate), "CUSTOM-") {
+		candidate = "CUSTOM-" + candidate
+	}
+	candidate = strings.ToUpper(candidate)
+	var safe []byte
+	for _, b := range []byte(candidate) {
+		if (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-' {
+			safe = append(safe, b)
 		}
-		ruleID = "CUSTOM-" + string(clean)
 	}
-	if !strings.HasPrefix(strings.ToUpper(ruleID), "CUSTOM-") {
-		ruleID = "CUSTOM-" + ruleID
-	}
-	return strings.ToUpper(ruleID)
+	return string(safe)
 }
 
 func splitNonEmpty(s, sep string) []string {

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1947,6 +1947,95 @@ func TestServer_CreateCustomRuleNoPatterns(t *testing.T) {
 	}
 }
 
+// TestServer_CreateCustomRule_PathTraversalIDStaysInsideRulesDir
+// asserts the file written for a traversal-shaped rule_id lands
+// inside CustomRulesDir, not above it. The byte filter in
+// normalizeCustomRuleID strips the path separators so the call
+// is benign even though the input string carries "..".
+func TestServer_CreateCustomRule_PathTraversalIDStaysInsideRulesDir(t *testing.T) {
+	srv := newTestServer(t)
+	root := t.TempDir()
+	rulesDir := filepath.Join(root, "rules")
+	srv.cfgPath = filepath.Join(root, "oktsec.yaml")
+	srv.cfg.CustomRulesDir = rulesDir
+	srv.scanner = nil
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	form := url.Values{
+		"name":     {"Traversal Test"},
+		"rule_id":  {"../../etc/cron.d/pwn"},
+		"severity": {"high"},
+		"category": {"custom"},
+		"patterns": {"foo"},
+	}
+	req := httptest.NewRequest("POST", "/dashboard/rules/custom", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("traversal id status = %d, want 302; body=%s", w.Code, w.Body.String())
+	}
+
+	// Walk from `root` and assert the only file written below it
+	// is inside rulesDir. A successful traversal would have
+	// dropped a file at `root/etc/...` or above.
+	var written []string
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		written = append(written, p)
+		return nil
+	})
+	for _, p := range written {
+		rel, err := filepath.Rel(rulesDir, p)
+		if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			t.Errorf("file written outside CustomRulesDir: %s", p)
+		}
+	}
+	if len(written) == 0 {
+		t.Error("no rule file was written; expected a sanitised id under CustomRulesDir")
+	}
+}
+
+// TestServer_CreateCustomRule_BarePrefixIDRejected covers the
+// degenerate case where the user-supplied rule_id is built
+// entirely of bytes the normaliser drops. The result collapses
+// to "CUSTOM-" and the handler must refuse with 400 instead of
+// writing a CUSTOM-.yaml file.
+func TestServer_CreateCustomRule_BarePrefixIDRejected(t *testing.T) {
+	srv := newTestServer(t)
+	dir := t.TempDir()
+	srv.cfgPath = filepath.Join(dir, "oktsec.yaml")
+	srv.cfg.CustomRulesDir = filepath.Join(dir, "custom-rules")
+	srv.scanner = nil
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	form := url.Values{
+		"name":     {"Bare Prefix"},
+		"rule_id":  {"../"},
+		"severity": {"high"},
+		"category": {"custom"},
+		"patterns": {"foo"},
+	}
+	req := httptest.NewRequest("POST", "/dashboard/rules/custom", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bare-prefix id status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "alphanumeric") {
+		t.Errorf("400 body should explain the alphanumeric rule; got %q", w.Body.String())
+	}
+}
+
 func TestServer_DeleteCustomRule(t *testing.T) {
 	srv := newTestServer(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

`handleCreateCustomRule` built the on-disk filename via `filepath.Join(s.cfg.CustomRulesDir, ruleID + ".yaml")` with a `ruleID` derived from `r.FormValue("rule_id")`. `normalizeCustomRuleID` only ran the byte-level character filter when the form supplied an empty `rule_id`; a non-empty value was uppercased and prefixed with `CUSTOM-`, then handed straight to `filepath.Join`. A request carrying `rule_id=../../etc/cron.d/pwn` therefore resolved to a file written above `CustomRulesDir`.

## Changes

- `normalizeCustomRuleID` applies the A-Z/0-9/dash byte filter to the final id (auto-derived or user-supplied), so the helper has a single contract: output is always a safe filename component prefixed with `CUSTOM-`.
- The handler refuses an id that collapses to the bare `CUSTOM-` prefix (the user typed only filtered bytes), so a degenerate write does not silently succeed.
- The handler validates the constructed filename with the existing `safeRuleIDRe` regex **and** `filepath.IsLocal` before the write. Belt-and-braces: the regex is the contract DELETE already enforces; `IsLocal` is the static-analysis sanitiser CodeQL recognises for `go/path-injection`.

## Tests

- `TestNormalizeCustomRuleID` gains five payloads covering embedded `..`, nested separators, prefixed traversal, and bare-prefix collapse.
- `TestServer_CreateCustomRule_PathTraversalIDStaysInsideRulesDir` walks the temp dir tree after a traversal POST and asserts every file written sits inside `CustomRulesDir`.
- `TestServer_CreateCustomRule_BarePrefixIDRejected` pins the 400 path for `"../"`-shaped input.

## Closes

CodeQL alert #9 (`go/path-injection`) at `internal/dashboard/handlers.go:2402`.

## Test plan

- [x] `go test ./internal/dashboard -run 'NormalizeCustomRuleID|CreateCustomRule|DeleteCustomRule' -count=1`
- [x] `go test ./internal/dashboard -count=1`
- [x] `make vet`
- [x] `make lint`