### PR TITLE
Harden delegation enforcement to runtime authority semantics

### DIFF
--- a/internal/dashboard/runtime_posture_test.go
+++ b/internal/dashboard/runtime_posture_test.go
@@ -216,6 +216,30 @@ func TestRuntimePosture_LocalSignedIdentityIsEnough(t *testing.T) {
 	}
 }
 
+// TestRuntimePosture_DelegationSummaryOnlyWhenRequireDelegation —
+// the identity_context dimension should claim "Delegation chain
+// enforced." only when identity.require_delegation is true.
+// Without the flag, the page must NOT advertise a guarantee
+// the runtime is not actually enforcing.
+func TestRuntimePosture_DelegationSummaryOnlyWhenRequireDelegation(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = true
+
+	in.Identity.RequireDelegation = false
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+	if strings.Contains(id.Summary, "Delegation chain enforced") {
+		t.Errorf("identity_context advertises delegation enforcement when require_delegation=false: %q", id.Summary)
+	}
+
+	in.Identity.RequireDelegation = true
+	snap = buildRuntimePostureSnapshot(in)
+	id = findDimension(t, snap, PostureDimIdentityContext)
+	if !strings.Contains(id.Summary, "Delegation chain enforced") {
+		t.Errorf("identity_context missing delegation summary when require_delegation=true: %q", id.Summary)
+	}
+}
+
 // TestRuntimePosture_AuditFallbackDoesNotOverrideRuntimePartial —
 // a runtime-partial state must stay setup_pending even when the
 // audit chain is valid and the auditcheck score is high. The

--- a/internal/gateway/concurrency.go
+++ b/internal/gateway/concurrency.go
@@ -76,4 +76,3 @@ func (cl *concurrencyLimiter) acquire(ctx context.Context, agent string) (func()
 		return func() {}, ctx.Err()
 	}
 }
-

--- a/internal/gateway/concurrency.go
+++ b/internal/gateway/concurrency.go
@@ -7,14 +7,16 @@ import (
 	"github.com/oktsec/oktsec/internal/config"
 )
 
-// Defaults when an Agent config omits a cap. Both numbers are intentionally
-// conservative: the gateway is the shared path through which N sub-agents
-// hit M backends, so a single rogue agent blasting concurrency hurts peers.
-// Operators who need more can override per-agent or pass < 0 for unlimited.
-const (
-	defaultMaxConcurrentCalls = 5
-	defaultMaxDelegationDepth = 3
-)
+// Default when an Agent config omits a concurrency cap. Conservative
+// because the gateway is the shared path through which N sub-agents
+// hit M backends, so a single rogue agent blasting concurrency hurts
+// peers. Operators who need more can override per-agent or pass < 0
+// for unlimited.
+//
+// The matching delegation-depth default lives in internal/policy
+// (DefaultMaxDelegationDepth) so the proxy and gateway evaluate the
+// cap with one helper.
+const defaultMaxConcurrentCalls = 5
 
 // concurrencyLimiter hands out per-agent semaphore slots. Slots are created
 // lazily on first use and never deleted (the set of agent names is bounded
@@ -75,18 +77,3 @@ func (cl *concurrencyLimiter) acquire(ctx context.Context, agent string) (func()
 	}
 }
 
-// resolveDelegationDepth picks the effective delegation depth cap for an agent.
-func resolveDelegationDepth(cfg *config.Config, agent string) int {
-	if cfg == nil {
-		return defaultMaxDelegationDepth
-	}
-	if ac, ok := cfg.Agents[agent]; ok {
-		switch {
-		case ac.MaxDelegationDepth < 0:
-			return -1
-		case ac.MaxDelegationDepth > 0:
-			return ac.MaxDelegationDepth
-		}
-	}
-	return defaultMaxDelegationDepth
-}

--- a/internal/gateway/concurrency_test.go
+++ b/internal/gateway/concurrency_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policy"
 )
 
 func TestConcurrencyLimiter_EnforcesPerAgentCap(t *testing.T) {
@@ -100,6 +101,9 @@ func TestConcurrencyLimiter_ContextCancel(t *testing.T) {
 	}
 }
 
