### PR TITLE
Reframe /dashboard/audit as Agent Runtime Posture

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -454,9 +454,33 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Phase 4A — Agent Runtime Posture view model. The handler
+	// stays an orchestrator: it gathers connection health, runtime
+	// readiness, identity config, and the auditcheck score, then
+	// hands them to the pure builder. The template renders the
+	// snapshot directly and never re-derives freshness or status
+	// from raw timestamps.
+	connection := s.computeClaudeCodeConnectionHealth(r.Context())
+	posture := buildRuntimePostureSnapshot(PostureInputs{
+		Connection:         connection,
+		Identity:           s.cfg.Identity,
+		Cfg:                s.cfg,
+		HookInstalled:      connection.HookInstalled,
+		Auditcheck:         findings,
+		AuditcheckSummary:  summary,
+		AuditcheckScore:    score,
+		AuditcheckGrade:    grade,
+		FixableCount:       fixableCount,
+		RuntimeStoreReady:  s.runtimeStore() != nil,
+		AuditChainValid:    chainResult.Valid,
+		AuditChainEntries:  chainResult.Entries,
+		HasRuntimeEvidence: connection.Runtime.HasEvidence,
+	})
+
 	data := map[string]any{
 		"Active":      "audit",
 		"RequireSig":  s.cfg.Identity.RequireSignature,
+		"Posture":     posture,
 		"Score":       score,
 		"Grade":       grade,
 		"Groups":      groups,

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -5205,8 +5205,12 @@ func (s *Server) handleAuditFix(w http.ResponseWriter, r *http.Request) {
 <div class="ps-f-body"><span class="ps-f-title">%s</span></div>
 <div class="ps-f-act"><span style="color:var(--success);font-size:1.1rem">&#10003;</span></div>
 </div>`, template.HTMLEscapeString(checkID), template.HTMLEscapeString(desc))
-	// OOB score update
-	s.writeScoreOOB(w, score, grade)
+	// OOB refresh of the secondary hardening block. Score and
+	// grade are unused here — writeHardeningOOB rebuilds the
+	// runtime posture so the suppress rules still apply.
+	_ = score
+	_ = grade
+	s.writeHardeningOOB(r.Context(), w)
 }
 
 // handleAuditFixAll applies all available auto-fixes and returns an HTML summary.
@@ -5232,16 +5236,24 @@ func (s *Server) handleAuditFixAll(w http.ResponseWriter, r *http.Request) {
 	}
 	s.logger.Info("auto-fix-all applied", "count", len(applied))
 
-	newFindings, _, _ := s.cachedRunChecks()
-	score, grade := auditcheck.ComputeHealthScore(newFindings)
+	// Neutral confirmation block. The legacy ps-celebrate UI
+	// rendered the hardening grade as a celebration headline,
+	// which the runtime-first hero retired. The reload link
+	// rebuilds the page with the runtime posture intact.
+	fmt.Fprintf(w, `<div style="padding:24px;text-align:center">
+<div style="font-size:1rem;font-weight:600;color:var(--success);margin-bottom:8px">%d fix%s applied</div>
+<div style="font-size:0.8125rem;color:var(--text2)"><a href="/dashboard/audit">Reload to see remaining findings &rarr;</a></div>
+</div>`, len(applied), pluralEs(len(applied)))
+	s.writeHardeningOOB(r.Context(), w)
+}
 
-	// Celebration
-	fmt.Fprintf(w, `<div class="ps-celebrate">
-<div class="ps-celebrate-score">%d</div>
-<div class="ps-celebrate-grade">Grade %s</div>
-<div class="ps-celebrate-msg">%d fixes applied. <a href="/dashboard/audit">Reload to see remaining findings.</a></div>
-</div>`, score, grade, len(applied))
-	s.writeScoreOOB(w, score, grade)
+// pluralEs returns "es" when n != 1, otherwise empty. Local
+// helper so the inline template strings above stay readable.
+func pluralEs(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "es"
 }
 
 // handleAuditEnrich calls the LLM to generate one-line risk descriptions for each finding.
@@ -5348,17 +5360,73 @@ func (s *Server) handleAuditEnrich(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) writeScoreOOB(w http.ResponseWriter, score int, grade string) {
-	color := "var(--danger)"
-	if score >= 90 {
-		color = "var(--success)"
-	} else if score >= 60 {
-		color = "var(--warn)"
+// writeHardeningOOB emits an out-of-band swap that replaces the
+// rp-hardening secondary section after an auto-fix mutates the
+// configuration. The shape mirrors tmpl_audit.go so a Fix or
+// Fix-all click can never reintroduce the legacy ps-ring /
+// ps-grade-label visualisation that the runtime-first hero
+// retired. Suppress rules also mirror the page render: when
+// runtime cannot prove protection right now (setup_pending or
+// partial), the grade is hidden and only the neutral count + the
+// suppressed-reason copy render — the same contract the
+// initial GET enforces.
+func (s *Server) writeHardeningOOB(ctx context.Context, w http.ResponseWriter) {
+	allFindings, _, _ := s.cachedRunChecks()
+	var findings []auditcheck.Finding
+	for _, f := range allFindings {
+		if f.Severity == auditcheck.Info && !s.cfg.Identity.RequireSignature {
+			continue
+		}
+		findings = append(findings, f)
 	}
-	fmt.Fprintf(w, `<div id="posture-score" hx-swap-oob="true" class="ps-hero-score">
-<div class="ps-ring" style="--pct:%d;--clr:%s"><span class="ps-num">%d</span></div>
-<div class="ps-grade-label">Grade %s</div>
-</div>`, score, color, score, grade)
+	score, grade := auditcheck.ComputeHealthScore(findings)
+	summary := auditcheck.Summarize(findings)
+	fixable := 0
+	for _, f := range findings {
+		if _, ok := fixableChecks[f.CheckID]; ok && f.Severity > auditcheck.Info {
+			fixable++
+		}
+	}
+
+	connection := s.computeClaudeCodeConnectionHealth(ctx)
+	snap := buildRuntimePostureSnapshot(PostureInputs{
+		Connection:         connection,
+		Identity:           s.cfg.Identity,
+		Cfg:                s.cfg,
+		HookInstalled:      connection.HookInstalled,
+		Auditcheck:         findings,
+		AuditcheckSummary:  summary,
+		AuditcheckScore:    score,
+		AuditcheckGrade:    grade,
+		FixableCount:       fixable,
+		RuntimeStoreReady:  s.runtimeStore() != nil,
+		HasRuntimeEvidence: connection.Runtime.HasEvidence,
+	})
+
+	h := snap.Hardening
+	plural := ""
+	if h.TotalChecks != 1 {
+		plural = "s"
+	}
+	fixableMeta := ""
+	if h.FixableCount > 0 {
+		fixableMeta = fmt.Sprintf(", <strong>%d</strong> auto-fixable", h.FixableCount)
+	}
+	fmt.Fprintf(w, `<div id="rp-hardening" hx-swap-oob="true" class="rp-hardening">
+<div class="rp-hardening-head">
+<span class="rp-hardening-title">Static deployment checks</span>
+<span class="rp-hardening-meta"><strong>%d</strong> check%s available%s.</span>
+</div>`,
+		h.TotalChecks, plural, fixableMeta,
+	)
+	if h.Suppressed {
+		fmt.Fprintf(w, `<div class="rp-hardening-suppressed">%s</div>`,
+			template.HTMLEscapeString(h.Reason))
+	} else {
+		fmt.Fprintf(w, `<div class="rp-hardening-grade"><span class="g">Grade %s</span>based on static deployment checks.</div>`,
+			template.HTMLEscapeString(h.Grade))
+	}
+	fmt.Fprint(w, `</div>`)
 }
 
 func (s *Server) writeEnrichedFinding(w http.ResponseWriter, f auditcheck.Finding, risk string) {

--- a/internal/dashboard/runtime_posture.go
+++ b/internal/dashboard/runtime_posture.go
@@ -199,9 +199,13 @@ func evidenceFreshness(in PostureInputs) string {
 }
 
 // postureStatusAndTitle is the spec's status decision tree
-// inlined. The order matters: setup_pending wins outright when
-// the connection isn't healthy (no runtime evidence is even
-// possible to evaluate); the other branches fall in spec order.
+// inlined. The order is deliberate and the two axes — freshness
+// and coverage — are kept independent so the page never reads
+// "stale" off a fresh blind event or "protected" off an
+// observed-only one. Setup_pending wins outright; otherwise we
+// branch first on "is there fresh real activity?", then by
+// coverage; heartbeat-only and stale-evidence cases follow
+// after.
 func postureStatusAndTitle(in PostureInputs, freshness string) (status string, suppress bool, title, summary string) {
 	rt := in.Connection.Runtime
 
@@ -225,33 +229,45 @@ func postureStatusAndTitle(in PostureInputs, freshness string) (status string, s
 			"Hooks are present but Oktsec has not received runtime evidence yet."
 	}
 
-	// protected — fresh real event under protected coverage.
-	if rt.HasFreshRealEvent && rt.CoverageStage == PostureCellProtected {
-		return PostureStatusProtected, false,
-			"Protected — fresh runtime evidence",
-			"Real hook activity is reaching Oktsec under protected coverage."
-	}
-
-	// observing — fresh heartbeat OR fresh real event without
-	// protected coverage. Heartbeat-only must never read as
-	// protected; the spec's invariant is reused verbatim from 3C.
-	if rt.HasFreshHeartbeat || (rt.HasFreshRealEvent && rt.CoverageStage != PostureCellBlind) {
-		// Hardening grade may show as secondary because the
-		// connection is at least diagnostically healthy. The
-		// status itself stays observing — the template will not
-		// claim "protected" off this branch.
-		t := "Observing — heartbeat received, no tool activity yet"
-		s := "Hook path is reachable. Run a real agent action so Oktsec can lift coverage from observed to protected."
-		if rt.HasFreshRealEvent {
-			t = "Observing — fresh activity, coverage not yet at full enforcement"
-			s = "Real hook activity is reaching Oktsec but coverage is observed-only. Configure tool policies or block-capable hooks to enable full enforcement."
+	// Fresh real event branch — freshness alone never decides
+	// status; we still split by coverage stage so an observed
+	// or blind event does not get promoted to protected, and a
+	// fresh-but-blind event does not collapse into the stale
+	// "degraded" branch below.
+	if rt.HasFreshRealEvent {
+		switch rt.CoverageStage {
+		case PostureCellProtected:
+			return PostureStatusProtected, false,
+				"Protected — fresh runtime evidence",
+				"Real hook activity is reaching Oktsec under protected coverage."
+		case PostureCellObserved:
+			return PostureStatusObserving, false,
+				"Observing — fresh activity, coverage not yet at full enforcement",
+				"Real hook activity is reaching Oktsec but coverage is observed-only. Configure tool policies or block-capable hooks to enable full enforcement."
+		case PostureCellBlind:
+			return PostureStatusBlind, false,
+				"Blind — agent activity observed but not covered",
+				"Real hook activity is reaching Oktsec but no coverage layer is protecting the surface. Configure block-capable hooks or tool policies so coverage can lift to observed or protected."
+		default:
+			// CoverageStage is empty: we have a real event but
+			// the runtime did not yet attach a coverage stage.
+			// Observing is the safe label — never protected.
+			return PostureStatusObserving, false,
+				"Observing — fresh activity, coverage not yet evaluated",
+				"Real hook activity is reaching Oktsec. Coverage stage will appear once the next event tags one."
 		}
-		return PostureStatusObserving, false, t, s
 	}
 
-	// degraded — there IS evidence but it is stale. Score may
-	// still appear as secondary so the operator can see the
-	// historical hardening picture.
+	// Fresh heartbeat only — diagnostic. Heartbeat must never
+	// read as protected; the 3C invariant is reused verbatim.
+	if rt.HasFreshHeartbeat {
+		return PostureStatusObserving, false,
+			"Observing — heartbeat received, no tool activity yet",
+			"Hook path is reachable. Run a real agent action so Oktsec can lift coverage from observed to protected."
+	}
+
+	// degraded — there IS evidence but neither a fresh real
+	// event nor a fresh heartbeat. Stale by definition.
 	if rt.HasEvidence {
 		return PostureStatusDegraded, false,
 			"Degraded — runtime evidence is stale",
@@ -259,8 +275,7 @@ func postureStatusAndTitle(in PostureInputs, freshness string) (status string, s
 	}
 
 	// blind — connector is healthy enough to evaluate, but
-	// nothing has been observed. Hardening grade may show as
-	// secondary; status reads as a coverage gap.
+	// nothing has been observed at all.
 	return PostureStatusBlind, false,
 		"Blind — connector ready but no runtime activity observed",
 		"Agents and tools are configured but Oktsec has not observed any runtime activity for them."
@@ -305,12 +320,17 @@ func buildConnectionDimension(in PostureInputs, freshness string) RuntimePosture
 		dim.Summary = "Hooks installed; last event is older than the freshness window."
 		dim.Evidence = "Last event: " + safeDash(in.Connection.LastEvent)
 	case "ready":
+		// Connection is about reachability. Protection is the
+		// coverage dimension's job — promoting connection to
+		// "protected" off a fresh real event painted a green
+		// pill that disagreed with an observed-only or blind
+		// coverage row in the same view.
 		switch {
 		case rt.HasFreshRealEvent:
-			dim.Status = PostureCellProtected
-			dim.Summary = "Hooks installed and receiving fresh real activity."
+			dim.Status = PostureCellOK
+			dim.Summary = "Hook path reachable; receiving fresh real activity."
 		case rt.HasFreshHeartbeat:
-			dim.Status = PostureCellObserved
+			dim.Status = PostureCellOK
 			dim.Summary = "Hook path is reachable (heartbeat). Waiting for real tool activity."
 		default:
 			dim.Status = PostureCellObserved

--- a/internal/dashboard/runtime_posture.go
+++ b/internal/dashboard/runtime_posture.go
@@ -1,0 +1,573 @@
+package dashboard
+
+import (
+	"strings"
+
+	"github.com/oktsec/oktsec/internal/auditcheck"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+)
+
+// runtime_posture.go projects the dashboard's runtime evidence
+// into the Agent Runtime Posture view-model the /dashboard/audit
+// page renders. The Phase 4A spec is explicit: this page is a
+// runtime-evidence summary first, NOT a hardening-score headline.
+// The legacy auditcheck output stays present but lands as a
+// secondary "Hardening checks" section, and its grade/score is
+// suppressed entirely whenever runtime cannot prove the agent is
+// being protected right now.
+//
+// Why a separate file: handleAudit was already large and mixed
+// auditcheck rendering with chain verification with LLM stats.
+// The Phase 4A spec calls for a pure builder so handleAudit can
+// stay an orchestrator (gather inputs, call builder, pass view
+// model) and the freshness/coverage/identity rules live in one
+// testable place.
+
+// Status values for the hero band. The page never shows raw
+// timestamps as status — fresh / stale / expired / none are
+// separate states (per the Phase 4A guardrails) and they map onto
+// these five enum values.
+const (
+	PostureStatusSetupPending = "setup_pending"
+	PostureStatusObserving    = "observing"
+	PostureStatusProtected    = "protected"
+	PostureStatusDegraded     = "degraded"
+	PostureStatusBlind        = "blind"
+)
+
+// Evidence freshness buckets. Computed once and reused across
+// dimensions so the template never re-derives freshness from
+// timestamps.
+const (
+	PostureFreshnessFresh   = "fresh"
+	PostureFreshnessStale   = "stale"
+	PostureFreshnessExpired = "expired"
+	PostureFreshnessNone    = "none"
+)
+
+// Dimension ids — the spec lists exactly five.
+const (
+	PostureDimConnection      = "connection"
+	PostureDimCoverage        = "coverage"
+	PostureDimEnforcement     = "enforcement"
+	PostureDimIdentityContext = "identity_context"
+	PostureDimEvidence        = "evidence"
+)
+
+// Per-dimension status enum. Distinct from the top-level posture
+// status: a dimension can be "blind" even when the overall page
+// is "observing" (e.g. hooks observed, egress blind).
+const (
+	PostureCellProtected     = "protected"
+	PostureCellObserved      = "observed"
+	PostureCellPartial       = "partial"
+	PostureCellBlind         = "blind"
+	PostureCellNotConfigured = "not_configured"
+	PostureCellStale         = "stale"
+	PostureCellOK            = "ok" // identity / evidence dimensions when everything is in order
+	PostureCellWarn          = "warn"
+)
+
+// RuntimePostureSnapshot is the value handleAudit hands to the
+// template. Fields are intentionally template-friendly: every
+// status is a string the template can match against, every
+// boolean has an explicit name, and the hardening summary is a
+// substruct rather than a flat field set so the template can
+// branch on .Hardening.Suppressed without spelunking the parent.
+type RuntimePostureSnapshot struct {
+	Status            string                    // setup_pending | observing | protected | degraded | blind
+	Title             string                    // hero headline derived from Status
+	Summary           string                    // one-line explanation under the title
+	EvidenceFreshness string                    // fresh | stale | expired | none — informational, not status
+	SuppressScore     bool                      // when true, hide score ring + grade + alarmist copy
+	Dimensions        []RuntimePostureDimension // ordered: connection, coverage, enforcement, identity_context, evidence
+	Signals           []RuntimePostureSignal    // gaps and next actions surfaced under the dimensions block
+	Hardening         RuntimeHardeningSummary   // legacy auditcheck rollup — secondary section
+}
+
+// RuntimePostureDimension is one row in the Runtime dimensions
+// block. The template renders Label + Status pill + Summary
+// line + Evidence detail; clicking opens (in a later slice) the
+// drill-down for that dimension.
+type RuntimePostureDimension struct {
+	ID       string
+	Label    string
+	Status   string
+	Summary  string
+	Evidence string
+}
+
+// RuntimePostureSignal is one gap/next-action row. Severity
+// drives the badge colour; ActionLabel + ActionHref render an
+// inline link the operator can click. Source records where the
+// signal came from (runtime/activity/auditcheck/config) so the
+// template can render a small attribution chip.
+type RuntimePostureSignal struct {
+	ID          string
+	Dimension   string
+	Status      string // ok | warn | fail | info
+	Severity    string // info | low | medium | high | critical
+	Title       string
+	Detail      string
+	Evidence    string
+	Source      string
+	ActionLabel string
+	ActionHref  string
+}
+
+// RuntimeHardeningSummary wraps the existing auditcheck output
+// for the secondary "Hardening checks" section. When Suppressed
+// is true the template must hide the grade, the score, and any
+// alarmist headline copy; the neutral counts and the
+// auto-fixable count remain visible so the operator still has a
+// clear path to remediation.
+type RuntimeHardeningSummary struct {
+	Score        int
+	Grade        string
+	TotalChecks  int
+	Critical     int
+	High         int
+	Medium       int
+	Info         int
+	FixableCount int
+	Suppressed   bool
+	Reason       string // displayed when Suppressed is true ("Runtime evidence required before showing a hardening grade.")
+}
+
+// PostureInputs is the read-only bundle the orchestrator passes
+// into the builder. Keeping the builder pure (no DB/store calls)
+// lets the test suite construct snapshots from fixtures without
+// spinning up a runtime.Store, and makes every status decision
+// reproducible from a single struct value.
+type PostureInputs struct {
+	Connection         claudecode.ConnectorHealth
+	Identity           config.IdentityConfig
+	Cfg                *config.Config
+	HookInstalled      bool
+	Auditcheck         []auditcheck.Finding
+	AuditcheckSummary  auditcheck.Summary
+	AuditcheckScore    int
+	AuditcheckGrade    string
+	FixableCount       int
+	RuntimeStoreReady  bool
+	AuditChainValid    bool
+	AuditChainEntries  int
+	HasRuntimeEvidence bool // mirrors Connection.Runtime.HasEvidence; broken out so tests can flip it independently of a full ConnectorHealth fixture
+}
+
+// buildRuntimePostureSnapshot is the pure projection from
+// PostureInputs to view-model. No I/O, no global state — every
+// rule lives here.
+func buildRuntimePostureSnapshot(in PostureInputs) RuntimePostureSnapshot {
+	freshness := evidenceFreshness(in)
+	status, suppress, title, summary := postureStatusAndTitle(in, freshness)
+
+	snap := RuntimePostureSnapshot{
+		Status:            status,
+		Title:             title,
+		Summary:           summary,
+		EvidenceFreshness: freshness,
+		SuppressScore:     suppress,
+		Dimensions:        buildDimensions(in, status, freshness),
+		Hardening:         buildHardeningSummary(in, suppress),
+	}
+	snap.Signals = buildSignals(in, snap.Dimensions)
+	return snap
+}
+
+// evidenceFreshness collapses the runtime-evidence flags into one
+// of four buckets. The page shows the bucket as informational
+// metadata; status decisions consume the underlying booleans
+// directly so a "stale" bucket cannot be promoted to "protected".
+func evidenceFreshness(in PostureInputs) string {
+	rt := in.Connection.Runtime
+	switch {
+	case rt.HasFreshRealEvent || rt.HasFreshHeartbeat:
+		return PostureFreshnessFresh
+	case rt.HasEvidence:
+		return PostureFreshnessStale
+	case in.Connection.LastEvent != "":
+		// Audit-side last event existed once but no runtime row.
+		// Treat as expired because runtime is the contract going
+		// forward and the audit timestamp is no longer the
+		// authoritative signal.
+		return PostureFreshnessExpired
+	default:
+		return PostureFreshnessNone
+	}
+}
+
+// postureStatusAndTitle is the spec's status decision tree
+// inlined. The order matters: setup_pending wins outright when
+// the connection isn't healthy (no runtime evidence is even
+// possible to evaluate); the other branches fall in spec order.
+func postureStatusAndTitle(in PostureInputs, freshness string) (status string, suppress bool, title, summary string) {
+	rt := in.Connection.Runtime
+
+	// setup_pending — runtime is not in a state where evidence
+	// can be evaluated. Suppress hard score so we never headline
+	// a hardening grade for a setup nobody finished.
+	switch in.Connection.Status {
+	case "not_installed", "disconnected", "partial":
+		return PostureStatusSetupPending, true,
+			"Setup pending",
+			"Runtime evidence is not available yet. Finish the connector setup before hardening claims apply."
+	}
+	if !in.RuntimeStoreReady {
+		return PostureStatusSetupPending, true,
+			"Setup pending",
+			"Runtime store is not reachable. Finish the connector setup before hardening claims apply."
+	}
+	if !in.HasRuntimeEvidence && !rt.HasFreshHeartbeat {
+		return PostureStatusSetupPending, true,
+			"Setup pending",
+			"Hooks are present but Oktsec has not received runtime evidence yet."
+	}
+
+	// protected — fresh real event under protected coverage.
+	if rt.HasFreshRealEvent && rt.CoverageStage == PostureCellProtected {
+		return PostureStatusProtected, false,
+			"Protected — fresh runtime evidence",
+			"Real hook activity is reaching Oktsec under protected coverage."
+	}
+
+	// observing — fresh heartbeat OR fresh real event without
+	// protected coverage. Heartbeat-only must never read as
+	// protected; the spec's invariant is reused verbatim from 3C.
+	if rt.HasFreshHeartbeat || (rt.HasFreshRealEvent && rt.CoverageStage != PostureCellBlind) {
+		// Hardening grade may show as secondary because the
+		// connection is at least diagnostically healthy. The
+		// status itself stays observing — the template will not
+		// claim "protected" off this branch.
+		t := "Observing — heartbeat received, no tool activity yet"
+		s := "Hook path is reachable. Run a real agent action so Oktsec can lift coverage from observed to protected."
+		if rt.HasFreshRealEvent {
+			t = "Observing — fresh activity, coverage not yet at full enforcement"
+			s = "Real hook activity is reaching Oktsec but coverage is observed-only. Configure tool policies or block-capable hooks to enable full enforcement."
+		}
+		return PostureStatusObserving, false, t, s
+	}
+
+	// degraded — there IS evidence but it is stale. Score may
+	// still appear as secondary so the operator can see the
+	// historical hardening picture.
+	if rt.HasEvidence {
+		return PostureStatusDegraded, false,
+			"Degraded — runtime evidence is stale",
+			"The last runtime event is outside the freshness window. Run a fresh agent action to refresh posture."
+	}
+
+	// blind — connector is healthy enough to evaluate, but
+	// nothing has been observed. Hardening grade may show as
+	// secondary; status reads as a coverage gap.
+	return PostureStatusBlind, false,
+		"Blind — connector ready but no runtime activity observed",
+		"Agents and tools are configured but Oktsec has not observed any runtime activity for them."
+}
+
+// buildDimensions walks the five spec dimensions in order and
+// builds a row per dimension. Each row's Status is independent:
+// the connection dimension can be "ok" while coverage is
+// "blind", and the template renders both side-by-side without
+// re-deriving any rule.
+func buildDimensions(in PostureInputs, postureStatus, freshness string) []RuntimePostureDimension {
+	return []RuntimePostureDimension{
+		buildConnectionDimension(in, freshness),
+		buildCoverageDimension(in),
+		buildEnforcementDimension(in),
+		buildIdentityContextDimension(in),
+		buildEvidenceDimension(in),
+	}
+}
+
+func buildConnectionDimension(in PostureInputs, freshness string) RuntimePostureDimension {
+	rt := in.Connection.Runtime
+	dim := RuntimePostureDimension{
+		ID:    PostureDimConnection,
+		Label: "Connection",
+	}
+	switch in.Connection.Status {
+	case "not_installed":
+		dim.Status = PostureCellNotConfigured
+		dim.Summary = "Claude Code is not installed."
+		dim.Evidence = in.Connection.Reason
+	case "disconnected":
+		dim.Status = PostureCellNotConfigured
+		dim.Summary = "Claude Code is installed but no Oktsec hook is wired."
+		dim.Evidence = in.Connection.Reason
+	case "partial":
+		dim.Status = PostureCellPartial
+		dim.Summary = "Hooks are installed but Oktsec has not received a real event yet."
+		dim.Evidence = in.Connection.Reason
+	case "stale":
+		dim.Status = PostureCellStale
+		dim.Summary = "Hooks installed; last event is older than the freshness window."
+		dim.Evidence = "Last event: " + safeDash(in.Connection.LastEvent)
+	case "ready":
+		switch {
+		case rt.HasFreshRealEvent:
+			dim.Status = PostureCellProtected
+			dim.Summary = "Hooks installed and receiving fresh real activity."
+		case rt.HasFreshHeartbeat:
+			dim.Status = PostureCellObserved
+			dim.Summary = "Hook path is reachable (heartbeat). Waiting for real tool activity."
+		default:
+			dim.Status = PostureCellObserved
+			dim.Summary = "Hooks ready. Waiting for runtime evidence."
+		}
+		dim.Evidence = "Freshness: " + freshness
+	default:
+		dim.Status = PostureCellNotConfigured
+		dim.Summary = "Connector status is unknown."
+	}
+	return dim
+}
+
+func buildCoverageDimension(in PostureInputs) RuntimePostureDimension {
+	rt := in.Connection.Runtime
+	dim := RuntimePostureDimension{
+		ID:    PostureDimCoverage,
+		Label: "Coverage",
+	}
+	switch rt.CoverageStage {
+	case PostureCellProtected:
+		dim.Status = PostureCellProtected
+		dim.Summary = "Hook surface is protected by block-capable handlers."
+	case PostureCellObserved:
+		dim.Status = PostureCellObserved
+		dim.Summary = "Hook surface is observed-only. Real events are reaching Oktsec but cannot be blocked."
+	case PostureCellBlind:
+		dim.Status = PostureCellBlind
+		dim.Summary = "No coverage observed for the hook surface."
+	default:
+		if !in.HasRuntimeEvidence {
+			dim.Status = PostureCellNotConfigured
+			dim.Summary = "Runtime has not observed any coverage signal yet."
+		} else {
+			dim.Status = PostureCellPartial
+			dim.Summary = "Coverage signal is incomplete."
+		}
+	}
+	if rt.HasFreshHeartbeat && !rt.HasFreshRealEvent {
+		dim.Evidence = "Heartbeat is fresh; real coverage will appear after the next tool call."
+	}
+	return dim
+}
+
+func buildEnforcementDimension(in PostureInputs) RuntimePostureDimension {
+	dim := RuntimePostureDimension{
+		ID:    PostureDimEnforcement,
+		Label: "Enforcement",
+	}
+	cfg := in.Cfg
+	if cfg == nil {
+		dim.Status = PostureCellNotConfigured
+		dim.Summary = "No config loaded."
+		return dim
+	}
+	enforcers := []string{}
+	missing := []string{}
+	if in.HookInstalled {
+		enforcers = append(enforcers, "hooks")
+	}
+	if len(cfg.MCPServers) > 0 && cfg.Gateway.Enabled {
+		enforcers = append(enforcers, "gateway")
+	} else if len(cfg.MCPServers) > 0 {
+		missing = append(missing, "gateway disabled but MCP servers configured")
+	}
+	if cfg.Quarantine.Enabled {
+		enforcers = append(enforcers, "quarantine")
+	}
+	if cfg.ForwardProxy.Enabled {
+		enforcers = append(enforcers, "egress controls")
+	} else {
+		// Per-agent egress policies still count as enforcement
+		// even when the top-level forward proxy is off.
+		for _, a := range cfg.Agents {
+			if a.Egress != nil {
+				enforcers = append(enforcers, "egress controls")
+				break
+			}
+		}
+	}
+	switch {
+	case len(enforcers) == 0:
+		dim.Status = PostureCellBlind
+		dim.Summary = "No enforcement controls active."
+	case len(missing) > 0:
+		dim.Status = PostureCellPartial
+		dim.Summary = "Active: " + strings.Join(enforcers, ", ") + ". Gaps: " + strings.Join(missing, "; ") + "."
+	default:
+		dim.Status = PostureCellOK
+		dim.Summary = "Active: " + strings.Join(enforcers, ", ") + "."
+	}
+	return dim
+}
+
+func buildIdentityContextDimension(in PostureInputs) RuntimePostureDimension {
+	dim := RuntimePostureDimension{
+		ID:    PostureDimIdentityContext,
+		Label: "Identity context",
+	}
+	if in.Identity.RequireSignature {
+		dim.Status = PostureCellOK
+		dim.Summary = "Local signed identity required (Ed25519)."
+		if in.Identity.RequireDelegation {
+			dim.Summary += " Delegation chain enforced."
+		}
+	} else {
+		dim.Status = PostureCellWarn
+		dim.Summary = "Signature is not required. Local development mode."
+		dim.Evidence = "Set identity.require_signature=true to enforce signed identity on every request."
+	}
+	return dim
+}
+
+func buildEvidenceDimension(in PostureInputs) RuntimePostureDimension {
+	dim := RuntimePostureDimension{
+		ID:    PostureDimEvidence,
+		Label: "Evidence",
+	}
+	switch {
+	case !in.RuntimeStoreReady:
+		dim.Status = PostureCellNotConfigured
+		dim.Summary = "Runtime store is not reachable."
+	case !in.AuditChainValid:
+		dim.Status = PostureCellWarn
+		dim.Summary = "Audit chain integrity check failed."
+	default:
+		dim.Status = PostureCellOK
+		dim.Summary = "Runtime + audit evidence is durable. Audit chain verified."
+	}
+	if in.AuditChainEntries > 0 {
+		dim.Evidence = "Audit chain spans " + intToStr(in.AuditChainEntries) + " entries."
+	}
+	return dim
+}
+
+// buildSignals collects the gaps + next actions the page surfaces
+// under the dimensions block. The list is intentionally short
+// (top 3-4 items) — the legacy hardening section below carries
+// the long tail of auditcheck findings.
+func buildSignals(in PostureInputs, dims []RuntimePostureDimension) []RuntimePostureSignal {
+	signals := []RuntimePostureSignal{}
+	for _, dim := range dims {
+		switch dim.Status {
+		case PostureCellWarn, PostureCellBlind, PostureCellPartial, PostureCellStale, PostureCellNotConfigured:
+			signals = append(signals, RuntimePostureSignal{
+				ID:        "dim-" + dim.ID,
+				Dimension: dim.ID,
+				Status:    dimensionSignalStatus(dim.Status),
+				Severity:  dimensionSignalSeverity(dim.Status),
+				Title:     dim.Label + ": " + dimensionStatusLabel(dim.Status),
+				Detail:    dim.Summary,
+				Evidence:  dim.Evidence,
+				Source:    "runtime",
+			})
+		}
+	}
+	return signals
+}
+
+// buildHardeningSummary wraps the existing auditcheck output for
+// the secondary section. SuppressScore = true means the template
+// hides the grade and the score; the counts and the fixable
+// count remain visible so the operator still has a path to
+// remediation. Reason is the one-line copy the template renders
+// in place of the suppressed grade.
+func buildHardeningSummary(in PostureInputs, suppress bool) RuntimeHardeningSummary {
+	h := RuntimeHardeningSummary{
+		Score:        in.AuditcheckScore,
+		Grade:        in.AuditcheckGrade,
+		TotalChecks:  len(in.Auditcheck),
+		Critical:     in.AuditcheckSummary.Critical,
+		High:         in.AuditcheckSummary.High,
+		Medium:       in.AuditcheckSummary.Medium,
+		Info:         in.AuditcheckSummary.Info,
+		FixableCount: in.FixableCount,
+		Suppressed:   suppress,
+	}
+	if suppress {
+		h.Reason = "Runtime evidence required before showing a hardening grade."
+	}
+	return h
+}
+
+// dimensionSignalStatus maps a dimension status into the
+// signal-level status enum the template uses to colour the
+// signal pill.
+func dimensionSignalStatus(s string) string {
+	switch s {
+	case PostureCellWarn, PostureCellPartial, PostureCellStale:
+		return "warn"
+	case PostureCellBlind, PostureCellNotConfigured:
+		return "fail"
+	default:
+		return "info"
+	}
+}
+
+// dimensionSignalSeverity converts a dimension status into the
+// auditcheck-style severity word the template uses for the badge.
+// Blind / not_configured for connection or coverage are high
+// because they're operator-visible gaps that gate everything
+// else; warn states are medium.
+func dimensionSignalSeverity(s string) string {
+	switch s {
+	case PostureCellBlind, PostureCellNotConfigured:
+		return "high"
+	case PostureCellWarn, PostureCellPartial:
+		return "medium"
+	case PostureCellStale:
+		return "low"
+	default:
+		return "info"
+	}
+}
+
+// dimensionStatusLabel pretty-prints a dimension status for the
+// signal title.
+func dimensionStatusLabel(s string) string {
+	switch s {
+	case PostureCellNotConfigured:
+		return "not configured"
+	case PostureCellPartial:
+		return "partial"
+	case PostureCellBlind:
+		return "blind"
+	case PostureCellStale:
+		return "stale"
+	case PostureCellWarn:
+		return "needs attention"
+	default:
+		return s
+	}
+}
+
+func safeDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// intToStr is a small zero-import int formatter so the file does
+// not reach for strconv just for one usage. Audit chain entries
+// are non-negative so we do not need to handle the sign bit.
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + intToStr(-n)
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/dashboard/runtime_posture_test.go
+++ b/internal/dashboard/runtime_posture_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -421,6 +422,133 @@ func TestRuntimePosture_FreshHeartbeatIsDiagnosticNotProtected(t *testing.T) {
 		if strings.Contains(body, banned) {
 			t.Errorf("audit page claimed protection on a heartbeat-only state via copy %q", banned)
 		}
+	}
+}
+
+// newAuditFixTestServer wires a Server whose cfgPath points to a
+// fresh tempfile so saveConfig() — called by the auto-fix
+// handlers — can write without erroring. Pure dashboard
+// fixtures default to cfgPath="" which is fine for read-only
+// pages but breaks any handler that mutates config.
+func newAuditFixTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv := newTestServer(t)
+	dir := t.TempDir()
+	srv.cfgPath = filepath.Join(dir, "oktsec.yaml")
+	srv.cfg.Identity.RequireSignature = false // ensures SIG-001 is a fixable finding
+	return srv
+}
+
+// TestRuntimePosture_AuditFixDoesNotReintroduceLegacyScoreUI is
+// the regression for the auto-fix OOB bug found in review.
+// /dashboard/api/audit/fix/{checkID} previously appended an
+// out-of-band swap that emitted ps-ring + ps-grade-label markup,
+// which would have re-injected the retired hardening hero into
+// a runtime-first page after a single click. The OOB now
+// targets the runtime-aware rp-hardening section and applies
+// the same suppress rules the initial GET enforces.
+func TestRuntimePosture_AuditFixDoesNotReintroduceLegacyScoreUI(t *testing.T) {
+	srv := newAuditFixTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("POST", "/dashboard/api/audit/fix/SIG-001", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fix endpoint status = %d, body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+
+	for _, banned := range []string{
+		`class="ps-ring"`,         // legacy score ring markup
+		`ps-grade-label`,          // legacy grade chip class name
+		`id="posture-score"`,      // legacy OOB target id
+		`class="ps-hero-score"`,   // legacy hero score wrapper
+		`class="ps-celebrate"`,    // legacy celebration block
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("fix endpoint reintroduced legacy artefact %q; body=%.500s", banned, body)
+		}
+	}
+
+	if !strings.Contains(body, `id="rp-hardening"`) {
+		t.Errorf("fix endpoint did not emit the runtime-aware rp-hardening OOB swap; body=%.500s", body)
+	}
+	if !strings.Contains(body, `hx-swap-oob="true"`) {
+		t.Errorf("fix endpoint OOB swap missing hx-swap-oob marker; body=%.500s", body)
+	}
+}
+
+// TestRuntimePosture_AuditFixAllDoesNotReintroduceLegacyScoreUI
+// is the same regression on the bulk fix-all endpoint. The
+// ps-celebrate block previously rendered the hardening grade as
+// a celebration headline; it is replaced by a neutral "N fixes
+// applied" confirmation.
+func TestRuntimePosture_AuditFixAllDoesNotReintroduceLegacyScoreUI(t *testing.T) {
+	srv := newAuditFixTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("POST", "/dashboard/api/audit/fix-all", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fix-all endpoint status = %d, body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+
+	for _, banned := range []string{
+		`class="ps-ring"`,
+		`ps-grade-label`,
+		`id="posture-score"`,
+		`class="ps-hero-score"`,
+		`class="ps-celebrate"`,
+		`class="ps-celebrate-score"`,
+		`class="ps-celebrate-grade"`,
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("fix-all endpoint reintroduced legacy artefact %q; body=%.500s", banned, body)
+		}
+	}
+
+	if !strings.Contains(body, `id="rp-hardening"`) {
+		t.Errorf("fix-all endpoint did not emit the runtime-aware rp-hardening OOB swap; body=%.500s", body)
+	}
+}
+
+// TestRuntimePosture_AuditFixHonoursSuppressRule asserts the
+// auto-fix OOB respects the same suppress contract the page
+// render uses: when the runtime cannot prove protection right
+// now (here: connector not installed → setup_pending), the
+// rebuilt rp-hardening block must not carry a Grade chip
+// either. Otherwise a Fix click could un-suppress the score
+// after the initial GET correctly hid it.
+func TestRuntimePosture_AuditFixHonoursSuppressRule(t *testing.T) {
+	srv := newAuditFixTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	req := httptest.NewRequest("POST", "/dashboard/api/audit/fix/SIG-001", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fix endpoint status = %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// The test server has no Claude Code connector wired, so
+	// posture is setup_pending and SuppressScore is true. The
+	// rp-hardening block must therefore carry the suppressed
+	// reason copy and must NOT carry a "Grade <X>" chip.
+	if !strings.Contains(body, "Runtime evidence required") {
+		t.Errorf("fix OOB missing suppressed-reason copy; body=%.500s", body)
+	}
+	if strings.Contains(body, `class="g">Grade `) {
+		t.Errorf("fix OOB rendered a Grade chip while runtime suppress was active; body=%.500s", body)
 	}
 }
 

--- a/internal/dashboard/runtime_posture_test.go
+++ b/internal/dashboard/runtime_posture_test.go
@@ -1,0 +1,383 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/auditcheck"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtime_posture_test.go covers the Phase 4A spec acceptance:
+// the Agent Runtime Posture page must surface runtime evidence
+// first and never headline a hardening grade for a runtime state
+// nobody has finished setting up. The pure builder is exercised
+// with PostureInputs fixtures so the rules stay reproducible
+// without a live runtime.Store, plus a couple of end-to-end
+// cases hit /dashboard/audit through the real handler so the
+// template renders the right copy.
+
+// fixtureProtectedConnection returns a ConnectorHealth value
+// representing a fully wired Claude Code with fresh real tool
+// activity under protected coverage. Used by the protected /
+// hardening-secondary cases.
+func fixtureProtectedConnection() claudecode.ConnectorHealth {
+	return claudecode.ConnectorHealth{
+		ConnectorID:       "claude-code",
+		Status:            "ready",
+		Installed:         true,
+		HookInstalled:     true,
+		GatewayConfigured: true,
+		Runtime: claudecode.RuntimeEvidence{
+			HasEvidence:       true,
+			HasFreshHeartbeat: true,
+			HasFreshRealEvent: true,
+			CoverageStage:     PostureCellProtected,
+		},
+	}
+}
+
+// fixtureHeartbeatOnlyConnection returns a ConnectorHealth value
+// representing a connector that has emitted heartbeats but no
+// real tool activity yet. Used by the observing / heartbeat-only
+// cases.
+func fixtureHeartbeatOnlyConnection() claudecode.ConnectorHealth {
+	return claudecode.ConnectorHealth{
+		ConnectorID:   "claude-code",
+		Status:        "ready",
+		Installed:     true,
+		HookInstalled: true,
+		Runtime: claudecode.RuntimeEvidence{
+			HasEvidence:       true,
+			HasFreshHeartbeat: true,
+			HasFreshRealEvent: false,
+			CoverageStage:     "",
+		},
+	}
+}
+
+// baseInputsWithConnection bundles a connection into a
+// PostureInputs with neutral defaults (audit grade = A, runtime
+// store ready, signature required). Tests override only what
+// they care about.
+func baseInputsWithConnection(conn claudecode.ConnectorHealth) PostureInputs {
+	return PostureInputs{
+		Connection:         conn,
+		Identity:           config.IdentityConfig{RequireSignature: true},
+		Cfg:                &config.Config{},
+		HookInstalled:      conn.HookInstalled,
+		Auditcheck:         nil,
+		AuditcheckSummary:  auditcheck.Summary{},
+		AuditcheckScore:    100,
+		AuditcheckGrade:    "A",
+		FixableCount:       0,
+		RuntimeStoreReady:  true,
+		AuditChainValid:    true,
+		AuditChainEntries:  10,
+		HasRuntimeEvidence: conn.Runtime.HasEvidence,
+	}
+}
+
+// TestRuntimePosture_NoRuntimeEvidenceSuppressesScore — when
+// runtime cannot prove the agent is being protected, the page
+// must NOT render a hardening grade as the headline. Status
+// collapses to setup_pending and SuppressScore=true.
+func TestRuntimePosture_NoRuntimeEvidenceSuppressesScore(t *testing.T) {
+	in := baseInputsWithConnection(claudecode.ConnectorHealth{
+		Status: "not_installed",
+	})
+	in.HasRuntimeEvidence = false
+	snap := buildRuntimePostureSnapshot(in)
+
+	if snap.Status != PostureStatusSetupPending {
+		t.Errorf("Status = %q, want %q", snap.Status, PostureStatusSetupPending)
+	}
+	if !snap.SuppressScore {
+		t.Errorf("SuppressScore = false, want true on no-runtime-evidence state")
+	}
+	if !snap.Hardening.Suppressed {
+		t.Errorf("Hardening.Suppressed = false, want true (mirror of SuppressScore)")
+	}
+	if snap.Hardening.Reason == "" {
+		t.Errorf("Hardening.Reason should explain why the grade is hidden")
+	}
+}
+
+// TestRuntimePosture_HeartbeatOnlyShowsDiagnosticNotProtected —
+// a fresh heartbeat lifts status to observing, NOT protected.
+// Coverage dimension stays observed-only and the explanation
+// must say the heartbeat is diagnostic, not protection.
+func TestRuntimePosture_HeartbeatOnlyShowsDiagnosticNotProtected(t *testing.T) {
+	in := baseInputsWithConnection(fixtureHeartbeatOnlyConnection())
+	snap := buildRuntimePostureSnapshot(in)
+
+	if snap.Status != PostureStatusObserving {
+		t.Errorf("Status = %q, want %q (heartbeat-only must not be protected)", snap.Status, PostureStatusObserving)
+	}
+	if strings.Contains(strings.ToLower(snap.Title), "protected") {
+		t.Errorf("Heartbeat-only Title contains 'protected': %q", snap.Title)
+	}
+	if strings.Contains(strings.ToLower(snap.Summary), "protected coverage") {
+		t.Errorf("Heartbeat-only Summary claims protected coverage: %q", snap.Summary)
+	}
+	cov := findDimension(t, snap, PostureDimCoverage)
+	if cov.Status == PostureCellProtected {
+		t.Errorf("Coverage dimension reads protected on a heartbeat-only state")
+	}
+}
+
+// TestRuntimePosture_FreshProtectedHookShowsProtected — the
+// happy path: fresh real event + protected coverage = protected
+// posture. Hardening can show its grade as secondary because
+// runtime has actually proven it is being defended.
+func TestRuntimePosture_FreshProtectedHookShowsProtected(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	snap := buildRuntimePostureSnapshot(in)
+
+	if snap.Status != PostureStatusProtected {
+		t.Errorf("Status = %q, want %q", snap.Status, PostureStatusProtected)
+	}
+	if snap.SuppressScore {
+		t.Errorf("SuppressScore = true on protected state; expected false so hardening grade can appear secondary")
+	}
+	if snap.Hardening.Suppressed {
+		t.Errorf("Hardening.Suppressed = true on protected state")
+	}
+}
+
+// TestRuntimePosture_ExpiredProtectedHookDoesNotShowProtected —
+// a connector that USED to have evidence but no longer has fresh
+// rows must not surface as protected. Stale runtime is
+// degraded — the operator needs to see the freshness gap, not a
+// false-positive protected pill.
+func TestRuntimePosture_ExpiredProtectedHookDoesNotShowProtected(t *testing.T) {
+	conn := claudecode.ConnectorHealth{
+		Status:        "stale",
+		Installed:     true,
+		HookInstalled: true,
+		Runtime: claudecode.RuntimeEvidence{
+			HasEvidence:       true,
+			HasFreshHeartbeat: false,
+			HasFreshRealEvent: false,
+			// Coverage stage from the last observed event — value
+			// is irrelevant once HasFreshRealEvent is false.
+			CoverageStage: PostureCellProtected,
+		},
+	}
+	in := baseInputsWithConnection(conn)
+	snap := buildRuntimePostureSnapshot(in)
+
+	if snap.Status == PostureStatusProtected {
+		t.Errorf("Status = %q, want anything but protected on expired evidence", snap.Status)
+	}
+	if snap.EvidenceFreshness == PostureFreshnessFresh {
+		t.Errorf("EvidenceFreshness = fresh on a stale connection")
+	}
+}
+
+// TestRuntimePosture_RequireSignatureFalseIsIdentityFinding —
+// dev-mode signature is a finding on the identity_context
+// dimension, but it does NOT mention Okta/Auth0/Entra (those
+// are out of scope per the Phase 4A guardrails).
+func TestRuntimePosture_RequireSignatureFalseIsIdentityFinding(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = false
+	snap := buildRuntimePostureSnapshot(in)
+
+	id := findDimension(t, snap, PostureDimIdentityContext)
+	if id.Status == PostureCellOK {
+		t.Errorf("identity_context Status = ok with RequireSignature=false")
+	}
+	if !strings.Contains(strings.ToLower(id.Summary), "signature") {
+		t.Errorf("identity_context summary missing signature reference: %q", id.Summary)
+	}
+	for _, vendor := range []string{"okta", "auth0", "entra"} {
+		if strings.Contains(strings.ToLower(id.Summary+id.Evidence), vendor) {
+			t.Errorf("identity_context dimension mentions vendor %q (must stay vendor-neutral): summary=%q evidence=%q", vendor, id.Summary, id.Evidence)
+		}
+	}
+}
+
+// TestRuntimePosture_LocalSignedIdentityIsEnough — RequireSignature=true
+// alone is sufficient for a positive identity_context state.
+// Missing IdP integration is not a finding.
+func TestRuntimePosture_LocalSignedIdentityIsEnough(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+	if id.Status != PostureCellOK {
+		t.Errorf("identity_context Status = %q, want ok", id.Status)
+	}
+}
+
+// TestRuntimePosture_AuditFallbackDoesNotOverrideRuntimePartial —
+// a runtime-partial state must stay setup_pending even when the
+// audit chain is valid and the auditcheck score is high. The
+// fix in Phase 3 was that audit fallback never resurrects a
+// runtime-empty page; the same rule applies to posture.
+func TestRuntimePosture_AuditFallbackDoesNotOverrideRuntimePartial(t *testing.T) {
+	conn := claudecode.ConnectorHealth{
+		Status:        "partial",
+		Installed:     true,
+		HookInstalled: true,
+		Runtime:       claudecode.RuntimeEvidence{},
+	}
+	in := baseInputsWithConnection(conn)
+	in.HasRuntimeEvidence = false
+	in.AuditcheckScore = 95
+	in.AuditcheckGrade = "A"
+	in.AuditChainValid = true
+
+	snap := buildRuntimePostureSnapshot(in)
+	if snap.Status != PostureStatusSetupPending {
+		t.Errorf("Status = %q, want setup_pending; audit fallback overrode runtime-partial", snap.Status)
+	}
+	if !snap.SuppressScore {
+		t.Errorf("SuppressScore = false on runtime-partial state; audit chain validity should not unlock the score")
+	}
+}
+
+// TestRuntimePosture_EvidenceStoreShowsRuntimeAndAuditChain — the
+// evidence dimension is "ok" only when BOTH the runtime store is
+// reachable AND the audit chain verifies. Either failure flips
+// the dimension to a warn / not_configured shape.
+func TestRuntimePosture_EvidenceStoreShowsRuntimeAndAuditChain(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	snap := buildRuntimePostureSnapshot(in)
+	ev := findDimension(t, snap, PostureDimEvidence)
+	if ev.Status != PostureCellOK {
+		t.Errorf("evidence Status = %q, want ok with both runtime store + chain healthy", ev.Status)
+	}
+
+	// Runtime store unavailable -> not_configured.
+	in.RuntimeStoreReady = false
+	snap = buildRuntimePostureSnapshot(in)
+	ev = findDimension(t, snap, PostureDimEvidence)
+	if ev.Status != PostureCellNotConfigured {
+		t.Errorf("evidence Status = %q, want not_configured when runtime store missing", ev.Status)
+	}
+
+	// Audit chain invalid -> warn.
+	in.RuntimeStoreReady = true
+	in.AuditChainValid = false
+	snap = buildRuntimePostureSnapshot(in)
+	ev = findDimension(t, snap, PostureDimEvidence)
+	if ev.Status != PostureCellWarn {
+		t.Errorf("evidence Status = %q, want warn when audit chain invalid", ev.Status)
+	}
+}
+
+// TestRuntimePosture_HardeningChecksAreSecondary — even on the
+// happy path the hardening summary must not become the headline.
+// The hero's Title is the runtime status, not the auditcheck
+// grade word.
+func TestRuntimePosture_HardeningChecksAreSecondary(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.AuditcheckGrade = "A"
+	snap := buildRuntimePostureSnapshot(in)
+
+	for _, banned := range []string{"Deployment needs attention", "Critical security gaps detected", "Deployment secured"} {
+		if strings.Contains(snap.Title, banned) || strings.Contains(snap.Summary, banned) {
+			t.Errorf("hero copy carries legacy hardening headline %q: title=%q summary=%q", banned, snap.Title, snap.Summary)
+		}
+	}
+	if snap.Hardening.Grade == "" {
+		t.Errorf("Hardening.Grade should be available for the secondary section")
+	}
+}
+
+// TestRuntimePosture_SuppressedHardeningHidesGradeAndScore is the
+// explicit guardrail gus called out: when SuppressScore=true the
+// rendered audit page must NOT show the score ring, the Grade
+// label, or any alarmist headline copy. The neutral check count
+// must remain visible so the operator can still navigate to
+// remediation.
+func TestRuntimePosture_SuppressedHardeningHidesGradeAndScore(t *testing.T) {
+	srv := newTestServer(t)
+	srv.cfg.Identity.RequireSignature = false
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+
+	body := fetchAuditHTML(t, cookie, handler)
+
+	for _, banned := range []string{
+		"ps-ring",                         // legacy score ring CSS class
+		"ps-grade-label",                  // legacy grade chip
+		"Deployment needs attention",      // legacy hero copy
+		"Critical security gaps detected", // legacy hero copy
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("audit page leaked legacy score artefact %q (suppress contract broken)", banned)
+		}
+	}
+
+	if !strings.Contains(body, "Hardening checks") {
+		t.Errorf("audit page must keep the Hardening checks section header even when suppressed")
+	}
+	if !strings.Contains(body, "Runtime evidence required") {
+		t.Errorf("audit page must show the suppressed reason copy")
+	}
+}
+
+// TestRuntimePosture_FreshHeartbeatIsDiagnosticNotProtected pairs
+// with the heartbeat-only snapshot test above but exercises the
+// full handler + template path, asserting the rendered HTML
+// never tells the operator the agent is protected on the back of
+// a heartbeat.
+func TestRuntimePosture_FreshHeartbeatIsDiagnosticNotProtected(t *testing.T) {
+	srv, rs, _ := newRuntimeGraphTestServer(t)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Seed a fresh heartbeat session — no real tool activity.
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-rp"}`,
+		"heartbeat-2026-04-30-rp", "local-codex", now.Add(-1*time.Minute), runtime.OutcomeRefs{})
+
+	body := fetchAuditHTML(t, cookie, handler)
+
+	if !strings.Contains(body, "Agent Runtime Posture") {
+		t.Errorf("audit page missing the runtime hero")
+	}
+	for _, banned := range []string{
+		"Protected — fresh runtime evidence",
+		"Hooks installed and receiving fresh real activity",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("audit page claimed protection on a heartbeat-only state via copy %q", banned)
+		}
+	}
+}
+
+// fetchAuditHTML hits /dashboard/audit with a logged-in cookie
+// and returns the rendered body.
+func fetchAuditHTML(t *testing.T, cookie *http.Cookie, handler http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/dashboard/audit", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("audit page status = %d, body=%s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+// findDimension returns the dimension row with the given id or
+// fails the test if it is absent.
+func findDimension(t *testing.T, snap RuntimePostureSnapshot, id string) RuntimePostureDimension {
+	t.Helper()
+	for _, d := range snap.Dimensions {
+		if d.ID == id {
+			return d
+		}
+	}
+	t.Fatalf("dimension %q not found in snapshot; have %d dimensions", id, len(snap.Dimensions))
+	return RuntimePostureDimension{}
+}

--- a/internal/dashboard/runtime_posture_test.go
+++ b/internal/dashboard/runtime_posture_test.go
@@ -291,6 +291,75 @@ func TestRuntimePosture_HardeningChecksAreSecondary(t *testing.T) {
 	}
 }
 
