### PR TITLE
Cap LLM queue buffer size to bound channel allocation

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -3558,7 +3558,13 @@ func (s *Server) handleSaveLLM(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if v := r.FormValue("queue_size"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		// Bound the value before it reaches the config: a request
+		// supplying queue_size=2147483647 would otherwise drive a
+		// >2GiB channel buffer allocation in NewQueue. NewQueue
+		// also clamps defensively, but keeping the form gate
+		// explicit closes the path-from-input flow CodeQL traces
+		// for go/uncontrolled-allocation-size.
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= llm.MaxQueueBufferSize {
 			s.cfg.LLM.QueueSize = n
 		}
 	}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -307,6 +307,34 @@ func TestQueueBackpressure(t *testing.T) {
 	}
 }
 
+// TestNewQueue_ClampsBufferSizeToMaxQueueBufferSize asserts the
+// channel buffer is bounded regardless of how large BufferSize is
+// in the config. Closes the go/uncontrolled-allocation-size alert
+// path: even if the dashboard form gate is bypassed, NewQueue
+// will not trigger an attacker-influenced allocation.
+func TestNewQueue_ClampsBufferSizeToMaxQueueBufferSize(t *testing.T) {
+	mock := &mockAnalyzer{result: &AnalysisResult{ProviderName: "mock", Model: "test"}}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	q := NewQueue(mock, QueueConfig{Workers: 1, BufferSize: MaxQueueBufferSize * 100}, logger)
+	if got := cap(q.ch); got != MaxQueueBufferSize {
+		t.Errorf("channel cap = %d, want %d (clamp to MaxQueueBufferSize)", got, MaxQueueBufferSize)
+	}
+}
+
+// TestNewQueue_DefaultBufferSizeWhenNonPositive pins the existing
+// default behaviour: a zero or negative BufferSize falls back to
+// 100, not to MaxQueueBufferSize.
+func TestNewQueue_DefaultBufferSizeWhenNonPositive(t *testing.T) {
+	mock := &mockAnalyzer{result: &AnalysisResult{ProviderName: "mock", Model: "test"}}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	for _, in := range []int{0, -1, -100} {
+		q := NewQueue(mock, QueueConfig{Workers: 1, BufferSize: in}, logger)
+		if got := cap(q.ch); got != 100 {
+			t.Errorf("BufferSize=%d: channel cap = %d, want 100", in, got)
+		}
+	}
+}
+
 func TestQueueDailyLimit(t *testing.T) {
 	mock := &mockAnalyzer{
 		result: &AnalysisResult{ProviderName: "mock", Model: "test"},

--- a/internal/llm/queue.go
+++ b/internal/llm/queue.go
@@ -45,18 +45,34 @@ type Queue struct {
 // QueueConfig configures the analysis queue.
 type QueueConfig struct {
 	Workers      int   // concurrent analysis workers (default: 3)
-	BufferSize   int   // channel buffer (default: 100)
+	BufferSize   int   // channel buffer (default: 100, hard cap MaxQueueBufferSize)
 	MaxDailyReqs int64 // 0 = unlimited
 	TwoStage     bool  // enable two-stage classification (fast check + full analysis)
 }
 
-// NewQueue creates an analysis queue.
+// MaxQueueBufferSize is the upper bound NewQueue will honour for
+// the channel buffer. The value is generous (100x the default) so
+// operators with legitimate high-throughput workloads stay
+// supported, but bounded enough that a stray or attacker-supplied
+// QueueSize cannot trigger an unbounded `make(chan, n)` and
+// exhaust process memory. Anything larger is silently clamped to
+// this cap; the dashboard form handler also rejects values above
+// it before they reach the config.
+const MaxQueueBufferSize = 10000
+
+// NewQueue creates an analysis queue. BufferSize is clamped to
+// MaxQueueBufferSize before allocation, so callers cannot trigger
+// an unbounded channel allocation regardless of how the config
+// was populated.
 func NewQueue(analyzer Analyzer, cfg QueueConfig, logger *slog.Logger) *Queue {
 	if cfg.Workers <= 0 {
 		cfg.Workers = 3
 	}
 	if cfg.BufferSize <= 0 {
 		cfg.BufferSize = 100
+	}
+	if cfg.BufferSize > MaxQueueBufferSize {
+		cfg.BufferSize = MaxQueueBufferSize
 	}
 
 	return &Queue{


### PR DESCRIPTION
## Summary

The dashboard settings handler accepted any positive integer for `queue_size`, wrote it to `s.cfg.LLM.QueueSize`, and let it flow into `NewQueue`'s `make(chan AnalysisRequest, BufferSize)` call. A request supplying `queue_size=2147483647` would have driven a multi-GiB channel buffer allocation and OOM'd the proxy.

## Changes

- `llm.MaxQueueBufferSize` (10000) caps the buffer `NewQueue` is willing to allocate. Anything larger is silently clamped, so callers that build a config from disk or env cannot trigger an unbounded `make()` either. Default-on-non-positive (100) is preserved.
- The dashboard form gate now refuses `queue_size` values above `MaxQueueBufferSize`, so the path-from-input flow CodeQL traces is bounded before the value reaches the config. Behaviour matches the existing handler convention of silently rejecting out-of-range values for sibling fields (`temperature`, `max_concurrent`, `max_daily`).

## Tests

- `TestNewQueue_ClampsBufferSizeToMaxQueueBufferSize` feeds a 100x oversized `BufferSize` and asserts `cap(q.ch) == MaxQueueBufferSize`.
- `TestNewQueue_DefaultBufferSizeWhenNonPositive` pins the existing 100-default for zero/negative input.

## Closes

CodeQL alert #10 (`go/uncontrolled-allocation-size`) at `internal/llm/queue.go:64`.

## Test plan

- [x] `go test ./internal/llm -run 'TestNewQueue|TestQueue' -count=1`
- [x] `go test ./internal/llm ./internal/dashboard -count=1`
- [x] `make vet`
- [x] `make lint`