### PR TITLE
Surface runtime sessions and hook coverage drill-down

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2010,20 +2010,23 @@ func runtimeSessionsTemplateData(rows []sessionListRow, rangeParam string, requi
 }
 
 func (s *Server) handleSessionsExport(w http.ResponseWriter, r *http.Request) {
-	rangeParam := r.URL.Query().Get("range")
+	rangeParam := parseSessionsRange(r.URL.Query().Get("range"))
 	format := r.URL.Query().Get("format")
+	since := sessionsRangeSince(rangeParam)
+	sinceStr := since.UTC().Format(time.RFC3339)
 
-	var since string
-	switch rangeParam {
-	case "7d":
-		since = time.Now().Add(-7 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	case "30d":
-		since = time.Now().Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	default:
-		since = time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	// Mirror the Sessions list decision: when runtime is reachable
+	// AND the window has runtime rows, the export must reflect the
+	// same dataset the operator just saw on /dashboard/sessions.
+	// Falling through to audit when runtime has rows would hand the
+	// operator a different (legacy) shape and break the audit
+	// promise the page makes.
+	if rows, ok := s.runtimeSessionRows(r.Context(), since, sessionsExportLimit); ok && len(rows) > 0 {
+		writeRuntimeSessionsExport(w, format, rows)
+		return
 	}
 
-	sessions, err := s.audit.QuerySessions(since, 500)
+	sessions, err := s.audit.QuerySessions(sinceStr, sessionsExportLimit)
 	if err != nil {
 		http.Error(w, "query error", http.StatusInternalServerError)
 		return
@@ -2042,6 +2045,51 @@ func (s *Server) handleSessionsExport(w http.ResponseWriter, r *http.Request) {
 	default: // json
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(sessions)
+	}
+}
+
+// sessionsExportLimit gives the bulk export a higher cap than the
+// page render — operators may genuinely want the full window in
+// one file — but still bounded so an attacker-supplied range
+// cannot stream the entire history.
+const sessionsExportLimit = 500
+
+// writeRuntimeSessionsExport emits the same sessionListRow shape
+// the runtime page renders, in JSON or CSV. JSON wraps the rows
+// under {source: "runtime", sessions: [...]} so a downstream
+// consumer can detect the runtime path and tell it apart from
+// the legacy SessionSummary array. CSV header lists every
+// runtime field explicitly so the column order is stable.
+func writeRuntimeSessionsExport(w http.ResponseWriter, format string, rows []sessionListRow) {
+	switch format {
+	case "csv":
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", "attachment; filename=sessions.csv")
+		_, _ = w.Write([]byte("session_id,principal_id,client_id,connector_id,status,started_at,last_seen_at,duration,event_count,tool_event_count,subagent_count,task_count,block_count,heartbeat_only\n"))
+		for _, sr := range rows {
+			_, _ = fmt.Fprintf(w, "%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%d,%d,%t\n",
+				csvEscape(sr.SessionID),
+				csvEscape(sr.PrincipalID),
+				csvEscape(sr.ClientID),
+				csvEscape(sr.ConnectorID),
+				csvEscape(sr.Status),
+				csvEscape(sr.StartedAt),
+				csvEscape(sr.LastSeenAt),
+				csvEscape(sr.Duration),
+				sr.EventCount,
+				sr.ToolEventCount,
+				sr.SubagentCount,
+				sr.TaskCount,
+				sr.BlockCount,
+				sr.IsHeartbeatOnly,
+			)
+		}
+	default: // json
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"source":   "runtime",
+			"sessions": rows,
+		})
 	}
 }
 

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1712,6 +1712,19 @@ func (s *Server) handleEventPage(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSessionExport(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
+	if detail, ok := s.runtimeSessionDetail(r.Context(), sessionID); ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="session-%s.json"`, truncateID(sessionID)))
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
+			"source":  "runtime",
+			"session": detail.Session,
+			"actors":  detail.Actors,
+			"events":  detail.Events,
+		})
+		return
+	}
 	trace, err := s.audit.BuildSessionTrace(sessionID)
 	if err != nil || trace == nil {
 		http.Error(w, "session not found", http.StatusNotFound)
@@ -1726,6 +1739,10 @@ func (s *Server) handleSessionExport(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSessionCSV(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
+	if detail, ok := s.runtimeSessionDetail(r.Context(), sessionID); ok {
+		writeRuntimeSessionCSV(w, sessionID, detail)
+		return
+	}
 	trace, err := s.audit.BuildSessionTrace(sessionID)
 	if err != nil || trace == nil {
 		http.Error(w, "session not found", http.StatusNotFound)
@@ -1750,6 +1767,47 @@ func (s *Server) handleSessionCSV(w http.ResponseWriter, r *http.Request) {
 			i+1, step.Timestamp, step.ToolName, step.Verdict, step.Decision,
 			step.LatencyMs, step.GapMs, step.PlanStep, step.PlanTotal,
 			step.EventID, reasoning,
+		)
+	}
+}
+
+// writeRuntimeSessionCSV emits the runtime CSV column set per the
+// Phase 3C spec. The columns are deliberately distinct from the
+// audit CSV — runtime carries hashes (input/output) instead of
+// tool input bodies, so the legacy "Reasoning" column is not
+// applicable. Header comments document the source so an operator
+// piping the file into a downstream tool knows the row shape up
+// front.
+func writeRuntimeSessionCSV(w http.ResponseWriter, sessionID string, detail *runtimeSessionDetailView) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="session-%s.csv"`, truncateID(sessionID)))
+	fmt.Fprintf(w, "# Runtime Session Export\r\n")
+	fmt.Fprintf(w, "# Generated: %s\r\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(w, "# Session ID: %s\r\n", detail.Session.SessionID)
+	fmt.Fprintf(w, "# Principal: %s\r\n", detail.Session.PrincipalID)
+	fmt.Fprintf(w, "# Status: %s\r\n", detail.Session.StatusLabel)
+	fmt.Fprintf(w, "# Events: %d\r\n", detail.Session.EventCount)
+	fmt.Fprintf(w, "\r\n")
+	fmt.Fprintf(w, "timestamp,actor,kind,hook_event,lifecycle,stage,tool_name,tool_use_id,tool_input_hash,tool_output_hash,status,policy_decision,coverage_mode,confidence,latency_ms,audit_entry_id,activity_event_id\r\n")
+	for _, ev := range detail.Events {
+		fmt.Fprintf(w, "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s,%s\r\n",
+			csvEscape(ev.Timestamp),
+			csvEscape(ev.ActorLabel),
+			csvEscape(ev.ActorKind),
+			csvEscape(ev.HookEventName),
+			csvEscape(ev.Lifecycle),
+			csvEscape(ev.Stage),
+			csvEscape(ev.ToolName),
+			csvEscape(ev.ToolUseID),
+			csvEscape(ev.ToolInputHash),
+			csvEscape(ev.ToolOutputHash),
+			csvEscape(ev.Status),
+			csvEscape(ev.PolicyDecision),
+			csvEscape(ev.CoverageMode),
+			ev.Confidence,
+			ev.LatencyMs,
+			csvEscape(ev.AuditEntryID),
+			csvEscape(ev.ActivityEventID),
 		)
 	}
 }
@@ -1842,23 +1900,21 @@ func csvEscape(s string) string {
 }
 
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
-	rangeParam := r.URL.Query().Get("range")
-	if rangeParam == "" {
-		rangeParam = "24h"
+	rangeParam := parseSessionsRange(r.URL.Query().Get("range"))
+	since := sessionsRangeSince(rangeParam)
+	sinceStr := since.UTC().Format(time.RFC3339)
+
+	// Runtime first: when runtime is wired AND the window has at
+	// least one runtime row, render the runtime view. An empty
+	// runtime result with ok=true still falls through to legacy
+	// because pre-3B installs and existing audit-only tests rely on
+	// the audit shape rendering when no runtime evidence exists.
+	if rows, ok := s.runtimeSessionRows(r.Context(), since, sessionsRowLimit); ok && len(rows) > 0 {
+		s.renderTemplate(w, runtimeSessionsPageTmpl, runtimeSessionsTemplateData(rows, rangeParam, s.cfg.Identity.RequireSignature))
+		return
 	}
 
-	var since string
-	switch rangeParam {
-	case "7d":
-		since = time.Now().Add(-7 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	case "30d":
-		since = time.Now().Add(-30 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	default:
-		rangeParam = "24h"
-		since = time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
-	}
-
-	sessions, err := s.audit.QuerySessions(since, 200)
+	sessions, err := s.audit.QuerySessions(sinceStr, sessionsRowLimit)
 	if err != nil {
 		s.logger.Error("query sessions", "error", err)
 		sessions = nil
@@ -1903,6 +1959,54 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		"RequireSig":     s.cfg.Identity.RequireSignature,
 	}
 	s.renderTemplate(w, sessionsPageTmpl, data)
+}
+
+// runtimeSessionsTemplateData builds the data map the runtime
+// Sessions template consumes. Stats follow the spec: total
+// counts every rendered row, threat count excludes heartbeat-only,
+// average duration uses ended/active windows and ignores
+// non-positive intervals.
+func runtimeSessionsTemplateData(rows []sessionListRow, rangeParam string, requireSig bool) map[string]any {
+	totalEvents := int64(0)
+	threats := 0
+	var totalDuration time.Duration
+	durCount := 0
+	for _, r := range rows {
+		totalEvents += r.EventCount
+		if r.Threat {
+			threats++
+		}
+		if r.IsHeartbeatOnly {
+			// 0s by spec — does not count toward avg duration.
+			continue
+		}
+		if r.Duration == "" || r.Duration == "—" {
+			continue
+		}
+		if d, err := time.ParseDuration(r.Duration); err == nil && d > 0 {
+			totalDuration += d
+			durCount++
+		}
+	}
+	avgDuration := "-"
+	if durCount > 0 {
+		avg := totalDuration / time.Duration(durCount)
+		if avg >= time.Second {
+			avgDuration = avg.Round(time.Second).String()
+		} else if avg > 0 {
+			avgDuration = avg.Round(time.Millisecond).String()
+		}
+	}
+	return map[string]any{
+		"Active":         "sessions",
+		"Sessions":       rows,
+		"Range":          rangeParam,
+		"TotalSessions":  len(rows),
+		"ThreatSessions": threats,
+		"AvgDuration":    avgDuration,
+		"TotalEvents":    totalEvents,
+		"RequireSig":     requireSig,
+	}
 }
 
 func (s *Server) handleSessionsExport(w http.ResponseWriter, r *http.Request) {
@@ -1977,6 +2081,22 @@ func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	if sessionID == "" {
 		s.handleNotFound(w, r)
+		return
+	}
+
+	// Runtime first: when runtime has a session row for this id we
+	// render the runtime detail (actor tree + hashed timeline) and
+	// skip the audit trace. AI analysis is intentionally hidden in
+	// the runtime view for this slice — the Phase 3D-era runtime
+	// shape predates the session-analysis schema and we do not
+	// silently mix the two surfaces. Audit-only sessions keep their
+	// existing AI flow.
+	if detail, ok := s.runtimeSessionDetail(r.Context(), sessionID); ok {
+		s.renderTemplate(w, runtimeSessionDetailTmpl, map[string]any{
+			"Active":     "sessions",
+			"Detail":     detail,
+			"RequireSig": s.cfg.Identity.RequireSignature,
+		})
 		return
 	}
 

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/coverage"
+	"github.com/oktsec/oktsec/internal/runtime"
 )
 
 // activityQueryTimeout bounds the activity Store.Query call the
@@ -233,19 +234,7 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 	cells := coverage.Compute(s.cfg, nil)
 	cellCoverage, cellConnector := lookupCell(cells, principalID, surface)
 
-	data := struct {
-		PrincipalID   string
-		Surface       string
-		SurfaceLabel  string
-		Coverage      string
-		CoverageLabel string
-		ConnectorID   string
-		Connector     string
-		Explanation   string
-		NextAction    coverageAction
-		Events        []activityEventDTO
-		Limit         int
-	}{
+	data := coverageCellDrawerData{
 		PrincipalID:   principalID,
 		Surface:       surface,
 		SurfaceLabel:  surfaceDisplayName(surface),
@@ -256,6 +245,23 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		Explanation:   coverageExplanation(cellCoverage),
 		NextAction:    coverageNextAction(cellCoverage, surface, principalID),
 		Limit:         drillDownEventLimit,
+	}
+
+	// For surface=hooks, prefer the runtime store: it carries the
+	// per-hook lifecycle / tool / coverage shape the drawer is
+	// supposed to surface. Heartbeat-only state renders a
+	// diagnostic banner instead of an "everything fine" empty list.
+	// mcp_http and http_egress_proxy keep the activity-store path
+	// untouched — runtime hook events do not represent those
+	// surfaces.
+	if surface == "hooks" {
+		if rows, mode, ok := s.runtimeHookDrawerEvents(r.Context(), principalID, drillDownEventLimit); ok {
+			data.HookSource = "runtime"
+			data.HookEvents = rows
+			data.HeartbeatOnly = mode == "heartbeat_only"
+			s.renderCoverageDrawer(w, data)
+			return
+		}
 	}
 
 	store := s.coverageActivityStore()
@@ -273,6 +279,141 @@ func (s *Server) handleCoverageCellDrawer(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	s.renderCoverageDrawer(w, data)
+}
+
+// coverageCellDrawerData is the shape coverageCellDrawerTmpl
+// consumes. HookSource / HookEvents / HeartbeatOnly are populated
+// only when the runtime branch fires for surface=hooks; the
+// legacy activity branch leaves them empty and the template
+// renders the existing Events list.
+type coverageCellDrawerData struct {
+	PrincipalID   string
+	Surface       string
+	SurfaceLabel  string
+	Coverage      string
+	CoverageLabel string
+	ConnectorID   string
+	Connector     string
+	Explanation   string
+	NextAction    coverageAction
+	Events        []activityEventDTO
+	Limit         int
+	HookSource    string // "runtime" when runtime branch served the response
+	HookEvents    []runtimeHookDrawerRow
+	HeartbeatOnly bool
+}
+
+// runtimeHookDrawerRow is the one-row shape the runtime branch
+// passes into the template. Kept distinct from runtimeEventView
+// so the drawer can stay narrow (no hashes, no actor metadata
+// the drawer does not render) and the Sessions detail page can
+// keep its own richer shape.
+type runtimeHookDrawerRow struct {
+	Timestamp      string
+	HookEventName  string
+	ToolName       string
+	ActorLabel     string
+	Status         string
+	PolicyDecision string
+	CoverageMode   string
+	Confidence     int
+	SessionID      string
+	IsHeartbeat    bool
+}
+
+// runtimeHookDrawerEvents queries runtime hook events for one
+// principal and splits them into "real" and "heartbeat" classes.
+// Returns:
+//
+//   - (rows, "real", true) when at least one non-heartbeat event
+//     exists in the principal's recent runtime evidence.
+//   - (nil, "heartbeat_only", true) when the principal's runtime
+//     evidence is heartbeat-only — the drawer shows the diagnostic
+//     banner without falling back to activity rows that pre-date
+//     the heartbeat-only state.
+//   - (nil, "", false) when runtime is unavailable or the query
+//     returned zero rows; the caller then runs the legacy
+//     activity-store branch.
+func (s *Server) runtimeHookDrawerEvents(ctx context.Context, principalID string, limit int) ([]runtimeHookDrawerRow, string, bool) {
+	store := s.runtimeStore()
+	if store == nil {
+		return nil, "", false
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, activityQueryTimeout)
+	defer cancel()
+	events, err := store.QueryEvents(queryCtx, runtime.EventQuery{
+		PrincipalID: principalID,
+		Limit:       limit * 4, // headroom so dropping heartbeats still leaves room for `limit` real rows
+	})
+	if err != nil {
+		s.logger.Warn("coverage hook drawer: runtime QueryEvents failed", "error", err, "principal_id", principalID)
+		return nil, "", false
+	}
+	if len(events) == 0 {
+		return nil, "", false
+	}
+
+	real := make([]runtimeHookDrawerRow, 0, len(events))
+	sawHeartbeat := false
+	for _, ev := range events {
+		if runtime.IsHeartbeatSession(ev.SessionID) {
+			sawHeartbeat = true
+			continue
+		}
+		real = append(real, runtimeHookDrawerRow{
+			Timestamp:      formatRuntimeTimestamp(ev.Timestamp),
+			HookEventName:  ev.HookEventName,
+			ToolName:       ev.ToolName,
+			ActorLabel:     hookDrawerActorLabel(ev),
+			Status:         ev.Status,
+			PolicyDecision: ev.PolicyDecision,
+			CoverageMode:   ev.CoverageMode,
+			Confidence:     ev.Confidence,
+			SessionID:      ev.SessionID,
+			IsHeartbeat:    false,
+		})
+		if len(real) >= limit {
+			break
+		}
+	}
+	if len(real) > 0 {
+		return real, "real", true
+	}
+	if sawHeartbeat {
+		return nil, "heartbeat_only", true
+	}
+	return nil, "", false
+}
+
+// hookDrawerActorLabel picks a short display string for the
+// drawer row. The drawer does not have access to the actor map
+// (those are queried per-session, not per-principal) so it falls
+// back to the tail of the actor id when nothing better is on
+// hand. Roots resolve to the principal id which the drawer header
+// already shows; we elide that case to avoid duplication.
+func hookDrawerActorLabel(ev runtime.HookEvent) string {
+	if ev.ActorID == "" {
+		return ""
+	}
+	if strings.HasSuffix(ev.ActorID, ":root") {
+		return ""
+	}
+	if strings.Contains(ev.ActorID, ":subagent:") || strings.Contains(ev.ActorID, ":subagent-type:") {
+		tail := actorIDTail(ev.ActorID)
+		return "subagent/" + tail
+	}
+	if strings.Contains(ev.ActorID, ":task:") {
+		tail := actorIDTail(ev.ActorID)
+		return "task/" + tail
+	}
+	return actorIDTail(ev.ActorID)
+}
+
+// renderCoverageDrawer emits the drawer HTML. The split out of
+// handleCoverageCellDrawer is just so the runtime and legacy
+// branches above stay readable.
+func (s *Server) renderCoverageDrawer(w http.ResponseWriter, data coverageCellDrawerData) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := coverageCellDrawerTmpl.Execute(w, data); err != nil {
@@ -467,6 +608,32 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
   <pre class="cd-next-cmd"><code>{{.NextAction.Command}}</code></pre>
   {{end}}
 </div>
+{{if eq .HookSource "runtime"}}
+<div class="cd-events">
+  {{if .HeartbeatOnly}}
+    <div class="cd-empty" style="padding:var(--sp-3) 0">Heartbeat reached the gateway. No hook activity recorded yet.</div>
+  {{else if .HookEvents}}
+    <h4>Runtime hook events</h4>
+    {{range .HookEvents}}
+    <div class="cd-event">
+      <div class="cd-event-row">
+        <span class="cd-event-resource">{{.HookEventName}}{{if .ToolName}} &middot; {{.ToolName}}{{end}}</span>
+        <span class="cd-event-time" data-ts="{{.Timestamp}}">{{.Timestamp}}</span>
+      </div>
+      <div class="cd-event-meta">
+        {{if .ActorLabel}}{{.ActorLabel}} &middot; {{end}}
+        status: {{if .Status}}{{.Status}}{{else}}—{{end}} &middot;
+        policy: {{if .PolicyDecision}}{{.PolicyDecision}}{{else}}—{{end}} &middot;
+        coverage: {{.CoverageMode}}{{if gt .Confidence 0}} ({{.Confidence}}){{end}}
+      </div>
+      {{if .SessionID}}<div class="cd-event-meta"><a href="/dashboard/sessions/{{.SessionID}}" style="color:var(--accent);text-decoration:none">View session &rarr;</a></div>{{end}}
+    </div>
+    {{end}}
+  {{else}}
+    <div class="cd-empty">No runtime hook events recorded for this surface yet.</div>
+  {{end}}
+</div>
+{{else}}
 <div class="cd-events">
   <h4>Last {{.Limit}} activity events</h4>
   {{if .Events}}
@@ -488,4 +655,5 @@ var coverageCellDrawerTmpl = template.Must(template.New("coverage-cell-drawer").
     <div class="cd-empty">No activity recorded for this surface yet.</div>
   {{end}}
 </div>
+{{end}}
 `))

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -335,6 +335,12 @@ type runtimeHookDrawerRow struct {
 //   - (nil, "", false) when runtime is unavailable or the query
 //     returned zero rows; the caller then runs the legacy
 //     activity-store branch.
+//
+// The query runs Descending=true so the database LIMIT picks from
+// the newest window. An ASC query at the same limit would let an
+// older burst of events shadow a fresh tool call when the
+// principal's history is larger than the limit, and the operator
+// would never see the recent activity in the drawer.
 func (s *Server) runtimeHookDrawerEvents(ctx context.Context, principalID string, limit int) ([]runtimeHookDrawerRow, string, bool) {
 	store := s.runtimeStore()
 	if store == nil {
@@ -344,7 +350,11 @@ func (s *Server) runtimeHookDrawerEvents(ctx context.Context, principalID string
 	defer cancel()
 	events, err := store.QueryEvents(queryCtx, runtime.EventQuery{
 		PrincipalID: principalID,
-		Limit:       limit * 4, // headroom so dropping heartbeats still leaves room for `limit` real rows
+		// Headroom: dropping heartbeat sessions in this loop still
+		// has to leave room for `limit` real rows. Descending sort
+		// guarantees the headroom is taken from the freshest end.
+		Limit:      limit * 4,
+		Descending: true,
 	})
 	if err != nil {
 		s.logger.Warn("coverage hook drawer: runtime QueryEvents failed", "error", err, "principal_id", principalID)

--- a/internal/dashboard/handlers_activity.go
+++ b/internal/dashboard/handlers_activity.go
@@ -336,11 +336,15 @@ type runtimeHookDrawerRow struct {
 //     returned zero rows; the caller then runs the legacy
 //     activity-store branch.
 //
-// The query runs Descending=true so the database LIMIT picks from
-// the newest window. An ASC query at the same limit would let an
-// older burst of events shadow a fresh tool call when the
-// principal's history is larger than the limit, and the operator
-// would never see the recent activity in the drawer.
+// The "real" query pushes the heartbeat-session filter into SQL
+// (ExcludeHeartbeats=true) so a burst of fresh heartbeats cannot
+// fill an application-side LIMIT and hide an older real event
+// behind it. Combined with Descending=true the database returns
+// the newest `limit` real events directly. Heartbeat-only state
+// is detected by a second probe query that looks for any single
+// recent event for the principal — if that probe returns at
+// least one row but the real query was empty, we know the
+// principal's recent evidence is exclusively heartbeat.
 func (s *Server) runtimeHookDrawerEvents(ctx context.Context, principalID string, limit int) ([]runtimeHookDrawerRow, string, bool) {
 	store := s.runtimeStore()
 	if store == nil {
@@ -348,49 +352,49 @@ func (s *Server) runtimeHookDrawerEvents(ctx context.Context, principalID string
 	}
 	queryCtx, cancel := context.WithTimeout(ctx, activityQueryTimeout)
 	defer cancel()
-	events, err := store.QueryEvents(queryCtx, runtime.EventQuery{
-		PrincipalID: principalID,
-		// Headroom: dropping heartbeat sessions in this loop still
-		// has to leave room for `limit` real rows. Descending sort
-		// guarantees the headroom is taken from the freshest end.
-		Limit:      limit * 4,
-		Descending: true,
+
+	realEvents, err := store.QueryEvents(queryCtx, runtime.EventQuery{
+		PrincipalID:       principalID,
+		Limit:             limit,
+		Descending:        true,
+		ExcludeHeartbeats: true,
 	})
 	if err != nil {
-		s.logger.Warn("coverage hook drawer: runtime QueryEvents failed", "error", err, "principal_id", principalID)
+		s.logger.Warn("coverage hook drawer: runtime QueryEvents (real) failed", "error", err, "principal_id", principalID)
 		return nil, "", false
 	}
-	if len(events) == 0 {
-		return nil, "", false
+	if len(realEvents) > 0 {
+		rows := make([]runtimeHookDrawerRow, 0, len(realEvents))
+		for _, ev := range realEvents {
+			rows = append(rows, runtimeHookDrawerRow{
+				Timestamp:      formatRuntimeTimestamp(ev.Timestamp),
+				HookEventName:  ev.HookEventName,
+				ToolName:       ev.ToolName,
+				ActorLabel:     hookDrawerActorLabel(ev),
+				Status:         ev.Status,
+				PolicyDecision: ev.PolicyDecision,
+				CoverageMode:   ev.CoverageMode,
+				Confidence:     ev.Confidence,
+				SessionID:      ev.SessionID,
+				IsHeartbeat:    false,
+			})
+		}
+		return rows, "real", true
 	}
 
-	real := make([]runtimeHookDrawerRow, 0, len(events))
-	sawHeartbeat := false
-	for _, ev := range events {
-		if runtime.IsHeartbeatSession(ev.SessionID) {
-			sawHeartbeat = true
-			continue
-		}
-		real = append(real, runtimeHookDrawerRow{
-			Timestamp:      formatRuntimeTimestamp(ev.Timestamp),
-			HookEventName:  ev.HookEventName,
-			ToolName:       ev.ToolName,
-			ActorLabel:     hookDrawerActorLabel(ev),
-			Status:         ev.Status,
-			PolicyDecision: ev.PolicyDecision,
-			CoverageMode:   ev.CoverageMode,
-			Confidence:     ev.Confidence,
-			SessionID:      ev.SessionID,
-			IsHeartbeat:    false,
-		})
-		if len(real) >= limit {
-			break
-		}
+	// No real events. Probe whether the principal has ANY recent
+	// runtime evidence — if so it must be heartbeat-only. The
+	// single-row LIMIT keeps the probe cheap.
+	probe, err := store.QueryEvents(queryCtx, runtime.EventQuery{
+		PrincipalID: principalID,
+		Limit:       1,
+		Descending:  true,
+	})
+	if err != nil {
+		s.logger.Warn("coverage hook drawer: runtime QueryEvents (probe) failed", "error", err, "principal_id", principalID)
+		return nil, "", false
 	}
-	if len(real) > 0 {
-		return real, "real", true
-	}
-	if sawHeartbeat {
+	if len(probe) > 0 {
 		return nil, "heartbeat_only", true
 	}
 	return nil, "", false

--- a/internal/dashboard/runtime_sessions.go
+++ b/internal/dashboard/runtime_sessions.go
@@ -1,0 +1,401 @@
+package dashboard
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtime_sessions.go is the only file that knows how to project
+// runtime.Store rows into the Sessions list and detail views the
+// dashboard renders. Keeping the projection here means
+// internal/runtime stays consumable as a generic event substrate
+// (no client-specific or dashboard-specific knowledge bleeds into
+// types.go / store.go) and the Sessions handlers only need to
+// branch "runtime first, audit fallback" without re-implementing
+// status and heartbeat semantics each call site.
+
+// sessionsRowLimit caps both the runtime and the legacy queries so
+// the Sessions list has a single, predictable upper bound. Larger
+// than the per-page render budget on purpose: filtering happens
+// client-side in tmpl_sessions.go and the operator can scroll.
+const sessionsRowLimit = 200
+
+// sessionListRow is the row shape both the runtime list template
+// and the (planned) audit-bridged template render. The "Source"
+// field exists so a single template can be parameterised by the
+// origin store; today the runtime path is the only writer of this
+// shape. Audit fallback keeps using the legacy SessionSummary type
+// directly so we do not pay a translation cost for the fallback
+// path.
+type sessionListRow struct {
+	SessionID       string
+	PrincipalID     string
+	ClientID        string
+	ConnectorID     string
+	Status          string // active | ended | heartbeat
+	StatusLabel     string
+	StatusClass     string
+	StartedAt       string
+	LastSeenAt      string
+	Duration        string
+	EventCount      int64
+	ToolEventCount  int64
+	SubagentCount   int64
+	TaskCount       int64
+	BlockCount      int64
+	CoverageStage   string
+	Threat          bool
+	IsHeartbeatOnly bool
+	Source          string // runtime | audit
+	SearchData      string // joined free-text the client filter matches against
+}
+
+// runtimeActorView is one node in the actor tree the runtime
+// session detail page renders. Kind drives the icon/label choice
+// in the template; Parent/Root are wire data the template uses to
+// nest children under their parents.
+type runtimeActorView struct {
+	ID            string
+	ParentActorID string
+	Label         string
+	Kind          string
+	Source        string
+	ToolCount     int64
+	EventCount    int64
+	BlockCount    int64
+	FirstSeenAt   string
+	LastSeenAt    string
+}
+
+// runtimeEventView is one row in the runtime timeline. All
+// payload-shaped fields are explicitly hashes or tails — never raw
+// input/output. AuditEntryID is rendered as a link to the
+// /dashboard/events/ detail when present.
+type runtimeEventView struct {
+	ID              string
+	Timestamp       string
+	HookEventName   string
+	Lifecycle       string
+	Stage           string
+	ActorLabel      string
+	ActorKind       string
+	ToolName        string
+	ToolUseID       string
+	ToolInputHash   string
+	ToolOutputHash  string
+	TaskID          string
+	TaskSubject     string
+	FilePathTail    string
+	Status          string
+	PolicyDecision  string
+	CoverageMode    string
+	Confidence      int
+	AuditEntryID    string
+	ActivityEventID string
+	LatencyMs       int64
+	IsHeartbeat     bool
+}
+
+// runtimeSessionDetailView is the full payload the runtime detail
+// template consumes. JSONExportURL / CSVExportURL are pre-built so
+// the template can render the action buttons without knowing
+// route shapes.
+type runtimeSessionDetailView struct {
+	Session       sessionListRow
+	Actors        []runtimeActorView
+	Events        []runtimeEventView
+	IsRuntime     bool
+	JSONExportURL string
+	CSVExportURL  string
+}
+
+// parseSessionsRange normalises the ?range= query string into one
+// of the supported windows and returns the canonical token.
+// Anything unknown collapses to 24h so the URL bar always reflects
+// a valid state.
+func parseSessionsRange(rangeParam string) string {
+	switch rangeParam {
+	case "7d", "30d":
+		return rangeParam
+	default:
+		return "24h"
+	}
+}
+
+// sessionsRangeSince converts the canonical range token into an
+// absolute RFC3339 timestamp the audit and runtime stores both
+// accept as their "since" filter.
+func sessionsRangeSince(rangeParam string) time.Time {
+	switch rangeParam {
+	case "7d":
+		return time.Now().Add(-7 * 24 * time.Hour).UTC()
+	case "30d":
+		return time.Now().Add(-30 * 24 * time.Hour).UTC()
+	default:
+		return time.Now().Add(-24 * time.Hour).UTC()
+	}
+}
+
+// runtimeSessionRows is the runtime-first projection the Sessions
+// list handler calls. ok signals "runtime store reachable AND
+// query succeeded" — an empty rows slice with ok=true is a valid
+// "runtime is wired but the window is quiet" state and the caller
+// can choose to fall through to legacy. Returning ok=false means
+// the runtime store is not available or the query errored.
+func (s *Server) runtimeSessionRows(ctx context.Context, since time.Time, limit int) ([]sessionListRow, bool) {
+	store := s.runtimeStore()
+	if store == nil {
+		return nil, false
+	}
+	if limit <= 0 {
+		limit = sessionsRowLimit
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	sessions, err := store.QuerySessions(queryCtx, runtime.SessionQuery{
+		Since: since,
+		Limit: limit,
+	})
+	if err != nil {
+		s.logger.Warn("runtime sessions: QuerySessions failed", "error", err)
+		return nil, false
+	}
+	rows := make([]sessionListRow, 0, len(sessions))
+	for _, sess := range sessions {
+		rows = append(rows, projectSessionListRow(sess))
+	}
+	return rows, true
+}
+
+// runtimeSessionDetail returns the runtime detail view for one
+// session id. ok=true when the runtime store has a session row
+// for the id (regardless of whether actors/events exist); the
+// caller renders the runtime template. ok=false routes to the
+// legacy audit trace.
+func (s *Server) runtimeSessionDetail(ctx context.Context, sessionID string) (*runtimeSessionDetailView, bool) {
+	store := s.runtimeStore()
+	if store == nil || sessionID == "" {
+		return nil, false
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	detail, err := store.QuerySession(queryCtx, sessionID)
+	if err != nil {
+		s.logger.Warn("runtime sessions: QuerySession failed", "error", err, "session_id", sessionID)
+		return nil, false
+	}
+	if detail == nil || detail.SessionID == "" {
+		return nil, false
+	}
+
+	actors := make([]runtimeActorView, 0, len(detail.Actors))
+	for _, a := range detail.Actors {
+		actors = append(actors, runtimeActorView{
+			ID:            a.ID,
+			ParentActorID: a.ParentActorID,
+			Label:         actorDisplayLabel(a),
+			Kind:          a.Kind,
+			Source:        a.Source,
+			ToolCount:     a.ToolCount,
+			EventCount:    a.EventCount,
+			BlockCount:    a.BlockCount,
+			FirstSeenAt:   formatRuntimeTimestamp(a.FirstSeenAt),
+			LastSeenAt:    formatRuntimeTimestamp(a.LastSeenAt),
+		})
+	}
+
+	actorByID := make(map[string]runtime.Actor, len(detail.Actors))
+	for _, a := range detail.Actors {
+		actorByID[a.ID] = a
+	}
+
+	events := make([]runtimeEventView, 0, len(detail.Events))
+	for _, ev := range detail.Events {
+		events = append(events, projectEventView(ev, actorByID))
+	}
+
+	row := projectSessionListRow(detail.Session)
+	return &runtimeSessionDetailView{
+		Session:       row,
+		Actors:        actors,
+		Events:        events,
+		IsRuntime:     true,
+		JSONExportURL: "/dashboard/api/session/" + detail.SessionID + "/export",
+		CSVExportURL:  "/dashboard/api/session/" + detail.SessionID + "/csv",
+	}, true
+}
+
+// projectSessionListRow turns one runtime.Session into the
+// sessionListRow the templates consume. Heartbeat detection,
+// status mapping, threat counting, and search-data formatting
+// all live here so handlers and tests share one shape.
+func projectSessionListRow(sess runtime.Session) sessionListRow {
+	heartbeat := runtime.IsHeartbeatSession(sess.SessionID) || strings.EqualFold(sess.Status, runtime.SessionStatusHeartbeat)
+	status, label, class := sessionStatusFields(sess, heartbeat)
+	threat := !heartbeat && sess.BlockCount > 0
+	row := sessionListRow{
+		SessionID:       sess.SessionID,
+		PrincipalID:     sess.PrincipalID,
+		ClientID:        sess.ClientID,
+		ConnectorID:     sess.ConnectorID,
+		Status:          status,
+		StatusLabel:     label,
+		StatusClass:     class,
+		StartedAt:       formatRuntimeTimestamp(sess.StartedAt),
+		LastSeenAt:      formatRuntimeTimestamp(sess.LastSeenAt),
+		Duration:        sessionDurationString(sess, heartbeat),
+		EventCount:      sess.EventCount,
+		ToolEventCount:  sess.ToolEventCount,
+		SubagentCount:   sess.SubagentCount,
+		TaskCount:       sess.TaskCount,
+		BlockCount:      sess.BlockCount,
+		Threat:          threat,
+		IsHeartbeatOnly: heartbeat,
+		Source:          "runtime",
+	}
+	if heartbeat {
+		// Heartbeat rows are diagnostic only: zero out tool counts
+		// and skip threat/coverage badges so the row never reads
+		// as observed activity in the UI.
+		row.ToolEventCount = 0
+		row.SubagentCount = 0
+		row.TaskCount = 0
+		row.BlockCount = 0
+		row.Threat = false
+		row.CoverageStage = ""
+	} else if row.ToolEventCount > 0 {
+		row.CoverageStage = "tools"
+	}
+	row.SearchData = strings.ToLower(strings.Join([]string{
+		sess.SessionID, sess.PrincipalID, sess.ClientID, sess.ConnectorID, status, label,
+	}, " "))
+	return row
+}
+
+// sessionStatusFields maps a runtime.Session into the (status,
+// label, css class) triple the template needs. Heartbeat takes
+// precedence; an unended row is "active"; otherwise "ended".
+func sessionStatusFields(sess runtime.Session, heartbeat bool) (status, label, class string) {
+	switch {
+	case heartbeat:
+		return "heartbeat", "Diagnostic heartbeat", "heartbeat"
+	case sess.EndedAt.IsZero():
+		return "active", "Active", "active"
+	default:
+		return "ended", "Ended", "ended"
+	}
+}
+
+// sessionDurationString formats the elapsed time the row should
+// display. Active sessions read the open window from
+// StartedAt → LastSeenAt; ended sessions read the closed window
+// from StartedAt → EndedAt; heartbeat-only rows always read 0s
+// because their "duration" is an artefact of the upsert keepalive.
+func sessionDurationString(sess runtime.Session, heartbeat bool) string {
+	if heartbeat {
+		return "0s"
+	}
+	end := sess.EndedAt
+	if end.IsZero() {
+		end = sess.LastSeenAt
+	}
+	if end.IsZero() || sess.StartedAt.IsZero() {
+		return "—"
+	}
+	d := end.Sub(sess.StartedAt)
+	if d <= 0 {
+		return "—"
+	}
+	if d >= time.Second {
+		return d.Round(time.Second).String()
+	}
+	return d.Round(time.Millisecond).String()
+}
+
+// projectEventView translates one runtime.HookEvent into the
+// row the timeline template renders. The actor label is
+// resolved against the session's actor set so a
+// SubagentStart event renders as "subagent/research" instead of
+// the opaque actor id; if the actor is unknown (event references
+// an actor row outside the limit), we fall back to the parent id
+// tail.
+func projectEventView(ev runtime.HookEvent, actorByID map[string]runtime.Actor) runtimeEventView {
+	actorLabel, actorKind := "", ""
+	if a, ok := actorByID[ev.ActorID]; ok {
+		actorLabel = actorDisplayLabel(a)
+		actorKind = a.Kind
+	} else if ev.ActorID != "" {
+		actorLabel = actorIDTail(ev.ActorID)
+	}
+	return runtimeEventView{
+		ID:              ev.ID,
+		Timestamp:       formatRuntimeTimestamp(ev.Timestamp),
+		HookEventName:   ev.HookEventName,
+		Lifecycle:       ev.Lifecycle,
+		Stage:           ev.Stage,
+		ActorLabel:      actorLabel,
+		ActorKind:       actorKind,
+		ToolName:        ev.ToolName,
+		ToolUseID:       ev.ToolUseID,
+		ToolInputHash:   ev.ToolInputHash,
+		ToolOutputHash:  ev.ToolOutputHash,
+		TaskID:          ev.TaskID,
+		TaskSubject:     ev.TaskSubject,
+		FilePathTail:    ev.FilePathTail,
+		Status:          ev.Status,
+		PolicyDecision:  ev.PolicyDecision,
+		CoverageMode:    ev.CoverageMode,
+		Confidence:      ev.Confidence,
+		AuditEntryID:    ev.AuditEntryID,
+		ActivityEventID: ev.ActivityEventID,
+		LatencyMs:       ev.LatencyMs,
+		IsHeartbeat:     runtime.IsHeartbeatSession(ev.SessionID),
+	}
+}
+
+// actorDisplayLabel mirrors the runtime graph's label rules so
+// the Sessions detail page and the Graph page name the same actor
+// the same way. Root prefers PrincipalID (the policy identity),
+// subagents and tasks prefer their runtime label or the trailing
+// id segment.
+func actorDisplayLabel(a runtime.Actor) string {
+	switch a.Kind {
+	case runtime.ActorKindRoot:
+		if a.PrincipalID != "" {
+			return a.PrincipalID
+		}
+		if a.Label != "" {
+			return a.Label
+		}
+		return "root"
+	case runtime.ActorKindSubagent:
+		if a.Label != "" {
+			return "subagent/" + a.Label
+		}
+		return "subagent/" + actorIDTail(a.ID)
+	case runtime.ActorKindTask:
+		if a.Label != "" {
+			return "task/" + a.Label
+		}
+		return "task/" + actorIDTail(a.ID)
+	default:
+		if a.Label != "" {
+			return a.Label
+		}
+		return "actor/" + actorIDTail(a.ID)
+	}
+}
+
+// formatRuntimeTimestamp produces the RFC3339 string the templates
+// expect. Empty / zero times become an empty string so the
+// template renders an em-dash placeholder rather than the Go zero
+// value.
+func formatRuntimeTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/dashboard/runtime_sessions_test.go
+++ b/internal/dashboard/runtime_sessions_test.go
@@ -1,0 +1,429 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtime_sessions_test.go covers the Phase 3C full slice. The
+// shared scaffolding is newRuntimeGraphTestServer + seedRuntimeEvent
+// from runtime_graph_test.go: a temp-dir server with both an audit
+// store and a runtime store wired, and a helper that pushes one
+// hook event through Normalize+RecordHook so the runtime tables
+// fill the same way the production hooks handler would. Tests
+// here only need to declare what to seed and what to assert.
+
+// fetchSessionsHTML returns the rendered Sessions list HTML for
+// the given range token.
+func fetchSessionsHTML(t *testing.T, srv *Server, cookie *http.Cookie, handler http.Handler, rng string) string {
+	t.Helper()
+	url := "/dashboard/sessions"
+	if rng != "" {
+		url += "?range=" + rng
+	}
+	req := httptest.NewRequest("GET", url, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("sessions list status = %d, body=%s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+// fetchSessionDetailHTML returns the rendered detail HTML for one
+// session id.
+func fetchSessionDetailHTML(t *testing.T, srv *Server, cookie *http.Cookie, handler http.Handler, sessionID string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/dashboard/sessions/"+sessionID, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w.Code, w.Body.String()
+}
+
+// fetchSessionExport returns the raw response for one session
+// export endpoint (json, csv, etc.).
+func fetchSessionExport(t *testing.T, cookie *http.Cookie, handler http.Handler, sessionID, format string) (int, string, http.Header) {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/dashboard/api/session/"+sessionID+"/"+format, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w.Code, w.Body.String(), w.Result().Header
+}
+
+// TestSessions_RuntimePreferredOverAudit — when both runtime and
+// audit have rows for a window, the rendered list comes from
+// runtime. We assert by looking for the runtime-only header
+// columns ("Principal", "Client") that the legacy template never
+// produces.
+func TestSessions_RuntimePreferredOverAudit(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Runtime evidence: one root + one tool call.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-prefer"}`,
+		"sess-prefer", "local-codex", now.Add(-10*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-prefer","tool_name":"Read","tool_use_id":"u1"}`,
+		"sess-prefer", "local-codex", now.Add(-9*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	// Audit evidence for a different session id — should NOT
+	// surface because runtime has rows in this window.
+	auditStore.Log(audit.Entry{
+		ID: "audit-only", Timestamp: now.Add(-8 * time.Minute).Format(time.RFC3339),
+		FromAgent: "phantom-agent", ToAgent: "echo", Status: "delivered", PolicyDecision: "allow",
+		SessionID: "audit-phantom",
+	})
+	auditStore.Flush()
+
+	body := fetchSessionsHTML(t, srv, cookie, handler, "24h")
+	if !strings.Contains(body, "sess-prefer") {
+		t.Errorf("runtime session id missing from list; body=%.300s", body)
+	}
+	if strings.Contains(body, "audit-phantom") {
+		t.Errorf("audit-only session leaked into runtime-preferred view")
+	}
+	// Runtime template signature columns:
+	if !strings.Contains(body, ">Principal<") || !strings.Contains(body, ">Client<") {
+		t.Errorf("runtime template chrome missing — handler may not have picked the runtime branch")
+	}
+}
+
+// TestSessions_FallbacksToAuditWhenRuntimeEmpty — with no runtime
+// rows in the window, the legacy audit list still renders. We
+// assert by looking for an audit-only column ("Risk") that the
+// runtime template does not produce.
+func TestSessions_FallbacksToAuditWhenRuntimeEmpty(t *testing.T) {
+	srv, _, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	auditStore.Log(audit.Entry{
+		ID: "audit-fallback", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-a", ToAgent: "agent-b", Status: "delivered", PolicyDecision: "allow",
+		SessionID: "audit-fallback-session",
+	})
+	auditStore.Flush()
+
+	body := fetchSessionsHTML(t, srv, cookie, handler, "24h")
+	if !strings.Contains(body, ">Risk<") {
+		t.Errorf("audit template signature missing; runtime branch may have hijacked the empty-runtime case")
+	}
+	if !strings.Contains(body, "audit-fallback-session") {
+		t.Errorf("audit fallback row missing from list")
+	}
+}
+
+// TestSessions_HeartbeatOnlyRowIsDiagnostic — a heartbeat-prefixed
+// session id renders as a diagnostic row: muted styling, zero
+// tool count, no threat badge, "Diagnostic heartbeat" label.
+func TestSessions_HeartbeatOnlyRowIsDiagnostic(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30"}`,
+		"heartbeat-2026-04-30", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{})
+
+	body := fetchSessionsHTML(t, srv, cookie, handler, "24h")
+	if !strings.Contains(body, "Diagnostic heartbeat") {
+		t.Errorf("expected 'Diagnostic heartbeat' label; body=%.400s", body)
+	}
+	if !strings.Contains(body, `class="ss-heartbeat`) {
+		t.Errorf("expected ss-heartbeat row class for muted styling; body=%.400s", body)
+	}
+	// The threat badge markup is `<span class="ss-threat">N blocked</span>`.
+	// A heartbeat-only row must not render that span.
+	if strings.Contains(body, `class="ss-threat">`) {
+		t.Errorf("heartbeat-only row produced a threat badge")
+	}
+}
+
+// TestSessions_ActiveNoToolsShowsWaitingState — an active session
+// (no EndedAt) with zero tool events renders the neutral
+// "Waiting for first tool call" copy instead of an empty cell or
+// a threat label.
+func TestSessions_ActiveNoToolsShowsWaitingState(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Only a SessionStart — no PreToolUse, so ToolEventCount stays 0.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-waiting"}`,
+		"sess-waiting", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{})
+
+	body := fetchSessionsHTML(t, srv, cookie, handler, "24h")
+	if !strings.Contains(body, "Waiting for first tool call") {
+		t.Errorf("expected waiting-state copy; body=%.400s", body)
+	}
+}
+
+// TestSessions_RuntimeProtectedToolShowsCoverage — a runtime
+// session that emitted tool calls reports the activity counters
+// (tool count, subagent count where applicable) instead of the
+// waiting-state copy.
+func TestSessions_RuntimeProtectedToolShowsCoverage(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-cov"}`,
+		"sess-cov", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-cov","agent_id":"sa-1","agent_type":"research"}`,
+		"sess-cov", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-cov","agent_id":"sa-1","agent_type":"research","tool_name":"Read","tool_use_id":"u-cov"}`,
+		"sess-cov", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered", CoverageMode: "protected", Confidence: 90})
+
+	body := fetchSessionsHTML(t, srv, cookie, handler, "24h")
+	if strings.Contains(body, "Waiting for first tool call") {
+		t.Errorf("active-with-tools row should not show the waiting copy")
+	}
+	if !strings.Contains(body, "1 tool") {
+		t.Errorf("expected '1 tool' activity summary; body=%.400s", body)
+	}
+}
+
+// TestSessionDetail_RuntimeTreeAndTimeline — the runtime detail
+// page renders the actor tree (root + subagent) and at least one
+// timeline row referencing the seeded tool name.
+func TestSessionDetail_RuntimeTreeAndTimeline(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-detail"}`,
+		"sess-detail", "local-codex", now.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"sess-detail","agent_id":"sa-d","agent_type":"investigator"}`,
+		"sess-detail", "local-codex", now.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-detail","agent_id":"sa-d","agent_type":"investigator","tool_name":"Bash","tool_use_id":"u-detail"}`,
+		"sess-detail", "local-codex", now.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-detail")
+	if status != http.StatusOK {
+		t.Fatalf("detail status = %d, body=%s", status, body)
+	}
+	if !strings.Contains(body, "Actor tree") {
+		t.Errorf("runtime detail missing actor tree section")
+	}
+	if !strings.Contains(body, "Timeline") {
+		t.Errorf("runtime detail missing timeline section")
+	}
+	if !strings.Contains(body, "PreToolUse") {
+		t.Errorf("runtime timeline missing seeded PreToolUse event")
+	}
+	if !strings.Contains(body, "subagent") {
+		t.Errorf("runtime detail did not surface the subagent actor")
+	}
+	// AI sidebar must be hidden on runtime detail per spec.
+	if strings.Contains(body, "Analyze with AI") || strings.Contains(body, "ai-analyze-btn") {
+		t.Errorf("runtime detail leaked the audit AI button")
+	}
+}
+
+// TestSessionDetail_RuntimeDoesNotLeakRawPayload — even when the
+// hook envelope carries tool_input fields, the runtime detail
+// HTML must only show hashes/tails, never the raw bytes.
+func TestSessionDetail_RuntimeDoesNotLeakRawPayload(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-redact","tool_name":"Bash","tool_use_id":"u-redact","tool_input":{"command":"echo SUPER_SECRET_PAYLOAD_42"}}`,
+		"sess-redact", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-redact")
+	if status != http.StatusOK {
+		t.Fatalf("detail status = %d", status)
+	}
+	if strings.Contains(body, "SUPER_SECRET_PAYLOAD_42") {
+		t.Errorf("runtime detail HTML leaked raw tool input")
+	}
+}
+
+// TestSessionExport_RuntimeJSON — the JSON export of a runtime
+// session yields the runtime envelope shape (source, session,
+// actors, events) and never carries raw tool input.
+func TestSessionExport_RuntimeJSON(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-json","tool_name":"Read","tool_use_id":"u-json","tool_input":{"file":"SUPER_SECRET_FILENAME"}}`,
+		"sess-json", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body, _ := fetchSessionExport(t, cookie, handler, "sess-json", "export")
+	if status != http.StatusOK {
+		t.Fatalf("export status = %d, body=%s", status, body)
+	}
+	if strings.Contains(body, "SUPER_SECRET_FILENAME") {
+		t.Errorf("JSON export leaked raw payload field")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("export not valid JSON: %v", err)
+	}
+	if parsed["source"] != "runtime" {
+		t.Errorf(`expected "source":"runtime", got %v`, parsed["source"])
+	}
+	if _, ok := parsed["events"]; !ok {
+		t.Errorf("export missing events array")
+	}
+}
+
+// TestSessionExport_RuntimeCSV — the CSV export uses the runtime
+// column header set, not the legacy Step/Reasoning columns.
+func TestSessionExport_RuntimeCSV(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-csv","tool_name":"Read","tool_use_id":"u-csv"}`,
+		"sess-csv", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body, hdr := fetchSessionExport(t, cookie, handler, "sess-csv", "csv")
+	if status != http.StatusOK {
+		t.Fatalf("csv status = %d, body=%s", status, body)
+	}
+	if !strings.HasPrefix(hdr.Get("Content-Type"), "text/csv") {
+		t.Errorf("Content-Type = %q, want text/csv", hdr.Get("Content-Type"))
+	}
+	wantHeader := "timestamp,actor,kind,hook_event,lifecycle,stage,tool_name,tool_use_id,tool_input_hash,tool_output_hash,status,policy_decision,coverage_mode,confidence,latency_ms,audit_entry_id,activity_event_id"
+	if !strings.Contains(body, wantHeader) {
+		t.Errorf("runtime CSV header missing; got body=%.500s", body)
+	}
+	if strings.Contains(body, "Step,Timestamp,Tool,Verdict") {
+		t.Errorf("runtime CSV emitted the legacy audit header instead of the runtime shape")
+	}
+}
+
+// fetchCoverageDrawer hits the cell drawer endpoint for one
+// (principal, surface) pair and returns the rendered HTML.
+func fetchCoverageDrawer(t *testing.T, cookie *http.Cookie, handler http.Handler, principalID, surface string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/dashboard/api/coverage/cell?principal_id="+principalID+"&surface="+surface, nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	body, _ := io.ReadAll(w.Body)
+	return w.Code, string(body)
+}
+
+// TestCoverageHooksDrawer_UsesRuntimeRealEvents — when the
+// principal has runtime hook events, the drawer renders the
+// runtime block ("Runtime hook events" heading) with the seeded
+// hook event name.
+func TestCoverageHooksDrawer_UsesRuntimeRealEvents(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-drawer","tool_name":"Read","tool_use_id":"u-drawer"}`,
+		"sess-drawer", "local-codex", now.Add(-1*time.Minute), runtime.OutcomeRefs{Status: "delivered", CoverageMode: "protected"})
+
+	status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", "hooks")
+	if status != http.StatusOK {
+		t.Fatalf("drawer status = %d, body=%.300s", status, body)
+	}
+	if !strings.Contains(body, "Runtime hook events") {
+		t.Errorf("drawer did not render the runtime branch heading; body=%.500s", body)
+	}
+	if !strings.Contains(body, "PreToolUse") {
+		t.Errorf("runtime drawer missing seeded hook event")
+	}
+}
+
+// TestCoverageHooksDrawer_HeartbeatOnlyDiagnostic — when the only
+// runtime evidence for the principal is a heartbeat session, the
+// drawer renders the diagnostic banner and does not show the
+// "Runtime hook events" list nor fall back to the activity store.
+func TestCoverageHooksDrawer_HeartbeatOnlyDiagnostic(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-x"}`,
+		"heartbeat-2026-04-30-x", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{})
+
+	status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", "hooks")
+	if status != http.StatusOK {
+		t.Fatalf("drawer status = %d, body=%.300s", status, body)
+	}
+	if !strings.Contains(body, "Heartbeat reached the gateway") {
+		t.Errorf("expected heartbeat diagnostic copy; body=%.500s", body)
+	}
+	if strings.Contains(body, "Runtime hook events") {
+		t.Errorf("drawer rendered the runtime events block on a heartbeat-only state")
+	}
+	if strings.Contains(body, "Last 20 activity events") {
+		t.Errorf("drawer fell back to legacy activity events on a heartbeat-only state")
+	}
+}
+
+// TestCoverageDrawer_MCPAndEgressUnchanged — the runtime branch
+// only fires for surface=hooks. mcp_http and http_egress_proxy
+// continue to render the legacy activity-store block (the
+// "Last N activity events" heading) regardless of runtime
+// evidence.
+func TestCoverageDrawer_MCPAndEgressUnchanged(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Seed runtime evidence the runtime branch would otherwise pick up.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-other","tool_name":"Read","tool_use_id":"u-other"}`,
+		"sess-other", "local-codex", now.Add(-2*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	for _, surface := range []string{"mcp_http", "http_egress_proxy"} {
+		status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", surface)
+		if status != http.StatusOK {
+			t.Fatalf("drawer status for %s = %d", surface, status)
+		}
+		if strings.Contains(body, "Runtime hook events") {
+			t.Errorf("surface %s drawer leaked the runtime block", surface)
+		}
+		if strings.Contains(body, "Heartbeat reached the gateway") {
+			t.Errorf("surface %s drawer leaked the heartbeat diagnostic", surface)
+		}
+		if !strings.Contains(body, "Last 20 activity events") {
+			t.Errorf("surface %s drawer missing the legacy activity heading; body=%.500s", surface, body)
+		}
+	}
+}

--- a/internal/dashboard/runtime_sessions_test.go
+++ b/internal/dashboard/runtime_sessions_test.go
@@ -534,6 +534,49 @@ func TestCoverageHooksDrawer_PicksNewestEventOverOldBacklog(t *testing.T) {
 	}
 }
 
+// TestCoverageHooksDrawer_RealEventThen100NewerHeartbeats is the
+// adversarial regression for the SQL-side ExcludeHeartbeats
+// filter. The previous fix relied on application-side filtering
+// of a Descending limit*4 window, which still fails when 100+
+// heartbeats arrive AFTER a real event: every row in the window
+// is a heartbeat, the loop drops them all, and the drawer
+// incorrectly collapses to heartbeat_only despite the real event
+// being live in the table. Pushing the filter into SQL closes
+// this gap because the database returns the next N
+// non-heartbeat rows directly.
+func TestCoverageHooksDrawer_RealEventThen100NewerHeartbeats(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Real event first (oldest).
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-real-before-spam","tool_name":"OLDER_REAL_TOOL","tool_use_id":"u-real-old"}`,
+		"sess-real-before-spam", "local-codex", now.Add(-10*time.Minute),
+		runtime.OutcomeRefs{Status: "delivered"})
+
+	// 100 heartbeats AFTER the real event so a Descending window
+	// of any reasonable size is dominated by heartbeats.
+	for i := 0; i < 100; i++ {
+		seedRuntimeEvent(t, rs,
+			`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-after-`+strItoa(i)+`"}`,
+			"heartbeat-2026-04-30-after-"+strItoa(i), "local-codex",
+			now.Add(-5*time.Minute).Add(time.Duration(i)*time.Second), runtime.OutcomeRefs{})
+	}
+
+	status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", "hooks")
+	if status != http.StatusOK {
+		t.Fatalf("drawer status = %d", status)
+	}
+	if strings.Contains(body, "Heartbeat reached the gateway") {
+		t.Errorf("drawer collapsed to heartbeat-only despite a real event hidden behind 100 newer heartbeats; body=%.500s", body)
+	}
+	if !strings.Contains(body, "OLDER_REAL_TOOL") {
+		t.Errorf("drawer missed the real event when heartbeat spam arrived after it; body=%.500s", body)
+	}
+}
+
 // TestCoverageHooksDrawer_HeartbeatSpamDoesNotBuryRecentEvent
 // covers the more adversarial variant of the same bug: when
 // heartbeat keepalives flood the recent window, the drawer must

--- a/internal/dashboard/runtime_sessions_test.go
+++ b/internal/dashboard/runtime_sessions_test.go
@@ -395,6 +395,182 @@ func TestCoverageHooksDrawer_HeartbeatOnlyDiagnostic(t *testing.T) {
 	}
 }
 
