### PR TITLE
Derive session cookie Secure flag from request scheme

### DIFF
--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -344,6 +344,23 @@ func clientIP(r *http.Request) string {
 	return host
 }
 
+// isHTTPS reports whether the inbound request reached the
+// dashboard over a TLS-protected channel, either directly or
+// through a reverse proxy that set X-Forwarded-Proto. The session
+// cookie's Secure flag is derived from this so the browser only
+// withholds the cookie over plaintext when the operator has
+// genuinely fronted oktsec with TLS — a hardcoded Secure=true
+// would break the default localhost dev flow.
+func isHTTPS(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
+
 // generateAccessCode returns a random 8-digit numeric code.
 func generateAccessCode() string {
 	n, _ := rand.Int(rand.Reader, big.NewInt(100_000_000))

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -106,7 +106,7 @@ func (s *Server) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		Path:     "/dashboard",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   false, // localhost only
+		Secure:   isHTTPS(r),
 	})
 	http.Redirect(w, r, "/dashboard", http.StatusFound)
 }
@@ -117,13 +117,16 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		s.auth.InvalidateSession(cookie.Value)
 	}
 
-	// Clear the cookie
+	// Clear the cookie. The Secure flag must mirror the login
+	// path so a browser running over HTTPS does not refuse the
+	// expiry write because of attribute mismatch.
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    "",
 		Path:     "/dashboard",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
+		Secure:   isHTTPS(r),
 		MaxAge:   -1, // delete cookie
 	})
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -150,6 +151,108 @@ func TestServer_LoginFlow(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Overview") {
 		t.Error("dashboard should contain 'Overview'")
+	}
+}
+
+// loginAndExtractCookie posts a successful login and returns the
+// session cookie. It accepts a request mutator so individual tests
+// can flip r.TLS or set X-Forwarded-Proto without each rebuilding
+// the form / handler boilerplate.
+func loginAndExtractCookie(t *testing.T, srv *Server, handler http.Handler, mutate func(*http.Request)) *http.Cookie {
+	t.Helper()
+	form := url.Values{"code": {srv.AccessCode()}}
+	req := httptest.NewRequest("POST", "/dashboard/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if mutate != nil {
+		mutate(req)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("login status = %d, body=%s", w.Code, w.Body.String())
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			return c
+		}
+	}
+	t.Fatal("no session cookie after login")
+	return nil
+}
+
+// TestServer_LoginCookie_SecureOnPlainHTTP — a localhost dev
+// session over plain HTTP must NOT set Secure=true. Hardcoding
+// Secure=true would block the browser from sending the cookie
+// back over HTTP and break the default `oktsec serve` flow.
+func TestServer_LoginCookie_SecureOnPlainHTTP(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginAndExtractCookie(t, srv, handler, nil)
+	if cookie.Secure {
+		t.Errorf("Secure=true on plaintext request; want false")
+	}
+}
+
+// TestServer_LoginCookie_SecureWhenTLSTerminated — when oktsec
+// serves TLS directly, r.TLS is non-nil and the cookie must be
+// flagged Secure so the browser refuses to leak it over HTTP.
+func TestServer_LoginCookie_SecureWhenTLSTerminated(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginAndExtractCookie(t, srv, handler, func(r *http.Request) {
+		r.TLS = &tls.ConnectionState{HandshakeComplete: true}
+	})
+	if !cookie.Secure {
+		t.Errorf("Secure=false on TLS-terminated request; want true")
+	}
+}
+
+// TestServer_LoginCookie_SecureWhenForwardedProtoHTTPS — when a
+// reverse proxy fronts oktsec with HTTPS and forwards
+// X-Forwarded-Proto=https, the cookie must still flag Secure so
+// the user-agent honours the TLS guarantee.
+func TestServer_LoginCookie_SecureWhenForwardedProtoHTTPS(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginAndExtractCookie(t, srv, handler, func(r *http.Request) {
+		r.Header.Set("X-Forwarded-Proto", "https")
+	})
+	if !cookie.Secure {
+		t.Errorf("Secure=false with X-Forwarded-Proto: https; want true")
+	}
+}
+
+// TestServer_LogoutCookie_MirrorsLoginSecure — the logout path
+// writes an expiring cookie with the same attribute set as the
+// login cookie, so a Secure=true session is replaced by a
+// Secure=true expiry write. Without this, browsers serving over
+// HTTPS would refuse the expiry because the attribute mismatch
+// would not be considered the same cookie.
+func TestServer_LogoutCookie_MirrorsLoginSecure(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+	cookie := loginAndExtractCookie(t, srv, handler, func(r *http.Request) {
+		r.TLS = &tls.ConnectionState{HandshakeComplete: true}
+	})
+
+	req := httptest.NewRequest("POST", "/dashboard/logout", nil)
+	req.TLS = &tls.ConnectionState{HandshakeComplete: true}
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	var expiry *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			expiry = c
+			break
+		}
+	}
+	if expiry == nil {
+		t.Fatal("logout did not set a clearing cookie")
+	}
+	if !expiry.Secure {
+		t.Errorf("logout cookie Secure=false on TLS request; want true")
 	}
 }
 


### PR DESCRIPTION
## Summary

The login handler hard-coded `Secure: false` on the dashboard session cookie with the comment `// localhost only`, and the logout handler omitted the attribute entirely. An operator who fronts oktsec with a TLS-terminating reverse proxy (or who runs the proxy with its own TLS listener) was therefore writing the session token to a cookie a browser would happily resend over plaintext if a downgrade ever occurred.

## Changes

- New `isHTTPS(r)` helper: returns true when `r.TLS != nil` OR `X-Forwarded-Proto == "https"`.
- Login and logout cookies derive `Secure` from `isHTTPS(r)`.
- Logout cookie mirrors the login `Secure` flag so the expiry write is treated as the same cookie by the browser; otherwise an attribute mismatch could cause the browser to refuse the clear on HTTPS sessions.

Behaviour:

| scenario | `Secure` |
|---|---|
| plain HTTP localhost dev | `false` (unchanged) |
| oktsec serving TLS directly | `true` |
| reverse proxy fronting oktsec with HTTPS | `true` |

## Tests

- `TestServer_LoginCookie_SecureOnPlainHTTP` pins the dev flow.
- `TestServer_LoginCookie_SecureWhenTLSTerminated` covers direct-TLS.
- `TestServer_LoginCookie_SecureWhenForwardedProtoHTTPS` covers reverse-proxy.
- `TestServer_LogoutCookie_MirrorsLoginSecure` proves the expiry write picks up `Secure=true` on TLS requests.

## Closes

CodeQL alerts #1 and #2 (`go/cookie-secure-not-set`) at `internal/dashboard/handlers.go:103` and `:121`.

## Test plan

- [x] `go test ./internal/dashboard -run 'LoginCookie|LogoutCookie|LoginFlow' -count=1`
- [x] `go test ./internal/dashboard -count=1`
- [x] `make vet`
- [x] `make lint`