+// TestRuntimePosture_FreshBlindEventIsBlindNotStale is the
+// regression for the freshness-vs-coverage mixing bug found in
+// review of the original Phase 4A slice. Before the fix, a fresh
+// real event with CoverageStage=blind skipped the protected
+// branch (not protected coverage) AND the observing branch
+// (excluded blind explicitly), then fell into the HasEvidence
+// stale branch and headlined "Degraded — runtime evidence is
+// stale". The evidence is fresh; only coverage is blind.
+func TestRuntimePosture_FreshBlindEventIsBlindNotStale(t *testing.T) {
+	in := baseInputsWithConnection(claudecode.ConnectorHealth{
+		Status:        "ready",
+		Installed:     true,
+		HookInstalled: true,
+		Runtime: claudecode.RuntimeEvidence{
+			HasEvidence:       true,
+			HasFreshRealEvent: true,
+			HasFreshHeartbeat: false,
+			CoverageStage:     PostureCellBlind,
+		},
+	})
+	snap := buildRuntimePostureSnapshot(in)
+
+	if snap.Status == PostureStatusDegraded {
+		t.Errorf("Status = %q on fresh-but-blind state; want anything but degraded (evidence is fresh, only coverage is blind)", snap.Status)
+	}
+	for _, banned := range []string{"stale", "Stale"} {
+		if strings.Contains(snap.Title, banned) || strings.Contains(snap.Summary, banned) {
+			t.Errorf("hero copy mislabels fresh blind evidence as %q: title=%q summary=%q", banned, snap.Title, snap.Summary)
+		}
+	}
+	if snap.EvidenceFreshness != PostureFreshnessFresh {
+		t.Errorf("EvidenceFreshness = %q on fresh real event, want fresh", snap.EvidenceFreshness)
+	}
+}
+
+// TestRuntimePosture_FreshObservedEventDoesNotPaintConnectionProtected
+// is the regression for the second mixing bug: the connection
+// dimension was promoted to "protected" any time a fresh real
+// event arrived, regardless of coverage. That painted a green
+// protected pill on the Connection card while Coverage was only
+// observed. Connection is about reachability — protection
+// belongs to the coverage dimension.
+func TestRuntimePosture_FreshObservedEventDoesNotPaintConnectionProtected(t *testing.T) {
+	in := baseInputsWithConnection(claudecode.ConnectorHealth{
+		Status:        "ready",
+		Installed:     true,
+		HookInstalled: true,
+		Runtime: claudecode.RuntimeEvidence{
+			HasEvidence:       true,
+			HasFreshRealEvent: true,
+			HasFreshHeartbeat: false,
+			CoverageStage:     PostureCellObserved,
+		},
+	})
+	snap := buildRuntimePostureSnapshot(in)
+
+	conn := findDimension(t, snap, PostureDimConnection)
+	if conn.Status == PostureCellProtected {
+		t.Errorf("connection dimension Status = protected on observed-only event (must be ok/observed)")
+	}
+	cov := findDimension(t, snap, PostureDimCoverage)
+	if cov.Status == PostureCellProtected {
+		t.Errorf("coverage dimension Status = protected on observed-only event (sanity check)")
+	}
+	if snap.Status == PostureStatusProtected {
+		t.Errorf("top-level Status = protected on observed-only event")
+	}
+}
+
 // TestRuntimePosture_SuppressedHardeningHidesGradeAndScore is the
 // explicit guardrail gus called out: when SuppressScore=true the
 // rendered audit page must NOT show the score ring, the Grade

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -814,8 +814,12 @@ func TestServer_AuditPageProductInfo(t *testing.T) {
 		t.Fatalf("audit page: status = %d, want 200", w.Code)
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, "Security posture") {
-		t.Error("audit page should contain posture heading")
+	// Phase 4A renamed the hero from "Security posture" to
+	// "Agent Runtime Posture". The sidebar still says
+	// "Security Posture" but the page-level heading is the
+	// runtime-first one.
+	if !strings.Contains(body, "Agent Runtime Posture") {
+		t.Error("audit page should contain Agent Runtime Posture heading")
 	}
 	// "Priority Remediations" section only shown when there are critical/high
 	// findings — the test config triggers some, so at least verify the page

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -175,7 +175,7 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 
 <!-- Hardening — secondary section -->
 <div class="rp-section-title">Hardening checks</div>
-<div class="rp-hardening">
+<div id="rp-hardening" class="rp-hardening">
   <div class="rp-hardening-head">
     <span class="rp-hardening-title">Static deployment checks</span>
     <span class="rp-hardening-meta">

--- a/internal/dashboard/tmpl_audit.go
+++ b/internal/dashboard/tmpl_audit.go
@@ -4,26 +4,52 @@ import "html/template"
 
 var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layoutHead + `
 <style>
-/* ── Security Posture v2 ───────────────────────────────── */
+/* ── Agent Runtime Posture (Phase 4A) ─────────────────── */
+.rp-hero{display:flex;align-items:flex-start;gap:24px;padding:28px 32px;background:linear-gradient(135deg,var(--surface) 0%,rgba(56,139,253,0.04) 100%);border:1px solid var(--border);border-radius:14px;margin-bottom:24px;position:relative;overflow:hidden}
+.rp-hero::after{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--accent-light),transparent);opacity:0.4}
+.rp-hero-body{flex:1}
+.rp-eyebrow{font-size:0.65rem;text-transform:uppercase;letter-spacing:0.6px;color:var(--text3);font-weight:600;margin-bottom:6px}
+.rp-title{font-size:1.25rem;font-weight:700;color:var(--text);letter-spacing:0;margin-bottom:6px}
+.rp-summary{font-size:0.875rem;color:var(--text2);line-height:1.55;max-width:780px}
+.rp-status-pill{display:inline-block;padding:4px 12px;border-radius:6px;font-size:0.7rem;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;margin-left:12px;vertical-align:middle}
+.rp-status-pill.s-protected{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.30)}
+.rp-status-pill.s-observing{background:rgba(56,139,253,0.10);color:var(--accent);border:1px solid rgba(56,139,253,0.25)}
+.rp-status-pill.s-degraded{background:rgba(210,153,34,0.10);color:var(--warn);border:1px solid rgba(210,153,34,0.25)}
+.rp-status-pill.s-blind{background:rgba(248,81,73,0.10);color:var(--danger);border:1px solid rgba(248,81,73,0.25)}
+.rp-status-pill.s-setup_pending{background:transparent;color:var(--text3);border:1px solid var(--border)}
 
-/* Hero */
-.ps-hero{display:flex;align-items:center;gap:36px;padding:32px 36px;background:linear-gradient(135deg,var(--surface) 0%,rgba(139,92,246,0.03) 100%);border:1px solid var(--border);border-radius:14px;margin-bottom:24px;position:relative;overflow:hidden}
-.ps-hero::after{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--accent-light),transparent);opacity:0.4}
-.ps-hero-score{display:flex;flex-direction:column;align-items:center;gap:6px;flex-shrink:0}
-.ps-ring{width:110px;height:110px;border-radius:50%;background:conic-gradient(var(--clr,var(--success)) calc(var(--pct,0) * 1%),var(--surface2) 0);display:flex;align-items:center;justify-content:center;position:relative;box-shadow:0 0 24px rgba(0,0,0,0.2)}
-.ps-ring::before{content:'';position:absolute;inset:8px;border-radius:50%;background:var(--surface)}
-.ps-num{position:relative;font-size:2rem;font-weight:800;font-family:var(--sans);letter-spacing:0;color:var(--text)}
-.ps-grade-label{font-size:0.6875rem;color:var(--text3);font-family:var(--mono);letter-spacing:0.5px;text-transform:uppercase}
-.ps-hero-body{flex:1}
-.ps-hero-title{font-size:1.125rem;font-weight:700;color:var(--text);margin-bottom:4px;letter-spacing:0}
-.ps-hero-sub{font-size:0.8125rem;color:var(--text3);margin-bottom:6px}
-.ps-hero-detail{display:flex;gap:16px;margin-bottom:16px;font-size:0.72rem;color:var(--text3)}
-.ps-hero-detail span{display:flex;align-items:center;gap:4px}
-.ps-hero-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
-.ps-fix-all{padding:11px 28px;background:linear-gradient(135deg,#238636,#2ea043);border:none;border-radius:8px;color:#fff;font-size:0.8125rem;font-weight:600;cursor:pointer;transition:transform 0.2s,box-shadow 0.2s;font-family:var(--sans);letter-spacing:0;box-shadow:0 2px 8px rgba(35,134,54,0.3)}
-.ps-fix-all:hover{transform:translateY(-1px);box-shadow:0 4px 16px rgba(35,134,54,0.4)}
-.ps-fix-all:disabled{opacity:0.6;cursor:wait;transform:none}
-.ps-resolved{font-size:0.75rem;color:var(--success);display:flex;align-items:center;gap:6px;margin-top:8px}
+.rp-section-title{font-size:0.6875rem;text-transform:uppercase;letter-spacing:0.6px;color:var(--text3);font-weight:600;margin:24px 0 12px;padding-left:2px}
+.rp-dim-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;margin-bottom:24px}
+.rp-dim{padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:10px}
+.rp-dim-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
+.rp-dim-label{font-size:0.8125rem;font-weight:600;color:var(--text)}
+.rp-dim-pill{display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.62rem;font-weight:700;text-transform:uppercase;letter-spacing:0.5px}
+.rp-dim-pill.cell-ok,.rp-dim-pill.cell-protected{background:rgba(63,185,80,0.12);color:var(--success);border:1px solid rgba(63,185,80,0.30)}
+.rp-dim-pill.cell-observed{background:rgba(56,139,253,0.10);color:var(--accent);border:1px solid rgba(56,139,253,0.25)}
+.rp-dim-pill.cell-partial,.rp-dim-pill.cell-warn,.rp-dim-pill.cell-stale{background:rgba(210,153,34,0.10);color:var(--warn);border:1px solid rgba(210,153,34,0.25)}
+.rp-dim-pill.cell-blind{background:rgba(248,81,73,0.10);color:var(--danger);border:1px solid rgba(248,81,73,0.25)}
+.rp-dim-pill.cell-not_configured{background:transparent;color:var(--text3);border:1px solid var(--border)}
+.rp-dim-summary{font-size:0.78rem;color:var(--text2);line-height:1.5;margin-bottom:6px}
+.rp-dim-evidence{font-size:0.7rem;color:var(--text3);font-family:var(--mono);word-break:break-word}
+
+.rp-signals{margin-bottom:24px}
+.rp-signal{display:flex;align-items:flex-start;gap:14px;padding:12px 16px;background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px}
+.rp-signal-sev{flex-shrink:0;min-width:64px;padding-top:1px}
+.rp-signal-sev .ps-sev{display:inline-block;font-size:0.6rem;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;padding:3px 8px;border-radius:4px}
+.rp-signal-body{flex:1;min-width:0}
+.rp-signal-title{font-size:0.8rem;font-weight:600;color:var(--text)}
+.rp-signal-detail{font-size:0.75rem;color:var(--text3);margin-top:4px;line-height:1.5}
+
+.rp-hardening{padding:18px 22px;background:var(--surface);border:1px solid var(--border);border-radius:12px;margin-bottom:20px}
+.rp-hardening-head{display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:12px;margin-bottom:8px}
+.rp-hardening-title{font-size:0.9rem;font-weight:600;color:var(--text)}
+.rp-hardening-meta{font-size:0.75rem;color:var(--text3)}
+.rp-hardening-meta strong{color:var(--text2);font-weight:600}
+.rp-hardening-grade{font-size:0.78rem;color:var(--text2);margin-top:6px}
+.rp-hardening-grade .g{display:inline-block;padding:2px 10px;border-radius:4px;font-weight:700;background:var(--surface2);color:var(--text);border:1px solid var(--border);font-family:var(--mono);margin-right:6px}
+.rp-hardening-suppressed{font-size:0.75rem;color:var(--text3);font-style:italic;margin-top:6px}
+
+/* ── Security Posture v2 (legacy classes still used by findings list) ── */
 
 /* Status bar */
 .ps-status{display:flex;justify-content:space-between;align-items:center;padding:10px 0;margin-bottom:20px;border-bottom:1px solid var(--border);font-size:0.75rem;color:var(--text3)}
@@ -69,13 +95,6 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 .ps-enrich-btn{padding:7px 18px;background:rgba(139,92,246,0.06);border:1px solid var(--accent-border);color:var(--accent-light);border-radius:6px;font-size:0.75rem;font-weight:500;cursor:pointer;transition:background 0.15s,border-color 0.15s;display:flex;align-items:center;gap:6px}
 .ps-enrich-btn:hover{background:rgba(139,92,246,0.12);border-color:var(--accent-light)}
 
-/* Celebration */
-.ps-celebrate{text-align:center;padding:40px;background:linear-gradient(135deg,rgba(35,134,54,0.06),rgba(63,185,80,0.03));border:1px solid rgba(63,185,80,0.2);border-radius:14px;margin-bottom:24px}
-.ps-celebrate-score{font-size:3rem;font-weight:800;color:var(--success);font-family:var(--sans);letter-spacing:0}
-.ps-celebrate-grade{font-size:0.875rem;color:var(--text3);font-family:var(--mono);margin-top:4px}
-.ps-celebrate-msg{font-size:0.8125rem;color:var(--text2);margin-top:16px}
-.ps-celebrate-msg a{color:var(--accent-light);text-decoration:none}
-
 /* Loading */
 .htmx-indicator{display:none}
 .htmx-request .htmx-indicator,.htmx-request.htmx-indicator{display:inline}
@@ -100,13 +119,11 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 .ps-empty-filter{padding:24px;text-align:center;color:var(--text3);font-size:0.8rem}
 
 @media(max-width:768px){
-  .ps-hero{flex-direction:column;text-align:center;gap:20px;padding:24px}
-  .ps-hero-detail{justify-content:center}
   .ps-findings .ps-finding{flex-wrap:wrap}
 }
 </style>
 
-<p class="page-desc">Security posture: <strong>{{.TotalChecks}} finding{{if ne .TotalChecks 1}}s{{end}}</strong> to review.{{if gt .FixableCount 0}} <strong>{{.FixableCount}}</strong> can be auto-fixed.{{end}}</p>
+<p class="page-desc">Runtime evidence first. Hardening checks below as secondary context.</p>
 
 {{if .Sandbox}}
 <div style="display:flex;align-items:center;gap:8px;padding:10px 16px;border:1px solid var(--border);border-radius:10px;margin-bottom:20px;font-size:0.8125rem;color:var(--text3)">
@@ -115,33 +132,67 @@ var auditTmpl = template.Must(template.New("audit").Funcs(tmplFuncs).Parse(layou
 </div>
 {{end}}
 
-<!-- Hero -->
-<div class="ps-hero">
-  <div class="ps-hero-score" id="posture-score">
-    <div class="ps-ring" style="--pct:{{.Score}};--clr:{{if ge .Score 90}}var(--success){{else if ge .Score 60}}var(--warn){{else}}var(--danger){{end}}">
-      <span class="ps-num">{{.Score}}</span>
-    </div>
-    <div class="ps-grade-label">Grade {{.Grade}}</div>
-  </div>
-  <div class="ps-hero-body">
-    <div class="ps-hero-title">{{if ge .Score 90}}Deployment secured{{else if ge .Score 60}}Deployment needs attention{{else}}Critical security gaps detected{{end}}</div>
-    <div class="ps-hero-detail">
-      {{if gt .Summary.Critical 0}}<span><span class="ps-hero-dot" style="background:var(--danger)"></span>{{.Summary.Critical}} critical</span>{{end}}
-      {{if gt .Summary.High 0}}<span><span class="ps-hero-dot" style="background:var(--danger)"></span>{{.Summary.High}} high</span>{{end}}
-      {{if gt .Summary.Medium 0}}<span><span class="ps-hero-dot" style="background:var(--warn)"></span>{{.Summary.Medium}} medium</span>{{end}}
-      {{if gt .Summary.Info 0}}<span><span class="ps-hero-dot" style="background:var(--text3)"></span>{{.Summary.Info}} info</span>{{end}}
-    </div>
-    {{if gt .FixableCount 0}}
-    <button class="ps-fix-all"
-      hx-post="/dashboard/api/audit/fix-all"
-      hx-target="#posture-findings"
-      hx-swap="innerHTML"
-      hx-confirm="Apply {{.FixableCount}} safe fixes? This enables security features in your config.">Fix {{.FixableCount}} {{if eq .FixableCount 1}}issue{{else}}issues{{end}} automatically</button>
-    {{end}}
+{{with .Posture}}
+<!-- Hero — runtime-first -->
+<div class="rp-hero">
+  <div class="rp-hero-body">
+    <div class="rp-eyebrow">Agent Runtime Posture</div>
+    <div class="rp-title">{{.Title}}<span class="rp-status-pill s-{{.Status}}">{{.Status}}</span></div>
+    <div class="rp-summary">{{.Summary}}</div>
   </div>
 </div>
 
-<!-- Status bar -->
+<!-- Runtime dimensions -->
+<div class="rp-section-title">Runtime dimensions</div>
+<div class="rp-dim-grid">
+  {{range .Dimensions}}
+  <div class="rp-dim">
+    <div class="rp-dim-head">
+      <span class="rp-dim-label">{{.Label}}</span>
+      <span class="rp-dim-pill cell-{{.Status}}">{{.Status}}</span>
+    </div>
+    <div class="rp-dim-summary">{{.Summary}}</div>
+    {{if .Evidence}}<div class="rp-dim-evidence">{{.Evidence}}</div>{{end}}
+  </div>
+  {{end}}
+</div>
+
+{{if .Signals}}
+<div class="rp-section-title">Gaps and next actions</div>
+<div class="rp-signals">
+  {{range .Signals}}
+  <div class="rp-signal">
+    <div class="rp-signal-sev"><span class="ps-sev sev-{{.Severity}}">{{.Severity}}</span></div>
+    <div class="rp-signal-body">
+      <div class="rp-signal-title">{{.Title}}</div>
+      {{if .Detail}}<div class="rp-signal-detail">{{.Detail}}</div>{{end}}
+      {{if .Evidence}}<div class="rp-signal-detail">{{.Evidence}}</div>{{end}}
+    </div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+<!-- Hardening — secondary section -->
+<div class="rp-section-title">Hardening checks</div>
+<div class="rp-hardening">
+  <div class="rp-hardening-head">
+    <span class="rp-hardening-title">Static deployment checks</span>
+    <span class="rp-hardening-meta">
+      <strong>{{.Hardening.TotalChecks}}</strong> check{{if ne .Hardening.TotalChecks 1}}s{{end}} available{{if gt .Hardening.FixableCount 0}}, <strong>{{.Hardening.FixableCount}}</strong> auto-fixable{{end}}.
+    </span>
+  </div>
+  {{if .Hardening.Suppressed}}
+  <div class="rp-hardening-suppressed">{{.Hardening.Reason}}</div>
+  {{else}}
+  <div class="rp-hardening-grade">
+    <span class="g">Grade {{.Hardening.Grade}}</span>based on static deployment checks.
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+<!-- Status bar — audit trail + AI enrich (legacy advisory section) -->
 <div class="ps-status">
   <div>
     Audit trail: {{formatNum .ChainCount}} entries{{if .ChainValid}}, integrity verified{{end}}


### PR DESCRIPTION
## Summary

The audit page led with a hardening grade computed from static deployment checks. That grade ran ahead of runtime evidence: a brand-new install with no runtime activity could still surface a score, and a partial connection still painted "Critical security gaps detected" as the headline. Phase 3 made the rest of the dashboard runtime-first; this slice closes the same loop on the posture page so the operator sees what the agent is actually doing right now, not what `auditcheck` would say about the config in isolation.

## Architecture

`buildRuntimePostureSnapshot` in `internal/dashboard/runtime_posture.go` is a pure projection: connection health + runtime evidence + identity config + auditcheck output → a single view-model. `handleAudit` stays an orchestrator; the freshness / coverage / identity rules live in the builder so the template never re-derives status from raw timestamps.

### Status enum

`setup_pending | observing | protected | degraded | blind`. Drives the hero band; never displays as a hardening grade.

### Suppress score

True for `setup_pending` and `partial` connection. When set, the template hides:
- `ps-ring` score visualisation
- `Grade A/B/C` label
- "Deployment needs attention" / "Critical security gaps detected" copy

It keeps:
- Neutral hardening check count
- Auto-fixable count
- Suppressed reason: "Runtime evidence required before showing a hardening grade."

### Five dimensions

`connection`, `coverage`, `enforcement`, `identity_context`, `evidence`. Each carries its own status pill + summary + evidence line so the template renders without re-deriving any rule.

### Heartbeat semantics (3C invariant preserved)

A fresh heartbeat lifts status to `observing`, never `protected`. Coverage dimension stays `observed-only` on heartbeat-only state. Title / summary copy never mentions "protected" on a heartbeat-only state.

### Identity context — vendor-neutral

`require_signature=true` alone is sufficient for the OK state. Missing Okta/Auth0/Entra is NOT a finding. The rendered page never mentions vendor names. (Per-roadmap: external identity context is Order 6, not now.)

### Hardening = secondary

`SuppressScore=true` → "Static deployment checks / N checks available, M auto-fixable / Runtime evidence required before showing a hardening grade."

`SuppressScore=false` → "Static deployment checks / N checks available, M auto-fixable / Grade B based on static deployment checks."

Either way, the hero is the runtime status. The grade is never the headline.

## Out of scope

Per the Phase 4A guardrails: no delegation enforcement, no runtime AI analysis, no OIDC/JWT/IdP context, no Okta/Auth0/Entra integration, no global navigation rename, no runtime schema changes, no LLM-driven posture decisions.

## Tests

11 new tests in `internal/dashboard/runtime_posture_test.go`:

**9 spec acceptance tests:**
- `TestRuntimePosture_NoRuntimeEvidenceSuppressesScore`
- `TestRuntimePosture_HeartbeatOnlyShowsDiagnosticNotProtected`
- `TestRuntimePosture_FreshProtectedHookShowsProtected`
- `TestRuntimePosture_ExpiredProtectedHookDoesNotShowProtected`
- `TestRuntimePosture_RequireSignatureFalseIsIdentityFinding`
- `TestRuntimePosture_LocalSignedIdentityIsEnough`
- `TestRuntimePosture_AuditFallbackDoesNotOverrideRuntimePartial`
- `TestRuntimePosture_EvidenceStoreShowsRuntimeAndAuditChain`
- `TestRuntimePosture_HardeningChecksAreSecondary`

**2 explicit guardrails:**
- `TestRuntimePosture_SuppressedHardeningHidesGradeAndScore` — asserts `ps-ring`, `ps-grade-label`, "Deployment needs attention", "Critical security gaps detected" all absent when suppressed; "Hardening checks" header and the suppressed-reason copy still present.
- `TestRuntimePosture_FreshHeartbeatIsDiagnosticNotProtected` — seeds a real heartbeat session through the handler and asserts the rendered HTML never claims protection.

Adapted `TestServer_AuditPageProductInfo` to look for "Agent Runtime Posture" instead of "Security posture".

## Test plan

- [x] `go test ./internal/dashboard ./internal/runtime -count=1`
- [x] `go test ./internal/dashboard -run 'RuntimePosture|Overview|Coverage|Audit' -count=1`
- [x] `go build ./...`
- [x] `make vet`
- [x] `make lint`