+// TestResolveDelegationDepth — the helper now lives in
+// internal/policy. The gateway-side test stays as a smoke check
+// that the gateway calls into the canonical implementation.
 func TestResolveDelegationDepth(t *testing.T) {
 	cfg := &config.Config{
 		Agents: map[string]config.Agent{
@@ -107,13 +111,13 @@ func TestResolveDelegationDepth(t *testing.T) {
 			"wide":   {MaxDelegationDepth: -1},
 		},
 	}
-	if got := resolveDelegationDepth(cfg, "narrow"); got != 1 {
+	if got := policy.ResolveDelegationDepth(cfg, "narrow"); got != 1 {
 		t.Fatalf("narrow: got %d want 1", got)
 	}
-	if got := resolveDelegationDepth(cfg, "wide"); got != -1 {
+	if got := policy.ResolveDelegationDepth(cfg, "wide"); got != -1 {
 		t.Fatalf("wide: got %d want -1 (unlimited)", got)
 	}
-	if got := resolveDelegationDepth(cfg, "default"); got != defaultMaxDelegationDepth {
-		t.Fatalf("default: got %d want %d", got, defaultMaxDelegationDepth)
+	if got := policy.ResolveDelegationDepth(cfg, "default"); got != policy.DefaultMaxDelegationDepth {
+		t.Fatalf("default: got %d want %d", got, policy.DefaultMaxDelegationDepth)
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oktsec/oktsec/internal/llm"
 	"github.com/oktsec/oktsec/internal/mcputil"
 	"github.com/oktsec/oktsec/internal/netutil"
+	"github.com/oktsec/oktsec/internal/policy"
 	"github.com/oktsec/oktsec/internal/proxy"
 	"github.com/oktsec/oktsec/internal/verdict"
 )
@@ -679,7 +680,7 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 				// Enforce per-agent delegation depth cap. Crossing this line
 				// is how a rogue agent tries to fan out into a sub-tree of
 				// delegated children; we stop it at the gateway.
-				if maxDepth := resolveDelegationDepth(g.cfg, policyAgent); maxDepth > 0 && chainResult.Depth > maxDepth {
+				if maxDepth := policy.ResolveDelegationDepth(g.cfg, policyAgent); maxDepth > 0 && chainResult.Depth > maxDepth {
 					g.logger.Warn("delegation depth exceeded",
 						"agent", agent, "depth", chainResult.Depth, "max", maxDepth)
 					g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionDelegationDepthExceeded, "[]", toolArgs, sessionID, start)

--- a/internal/policy/delegation.go
+++ b/internal/policy/delegation.go
@@ -1,0 +1,42 @@
+package policy
+
+import "github.com/oktsec/oktsec/internal/config"
+
+// DefaultMaxDelegationDepth is the cap applied when the agent has
+// no per-agent override. The number is intentionally
+// conservative: a delegation chain is the trust path that backs
+// every authorization decision under this header, and a
+// runaway depth makes that path harder to audit. Operators who
+// genuinely need more can override per-agent or pass <0 for
+// unlimited.
+const DefaultMaxDelegationDepth = 3
+
+// ResolveDelegationDepth picks the effective delegation-depth
+// cap for an agent. The proxy and gateway both consume this
+// helper so the cap stays consistent across the two surfaces.
+//
+// Semantics:
+//   - per-agent MaxDelegationDepth < 0  → unlimited (returns -1).
+//   - per-agent MaxDelegationDepth > 0  → that exact cap.
+//   - per-agent MaxDelegationDepth == 0 → fall through to default.
+//   - agent unknown                     → default.
+//   - cfg == nil                        → default.
+//
+// "Depth" is the number of hops in the delegation chain (chain
+// length): a single token chain `root -> delegate` has depth 1;
+// `root -> a -> b` has depth 2. A cap of 1 therefore allows the
+// single-hop chain and blocks the two-hop one.
+func ResolveDelegationDepth(cfg *config.Config, agent string) int {
+	if cfg == nil {
+		return DefaultMaxDelegationDepth
+	}
+	if ac, ok := cfg.Agents[agent]; ok {
+		switch {
+		case ac.MaxDelegationDepth < 0:
+			return -1
+		case ac.MaxDelegationDepth > 0:
+			return ac.MaxDelegationDepth
+		}
+	}
+	return DefaultMaxDelegationDepth
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -257,6 +257,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.rejectAndLog(w, http.StatusForbidden, resp, &entry, start)
 		return
 	}
+	// When a chain is present the root authority is what
+	// drives the ACL decision below. Suspension must apply to
+	// that authority too — otherwise `agent suspend human`
+	// stops cutting off authority the moment human acts via a
+	// delegate. The check uses agent_suspended for symmetry
+	// with the sender/recipient checks above; the audit row's
+	// RootAgent + DelegationChain still explain why.
+	if delegation.Present {
+		if agent, ok := h.cfg.Agents[delegation.Root]; ok && agent.Suspended {
+			resp := MessageResponse{Status: audit.StatusRejected, MessageID: msgID, PolicyDecision: audit.DecisionAgentSuspended, VerifiedSender: verified}
+			h.rejectAndLog(w, http.StatusForbidden, resp, &entry, start)
+			return
+		}
+	}
 
 	// Step 3: ACL check. When delegation is present the
 	// effective authority is the chain's root, NOT req.From —

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -236,9 +236,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 1b: Delegation chain verification
-	if code, resp := h.checkDelegation(r, req.To, msgID, verified, &entry); resp != nil {
-		h.rejectAndLog(w, code, *resp, &entry, start)
-		return
+	var delegation delegationAuth
+	{
+		auth, code, dResp := h.checkDelegation(r, req.From, req.To, msgID, sigStatus, verified, &entry)
+		if dResp != nil {
+			h.rejectAndLog(w, code, *dResp, &entry, start)
+			return
+		}
+		delegation = auth
 	}
 
 	// Step 2: Agent suspension check
@@ -253,8 +258,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Step 3: ACL check
-	if !h.policy.CheckACL(req.From, req.To).Allowed {
+	// Step 3: ACL check. When delegation is present the
+	// effective authority is the chain's root, NOT req.From —
+	// the whole point of delegated authority is that the
+	// delegate inherits permission from the principal who
+	// issued the chain. The audit row keeps FromAgent=req.From
+	// so the actor stays clear; RootAgent + DelegationChainHash
+	// explain the authorisation source.
+	aclFrom := req.From
+	if delegation.Present {
+		aclFrom = delegation.Root
+	}
+	if !h.policy.CheckACL(aclFrom, req.To).Allowed {
 		resp := MessageResponse{Status: audit.StatusRejected, MessageID: msgID, PolicyDecision: audit.DecisionACLDenied, VerifiedSender: verified}
 		h.rejectAndLog(w, http.StatusForbidden, resp, &entry, start)
 		return
@@ -781,10 +796,47 @@ func (h *Handler) verifyIdentity(req *MessageRequest, reqKeyVersion int64) (sigS
 	return 1, true, result.Fingerprint
 }
 
-// checkDelegation verifies the delegation chain from the X-Oktsec-Delegation
-// header and populates the audit entry. Returns an HTTP response if the
-// request should be rejected (invalid chain or missing when required).
-func (h *Handler) checkDelegation(r *http.Request, recipient, msgID string, verified bool, entry *audit.Entry) (int, *MessageResponse) {
+// delegationAuth is the verified delegation context the
+// post-identity pipeline uses to make ACL decisions. Present is
+// false when no X-Oktsec-Delegation header arrived — the caller
+// then falls back to req.From for ACL. Present is true only after
+// the chain has passed every gate in checkDelegation: signature,
+// expiry, scope, depth, sender-binding, and (for the
+// require-signature-when-chain-present rule) cryptographic proof
+// the delegate issued the request.
+type delegationAuth struct {
+	Present   bool
+	Root      string // root delegator — the human/origin who granted authority
+	Delegate  string // final delegate — must equal req.From by contract
+	Depth     int
+	ChainHash string
+}
+
+// checkDelegation verifies the delegation chain from the
+// X-Oktsec-Delegation header. Phase 4B turns the wiring into
+// enforcement:
+//
+//   - Sender binding: a valid chain alone is not enough; the
+//     final Delegate of the chain must equal req.From, otherwise
+//     a stolen header would let an attacker reuse a chain issued
+//     for someone else.
+//   - Signature requirement: when a chain is present the request
+//     must be cryptographically signed by the delegate, even if
+//     identity.require_signature is false. Without this, the
+//     header degenerates into a bearer token: the chain proves
+//     the delegate WAS authorised, not that the delegate is
+//     issuing this particular request.
+//   - Depth cap: shared with the gateway via
+//     policy.ResolveDelegationDepth, so the proxy cannot be a
+//     weaker enforcement point than the gateway is.
+//
+// Returns:
+//   - (auth, 0, nil)              — header valid (or absent and not required)
+//   - (zero,  code, *MessageResponse) — request must be rejected
+//
+// The audit entry is populated for the success path; rejection
+// fields are filled by the caller via rejectAndLog.
+func (h *Handler) checkDelegation(r *http.Request, sender, recipient, msgID string, sigStatus int, verified bool, entry *audit.Entry) (delegationAuth, int, *MessageResponse) {
 	header := r.Header.Get("X-Oktsec-Delegation")
 
 	if header == "" {
@@ -796,12 +848,33 @@ func (h *Handler) checkDelegation(r *http.Request, recipient, msgID string, veri
 				PolicyDecision: audit.DecisionDelegationRequired,
 				VerifiedSender: verified,
 			}
-			return http.StatusUnauthorized, &resp
+			return delegationAuth{}, http.StatusUnauthorized, &resp
 		}
-		return 0, nil
+		return delegationAuth{}, 0, nil
 	}
 
-	// Header present — always verify (invalid = reject regardless of RequireDelegation)
+	// Header present — the request must be cryptographically
+	// signed by the delegate. Without the delegate's signature the
+	// chain is a bearer token: anyone who captures the header can
+	// replay it. checkIdentity has already reduced sigStatus to
+	// {-1: rejected, 0: unverified, 1: verified}; -1 was already
+	// rejected upstream, but 0 is allowed when identity.require
+	// _signature is false. Delegated requests MUST tighten that.
+	if sigStatus < 1 {
+		h.logger.Warn("delegated request without verified delegate signature",
+			"message_id", msgID, "from", sender)
+		resp := MessageResponse{
+			Status:         audit.StatusRejected,
+			MessageID:      msgID,
+			PolicyDecision: audit.DecisionSignatureRequired,
+			VerifiedSender: verified,
+		}
+		return delegationAuth{}, http.StatusUnauthorized, &resp
+	}
+
+	// Verify the chain — invalid means reject regardless of
+	// RequireDelegation (a present-but-broken chain is itself a
+	// signal something is wrong).
 	result := h.verifyDelegation(header, recipient)
 	if !result.Valid {
 		h.logger.Warn("delegation chain invalid",
@@ -812,28 +885,61 @@ func (h *Handler) checkDelegation(r *http.Request, recipient, msgID string, veri
 			PolicyDecision: audit.DecisionDelegationInvalid,
 			VerifiedSender: verified,
 		}
-		return http.StatusForbidden, &resp
+		return delegationAuth{}, http.StatusForbidden, &resp
 	}
 
-	// Valid chain — populate audit entry
+	// Sender binding: a valid chain that was issued for someone
+	// else is still a stolen token. Refuse anything where the
+	// final delegate does not match the actual request sender.
+	if result.Delegate != sender {
+		h.logger.Warn("delegation chain delegate does not match sender",
+			"message_id", msgID, "chain_delegate", result.Delegate, "from", sender)
+		resp := MessageResponse{
+			Status:         audit.StatusRejected,
+			MessageID:      msgID,
+			PolicyDecision: audit.DecisionDelegationInvalid,
+			VerifiedSender: verified,
+		}
+		return delegationAuth{}, http.StatusForbidden, &resp
+	}
+
+	// Depth cap. The cap applies to the sender (the agent we are
+	// gating). Same helper the gateway uses so a multi-surface
+	// deployment cannot be tighter on one path than the other.
+	if maxDepth := policy.ResolveDelegationDepth(h.cfg, sender); maxDepth > 0 && result.Depth > maxDepth {
+		h.logger.Warn("delegation depth exceeded",
+			"message_id", msgID, "from", sender, "depth", result.Depth, "max", maxDepth)
+		resp := MessageResponse{
+			Status:         audit.StatusRejected,
+			MessageID:      msgID,
+			PolicyDecision: audit.DecisionDelegationDepthExceeded,
+			VerifiedSender: verified,
+		}
+		return delegationAuth{}, http.StatusForbidden, &resp
+	}
+
+	// Valid chain — populate audit entry. The audit row carries
+	// FromAgent=sender (the actor) and RootAgent / DelegationChain
+	// / ChainHash / ParentAgent (the authority context) so a
+	// reader can answer "who delegated this" without re-parsing
+	// the header.
 	entry.DelegationChainHash = result.ChainHash
 	entry.RootAgent = result.Root
 	entry.AgentDepth = result.Depth
-
-	// Build human-readable chain summary
 	if result.Depth <= 2 {
 		entry.DelegationChain = result.Root + " -> " + result.Delegate
 	} else {
 		entry.DelegationChain = fmt.Sprintf("%s -> ... -> %s (%d hops)", result.Root, result.Delegate, result.Depth)
 	}
-
-	// ParentAgent is the delegator from the last token (the one that delegated to the current sender)
-	// For a chain like human -> A -> B, the ParentAgent of B is A.
-	// result.Root is the first delegator, result.Delegate is the final delegate.
-	// We parse the chain once more to get the parent from the last token.
 	entry.ParentAgent = h.extractParentAgent(header)
 
-	return 0, nil
+	return delegationAuth{
+		Present:   true,
+		Root:      result.Root,
+		Delegate:  result.Delegate,
+		Depth:     result.Depth,
+		ChainHash: result.ChainHash,
+	}, 0, nil
 }
 
 // verifyDelegation decodes and verifies a base64-encoded delegation chain

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1429,6 +1429,47 @@ func TestHandler_DelegationScopeViolation(t *testing.T) {
 	}
 }
 
+// TestHandler_DelegationSuspendedRootBlocksDelegate covers the
+// suspension half of the AND-strict authority model. Once
+// delegation.Root becomes the effective ACL principal, its
+// suspension state must gate authority too — otherwise
+// `agent suspend human` stops cutting off authority the moment
+// human acts via an unsuspended delegate, and the suspension
+// surface drifts away from the policy surface. The check uses
+// agent_suspended for symmetry with the existing
+// sender/recipient checks; the audit row's RootAgent +
+// DelegationChain still explain which authority was suspended.
+func TestHandler_DelegationSuspendedRootBlocksDelegate(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+	// Suspend the root authority while keeping the delegate
+	// active. Without the new gate the request would slip
+	// through because policy.CheckACL is happy with human's
+	// ACL.
+	human := ts.handler.cfg.Agents["human"]
+	human.Suspended = true
+	ts.handler.cfg.Agents["human"] = human
+
+	token := identity.CreateChainedDelegation(
+		humanPriv, "human", "test-agent",
+		[]string{"target-agent"}, nil,
+		time.Hour, "", 0, 3,
+	)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	w := signedDelegatedRequest(t, ts, "hello via suspended root", header)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionAgentSuspended {
+		t.Errorf("decision = %q, want %s (suspended root must not authorise via delegate)",
+			resp.PolicyDecision, audit.DecisionAgentSuspended)
+	}
+}
+
 // TestHandler_DelegationAuditStoresHashNotRawHeader is the
 // regression for Gap 4. The audit row must carry the chain hash
 // + a human-readable summary, never the base64 header. A future

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -940,8 +941,30 @@ func TestHandler_NoOverrideKeepsDefault(t *testing.T) {
 	}
 }
 
-// newDelegationTestSetup creates a test setup with keys for "human", "test-agent",
-// and "target-agent", with delegation-specific configuration.
+// newDelegationTestSetup builds the canonical Phase 4B
+// delegation fixture. Three identities, three keys, one
+// authority model:
+//
+//   - "human" is the root delegator. It has a key (so it can
+//     sign delegation tokens) and an ACL to target-agent. This
+//     is the agent whose authority a delegation chain inherits.
+//   - "test-agent" is the delegate. It has a key (so it can
+//     sign request bodies — Phase 4B requires a verified
+//     delegate signature whenever a chain is present) but NO
+//     direct ACL to target-agent. A direct request without a
+//     chain therefore fails ACL; the only way through is via a
+//     valid delegation chain rooted at human.
+//   - "target-agent" is the recipient.
+//
+// DefaultPolicy is "deny" — without that, an unknown sender
+// could pass ACL by accident and the chain-authority assertions
+// in the tests would be false-greens.
+//
+// RequireSignature is intentionally false: the Phase 4B contract
+// is that delegated requests demand cryptographic proof of the
+// delegate REGARDLESS of the global flag. A fixture that sets
+// require_signature=true would conflate the new gate with the
+// existing one.
 func newDelegationTestSetup(t *testing.T, requireDelegation bool) (*testSetup, ed25519.PrivateKey) {
 	t.Helper()
 
@@ -951,7 +974,6 @@ func newDelegationTestSetup(t *testing.T, requireDelegation bool) (*testSetup, e
 		t.Fatal(err)
 	}
 
-	// Generate keypairs for human, test-agent, and target-agent
 	humanPub, humanPriv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -971,15 +993,23 @@ func newDelegationTestSetup(t *testing.T, requireDelegation bool) (*testSetup, e
 	}
 
 	cfg := &config.Config{
-		Version: "1",
-		Server:  config.ServerConfig{Port: 0, LogLevel: "error"},
+		Version:       "1",
+		DefaultPolicy: "deny",
+		Server:        config.ServerConfig{Port: 0, LogLevel: "error"},
 		Identity: config.IdentityConfig{
 			KeysDir:           keysDir,
-			RequireSignature:  false, // simplify: focus on delegation
+			RequireSignature:  false,
 			RequireDelegation: requireDelegation,
 		},
 		Agents: map[string]config.Agent{
-			"test-agent": {CanMessage: []string{"target-agent"}},
+			// Root authority — direct ACL to target so a
+			// chain rooted here authorises the delivery.
+			"human": {CanMessage: []string{"target-agent"}},
+			// Delegate — has a key (so requests can be
+			// signed) but no direct ACL. Must rely on
+			// delegation.
+			"test-agent":   {},
+			"target-agent": {},
 		},
 	}
 
@@ -1013,6 +1043,29 @@ func newDelegationTestSetup(t *testing.T, requireDelegation bool) (*testSetup, e
 	return ts, humanPriv
 }
 
+// signedDelegatedRequest builds a MessageRequest signed by the
+// delegate (test-agent's privKey) with the given X-Oktsec-Delegation
+// header. Phase 4B rejects any delegated request that is not
+// cryptographically signed by the delegate, so every delegation
+// test that wants to reach the chain-verification logic must
+// sign through this helper.
+func signedDelegatedRequest(t *testing.T, ts *testSetup, content, header string) *httptest.ResponseRecorder {
+	t.Helper()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	sig := signMsg(ts.privKey, "test-agent", "target-agent", content, timestamp)
+	headers := map[string]string{}
+	if header != "" {
+		headers["X-Oktsec-Delegation"] = header
+	}
+	return postMessageWithHeaders(ts.handler, MessageRequest{
+		From:      "test-agent",
+		To:        "target-agent",
+		Content:   content,
+		Signature: sig,
+		Timestamp: timestamp,
+	}, headers)
+}
+
 // encodeDelegationHeader encodes a delegation chain as a base64 JSON string
 // suitable for the X-Oktsec-Delegation header.
 func encodeDelegationHeader(chain identity.DelegationChain) string {
@@ -1020,29 +1073,26 @@ func encodeDelegationHeader(chain identity.DelegationChain) string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
-func TestHandler_DelegationValidChain(t *testing.T) {
+// TestHandler_DelegationUsesRootAuthorityForACL — the canonical
+// happy path. test-agent has no direct ACL to target-agent;
+// human (root) does. A signed request with a valid
+// human -> test-agent chain must succeed because the chain
+// inherits root's authority. Audit row carries FromAgent=test-agent
+// (the actor) and RootAgent=human (the authoriser).
+func TestHandler_DelegationUsesRootAuthorityForACL(t *testing.T) {
 	ts, humanPriv := newDelegationTestSetup(t, false)
 
-	// Create a valid delegation chain: human -> test-agent
 	token := identity.CreateChainedDelegation(
 		humanPriv, "human", "test-agent",
 		[]string{"target-agent"}, nil,
 		time.Hour, "", 0, 3,
 	)
-	chain := identity.DelegationChain{*token}
-	header := encodeDelegationHeader(chain)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
 
-	w := postMessageWithHeaders(ts.handler, MessageRequest{
-		From:      "test-agent",
-		To:        "target-agent",
-		Content:   "hello with delegation",
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}, map[string]string{"X-Oktsec-Delegation": header})
-
+	w := signedDelegatedRequest(t, ts, "hello with delegation", header)
 	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", w.Code)
+		t.Errorf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
-
 	var resp MessageResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
@@ -1051,8 +1101,7 @@ func TestHandler_DelegationValidChain(t *testing.T) {
 		t.Errorf("status = %q, want delivered", resp.Status)
 	}
 
-	// Verify audit entry has delegation data
-	time.Sleep(100 * time.Millisecond) // wait for async write
+	time.Sleep(100 * time.Millisecond)
 	entries, err := ts.auditStore.Query(audit.QueryOpts{Limit: 1})
 	if err != nil {
 		t.Fatal(err)
@@ -1061,86 +1110,116 @@ func TestHandler_DelegationValidChain(t *testing.T) {
 		t.Fatal("expected at least one audit entry")
 	}
 	entry := entries[0]
+	if entry.FromAgent != "test-agent" {
+		t.Errorf("FromAgent = %q, want test-agent (sender stays the actor)", entry.FromAgent)
+	}
+	if entry.RootAgent != "human" {
+		t.Errorf("RootAgent = %q, want human (authoriser)", entry.RootAgent)
+	}
 	if entry.DelegationChainHash == "" {
 		t.Error("DelegationChainHash should be set for valid delegation")
 	}
 	if entry.DelegationChain == "" {
 		t.Error("DelegationChain should be set for valid delegation")
 	}
-	if entry.RootAgent != "human" {
-		t.Errorf("RootAgent = %q, want human", entry.RootAgent)
-	}
 }
 
-func TestHandler_DelegationExpiredToken(t *testing.T) {
+// TestHandler_DelegationBlocksWhenRootAuthorityLacksACL — the
+// AND-strict half of Gap 2. Reverse the fixture: give test-agent
+// direct ACL to target-agent and strip the root's ACL. With a
+// valid chain present, the ACL gate now evaluates the root's
+// permissions ONLY — the delegate's direct ACL is ignored. The
+// request must be denied with acl_denied (not delegation_invalid;
+// the chain itself is valid).
+func TestHandler_DelegationBlocksWhenRootAuthorityLacksACL(t *testing.T) {
 	ts, humanPriv := newDelegationTestSetup(t, false)
+	// Flip the fixture: delegate has direct ACL, root is not a
+	// registered policy principal at all. The keystore still
+	// has human's key (so the chain can verify), but cfg.Agents
+	// no longer carries it — DefaultPolicy=deny then refuses
+	// the request because the effective authoriser is unknown
+	// to policy.
+	ts.handler.cfg.Agents["test-agent"] = config.Agent{CanMessage: []string{"target-agent"}}
+	delete(ts.handler.cfg.Agents, "human")
+	ts.handler.policy = policy.NewEvaluator(ts.handler.cfg)
 
-	// Create an expired delegation token (TTL of -1h means it expired 1h ago)
-	now := time.Now().UTC()
-	token := &identity.DelegationToken{
-		Delegator: "human",
-		Delegate:  "test-agent",
-		Scope:     []string{"target-agent"},
-		IssuedAt:  now.Add(-2 * time.Hour),
-		ExpiresAt: now.Add(-1 * time.Hour), // expired
-		MaxDepth:  3,
-	}
-	// Compute token ID and sign
-	payload := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%d\n%d\n%s",
-		token.Delegator, token.Delegate, "target-agent",
-		token.IssuedAt.UTC().Format(time.RFC3339),
-		token.ExpiresAt.UTC().Format(time.RFC3339),
-		"", 0, 3, "")
-	sig := ed25519.Sign(humanPriv, []byte(payload))
-	token.Signature = base64.StdEncoding.EncodeToString(sig)
-
-	chain := identity.DelegationChain{*token}
-	header := encodeDelegationHeader(chain)
-
-	w := postMessageWithHeaders(ts.handler, MessageRequest{
-		From:      "test-agent",
-		To:        "target-agent",
-		Content:   "hello with expired delegation",
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}, map[string]string{"X-Oktsec-Delegation": header})
-
-	if w.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want 403 for expired delegation", w.Code)
-	}
-
-	var resp MessageResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatal(err)
-	}
-	if resp.PolicyDecision != audit.DecisionDelegationInvalid {
-		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionDelegationInvalid)
-	}
-}
-
-func TestHandler_DelegationInvalidSignature(t *testing.T) {
-	ts, _ := newDelegationTestSetup(t, false)
-
-	// Create a token signed with a wrong key
-	_, wrongPriv, _ := ed25519.GenerateKey(rand.Reader)
 	token := identity.CreateChainedDelegation(
-		wrongPriv, "human", "test-agent",
+		humanPriv, "human", "test-agent",
 		[]string{"target-agent"}, nil,
 		time.Hour, "", 0, 3,
 	)
-	chain := identity.DelegationChain{*token}
-	header := encodeDelegationHeader(chain)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
 
+	w := signedDelegatedRequest(t, ts, "hello with chain but no root ACL", header)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionACLDenied {
+		t.Errorf("decision = %q, want %s (AND-strict: delegate's direct ACL must be ignored when chain present)",
+			resp.PolicyDecision, audit.DecisionACLDenied)
+	}
+}
+
+// TestHandler_DelegationRequiresVerifiedDelegateSignature — Gap 0.
+// A request that carries a valid chain but no signature must be
+// rejected with signature_required, even if
+// identity.require_signature is false. Without this gate the
+// header degenerates into a bearer token: anyone who captures
+// it can replay.
+func TestHandler_DelegationRequiresVerifiedDelegateSignature(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+
+	token := identity.CreateChainedDelegation(
+		humanPriv, "human", "test-agent",
+		[]string{"target-agent"}, nil,
+		time.Hour, "", 0, 3,
+	)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	// Note: NO signature on the body. Same chain, same sender,
+	// different gate triggers.
 	w := postMessageWithHeaders(ts.handler, MessageRequest{
 		From:      "test-agent",
 		To:        "target-agent",
-		Content:   "hello with bad sig",
+		Content:   "hello with chain but no body signature",
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}, map[string]string{"X-Oktsec-Delegation": header})
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want 403 for invalid signature", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (delegated request requires verified signature); body=%s", w.Code, w.Body.String())
 	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionSignatureRequired {
+		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionSignatureRequired)
+	}
+}
 
+// TestHandler_DelegationDelegateMustMatchSender — Gap 1. A
+// chain issued for someone else is a stolen token. Even if the
+// chain verifies, the delegate at the tail must equal req.From.
+func TestHandler_DelegationDelegateMustMatchSender(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+
+	// Chain delegates to "other-agent" — but the sender will be
+	// test-agent. Stolen-token shape.
+	token := identity.CreateChainedDelegation(
+		humanPriv, "human", "other-agent",
+		[]string{"target-agent"}, nil,
+		time.Hour, "", 0, 3,
+	)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	w := signedDelegatedRequest(t, ts, "hello with chain for other agent", header)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
 	var resp MessageResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
@@ -1150,24 +1229,94 @@ func TestHandler_DelegationInvalidSignature(t *testing.T) {
 	}
 }
 
-func TestHandler_DelegationNotRequiredNoneProvided(t *testing.T) {
-	ts, _ := newDelegationTestSetup(t, false)
+// TestHandler_DelegationDepthExceededBlocksInProxy — Gap 3. The
+// proxy must enforce the same depth cap the gateway already
+// enforces, via the shared policy.ResolveDelegationDepth helper.
+// max_delegation_depth=1 allows a single-hop chain and blocks a
+// two-hop chain.
+func TestHandler_DelegationDepthExceededBlocksInProxy(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+	// Tighten the cap on the sender to 1 hop.
+	ac := ts.handler.cfg.Agents["test-agent"]
+	ac.MaxDelegationDepth = 1
+	ts.handler.cfg.Agents["test-agent"] = ac
 
-	// No delegation header, RequireDelegation=false — should pass through
+	// Build an intermediate "agent-mid" and a 2-hop chain
+	// human -> agent-mid -> test-agent. The chain's sender
+	// continues to be test-agent; depth = 2 exceeds cap = 1.
+	midPub, midPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysDir := ts.handler.cfg.Identity.KeysDir
+	midKP := &identity.Keypair{Name: "agent-mid", PublicKey: midPub, PrivateKey: midPriv}
+	if err := midKP.Save(keysDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ts.handler.keys.LoadFromDir(keysDir); err != nil {
+		t.Fatal(err)
+	}
+
+	tok1 := identity.CreateChainedDelegation(humanPriv, "human", "agent-mid",
+		[]string{"target-agent"}, nil, time.Hour, "", 0, 3)
+	// Second hop: ChainDepth=1 and ParentTokenID linked to
+	// tok1 so VerifyChain accepts the linkage. The chain
+	// itself is structurally valid; we want the proxy's depth
+	// cap (max_delegation_depth=1) to be the gate that fires,
+	// not the per-token MaxDepth.
+	tok2 := identity.CreateChainedDelegation(midPriv, "agent-mid", "test-agent",
+		[]string{"target-agent"}, nil, time.Hour, tok1.TokenID, 1, 3)
+	header := encodeDelegationHeader(identity.DelegationChain{*tok1, *tok2})
+
+	w := signedDelegatedRequest(t, ts, "hello via 2-hop chain", header)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionDelegationDepthExceeded {
+		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionDelegationDepthExceeded)
+	}
+}
+
+// TestHandler_DelegationMissingHeaderStillAllowedByDefault — when
+// the chain header is absent and require_delegation is off,
+// requests pass through normally. The fixture's ACL is set up
+// so test-agent has a direct chain via giving it temporary
+// CanMessage just for this test (the spec calls it the legacy
+// passthrough behaviour).
+func TestHandler_DelegationMissingHeaderStillAllowedByDefault(t *testing.T) {
+	ts, _ := newDelegationTestSetup(t, false)
+	// Without delegation, ACL evaluates the sender directly.
+	// Give the sender a one-off direct ACL so the legacy
+	// path is exercised in isolation.
+	ac := ts.handler.cfg.Agents["test-agent"]
+	ac.CanMessage = []string{"target-agent"}
+	ts.handler.cfg.Agents["test-agent"] = ac
+	ts.handler.policy = policy.NewEvaluator(ts.handler.cfg)
+
 	w := postMessageWithHeaders(ts.handler, MessageRequest{
 		From:      "test-agent",
 		To:        "target-agent",
 		Content:   "hello without delegation",
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}, nil)
-
 	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200 (delegation not required)", w.Code)
+		t.Errorf("status = %d, want 200 (delegation not required, direct ACL allows); body=%s", w.Code, w.Body.String())
 	}
 }
 
-func TestHandler_DelegationRequiredNoneProvided(t *testing.T) {
+// TestHandler_DelegationMissingHeaderRejectedWhenRequired — when
+// require_delegation=true the absence of the header is a hard
+// 401 with delegation_required, regardless of direct ACL.
+func TestHandler_DelegationMissingHeaderRejectedWhenRequired(t *testing.T) {
 	ts, _ := newDelegationTestSetup(t, true) // RequireDelegation=true
+	ac := ts.handler.cfg.Agents["test-agent"]
+	ac.CanMessage = []string{"target-agent"}
+	ts.handler.cfg.Agents["test-agent"] = ac
+	ts.handler.policy = policy.NewEvaluator(ts.handler.cfg)
 
 	w := postMessageWithHeaders(ts.handler, MessageRequest{
 		From:      "test-agent",
@@ -1177,9 +1326,8 @@ func TestHandler_DelegationRequiredNoneProvided(t *testing.T) {
 	}, nil)
 
 	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want 401 (delegation required but not provided)", w.Code)
+		t.Errorf("status = %d, want 401", w.Code)
 	}
-
 	var resp MessageResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
@@ -1189,35 +1337,140 @@ func TestHandler_DelegationRequiredNoneProvided(t *testing.T) {
 	}
 }
 
-func TestHandler_DelegationScopeViolation(t *testing.T) {
-	ts, humanPriv := newDelegationTestSetup(t, false)
+// TestHandler_DelegationInvalidHeaderRejectedEvenWhenNotRequired —
+// a malformed/invalid chain is rejected even when delegation is
+// optional. The presence of a broken header is itself a signal
+// something is wrong.
+func TestHandler_DelegationInvalidHeaderRejectedEvenWhenNotRequired(t *testing.T) {
+	ts, _ := newDelegationTestSetup(t, false)
 
-	// Create delegation with scope limited to "other-agent" (not target-agent)
+	// Token signed with a wrong key — chain verify fails.
+	_, wrongPriv, _ := ed25519.GenerateKey(rand.Reader)
 	token := identity.CreateChainedDelegation(
-		humanPriv, "human", "test-agent",
-		[]string{"other-agent"}, nil, // scope does NOT include target-agent
+		wrongPriv, "human", "test-agent",
+		[]string{"target-agent"}, nil,
 		time.Hour, "", 0, 3,
 	)
-	chain := identity.DelegationChain{*token}
-	header := encodeDelegationHeader(chain)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
 
-	w := postMessageWithHeaders(ts.handler, MessageRequest{
-		From:      "test-agent",
-		To:        "target-agent",
-		Content:   "hello with wrong scope",
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}, map[string]string{"X-Oktsec-Delegation": header})
-
+	w := signedDelegatedRequest(t, ts, "hello with bad sig in chain", header)
 	if w.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want 403 for scope violation", w.Code)
+		t.Errorf("status = %d, want 403", w.Code)
 	}
-
 	var resp MessageResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
 	if resp.PolicyDecision != audit.DecisionDelegationInvalid {
 		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionDelegationInvalid)
+	}
+}
+
+// TestHandler_DelegationExpiredTokenRejected — same shape as the
+// invalid-signature test but for expiry. Kept distinct because
+// it exercises a different VerifyChain branch.
+func TestHandler_DelegationExpiredTokenRejected(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+
+	now := time.Now().UTC()
+	token := &identity.DelegationToken{
+		Delegator: "human",
+		Delegate:  "test-agent",
+		Scope:     []string{"target-agent"},
+		IssuedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+		MaxDepth:  3,
+	}
+	payload := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n%d\n%d\n%s",
+		token.Delegator, token.Delegate, "target-agent",
+		token.IssuedAt.UTC().Format(time.RFC3339),
+		token.ExpiresAt.UTC().Format(time.RFC3339),
+		"", 0, 3, "")
+	sig := ed25519.Sign(humanPriv, []byte(payload))
+	token.Signature = base64.StdEncoding.EncodeToString(sig)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	w := signedDelegatedRequest(t, ts, "hello with expired delegation", header)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionDelegationInvalid {
+		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionDelegationInvalid)
+	}
+}
+
+// TestHandler_DelegationScopeViolation — chain whose scope does
+// NOT include the request recipient is rejected with
+// delegation_invalid.
+func TestHandler_DelegationScopeViolation(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+
+	token := identity.CreateChainedDelegation(
+		humanPriv, "human", "test-agent",
+		[]string{"other-agent"}, nil, // scope omits target-agent
+		time.Hour, "", 0, 3,
+	)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	w := signedDelegatedRequest(t, ts, "hello with wrong scope", header)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+	var resp MessageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.PolicyDecision != audit.DecisionDelegationInvalid {
+		t.Errorf("decision = %q, want %s", resp.PolicyDecision, audit.DecisionDelegationInvalid)
+	}
+}
+
+// TestHandler_DelegationAuditStoresHashNotRawHeader is the
+// regression for Gap 4. The audit row must carry the chain hash
+// + a human-readable summary, never the base64 header. A future
+// refactor that accidentally writes the raw header somewhere
+// would surface here as a substring match in any audit field.
+func TestHandler_DelegationAuditStoresHashNotRawHeader(t *testing.T) {
+	ts, humanPriv := newDelegationTestSetup(t, false)
+
+	token := identity.CreateChainedDelegation(
+		humanPriv, "human", "test-agent",
+		[]string{"target-agent"}, nil,
+		time.Hour, "", 0, 3,
+	)
+	header := encodeDelegationHeader(identity.DelegationChain{*token})
+
+	w := signedDelegatedRequest(t, ts, "hello", header)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	time.Sleep(100 * time.Millisecond)
+	entries, err := ts.auditStore.Query(audit.QueryOpts{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected audit entry")
+	}
+	entry := entries[0]
+	for _, field := range []string{
+		entry.DelegationChain,
+		entry.DelegationChainHash,
+		entry.RootAgent,
+		entry.ParentAgent,
+		entry.Intent,
+		entry.RulesTriggered,
+	} {
+		if field != "" && strings.Contains(field, header) {
+			t.Errorf("audit field leaked raw delegation header: %q", field)
+		}
+	}
+	if entry.DelegationChainHash == "" {
+		t.Error("DelegationChainHash should be set so the row is forensically usable")
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 4B closes the gap between "we wire `X-Oktsec-Delegation` through the pipeline" and "we control runtime authority". The existing wiring validated chains and stored audit metadata but did not enforce delegated authority: a valid header was accepted regardless of who claimed to send the request, the ACL gate kept evaluating the sender's own permissions, and the proxy had no depth cap (the gateway already had one, so the surfaces were asymmetric). This PR makes the chain the authorisation, not the audit annotation.

## Five gates, one contract

| Gate | Failure decision | Rationale |
|---|---|---|
| Verified delegate signature when chain present | `signature_required` (401) | Without it the header is a bearer token; capture = replay |
| Final delegate matches `req.From` | `delegation_invalid` (403) | Sender binding makes the chain non-replayable across identities |
| ACL evaluates the chain's root authority (AND-strict) | `acl_denied` (403) | Authority semantics — delegate's direct ACL ignored when chain present |
| Per-agent depth cap (shared helper) | `delegation_depth_exceeded` (403) | Proxy and gateway must not be asymmetric |
| Raw header never reaches audit | n/a | Hash + summary only; regression test guards future refactors |

## Architecture

- New `internal/policy/delegation.go` (`ResolveDelegationDepth`, `DefaultMaxDelegationDepth`). Identity stays crypto-pure; policy owns the per-agent cap. Gateway and proxy both consume it — single source of truth.
- `checkDelegation` returns a `delegationAuth` struct (`Present`, `Root`, `Delegate`, `Depth`, `ChainHash`). The handler stays orchestrator: `aclFrom = req.From` without chain, `aclFrom = delegation.Root` with chain, `policy.CheckACL(aclFrom, req.To)` once.
- `policy.CheckACL` itself is unchanged. The authority decision lives at the call site, not inside the evaluator.
- Audit row: `FromAgent=req.From` (actor stays clear), `RootAgent` + `DelegationChainHash` + `DelegationChain` (authority context).

## Tests

`internal/proxy/handler_test.go` — 11 tests, fixture rewritten with `DefaultPolicy=deny` + a three-identity model (human / test-agent / target-agent). `signedDelegatedRequest` helper signs every chain test so the new Gap 0 gate doesn't intercept tests that want to reach the chain logic.

- `TestHandler_DelegationUsesRootAuthorityForACL` — happy path: test-agent has no direct ACL, root has ACL, valid chain wins.
- `TestHandler_DelegationBlocksWhenRootAuthorityLacksACL` — AND-strict: delegate has direct ACL, root removed from `cfg.Agents`, chain valid → still `acl_denied`.
- `TestHandler_DelegationRequiresVerifiedDelegateSignature` — chain valid + no body sig → `signature_required` (Gap 0).
- `TestHandler_DelegationDelegateMustMatchSender` — chain delegate ≠ from → `delegation_invalid` (Gap 1).
- `TestHandler_DelegationDepthExceededBlocksInProxy` — `max_delegation_depth=1` + 2-hop chain → `delegation_depth_exceeded` (Gap 3).
- `TestHandler_DelegationMissingHeaderStillAllowedByDefault` / `MissingHeaderRejectedWhenRequired` / `InvalidHeaderRejectedEvenWhenNotRequired`.
- `TestHandler_DelegationExpiredTokenRejected` / `ScopeViolation` — kept under the new contract (signed).
- `TestHandler_DelegationAuditStoresHashNotRawHeader` — regression for Gap 4: audit field substring search for the raw base64 header.

`internal/dashboard/runtime_posture_test.go`:
- `TestRuntimePosture_DelegationSummaryOnlyWhenRequireDelegation` — identity_context dimension must not advertise "Delegation chain enforced" when the flag is off.

`internal/gateway/concurrency_test.go`:
- `TestResolveDelegationDepth` updated to call `policy.ResolveDelegationDepth` — same source of truth as the proxy now.

## Out of scope

Okta/Auth0/IdP integration, new dashboard pages, tool-scope enforcement on `/v1/message`, gateway response-scope redesign, CLI UX changes for `oktsec delegate`, sessions/coverage UI changes.

## Test plan

- [x] `go test ./internal/proxy ./internal/identity ./internal/gateway ./internal/policy ./internal/dashboard -count=1`
- [x] `go build ./...`
- [x] `make vet`
- [x] `make lint`