+// TestSessionsExport_RuntimePreferredOverAudit covers a P2 caught
+// in review of the original Phase 3C slice: the Sessions list
+// rendered runtime rows, but /dashboard/api/sessions/export was
+// still wired to s.audit.QuerySessions, so an operator who
+// clicked JSON or CSV on the runtime page would receive the
+// legacy audit shape for a different set of session ids. The
+// export must follow the same runtime-first decision as the page
+// itself.
+func TestSessionsExport_RuntimePreferredOverAudit(t *testing.T) {
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"sess-export"}`,
+		"sess-export", "local-codex", now.Add(-10*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-export","tool_name":"Read","tool_use_id":"u-export"}`,
+		"sess-export", "local-codex", now.Add(-9*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+
+	auditStore.Log(audit.Entry{
+		ID: "audit-export-phantom", Timestamp: now.Add(-8 * time.Minute).Format(time.RFC3339),
+		FromAgent: "phantom-export", ToAgent: "echo", Status: "delivered", PolicyDecision: "allow",
+		SessionID: "audit-export-phantom",
+	})
+	auditStore.Flush()
+
+	// JSON export must carry runtime rows + source marker.
+	reqJSON := httptest.NewRequest("GET", "/dashboard/api/sessions/export?format=json&range=24h", nil)
+	reqJSON.AddCookie(cookie)
+	wJSON := httptest.NewRecorder()
+	handler.ServeHTTP(wJSON, reqJSON)
+	if wJSON.Code != http.StatusOK {
+		t.Fatalf("json export status = %d, body=%s", wJSON.Code, wJSON.Body.String())
+	}
+	jsonBody := wJSON.Body.String()
+	if !strings.Contains(jsonBody, `"source":"runtime"`) {
+		t.Errorf(`JSON export missing "source":"runtime"; body=%.300s`, jsonBody)
+	}
+	if !strings.Contains(jsonBody, "sess-export") {
+		t.Errorf("JSON export missing runtime session id; body=%.300s", jsonBody)
+	}
+	if strings.Contains(jsonBody, "audit-export-phantom") {
+		t.Errorf("JSON export leaked audit-only row when runtime had data")
+	}
+
+	// CSV export must use the runtime header row.
+	reqCSV := httptest.NewRequest("GET", "/dashboard/api/sessions/export?format=csv&range=24h", nil)
+	reqCSV.AddCookie(cookie)
+	wCSV := httptest.NewRecorder()
+	handler.ServeHTTP(wCSV, reqCSV)
+	if wCSV.Code != http.StatusOK {
+		t.Fatalf("csv export status = %d", wCSV.Code)
+	}
+	csvBody := wCSV.Body.String()
+	if !strings.Contains(csvBody, "session_id,principal_id,client_id,connector_id,status,started_at,last_seen_at,duration,event_count,tool_event_count,subagent_count,task_count,block_count,heartbeat_only") {
+		t.Errorf("CSV export missing runtime header; body=%.300s", csvBody)
+	}
+	if !strings.Contains(csvBody, "sess-export") {
+		t.Errorf("CSV export missing runtime session id; body=%.300s", csvBody)
+	}
+	if strings.Contains(csvBody, "audit-export-phantom") {
+		t.Errorf("CSV export leaked audit-only row when runtime had data")
+	}
+}
+
+// TestSessionsExport_FallsBackToAuditWhenRuntimeEmpty pairs with
+// the test above: when the runtime store has no rows in the
+// window, the export must keep using the legacy audit shape so
+// pre-3B installs and audit-only fixtures still produce a usable
+// download.
+func TestSessionsExport_FallsBackToAuditWhenRuntimeEmpty(t *testing.T) {
+	srv, _, auditStore := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	auditStore.Log(audit.Entry{
+		ID: "audit-only-export", Timestamp: now.Add(-3 * time.Minute).Format(time.RFC3339),
+		FromAgent: "agent-a", ToAgent: "agent-b", Status: "delivered", PolicyDecision: "allow",
+		SessionID: "audit-only-export-session",
+	})
+	auditStore.Flush()
+
+	req := httptest.NewRequest("GET", "/dashboard/api/sessions/export?format=csv&range=24h", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("export status = %d", w.Code)
+	}
+	csvBody := w.Body.String()
+	// Legacy header signature.
+	if !strings.Contains(csvBody, "session_id,started_at,ended_at,duration,events,agents,blocks,quarantines,flags,risk_score") {
+		t.Errorf("audit-fallback CSV header missing; body=%.300s", csvBody)
+	}
+	if !strings.Contains(csvBody, "audit-only-export-session") {
+		t.Errorf("audit-fallback row missing")
+	}
+}
+
+// TestCoverageHooksDrawer_PicksNewestEventOverOldBacklog is the
+// regression for the second P2: runtimeHookDrawerEvents was using
+// the runtime store's default ASC-by-timestamp ordering, so a
+// principal with a long backlog never had its newest hook event
+// reach the drawer — the LIMIT cut from the oldest end. Seed an
+// 80-event backlog plus a single fresh event and assert the
+// drawer surfaces the fresh one.
+func TestCoverageHooksDrawer_PicksNewestEventOverOldBacklog(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// 80 old events, all the same shape. They live on a real
+	// (non-heartbeat) session id so the runtime branch fires.
+	for i := 0; i < 80; i++ {
+		seedRuntimeEvent(t, rs,
+			`{"hook_event_name":"PreToolUse","session_id":"sess-old","tool_name":"OldTool","tool_use_id":"u-old-`+strItoa(i)+`"}`,
+			"sess-old", "local-codex", now.Add(-2*time.Hour).Add(time.Duration(i)*time.Second),
+			runtime.OutcomeRefs{Status: "delivered"})
+	}
+	// One fresh event with a distinctive tool name so the
+	// assertion is unambiguous.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-fresh","tool_name":"FRESH_RECENT_TOOL","tool_use_id":"u-fresh"}`,
+		"sess-fresh", "local-codex", now.Add(-30*time.Second),
+		runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", "hooks")
+	if status != http.StatusOK {
+		t.Fatalf("drawer status = %d", status)
+	}
+	if !strings.Contains(body, "FRESH_RECENT_TOOL") {
+		t.Errorf("drawer truncated the newest event; body=%.500s", body)
+	}
+}
+
+// TestCoverageHooksDrawer_HeartbeatSpamDoesNotBuryRecentEvent
+// covers the more adversarial variant of the same bug: when
+// heartbeat keepalives flood the recent window, the drawer must
+// still surface the one real hook event in that window and must
+// NOT collapse to the heartbeat-only diagnostic. Without
+// Descending=true the heartbeats can dominate the LIMIT and the
+// real event never reaches the dedupe step.
+func TestCoverageHooksDrawer_HeartbeatSpamDoesNotBuryRecentEvent(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	for i := 0; i < 100; i++ {
+		seedRuntimeEvent(t, rs,
+			`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-spam-`+strItoa(i)+`"}`,
+			"heartbeat-2026-04-30-spam-"+strItoa(i), "local-codex",
+			now.Add(-1*time.Hour).Add(time.Duration(i)*time.Second), runtime.OutcomeRefs{})
+	}
+	// One real recent event in the same window.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"sess-real-after-spam","tool_name":"RECENT_REAL_TOOL","tool_use_id":"u-real"}`,
+		"sess-real-after-spam", "local-codex", now.Add(-10*time.Second),
+		runtime.OutcomeRefs{Status: "delivered"})
+
+	status, body := fetchCoverageDrawer(t, cookie, handler, "local-codex", "hooks")
+	if status != http.StatusOK {
+		t.Fatalf("drawer status = %d", status)
+	}
+	if strings.Contains(body, "Heartbeat reached the gateway") {
+		t.Errorf("drawer collapsed to heartbeat-only despite a real recent event; body=%.500s", body)
+	}
+	if !strings.Contains(body, "RECENT_REAL_TOOL") {
+		t.Errorf("drawer missed the real event behind heartbeat spam; body=%.500s", body)
+	}
+}
+
 // TestCoverageDrawer_MCPAndEgressUnchanged — the runtime branch
 // only fires for surface=hooks. mcp_http and http_egress_proxy
 // continue to render the legacy activity-store block (the

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -210,3 +210,171 @@ function analyzeSession(sid) {
 </script>
 
 ` + layoutFoot))
+
+// runtimeSessionDetailTmpl renders the runtime-backed session
+// page. It deliberately diverges from sessionTraceTmpl in two
+// ways: (1) the timeline is built from runtime hook events, which
+// carry hashes instead of raw input/output, and (2) the AI
+// analysis sidebar is hidden — the session-analysis schema and
+// the runtime envelope have not been reconciled yet, so showing
+// audit-driven analysis next to runtime evidence would mix two
+// stores. AI returns when the runtime path adopts the analysis
+// pipeline.
+var runtimeSessionDetailTmpl = template.Must(template.New("runtime-session-detail").Funcs(tmplFuncs).Parse(layoutHead + `
+<style>
+.rt-meta{font-size:var(--text-sm);color:var(--text3);margin-bottom:20px;display:flex;flex-wrap:wrap;gap:18px}
+.rt-meta b{color:var(--text);font-weight:500}
+.rt-meta .ss-status{display:inline-block;padding:2px 8px;border-radius:4px;font-size:var(--text-xs);font-weight:600}
+.rt-meta .ss-status.s-active{background:var(--success-muted);color:var(--success);border:1px solid var(--success-border)}
+.rt-meta .ss-status.s-ended{background:var(--surface2);color:var(--text2);border:1px solid var(--border)}
+.rt-meta .ss-status.s-heartbeat{background:transparent;color:var(--text3);border:1px solid var(--border)}
+
+.rt-actions{display:flex;gap:8px;margin-bottom:20px}
+.rt-actions a{padding:5px 12px;font-size:var(--text-xs);border:1px solid var(--border);border-radius:5px;color:var(--text2);text-decoration:none;background:transparent}
+.rt-actions a:hover{background:var(--surface2);color:var(--text)}
+
+.rt-stats{display:grid;grid-template-columns:repeat(5,1fr);margin-bottom:24px;background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+.rt-stat{padding:16px 20px;text-align:center}
+.rt-stat+.rt-stat{border-left:1px solid var(--border)}
+.rt-stat .label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:4px}
+.rt-stat .value{font-size:1.2rem;font-weight:600;color:var(--text)}
+.rt-stat .value.v-danger{color:var(--danger)}
+@media(max-width:1100px){.rt-stats{grid-template-columns:repeat(3,1fr)}.rt-stat:nth-child(n+4){border-top:1px solid var(--border)}}
+
+.rt-section{padding:16px 20px;background:var(--surface);border:1px solid var(--border);border-radius:10px;margin-bottom:24px}
+.rt-section h3{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin:0 0 12px 0;font-weight:600}
+
+.rt-actor{display:flex;align-items:center;gap:8px;padding:6px 0;font-size:var(--text-sm)}
+.rt-actor .name{font-weight:500;color:var(--text);font-family:var(--mono);font-size:0.78rem}
+.rt-actor .kind{font-size:0.62rem;padding:2px 7px;border-radius:4px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:var(--surface2);color:var(--text3);border:1px solid var(--border)}
+.rt-actor .kind.k-root{color:var(--accent);border-color:var(--accent-border);background:rgba(56,139,253,0.10)}
+.rt-actor .kind.k-subagent{color:var(--purple);border-color:var(--purple-border);background:var(--purple-muted)}
+.rt-actor .kind.k-task{color:var(--warn);border-color:var(--warn-border);background:var(--warn-muted)}
+.rt-actor .meta{font-size:var(--text-xs);color:var(--text3);margin-left:auto}
+.rt-actor .meta .blocks{color:var(--danger)}
+.rt-actor.indent-1{padding-left:24px}
+.rt-actor.indent-2{padding-left:48px}
+.rt-actor.indent-3{padding-left:72px}
+
+.rt-timeline{position:relative;padding-left:32px}
+.rt-timeline::before{content:'';position:absolute;left:11px;top:8px;bottom:8px;width:2px;background:var(--border)}
+.rt-row{position:relative;margin-bottom:14px;padding:12px 16px;background:var(--surface);border:1px solid var(--border);border-radius:8px}
+.rt-row::before{content:'';position:absolute;left:-25px;top:18px;width:10px;height:10px;border-radius:50%;background:var(--success);border:2px solid var(--bg);box-shadow:0 0 6px var(--success-muted)}
+.rt-row.s-blocked{border-left:3px solid var(--danger);background:var(--danger-muted)}
+.rt-row.s-blocked::before{background:var(--danger);box-shadow:0 0 6px var(--danger-muted)}
+.rt-row.s-quarantined{border-left:3px solid var(--warn);background:var(--warn-muted)}
+.rt-row.s-quarantined::before{background:var(--warn);box-shadow:0 0 6px var(--warn-muted)}
+.rt-row.s-heartbeat{opacity:0.55;border-left:3px solid var(--border);background:transparent}
+.rt-row.s-heartbeat::before{background:var(--text3)}
+
+.rt-row-header{display:flex;align-items:center;gap:8px;margin-bottom:6px;flex-wrap:wrap}
+.rt-event{font-weight:600;color:var(--text);font-size:var(--text-sm)}
+.rt-actor-tag{font-size:var(--text-xs);color:var(--text3);font-family:var(--mono)}
+.rt-stage{font-size:0.62rem;padding:2px 7px;border-radius:4px;text-transform:uppercase;letter-spacing:0.5px;background:var(--surface2);color:var(--text3);border:1px solid var(--border)}
+.rt-status{font-size:var(--text-xs);padding:2px 8px;border-radius:4px;font-weight:500}
+.rt-status.v-clean{color:var(--success);background:var(--success-muted);border:1px solid var(--success-border)}
+.rt-status.v-blocked{color:var(--danger);background:var(--danger-muted);border:1px solid var(--danger-border)}
+.rt-status.v-quarantined{color:var(--warn);background:var(--warn-muted);border:1px solid var(--warn-border)}
+.rt-status.v-delivered,.rt-status.v-allowed{color:var(--text2);background:var(--surface2);border:1px solid var(--border)}
+.rt-time{font-size:var(--text-xs);color:var(--text3);margin-left:auto;font-family:var(--mono)}
+.rt-meta-line{font-size:var(--text-xs);color:var(--text3);font-family:var(--mono);word-break:break-all}
+.rt-meta-line + .rt-meta-line{margin-top:4px}
+.rt-link{font-size:var(--text-xs);color:var(--accent);text-decoration:none;margin-top:6px;display:inline-block}
+.rt-link:hover{text-decoration:underline}
+.rt-empty{padding:40px;text-align:center;color:var(--text3)}
+.rt-diagnostic-banner{padding:12px 16px;background:var(--surface2);border:1px solid var(--border);border-radius:8px;font-size:var(--text-sm);color:var(--text2);margin-bottom:20px}
+</style>
+
+<div class="page-header" style="margin-bottom:8px">
+  <h1 style="margin-bottom:4px">Session</h1>
+</div>
+<p style="color:var(--text3);font-size:var(--text-sm);margin:0 0 16px">Runtime hook events for this session</p>
+
+<div class="rt-meta">
+  <span><b>Session:</b> <span style="font-family:var(--mono);font-size:var(--text-xs)">{{.Detail.Session.SessionID}}</span></span>
+  {{if .Detail.Session.PrincipalID}}<span><b>Principal:</b> <span style="font-family:var(--mono);font-size:var(--text-xs)">{{.Detail.Session.PrincipalID}}</span></span>{{end}}
+  {{if .Detail.Session.ClientID}}<span><b>Client:</b> {{.Detail.Session.ClientID}}</span>{{end}}
+  {{if .Detail.Session.ConnectorID}}<span><b>Connector:</b> {{.Detail.Session.ConnectorID}}</span>{{end}}
+  <span><b>Status:</b> <span class="ss-status s-{{.Detail.Session.StatusClass}}">{{.Detail.Session.StatusLabel}}</span></span>
+</div>
+
+<div class="rt-actions">
+  <a href="{{.Detail.JSONExportURL}}">JSON</a>
+  <a href="{{.Detail.CSVExportURL}}">CSV</a>
+</div>
+
+{{if .Detail.Session.IsHeartbeatOnly}}
+<div class="rt-diagnostic-banner">
+  This session id is a heartbeat keepalive. The events below are diagnostic only — no real hook activity has been recorded.
+</div>
+{{end}}
+
+<div class="rt-stats">
+  <div class="rt-stat">
+    <div class="label">Events</div>
+    <div class="value">{{.Detail.Session.EventCount}}</div>
+  </div>
+  <div class="rt-stat">
+    <div class="label">Tool calls</div>
+    <div class="value">{{.Detail.Session.ToolEventCount}}</div>
+  </div>
+  <div class="rt-stat">
+    <div class="label">Subagents</div>
+    <div class="value">{{.Detail.Session.SubagentCount}}</div>
+  </div>
+  <div class="rt-stat">
+    <div class="label">Tasks</div>
+    <div class="value">{{.Detail.Session.TaskCount}}</div>
+  </div>
+  <div class="rt-stat">
+    <div class="label">Blocks</div>
+    <div class="value{{if gt .Detail.Session.BlockCount 0}} v-danger{{end}}">{{.Detail.Session.BlockCount}}</div>
+  </div>
+</div>
+
+{{if .Detail.Actors}}
+<div class="rt-section">
+  <h3>Actor tree</h3>
+  {{range .Detail.Actors}}
+  <div class="rt-actor{{if eq .Kind "subagent"}} indent-1{{else if eq .Kind "task"}} indent-2{{end}}">
+    <span class="name">{{.Label}}</span>
+    {{if .Kind}}<span class="kind k-{{.Kind}}">{{.Kind}}</span>{{end}}
+    <span class="meta">
+      {{.EventCount}} event{{if ne .EventCount 1}}s{{end}}{{if gt .ToolCount 0}} &middot; {{.ToolCount}} tool{{if ne .ToolCount 1}}s{{end}}{{end}}{{if gt .BlockCount 0}} &middot; <span class="blocks">{{.BlockCount}} blocked</span>{{end}}
+    </span>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+<div class="rt-section">
+  <h3>Timeline</h3>
+  {{if .Detail.Events}}
+  <div class="rt-timeline">
+    {{range .Detail.Events}}
+    <div class="rt-row{{if .IsHeartbeat}} s-heartbeat{{end}}{{if eq .Status "blocked"}} s-blocked{{end}}{{if eq .Status "quarantined"}} s-quarantined{{end}}">
+      <div class="rt-row-header">
+        <span class="rt-event">{{.HookEventName}}</span>
+        {{if .ActorLabel}}<span class="rt-actor-tag">{{.ActorLabel}}</span>{{end}}
+        {{if .ToolName}}<span class="rt-actor-tag">tool: {{.ToolName}}</span>{{end}}
+        {{if .Stage}}<span class="rt-stage">{{.Stage}}</span>{{end}}
+        {{if .Status}}<span class="rt-status v-{{.Status}}">{{.Status}}</span>{{end}}
+        <span class="rt-time" data-ts="{{.Timestamp}}">{{.Timestamp}}</span>
+      </div>
+      {{if .ToolUseID}}<div class="rt-meta-line">use_id: {{.ToolUseID}}</div>{{end}}
+      {{if .ToolInputHash}}<div class="rt-meta-line">input: sha256:{{truncate .ToolInputHash 16}}</div>{{end}}
+      {{if .ToolOutputHash}}<div class="rt-meta-line">output: sha256:{{truncate .ToolOutputHash 16}}</div>{{end}}
+      {{if .FilePathTail}}<div class="rt-meta-line">path: {{.FilePathTail}}</div>{{end}}
+      {{if .TaskSubject}}<div class="rt-meta-line">task: {{.TaskSubject}}</div>{{end}}
+      {{if .CoverageMode}}<div class="rt-meta-line">coverage: {{.CoverageMode}}{{if gt .Confidence 0}} &middot; confidence {{.Confidence}}{{end}}</div>{{end}}
+      {{if and (ne .PolicyDecision "") (ne .PolicyDecision .Status)}}<div class="rt-meta-line">policy: {{.PolicyDecision}}</div>{{end}}
+      {{if gt .LatencyMs 0}}<div class="rt-meta-line">latency: {{.LatencyMs}}ms</div>{{end}}
+      {{if .AuditEntryID}}<a href="/dashboard/events/{{.AuditEntryID}}" class="rt-link">View audit entry &rarr;</a>{{end}}
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="rt-empty">No hook events recorded for this session.</div>
+  {{end}}
+</div>
+` + layoutFoot))

--- a/internal/dashboard/tmpl_sessions.go
+++ b/internal/dashboard/tmpl_sessions.go
@@ -162,3 +162,161 @@ function filterThreats(mode, btn) {
 </div>
 {{end}}
 `
+
+// runtimeSessionsPageTmpl renders the Sessions list when runtime
+// evidence is present. It reuses the same chrome (header,
+// search/filters, stat cards) as sessionsPageTmpl but replaces
+// the agent/threat columns with runtime-native columns: the
+// principal+client identity, the lifecycle status, and the runtime
+// counters. Heartbeat-only rows render as a muted "Diagnostic
+// heartbeat" pill so they never look like real activity.
+var runtimeSessionsPageTmpl = template.Must(template.New("sessions-runtime").Funcs(tmplFuncs).Parse(layoutHead + `
+<style>
+.ss-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px}
+.ss-filters{display:flex;gap:8px;align-items:center}
+.ss-filters select{padding:6px 10px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:var(--text-sm)}
+.ss-stats{display:grid;grid-template-columns:repeat(4,1fr);margin-bottom:20px;background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+.ss-stat{padding:16px 20px;text-align:center}
+.ss-stat+.ss-stat{border-left:1px solid var(--border)}
+.ss-stat .label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);margin-bottom:4px}
+.ss-stat .value{font-size:1.2rem;font-weight:600;color:var(--text)}
+.ss-stat .value.v-danger{color:var(--danger)}
+
+.ss-search{margin-bottom:16px;position:relative}
+.ss-search input{width:100%;padding:10px 14px 10px 36px;background:var(--surface);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:var(--text-sm)}
+.ss-search input::placeholder{color:var(--text3)}
+.ss-search svg{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text3);width:14px;height:14px}
+
+.ss-table{width:100%;border-collapse:collapse}
+.ss-table th{text-align:left;padding:10px 14px;font-size:var(--text-xs);text-transform:uppercase;letter-spacing:var(--ls-caps);color:var(--text3);border-bottom:1px solid var(--border)}
+.ss-table td{padding:14px;border-bottom:1px solid var(--border);font-size:var(--text-sm);color:var(--text2);vertical-align:top}
+.ss-table tr:hover{background:var(--surface)}
+.ss-table tr.ss-hidden{display:none}
+.ss-table tr.ss-heartbeat td{color:var(--text3)}
+.ss-table tr.ss-heartbeat .ss-session-name{color:var(--text3)}
+.ss-table a{color:var(--accent);text-decoration:none}
+.ss-table a:hover{text-decoration:underline}
+.ss-table .r{text-align:right}
+.ss-session-name{font-weight:500;color:var(--accent);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;max-width:240px}
+.ss-mono{font-family:var(--mono);font-size:var(--text-xs);color:var(--text2)}
+
+.ss-status{display:inline-block;padding:2px 8px;border-radius:4px;font-size:var(--text-xs);font-weight:600;letter-spacing:0.02em}
+.ss-status.s-active{background:var(--success-muted);color:var(--success);border:1px solid var(--success-border)}
+.ss-status.s-ended{background:var(--surface2);color:var(--text2);border:1px solid var(--border)}
+.ss-status.s-heartbeat{background:transparent;color:var(--text3);border:1px solid var(--border)}
+
+.ss-threat{display:inline-block;padding:2px 7px;border-radius:4px;font-weight:500;font-size:var(--text-xs);background:var(--danger-muted);color:var(--danger);border:1px solid var(--danger-border)}
+.ss-waiting{font-size:var(--text-xs);color:var(--text3);font-style:italic}
+
+.ss-filter-btn{padding:5px 12px;font-size:var(--text-xs);background:var(--surface);border:1px solid var(--border);border-radius:5px;color:var(--text3);cursor:pointer;white-space:nowrap}
+.ss-filter-btn:hover{background:var(--surface2)}
+.ss-filter-btn.active{background:var(--accent);color:#fff;border-color:var(--accent)}
+.ss-empty{text-align:center;padding:40px;color:var(--text3)}
+.ss-export{display:flex;gap:8px}
+.ss-export a{padding:4px 10px;font-size:var(--text-xs);border:1px solid var(--border);border-radius:5px;color:var(--text2);text-decoration:none}
+.ss-export a:hover{background:var(--surface2)}
+</style>
+
+<div class="ss-header">
+  <h1>Sessions</h1>
+  <div class="ss-filters">
+    <select id="ss-range" onchange="window.location='/dashboard/sessions?range='+this.value">
+      <option value="24h"{{if eq .Range "24h"}} selected{{end}}>Last 24 hours</option>
+      <option value="7d"{{if eq .Range "7d"}} selected{{end}}>Last 7 days</option>
+      <option value="30d"{{if eq .Range "30d"}} selected{{end}}>Last 30 days</option>
+    </select>
+    <div class="ss-export">
+      <a href="/dashboard/api/sessions/export?format=json&range={{.Range}}">JSON</a>
+      <a href="/dashboard/api/sessions/export?format=csv&range={{.Range}}">CSV</a>
+    </div>
+  </div>
+</div>
+
+<div class="ss-stats">
+  <div class="ss-stat">
+    <div class="label">With threats</div>
+    <div class="value{{if gt .ThreatSessions 0}} v-danger{{end}}">{{.ThreatSessions}}</div>
+  </div>
+  <div class="ss-stat">
+    <div class="label">Sessions</div>
+    <div class="value">{{.TotalSessions}}</div>
+  </div>
+  <div class="ss-stat">
+    <div class="label">Total events</div>
+    <div class="value">{{.TotalEvents}}</div>
+  </div>
+  <div class="ss-stat">
+    <div class="label">Avg duration</div>
+    <div class="value">{{.AvgDuration}}</div>
+  </div>
+</div>
+
+<div style="display:flex;gap:12px;align-items:center;margin-bottom:16px">
+  <div class="ss-search" style="flex:1;margin-bottom:0">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    <input type="text" id="ss-filter" placeholder="Search by session, principal, client, connector, or status..." oninput="filterSessions(this.value)">
+  </div>
+  <div style="display:flex;gap:4px">
+    <button class="ss-filter-btn active" onclick="filterThreats('all',this)">All</button>
+    <button class="ss-filter-btn" onclick="filterThreats('threats',this)">With threats</button>
+    <button class="ss-filter-btn" onclick="filterThreats('clean',this)">Clean</button>
+    <button class="ss-filter-btn" onclick="filterThreats('diagnostic',this)">Diagnostic</button>
+  </div>
+</div>
+
+<table class="ss-table" id="ss-table">
+  <thead>
+    <tr>
+      <th style="width:22%">Session</th>
+      <th style="width:18%">Principal</th>
+      <th style="width:10%">Client</th>
+      <th style="width:12%">Status</th>
+      <th style="width:12%">Activity</th>
+      <th style="width:9%" class="r">Events</th>
+      <th style="width:8%">Duration</th>
+      <th style="width:9%">Started</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .Sessions}}
+    <tr class="{{if .IsHeartbeatOnly}}ss-heartbeat {{end}}" data-search="{{.SearchData}}" data-threats="{{if .Threat}}yes{{else if .IsHeartbeatOnly}}diagnostic{{else}}no{{end}}">
+      <td><a href="/dashboard/sessions/{{.SessionID}}" class="ss-session-name" title="{{.SessionID}}">{{truncate .SessionID 28}}</a></td>
+      <td class="ss-mono">{{if .PrincipalID}}{{.PrincipalID}}{{else}}<span style="color:var(--text3)">&mdash;</span>{{end}}</td>
+      <td class="ss-mono">{{if .ClientID}}{{.ClientID}}{{else}}<span style="color:var(--text3)">&mdash;</span>{{end}}</td>
+      <td><span class="ss-status s-{{.StatusClass}}">{{.StatusLabel}}</span></td>
+      <td>
+        {{if .Threat}}<span class="ss-threat">{{.BlockCount}} blocked</span>
+        {{else if .IsHeartbeatOnly}}<span style="color:var(--text3);font-size:var(--text-xs)">heartbeat only</span>
+        {{else if eq .ToolEventCount 0}}<span class="ss-waiting">Waiting for first tool call</span>
+        {{else}}<span style="color:var(--text2)">{{.ToolEventCount}} tool{{if ne .ToolEventCount 1}}s{{end}}{{if gt .SubagentCount 0}} &middot; {{.SubagentCount}} subagent{{if ne .SubagentCount 1}}s{{end}}{{end}}</span>{{end}}
+      </td>
+      <td class="r">{{.EventCount}}</td>
+      <td>{{.Duration}}</td>
+      <td style="font-size:var(--text-xs);color:var(--text2);white-space:nowrap" data-ts="{{.StartedAt}}">{{.StartedAt}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+<script>
+var currentThreatFilter = 'all';
+function filterSessions(q) {
+  q = q.toLowerCase();
+  document.querySelectorAll('#ss-table tbody tr').forEach(function(row) {
+    var text = (row.getAttribute('data-search') || '').toLowerCase();
+    var matchSearch = q === '' || text.indexOf(q) !== -1;
+    var threats = row.getAttribute('data-threats');
+    var matchThreat = currentThreatFilter === 'all'
+      || (currentThreatFilter === 'threats' && threats === 'yes')
+      || (currentThreatFilter === 'clean' && threats === 'no')
+      || (currentThreatFilter === 'diagnostic' && threats === 'diagnostic');
+    row.classList.toggle('ss-hidden', !matchSearch || !matchThreat);
+  });
+}
+function filterThreats(mode, btn) {
+  currentThreatFilter = mode;
+  document.querySelectorAll('.ss-filter-btn').forEach(function(b) { b.classList.remove('active'); });
+  btn.classList.add('active');
+  filterSessions(document.getElementById('ss-filter').value);
+}
+</script>
+` + layoutFoot))

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -730,6 +730,10 @@ func (s *Store) QueryEvents(ctx context.Context, q EventQuery) ([]HookEvent, err
 	}
 	args = append(args, limit)
 	limitPh := s.placeholder(idx + 1)
+	order := "ASC"
+	if q.Descending {
+		order = "DESC"
+	}
 	query := `SELECT id, timestamp, session_id, principal_id,
         actor_id, parent_actor_id, root_actor_id,
         client_id, connector_id,
@@ -740,7 +744,7 @@ func (s *Store) QueryEvents(ctx context.Context, q EventQuery) ([]HookEvent, err
         status, policy_decision, coverage_mode, confidence,
         audit_entry_id, activity_event_id, latency_ms
         FROM runtime_hook_events WHERE ` + where + `
-        ORDER BY timestamp ASC LIMIT ` + limitPh
+        ORDER BY timestamp ` + order + ` LIMIT ` + limitPh
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: query events: %w", err)

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -728,6 +728,13 @@ func (s *Store) QueryEvents(ctx context.Context, q EventQuery) ([]HookEvent, err
 	if !q.Until.IsZero() {
 		add("timestamp <= "+s.placeholder(idx+1), q.Until.UTC().Format(time.RFC3339Nano))
 	}
+	if q.ExcludeHeartbeats {
+		// Heartbeat sessions are diagnostic — see runtime.IsHeartbeatSession.
+		// The literal prefix is fixed by the same helper, so the filter is
+		// safe against any future heartbeat-id schema change because the
+		// constant lives next to the helper.
+		add("session_id NOT LIKE 'heartbeat-%'")
+	}
 	args = append(args, limit)
 	limitPh := s.placeholder(idx + 1)
 	order := "ASC"

--- a/internal/runtime/types.go
+++ b/internal/runtime/types.go
@@ -153,16 +153,24 @@ type ActorQuery struct {
 // N hook events" listing — must set Descending=true so the LIMIT
 // selects the freshest evidence rather than truncating an
 // oldest-first window.
+//
+// ExcludeHeartbeats pushes the heartbeat-session filter into
+// SQL (WHERE session_id NOT LIKE 'heartbeat-%'). Application-side
+// filtering paired with a small LIMIT is unsafe because a flood
+// of fresh heartbeat keepalives can fill the LIMIT window and
+// hide real hook activity behind it; the SQL filter lets the
+// caller request the next N real events directly.
 type EventQuery struct {
-	SessionID    string
-	ActorID      string
-	PrincipalID  string
-	HookEventName string
-	AuditEntryID string
-	Since        time.Time
-	Until        time.Time
-	Limit        int
-	Descending   bool
+	SessionID         string
+	ActorID           string
+	PrincipalID       string
+	HookEventName     string
+	AuditEntryID      string
+	Since             time.Time
+	Until             time.Time
+	Limit             int
+	Descending        bool
+	ExcludeHeartbeats bool
 }
 
 // EdgeQuery filters runtime_actors-derived edges. Empty PrincipalID

--- a/internal/runtime/types.go
+++ b/internal/runtime/types.go
@@ -146,6 +146,13 @@ type ActorQuery struct {
 // EventQuery filters runtime_hook_events. The dashboard's
 // timeline view passes (SessionID, Since) most often; the audit
 // drill-down passes AuditEntryID alone.
+//
+// Descending flips the ORDER BY clause from ASC to DESC. The
+// session-detail timeline reads chronologically (default ASC),
+// but newest-first surfaces — like the coverage drawer's "last
+// N hook events" listing — must set Descending=true so the LIMIT
+// selects the freshest evidence rather than truncating an
+// oldest-first window.
 type EventQuery struct {
 	SessionID    string
 	ActorID      string
@@ -155,6 +162,7 @@ type EventQuery struct {
 	Since        time.Time
 	Until        time.Time
 	Limit        int
+	Descending   bool
 }
 
 // EdgeQuery filters runtime_actors-derived edges. Empty PrincipalID


### PR DESCRIPTION
## Summary

Sessions list and detail now prefer runtime evidence when the runtime store has rows in the requested window. The hooks coverage drawer separates real hook events from heartbeat diagnostics. Legacy audit sessions remain the fallback so pre-3B installs and audit-only fixtures keep rendering.

## Changes

**Sessions list** (`/dashboard/sessions`)
- `handleSessions` tries `runtimeSessionRows` first; falls through to `audit.QuerySessions` when runtime returns `ok=false` or zero rows.
- Runtime template columns: principal, client, status pill (active / ended / heartbeat), activity summary, event count, duration, started.
- Heartbeat sessions render muted with a "Diagnostic heartbeat" pill, active-with-no-tools rows show a neutral "Waiting for first tool call" copy, threats only count `BlockCount > 0` and exclude heartbeat-only rows from the counter.
- Search/filter scripting carries through; the search index now includes principal / client / connector tokens. New "Diagnostic" filter pill alongside All / With threats / Clean.

**Session detail** (`/dashboard/sessions/{id}`)
- `handleSessionTrace` tries `runtimeSessionDetail` first; falls through to `audit.BuildSessionTrace` when the runtime store has no row for the id.
- Runtime detail template renders the actor tree (root, subagent, task) and a hashed timeline. Tool rows show `use_id`, `sha256:input/output` prefixes, status, policy decision, coverage mode, latency, and link to the audit entry when `AuditEntryID` is populated. Raw payloads never reach the HTML.
- AI analysis sidebar is hidden on the runtime path. The runtime envelope and the session-analysis schema have not been reconciled yet, and showing audit-driven analysis next to runtime evidence would mix two stores. Audit-only sessions keep their existing AI behaviour.

**Exports** (`/dashboard/api/session/{id}/export`, `/csv`)
- JSON: `{source: "runtime", session, actors, events}` for runtime sessions; legacy `SessionTrace` JSON otherwise.
- CSV: runtime column header (`timestamp,actor,kind,hook_event,lifecycle,stage,tool_name,tool_use_id,tool_input_hash,tool_output_hash,status,policy_decision,coverage_mode,confidence,latency_ms,audit_entry_id,activity_event_id`) for runtime sessions; legacy Step/Reasoning columns otherwise.
- SARIF stays legacy-only and the runtime detail template does not link to it.

**Coverage hooks drawer** (`/dashboard/api/coverage/cell?surface=hooks`)
- For `surface=hooks`, queries runtime hook events for the principal first.
- Real (non-heartbeat) events → "Runtime hook events" block with hook event name, tool name, actor label, status, policy, coverage mode, link to session.
- Heartbeat-only state → "Heartbeat reached the gateway" diagnostic banner; **no fallback to the activity store** so an operator does not see stale activity rows next to a fresh heartbeat-only state.
- `mcp_http` and `http_egress_proxy` continue to render the legacy activity drawer untouched.

## Tests

12 new cases in `internal/dashboard/runtime_sessions_test.go` covering the spec acceptance:
- `TestSessions_RuntimePreferredOverAudit`
- `TestSessions_FallbacksToAuditWhenRuntimeEmpty`
- `TestSessions_HeartbeatOnlyRowIsDiagnostic`
- `TestSessions_ActiveNoToolsShowsWaitingState`
- `TestSessions_RuntimeProtectedToolShowsCoverage`
- `TestSessionDetail_RuntimeTreeAndTimeline` (also asserts AI button hidden)
- `TestSessionDetail_RuntimeDoesNotLeakRawPayload`
- `TestSessionExport_RuntimeJSON`
- `TestSessionExport_RuntimeCSV`
- `TestCoverageHooksDrawer_UsesRuntimeRealEvents`
- `TestCoverageHooksDrawer_HeartbeatOnlyDiagnostic`
- `TestCoverageDrawer_MCPAndEgressUnchanged`

## Out of scope

Graph, Security Posture redesign, AI analysis for runtime sessions, Claude Code settings/install changes, runtime schema changes.

## Test plan

- [x] `go test ./internal/dashboard -run 'Sessions|SessionDetail|CoverageCellDrawer|Runtime' -count=1`
- [x] `go test ./internal/runtime -count=1`
- [x] `go test ./internal/dashboard -count=1`
- [x] `go test ./... -count=1` — green except the known `internal/hooks/TestServeHTTP_ActivityIDMatchesRuntimeRow` SQLite-busy flake; passes on standalone re-run.
- [x] `make build`
- [x] `make vet`
- [x] `make lint`