### PR TITLE
Re-enable Analyze-with-AI on runtime session detail

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2124,6 +2124,34 @@ func (s *Server) handleSessionAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Runtime first. When the runtime store has the session,
+	// the analyser must consume runtime evidence and persist
+	// under the runtime: namespace so the result never appears
+	// next to the audit-trace AI sidebar (and vice versa). The
+	// audit fallback only runs when the runtime store has no
+	// row for the id.
+	if env, ok := s.buildRuntimeSessionAnalysisEnvelope(r.Context(), sessionID); ok {
+		if reason := runtimeAnalysisRejectionReason(env); reason != "" {
+			http.Error(w, reason, http.StatusBadRequest)
+			return
+		}
+		analysis, err := s.analyzeRuntimeSession(r.Context(), env)
+		if err != nil {
+			s.logger.Warn("runtime session analysis failed", "error", err, "session", sessionID)
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		model := s.cfg.LLM.Provider + "/" + s.cfg.LLM.Model
+		if store, ok := s.audit.(*audit.Store); ok {
+			if saveErr := store.SaveSessionAnalysis(runtimeSessionAnalysisKey(sessionID), analysis, model); saveErr != nil {
+				s.logger.Warn("failed to save runtime session analysis", "error", saveErr)
+			}
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(analysis))
+		return
+	}
+
 	trace, err := s.audit.BuildSessionTrace(sessionID)
 	if err != nil || trace == nil {
 		http.Error(w, "session not found", http.StatusNotFound)
@@ -2137,7 +2165,10 @@ func (s *Server) handleSessionAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Persist to DB as evidence
+	// Persist to DB as evidence under the bare sessionID. This
+	// key namespace stays distinct from runtimeSessionAnalysisKey
+	// so a session with both runtime and audit evidence keeps
+	// the two analyses isolated.
 	model := s.cfg.LLM.Provider + "/" + s.cfg.LLM.Model
 	if store, ok := s.audit.(*audit.Store); ok {
 		if saveErr := store.SaveSessionAnalysis(sessionID, analysis, model); saveErr != nil {
@@ -2158,16 +2189,46 @@ func (s *Server) handleSessionTrace(w http.ResponseWriter, r *http.Request) {
 
 	// Runtime first: when runtime has a session row for this id we
 	// render the runtime detail (actor tree + hashed timeline) and
-	// skip the audit trace. AI analysis is intentionally hidden in
-	// the runtime view for this slice — the Phase 3D-era runtime
-	// shape predates the session-analysis schema and we do not
-	// silently mix the two surfaces. Audit-only sessions keep their
-	// existing AI flow.
+	// skip the audit trace. The AI sidebar is rendered for runtime
+	// sessions that have real (non-heartbeat) activity; the saved
+	// analysis lives under the runtime: namespace so it never
+	// collides with the audit-trace analysis for the same id.
 	if detail, ok := s.runtimeSessionDetail(r.Context(), sessionID); ok {
+		canAnalyze := !detail.Session.IsHeartbeatOnly && detail.Session.EventCount > 0
+		disabledReason := ""
+		if !canAnalyze {
+			if detail.Session.IsHeartbeatOnly {
+				disabledReason = "Heartbeat-only sessions have no analysable activity."
+			} else {
+				disabledReason = "No runtime events recorded yet."
+			}
+		}
+
+		var savedAnalysis, analysisModel, analysisDate string
+		if canAnalyze {
+			if store, ok := s.audit.(*audit.Store); ok {
+				if r := store.QuerySessionAnalysis(runtimeSessionAnalysisKey(sessionID)); r != nil {
+					savedAnalysis = r.Text
+					analysisModel = r.Model
+					if t, err := time.Parse(time.RFC3339, r.Timestamp); err == nil {
+						analysisDate = t.Local().Format("Jan 02, 2006 15:04")
+					} else {
+						analysisDate = r.Timestamp
+					}
+				}
+			}
+		}
+
 		s.renderTemplate(w, runtimeSessionDetailTmpl, map[string]any{
-			"Active":     "sessions",
-			"Detail":     detail,
-			"RequireSig": s.cfg.Identity.RequireSignature,
+			"Active":                 "sessions",
+			"Detail":                 detail,
+			"RequireSig":             s.cfg.Identity.RequireSignature,
+			"LLMEnabled":             s.cfg.LLM.Enabled,
+			"CanAnalyze":             canAnalyze,
+			"AnalysisDisabledReason": disabledReason,
+			"SavedAnalysis":          savedAnalysis,
+			"AnalysisModel":          analysisModel,
+			"AnalysisDate":           analysisDate,
 		})
 		return
 	}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2128,9 +2128,18 @@ func (s *Server) handleSessionAnalyze(w http.ResponseWriter, r *http.Request) {
 	// the analyser must consume runtime evidence and persist
 	// under the runtime: namespace so the result never appears
 	// next to the audit-trace AI sidebar (and vice versa). The
-	// audit fallback only runs when the runtime store has no
-	// row for the id.
-	if env, ok := s.buildRuntimeSessionAnalysisEnvelope(r.Context(), sessionID); ok {
+	// audit fallback only runs when the runtime store is
+	// reachable AND the session is genuinely absent there —
+	// not when the runtime query itself errored, because the
+	// same id might also exist in audit and falling through
+	// would analyse a different dataset than what the page
+	// renders.
+	env, found, runtimeErr := s.buildRuntimeSessionAnalysisEnvelope(r.Context(), sessionID)
+	if runtimeErr != nil {
+		http.Error(w, "runtime store unavailable: "+runtimeErr.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	if found {
 		if reason := runtimeAnalysisRejectionReason(env); reason != "" {
 			http.Error(w, reason, http.StatusBadRequest)
 			return

--- a/internal/dashboard/runtime_session_analysis.go
+++ b/internal/dashboard/runtime_session_analysis.go
@@ -98,26 +98,37 @@ type runtimeSessionAnalysisEvent struct {
 
 // buildRuntimeSessionAnalysisEnvelope fetches the session +
 // actors + events from the runtime store and projects them into
-// the analysis envelope. Returns (nil, false) when the session
-// does not exist in runtime — the caller falls back to legacy
-// audit analysis. Heartbeat-only sessions return a non-nil
-// envelope with IsHeartbeatOnly=true; the handler refuses
-// analysis on that shape but still distinguishes "not in
-// runtime" from "in runtime but diagnostic-only".
-func (s *Server) buildRuntimeSessionAnalysisEnvelope(ctx context.Context, sessionID string) (*runtimeSessionAnalysisEnvelope, bool) {
+// the analysis envelope.
+//
+// Returns a tri-state result so the caller can keep the
+// runtime/audit boundary intact even under partial failure:
+//
+//   - (env, true,  nil)  — runtime has the session; envelope ready.
+//   - (nil, false, nil)  — runtime is reachable AND the session
+//     does not exist there. Audit fallback is the right move.
+//   - (nil, false, err)  — the runtime store errored mid-query.
+//     The caller MUST surface this as a service error (503),
+//     never as "session not in runtime", because the same
+//     session id may exist in audit and falling through would
+//     analyse a different dataset than what the page renders.
+//
+// Heartbeat-only sessions return a non-nil envelope with
+// IsHeartbeatOnly=true so the handler can refuse analysis with
+// a clear reason without re-querying the store.
+func (s *Server) buildRuntimeSessionAnalysisEnvelope(ctx context.Context, sessionID string) (*runtimeSessionAnalysisEnvelope, bool, error) {
 	store := s.runtimeStore()
 	if store == nil || sessionID == "" {
-		return nil, false
+		return nil, false, nil
 	}
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	detail, err := store.QuerySession(queryCtx, sessionID)
 	if err != nil {
 		s.logger.Warn("runtime session analysis: QuerySession failed", "error", err, "session_id", sessionID)
-		return nil, false
+		return nil, false, err
 	}
 	if detail == nil || detail.SessionID == "" {
-		return nil, false
+		return nil, false, nil
 	}
 
 	row := projectSessionListRow(detail.Session)
@@ -183,7 +194,7 @@ func (s *Server) buildRuntimeSessionAnalysisEnvelope(ctx context.Context, sessio
 			LatencyMs:      ev.LatencyMs,
 		})
 	}
-	return env, true
+	return env, true, nil
 }
 
 // runtimeSessionAnalysisPrompt is the system prompt for runtime

--- a/internal/dashboard/runtime_session_analysis.go
+++ b/internal/dashboard/runtime_session_analysis.go
@@ -1,0 +1,388 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtime_session_analysis.go is the runtime-evidence path for
+// "Analyze with AI" on /dashboard/sessions/{id}. The legacy
+// audit path in session_analysis.go converts a SessionTrace into
+// the prompt and saves the result keyed on the bare sessionID;
+// the runtime path needs a separate envelope, a separate prompt,
+// and a separate persistence key so the two surfaces never mix.
+//
+// Why a separate file: tmpl_session.go and the legacy analyzer
+// already speak the SessionTrace shape (humans/agents, raw tool
+// inputs, [HUMAN]/[AGENT] role tags). Runtime evidence is hash-
+// based and actor-tree-based; forcing it into the legacy shape
+// would either require lying about roles or leaking raw payload.
+// Keep them apart.
+
+// runtimeSessionAnalysisKey is the persistence key for runtime
+// analyses. Using a "runtime:" namespace prevents collisions
+// with the legacy audit path that saves under the bare session
+// id, so a session that exists in both stores never displays the
+// audit analysis next to runtime evidence.
+func runtimeSessionAnalysisKey(sessionID string) string {
+	return "runtime:" + sessionID
+}
+
+// runtimeSessionAnalysisEnvelope is the read-only payload the
+// runtime analyzer consumes. Every field is either metadata
+// already on the runtime session row (counts, timestamps, ids)
+// or a redacted projection (hash, tail). The struct exists so
+// the prompt builder cannot accidentally reach into raw hook
+// envelope fields.
+type runtimeSessionAnalysisEnvelope struct {
+	Source          string
+	SessionID       string
+	PrincipalID     string
+	ClientID        string
+	ConnectorID     string
+	Status          string
+	StartedAt       string
+	LastSeenAt      string
+	Duration        string
+	EventCount      int64
+	ToolEventCount  int64
+	SubagentCount   int64
+	TaskCount       int64
+	BlockCount      int64
+	IsHeartbeatOnly bool
+	Actors          []runtimeSessionAnalysisActor
+	Events          []runtimeSessionAnalysisEvent
+}
+
+type runtimeSessionAnalysisActor struct {
+	Label       string
+	Kind        string
+	ToolCount   int64
+	EventCount  int64
+	BlockCount  int64
+	FirstSeenAt string
+	LastSeenAt  string
+}
+
+// runtimeSessionAnalysisEvent — fields are deliberately a
+// subset of runtime.HookEvent. The omissions are intentional
+// and listed in runtime_session_analysis.go's package doc:
+//   - tool_input / tool_output (raw bytes)
+//   - cwd / cwd_hash (filesystem fingerprint)
+//   - transcript path
+//   - file path full (we keep the tail only)
+//   - task subject (can carry prompt-like content)
+//   - raw hook envelope JSON
+type runtimeSessionAnalysisEvent struct {
+	Timestamp      string
+	HookEventName  string
+	ActorLabel     string
+	ActorKind      string
+	ToolName       string
+	ToolUseID      string
+	ToolInputHash  string
+	ToolOutputHash string
+	FilePathTail   string
+	Status         string
+	PolicyDecision string
+	CoverageMode   string
+	Confidence     int
+	AuditEntryID   string
+	LatencyMs      int64
+}
+
+// buildRuntimeSessionAnalysisEnvelope fetches the session +
+// actors + events from the runtime store and projects them into
+// the analysis envelope. Returns (nil, false) when the session
+// does not exist in runtime — the caller falls back to legacy
+// audit analysis. Heartbeat-only sessions return a non-nil
+// envelope with IsHeartbeatOnly=true; the handler refuses
+// analysis on that shape but still distinguishes "not in
+// runtime" from "in runtime but diagnostic-only".
+func (s *Server) buildRuntimeSessionAnalysisEnvelope(ctx context.Context, sessionID string) (*runtimeSessionAnalysisEnvelope, bool) {
+	store := s.runtimeStore()
+	if store == nil || sessionID == "" {
+		return nil, false
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	detail, err := store.QuerySession(queryCtx, sessionID)
+	if err != nil {
+		s.logger.Warn("runtime session analysis: QuerySession failed", "error", err, "session_id", sessionID)
+		return nil, false
+	}
+	if detail == nil || detail.SessionID == "" {
+		return nil, false
+	}
+
+	row := projectSessionListRow(detail.Session)
+
+	env := &runtimeSessionAnalysisEnvelope{
+		Source:          "runtime",
+		SessionID:       detail.SessionID,
+		PrincipalID:     detail.PrincipalID,
+		ClientID:        detail.ClientID,
+		ConnectorID:     detail.ConnectorID,
+		Status:          row.Status,
+		StartedAt:       row.StartedAt,
+		LastSeenAt:      row.LastSeenAt,
+		Duration:        row.Duration,
+		EventCount:      detail.EventCount,
+		ToolEventCount:  detail.ToolEventCount,
+		SubagentCount:   detail.SubagentCount,
+		TaskCount:       detail.TaskCount,
+		BlockCount:      detail.BlockCount,
+		IsHeartbeatOnly: row.IsHeartbeatOnly,
+	}
+
+	actorByID := make(map[string]runtime.Actor, len(detail.Actors))
+	for _, a := range detail.Actors {
+		actorByID[a.ID] = a
+		env.Actors = append(env.Actors, runtimeSessionAnalysisActor{
+			Label:       actorDisplayLabel(a),
+			Kind:        a.Kind,
+			ToolCount:   a.ToolCount,
+			EventCount:  a.EventCount,
+			BlockCount:  a.BlockCount,
+			FirstSeenAt: formatRuntimeTimestamp(a.FirstSeenAt),
+			LastSeenAt:  formatRuntimeTimestamp(a.LastSeenAt),
+		})
+	}
+
+	for _, ev := range detail.Events {
+		// Drop heartbeat events from the analysis stream — they
+		// are diagnostic and never represent agent activity.
+		if runtime.IsHeartbeatSession(ev.SessionID) {
+			continue
+		}
+		actorLabel, actorKind := "", ""
+		if a, ok := actorByID[ev.ActorID]; ok {
+			actorLabel = actorDisplayLabel(a)
+			actorKind = a.Kind
+		}
+		env.Events = append(env.Events, runtimeSessionAnalysisEvent{
+			Timestamp:      formatRuntimeTimestamp(ev.Timestamp),
+			HookEventName:  ev.HookEventName,
+			ActorLabel:     actorLabel,
+			ActorKind:      actorKind,
+			ToolName:       ev.ToolName,
+			ToolUseID:      ev.ToolUseID,
+			ToolInputHash:  ev.ToolInputHash,
+			ToolOutputHash: ev.ToolOutputHash,
+			FilePathTail:   ev.FilePathTail,
+			Status:         ev.Status,
+			PolicyDecision: ev.PolicyDecision,
+			CoverageMode:   ev.CoverageMode,
+			Confidence:     ev.Confidence,
+			AuditEntryID:   ev.AuditEntryID,
+			LatencyMs:      ev.LatencyMs,
+		})
+	}
+	return env, true
+}
+
+// runtimeSessionAnalysisPrompt is the system prompt for runtime
+// analyses. Distinct from sessionAnalysisPrompt because the
+// inputs are structurally different and the recommendations
+// vocabulary is narrower:
+//
+//   - The model never sees raw tool input/output, only sha256
+//     prefixes and file path tails. The prompt says so up front
+//     so it does not fabricate content claims off a hash.
+//   - "Blocked" / "quarantined" events are evidence of an
+//     Oktsec control firing, NOT a verdict on the agent. The
+//     prompt repeats this so a single block does not produce
+//     "Suspend agent X".
+//   - The recommended-actions vocabulary is restricted to a
+//     short whitelist that maps onto runtime drill-downs that
+//     actually exist (sessions, events, rules) so the model
+//     cannot point the operator at an unimplemented page.
+//   - Heartbeat is diagnostic only. The prompt repeats this so
+//     a heartbeat-only session that somehow reaches analysis
+//     does not produce a risk claim.
+const runtimeSessionAnalysisPrompt = `You are a security analyst reviewing runtime hook evidence captured by Oktsec for one agent session.
+
+What you are looking at:
+- This is RUNTIME hook evidence, not raw conversation content. Every event was emitted by a Claude Code hook and recorded by Oktsec at the moment it fired.
+- Tool input and tool output are presented as sha256 prefixes only. Never infer the content of a tool call from a hash.
+- File paths are presented as the trailing component only.
+- "Blocked" and "quarantined" status mean Oktsec's runtime controls fired. They are evidence the system is defending the agent, not automatic proof the agent is malicious.
+- "Heartbeat" rows are diagnostic and have already been filtered out of this prompt.
+
+Roles:
+- The session has one root actor (the principal) and zero or more subagents and tasks. Each event is attributed to one actor. Recommend suspending an actor only if its runtime behaviour shows repeated unsafe action attempts that were NOT already blocked by Oktsec.
+
+Write a structured analysis using these exact sections:
+
+**Risk Level:** CRITICAL, HIGH, MEDIUM, LOW, or CLEAN. One sentence why, grounded in observed runtime behaviour, not in tool names.
+
+**What happened:** 2-3 sentences. Describe the actor chain and the highest-impact events.
+
+**Runtime control assessment:** Explain which coverage mode applied (protected, observed, or blind), what was blocked or quarantined, and whether Oktsec's controls were sufficient. If coverage was blind for any tool surface, call that out as a configuration gap.
+
+**Recommended actions:**
+Each action must link to a specific Oktsec dashboard page. Allowed shapes:
+- [Review session](/dashboard/sessions/<sessionID>) - reason
+- [Review event](/dashboard/events/<auditEntryID>) - reason. Use only when an audit entry id was attached to the event.
+- [Review rules](/dashboard/rules) - reason. Use only when a rule gap is the root cause.
+- No action needed - reason. Use when blocks were Oktsec controls firing correctly.
+
+Rules:
+- Start directly with **Risk Level:**.
+- Never use em dashes.
+- Do not invent tool inputs from a hash.
+- Do not recommend suspending an actor that was already protected by a block.
+- Keep it short. Maximum 4 bullets in recommended actions.
+
+Session metadata:
+%s
+
+Actor tree:
+%s
+
+Timeline (oldest first, heartbeats already filtered):
+%s
+`
+
+// analyzeRuntimeSession is the runtime equivalent of
+// analyzeSession. Same provider switch, same callClaude /
+// callOpenAI helpers, but a runtime-aware prompt assembled from
+// the analysis envelope.
+func (s *Server) analyzeRuntimeSession(ctx context.Context, env *runtimeSessionAnalysisEnvelope) (string, error) {
+	cfg := s.cfg.LLM
+	if !cfg.Enabled {
+		return "", fmt.Errorf("LLM not configured")
+	}
+	apiKey := cfg.APIKey
+	if apiKey == "" && cfg.APIKeyEnv != "" {
+		apiKey = os.Getenv(cfg.APIKeyEnv)
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("LLM API key not set")
+	}
+
+	prompt := buildRuntimeSessionAnalysisPrompt(env)
+
+	analysisCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	switch cfg.Provider {
+	case "claude":
+		return s.callClaude(analysisCtx, apiKey, cfg.Model, prompt)
+	case "openai":
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://api.openai.com/v1"
+		}
+		return s.callOpenAI(analysisCtx, apiKey, baseURL, cfg.Model, prompt)
+	default:
+		return "", fmt.Errorf("unsupported LLM provider %q for runtime session analysis", cfg.Provider)
+	}
+}
+
+// buildRuntimeSessionAnalysisPrompt assembles the prompt body.
+// Pulled out so the test suite can assert on the prompt shape
+// without round-tripping through the LLM client.
+func buildRuntimeSessionAnalysisPrompt(env *runtimeSessionAnalysisEnvelope) string {
+	if env == nil {
+		return ""
+	}
+	var meta strings.Builder
+	fmt.Fprintf(&meta, "- source: %s\n", env.Source)
+	fmt.Fprintf(&meta, "- session_id: %s\n", env.SessionID)
+	if env.PrincipalID != "" {
+		fmt.Fprintf(&meta, "- principal_id: %s\n", env.PrincipalID)
+	}
+	if env.ClientID != "" {
+		fmt.Fprintf(&meta, "- client_id: %s\n", env.ClientID)
+	}
+	if env.ConnectorID != "" {
+		fmt.Fprintf(&meta, "- connector_id: %s\n", env.ConnectorID)
+	}
+	fmt.Fprintf(&meta, "- status: %s\n", env.Status)
+	if env.StartedAt != "" {
+		fmt.Fprintf(&meta, "- started_at: %s\n", env.StartedAt)
+	}
+	if env.LastSeenAt != "" {
+		fmt.Fprintf(&meta, "- last_seen_at: %s\n", env.LastSeenAt)
+	}
+	if env.Duration != "" {
+		fmt.Fprintf(&meta, "- duration: %s\n", env.Duration)
+	}
+	fmt.Fprintf(&meta, "- events: %d (tool: %d, subagent: %d, task: %d, blocked: %d)\n",
+		env.EventCount, env.ToolEventCount, env.SubagentCount, env.TaskCount, env.BlockCount)
+
+	var tree strings.Builder
+	for _, a := range env.Actors {
+		fmt.Fprintf(&tree, "- %s [%s] events=%d tool_calls=%d blocked=%d\n",
+			a.Label, a.Kind, a.EventCount, a.ToolCount, a.BlockCount)
+	}
+	if tree.Len() == 0 {
+		tree.WriteString("(no actors recorded)\n")
+	}
+
+	var events strings.Builder
+	for i, ev := range env.Events {
+		if i >= 30 {
+			fmt.Fprintf(&events, "... and %d more events\n", len(env.Events)-30)
+			break
+		}
+		fmt.Fprintf(&events, "- %s actor=%s event=%s",
+			ev.Timestamp, ev.ActorLabel, ev.HookEventName)
+		if ev.ToolName != "" {
+			fmt.Fprintf(&events, " tool=%s", ev.ToolName)
+		}
+		if ev.ToolUseID != "" {
+			fmt.Fprintf(&events, " use_id=%s", ev.ToolUseID)
+		}
+		if ev.ToolInputHash != "" {
+			fmt.Fprintf(&events, " input=sha256:%s", truncStr(ev.ToolInputHash, 16))
+		}
+		if ev.ToolOutputHash != "" {
+			fmt.Fprintf(&events, " output=sha256:%s", truncStr(ev.ToolOutputHash, 16))
+		}
+		if ev.FilePathTail != "" {
+			fmt.Fprintf(&events, " path=%s", ev.FilePathTail)
+		}
+		if ev.Status != "" {
+			fmt.Fprintf(&events, " status=%s", ev.Status)
+		}
+		if ev.PolicyDecision != "" && ev.PolicyDecision != ev.Status {
+			fmt.Fprintf(&events, " policy=%s", ev.PolicyDecision)
+		}
+		if ev.CoverageMode != "" {
+			fmt.Fprintf(&events, " coverage=%s", ev.CoverageMode)
+		}
+		if ev.AuditEntryID != "" {
+			fmt.Fprintf(&events, " audit_entry_id=%s", ev.AuditEntryID)
+		}
+		events.WriteString("\n")
+	}
+	if events.Len() == 0 {
+		events.WriteString("(no non-heartbeat events recorded)\n")
+	}
+
+	return fmt.Sprintf(runtimeSessionAnalysisPrompt, meta.String(), tree.String(), events.String())
+}
+
+// runtimeAnalysisRejectionReason returns the operator-facing
+// reason string when an envelope is not eligible for AI
+// analysis. Keeping it here so the handler error and the
+// template's "AI disabled" copy stay in sync.
+func runtimeAnalysisRejectionReason(env *runtimeSessionAnalysisEnvelope) string {
+	switch {
+	case env == nil:
+		return "runtime session not found"
+	case env.IsHeartbeatOnly:
+		return "runtime session is heartbeat-only and has no analysable activity"
+	case len(env.Events) == 0:
+		return "runtime session has no recorded events to analyse"
+	default:
+		return ""
+	}
+}

--- a/internal/dashboard/runtime_session_analysis_test.go
+++ b/internal/dashboard/runtime_session_analysis_test.go
@@ -1,0 +1,363 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/runtime"
+)
+
+// runtime_session_analysis_test.go covers the Phase 4C runtime
+// AI flow. The fixture wires an OpenAI-compatible httptest
+// server so we can capture the prompt body and assert the
+// runtime path emits the expected envelope shape — without
+// reaching out to a real LLM provider.
+
+// fakeLLM is a minimal OpenAI-compatible /chat/completions
+// stub that records the most recent request body so a test can
+// inspect the prompt the runtime analyser built.
+type fakeLLM struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	last   []byte
+	reply  string
+}
+
+func newFakeLLM(t *testing.T, reply string) *fakeLLM {
+	t.Helper()
+	f := &fakeLLM{reply: reply}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.last = body
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": f.reply}},
+			},
+		})
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// promptText extracts the user-message content from the most
+// recent captured request. Tests assert against this so the
+// substring matches focus on the prompt body, not the JSON
+// envelope.
+func (f *fakeLLM) promptText(t *testing.T) string {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.last == nil {
+		t.Fatal("fake LLM did not receive a request")
+	}
+	var parsed struct {
+		Messages []struct {
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(f.last, &parsed); err != nil {
+		t.Fatalf("decode prompt JSON: %v; body=%s", err, string(f.last))
+	}
+	if len(parsed.Messages) == 0 {
+		t.Fatal("fake LLM request had no messages")
+	}
+	return parsed.Messages[0].Content
+}
+
+// newRuntimeAnalysisServer wires a Server with both the runtime
+// store AND an LLM config pointing at the fake LLM. cfgPath is
+// set so any config save in the request path can write.
+func newRuntimeAnalysisServer(t *testing.T, fake *fakeLLM) (*Server, *runtime.Store, *audit.Store) {
+	t.Helper()
+	srv, rs, auditStore := newRuntimeGraphTestServer(t)
+	srv.cfg.LLM = config.LLMConfig{
+		Enabled:  true,
+		Provider: "openai",
+		Model:    "test-model",
+		APIKey:   "test-key",
+		BaseURL:  fake.server.URL,
+	}
+	return srv, rs, auditStore
+}
+
+// seedRealActivity drops a SessionStart + SubagentStart +
+// PreToolUse with hashed input + a delivered status, so the
+// session has analysable real activity.
+func seedRealActivity(t *testing.T, rs *runtime.Store, sessionID string, ts time.Time, secret string) {
+	t.Helper()
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"`+sessionID+`"}`,
+		sessionID, "local-codex", ts.Add(-5*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SubagentStart","session_id":"`+sessionID+`","agent_id":"sa-1","agent_type":"research"}`,
+		sessionID, "local-codex", ts.Add(-4*time.Minute), runtime.OutcomeRefs{})
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"PreToolUse","session_id":"`+sessionID+`","agent_id":"sa-1","agent_type":"research","tool_name":"Read","tool_use_id":"u-real","tool_input":{"file":"`+secret+`"}}`,
+		sessionID, "local-codex", ts.Add(-3*time.Minute), runtime.OutcomeRefs{Status: "delivered"})
+}
+
+// postAnalyze fires the analyse endpoint and returns the
+// response.
+func postAnalyze(t *testing.T, handler http.Handler, cookie *http.Cookie, sessionID string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/dashboard/api/sessions/"+sessionID+"/analyze", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w.Code, w.Body.String()
+}
+
+// TestSessionDetail_RuntimeShowsAnalyzeButtonForRealActivity —
+// when LLM is enabled and the runtime session has real (non-
+// heartbeat) events, the runtime detail page renders the
+// runtime AI button.
+func TestSessionDetail_RuntimeShowsAnalyzeButtonForRealActivity(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-ai-real", now, "INNOCUOUS")
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-ai-real")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	if !strings.Contains(body, `id="rt-ai-analyze-btn"`) {
+		t.Errorf("runtime detail did not render the runtime AI button for real activity")
+	}
+}
+
+// TestSessionDetail_RuntimeHidesAnalyzeButtonForHeartbeatOnly —
+// heartbeat-only sessions never get an AI button. The
+// diagnostic banner stays.
+func TestSessionDetail_RuntimeHidesAnalyzeButtonForHeartbeatOnly(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-ai"}`,
+		"heartbeat-2026-04-30-ai", "local-codex", now.Add(-1*time.Minute), runtime.OutcomeRefs{})
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "heartbeat-2026-04-30-ai")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	if strings.Contains(body, `id="rt-ai-analyze-btn"`) {
+		t.Errorf("runtime detail rendered the AI button on a heartbeat-only session")
+	}
+	if !strings.Contains(body, "diagnostic") {
+		t.Errorf("runtime detail missing the diagnostic banner / wording for heartbeat-only")
+	}
+}
+
+// TestSessionAnalyze_RuntimeSessionDoesNotRequireAuditTrace —
+// the runtime path must work even when audit.BuildSessionTrace
+// would return nothing for the same id. The Phase 3C runtime
+// path stopped writing audit rows for runtime-only sessions, so
+// the analyser must not require them.
+func TestSessionAnalyze_RuntimeSessionDoesNotRequireAuditTrace(t *testing.T) {
+	fake := newFakeLLM(t, "**Risk Level:** CLEAN.\nFake reply.")
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-ai-no-audit", now, "INNOCUOUS")
+
+	status, body := postAnalyze(t, handler, cookie, "sess-ai-no-audit")
+	if status != http.StatusOK {
+		t.Fatalf("analyze status = %d, body=%s", status, body)
+	}
+	if !strings.Contains(body, "Fake reply") {
+		t.Errorf("response did not pass the LLM reply through; got %q", body)
+	}
+}
+
+// TestSessionAnalyze_RuntimePromptUsesHashesNotRawPayload —
+// the runtime envelope must redact tool_input / tool_output to
+// hashes only. Seed a session where tool_input carries a
+// distinctive secret string and assert the prompt does not
+// contain it. The prompt MUST contain the runtime "source"
+// marker and the seeded hook event name so the test catches a
+// regression that drops the runtime path entirely.
+func TestSessionAnalyze_RuntimePromptUsesHashesNotRawPayload(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	const secret = "SECRET_PAYLOAD_DO_NOT_LEAK_42"
+	seedRealActivity(t, rs, "sess-ai-redact", now, secret)
+
+	status, body := postAnalyze(t, handler, cookie, "sess-ai-redact")
+	if status != http.StatusOK {
+		t.Fatalf("analyze status = %d, body=%s", status, body)
+	}
+	prompt := fake.promptText(t)
+	if strings.Contains(prompt, secret) {
+		t.Errorf("prompt leaked raw tool_input value")
+	}
+	if !strings.Contains(prompt, "source: runtime") {
+		t.Errorf("prompt missing runtime source marker")
+	}
+	if !strings.Contains(prompt, "PreToolUse") {
+		t.Errorf("prompt missing seeded hook event name")
+	}
+	if !strings.Contains(prompt, "sha256:") {
+		t.Errorf("prompt missing hash marker for tool input")
+	}
+}
+
+// TestSessionAnalyze_RuntimeDoesNotDisplayLegacyAuditAnalysis —
+// when the runtime path saves an analysis under runtime:<id>,
+// a legacy audit analysis previously stored under the bare id
+// must NOT show up on the runtime detail page. Save both
+// directly into the audit store and assert the runtime detail
+// renders only the runtime version.
+func TestSessionAnalyze_RuntimeDoesNotDisplayLegacyAuditAnalysis(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, auditStore := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-ai-isolation", now, "INNOCUOUS")
+
+	const auditMarker = "AUDIT_ANALYSIS_SHOULD_NOT_RENDER"
+	const runtimeMarker = "RUNTIME_ANALYSIS_VISIBLE"
+	if err := auditStore.SaveSessionAnalysis("sess-ai-isolation", auditMarker, "test/audit"); err != nil {
+		t.Fatal(err)
+	}
+	if err := auditStore.SaveSessionAnalysis(runtimeSessionAnalysisKey("sess-ai-isolation"), runtimeMarker, "test/runtime"); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-ai-isolation")
+	if status != http.StatusOK {
+		t.Fatalf("detail status = %d", status)
+	}
+	if strings.Contains(body, auditMarker) {
+		t.Errorf("runtime detail displayed legacy audit analysis text")
+	}
+	if !strings.Contains(body, runtimeMarker) {
+		t.Errorf("runtime detail missing the runtime-keyed analysis text")
+	}
+}
+
+// TestSessionAnalyze_RuntimeSavedAnalysisRendersInDetail — full
+// round-trip: POST analyse, then GET detail and assert the
+// rendered HTML carries the LLM reply text.
+func TestSessionAnalyze_RuntimeSavedAnalysisRendersInDetail(t *testing.T) {
+	const llmText = "**Risk Level:** LOW. Fake assessment for the runtime path."
+	fake := newFakeLLM(t, llmText)
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-ai-roundtrip", now, "INNOCUOUS")
+
+	status, _ := postAnalyze(t, handler, cookie, "sess-ai-roundtrip")
+	if status != http.StatusOK {
+		t.Fatalf("analyze status = %d", status)
+	}
+
+	status, body := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-ai-roundtrip")
+	if status != http.StatusOK {
+		t.Fatalf("detail status = %d", status)
+	}
+	if !strings.Contains(body, "Fake assessment for the runtime path.") {
+		t.Errorf("detail did not render the saved runtime analysis text")
+	}
+	if !strings.Contains(body, `id="rt-ai-panel"`) {
+		t.Errorf("detail missing the runtime AI panel container")
+	}
+}
+
+// TestSessionAnalyze_HeartbeatOnlyRuntimeSessionRejected — a
+// heartbeat-only session must not reach the LLM. The handler
+// returns 400 with a clear reason, and the fake LLM must NOT
+// receive any request.
+func TestSessionAnalyze_HeartbeatOnlyRuntimeSessionRejected(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRuntimeEvent(t, rs,
+		`{"hook_event_name":"SessionStart","session_id":"heartbeat-2026-04-30-reject"}`,
+		"heartbeat-2026-04-30-reject", "local-codex", now.Add(-1*time.Minute), runtime.OutcomeRefs{})
+
+	status, body := postAnalyze(t, handler, cookie, "heartbeat-2026-04-30-reject")
+	if status != http.StatusBadRequest {
+		t.Fatalf("analyze status = %d, want 400; body=%s", status, body)
+	}
+	if !strings.Contains(body, "heartbeat") {
+		t.Errorf("rejection reason should mention heartbeat; got %q", body)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.last != nil {
+		t.Errorf("fake LLM received a request despite heartbeat-only rejection")
+	}
+}
+
+// TestSessionAnalyze_AuditFallbackStillWorksForLegacySession —
+// when no runtime row exists for the id, the analyser falls
+// back to the audit BuildSessionTrace path and saves under the
+// bare sessionID. Pre-Phase 4C behaviour preserved.
+func TestSessionAnalyze_AuditFallbackStillWorksForLegacySession(t *testing.T) {
+	fake := newFakeLLM(t, "**Risk Level:** CLEAN. Audit path reply.")
+	srv, _, auditStore := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	// Audit-only session: write a row directly. No runtime
+	// row for this id.
+	auditStore.Log(audit.Entry{
+		ID:             "audit-only-event",
+		Timestamp:      now.Add(-5 * time.Minute).Format(time.RFC3339),
+		FromAgent:      "human-user",
+		ToAgent:        "echo",
+		Status:         "delivered",
+		PolicyDecision: "allow",
+		SessionID:      "audit-only-session",
+		ContentHash:    "h",
+	})
+	auditStore.Flush()
+
+	status, body := postAnalyze(t, handler, cookie, "audit-only-session")
+	if status != http.StatusOK {
+		t.Fatalf("analyze status = %d, body=%s", status, body)
+	}
+	if !strings.Contains(body, "Audit path reply.") {
+		t.Errorf("audit fallback did not pass through LLM reply; got %q", body)
+	}
+	// And the saved analysis must live under the bare id, not
+	// runtime:<id>.
+	if got := auditStore.QuerySessionAnalysis("audit-only-session"); got == nil {
+		t.Errorf("audit fallback did not persist analysis under bare sessionID")
+	}
+	if got := auditStore.QuerySessionAnalysis(runtimeSessionAnalysisKey("audit-only-session")); got != nil {
+		t.Errorf("audit fallback wrote into the runtime: namespace")
+	}
+}

--- a/internal/dashboard/runtime_session_analysis_test.go
+++ b/internal/dashboard/runtime_session_analysis_test.go
@@ -361,3 +361,80 @@ func TestSessionAnalyze_AuditFallbackStillWorksForLegacySession(t *testing.T) {
 		t.Errorf("audit fallback wrote into the runtime: namespace")
 	}
 }
+
+// TestSessionAnalyze_RuntimeQueryErrorReturns503 — review #172
+// P2 #1: when buildRuntimeSessionAnalysisEnvelope sees a runtime
+// store error (here: underlying DB closed mid-flight), the
+// handler must surface 503 and NOT silently fall through to the
+// audit path. The fake LLM must also stay untouched, since the
+// runtime probe never succeeded.
+func TestSessionAnalyze_RuntimeQueryErrorReturns503(t *testing.T) {
+	fake := newFakeLLM(t, "ok")
+	srv, rs, auditStore := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-runtime-503", now, "INNOCUOUS")
+
+	// Force the runtime QuerySession to fail by closing the
+	// shared *sql.DB. audit.Store.Close is idempotent so the
+	// t.Cleanup re-close is safe.
+	if err := auditStore.Close(); err != nil {
+		t.Fatalf("close audit store: %v", err)
+	}
+
+	status, body := postAnalyze(t, handler, cookie, "sess-runtime-503")
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("analyze status = %d, want 503; body=%s", status, body)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.last != nil {
+		t.Errorf("fake LLM was called despite runtime query error")
+	}
+}
+
+// TestSessionAnalyze_RuntimeAIErrorPanelEscapesUpstreamXSS —
+// review #172 P2 #2: a hostile or misconfigured upstream LLM
+// can return arbitrary text in its error message. The handler
+// propagates that text to the client; the client-side error
+// renderer in tmpl_session.go MUST inject it into the DOM via
+// textContent, never via innerHTML +=. We assert both halves of
+// the contract: the API surfaces the error body so the JS catch
+// receives it, and the rendered template carries the canonical
+// textContent assignment with no innerHTML += anywhere in the
+// runtime AI fallback path.
+func TestSessionAnalyze_RuntimeAIErrorPanelEscapesUpstreamXSS(t *testing.T) {
+	xssBody := `{"error":{"message":"<img src=x onerror=alert(1)>"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(xssBody))
+	}))
+	t.Cleanup(server.Close)
+	fake := &fakeLLM{server: server}
+
+	srv, rs, _ := newRuntimeAnalysisServer(t, fake)
+	handler := srv.Handler()
+	cookie := loginSession(t, srv, handler)
+	now := time.Now().UTC()
+
+	seedRealActivity(t, rs, "sess-xss-1", now, "INNOCUOUS")
+
+	status, body := postAnalyze(t, handler, cookie, "sess-xss-1")
+	if status == http.StatusOK {
+		t.Fatalf("expected non-200 from analyze when LLM errors, got 200; body=%s", body)
+	}
+
+	detailStatus, detailBody := fetchSessionDetailHTML(t, srv, cookie, handler, "sess-xss-1")
+	if detailStatus != http.StatusOK {
+		t.Fatalf("detail status = %d", detailStatus)
+	}
+	if !strings.Contains(detailBody, "txt.textContent = 'Analysis failed: ' + e.message") {
+		t.Errorf("rt error path must build text via textContent; missing canonical line")
+	}
+	if strings.Contains(detailBody, "innerHTML += ") || strings.Contains(detailBody, "innerHTML+=") {
+		t.Errorf("rt error path must NOT use innerHTML += (XSS regression risk)")
+	}
+}

--- a/internal/dashboard/runtime_sessions_test.go
+++ b/internal/dashboard/runtime_sessions_test.go
@@ -240,9 +240,17 @@ func TestSessionDetail_RuntimeTreeAndTimeline(t *testing.T) {
 	if !strings.Contains(body, "subagent") {
 		t.Errorf("runtime detail did not surface the subagent actor")
 	}
-	// AI sidebar must be hidden on runtime detail per spec.
-	if strings.Contains(body, "Analyze with AI") || strings.Contains(body, "ai-analyze-btn") {
-		t.Errorf("runtime detail leaked the audit AI button")
+	// LLM is disabled in this fixture, so neither the legacy
+	// audit AI button (id=ai-analyze-btn) nor the runtime
+	// AI button (id=rt-ai-analyze-btn) should render. The
+	// substring "Analyze with AI" appears in the runtime JS
+	// fallback string regardless, so check the actual button
+	// markup instead of the label.
+	if strings.Contains(body, `id="ai-analyze-btn"`) {
+		t.Errorf("runtime detail leaked the legacy audit AI button")
+	}
+	if strings.Contains(body, `id="rt-ai-analyze-btn"`) {
+		t.Errorf("runtime AI button rendered with LLM disabled")
 	}
 }
 

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -283,6 +283,22 @@ var runtimeSessionDetailTmpl = template.Must(template.New("runtime-session-detai
 .rt-link:hover{text-decoration:underline}
 .rt-empty{padding:40px;text-align:center;color:var(--text3)}
 .rt-diagnostic-banner{padding:12px 16px;background:var(--surface2);border:1px solid var(--border);border-radius:8px;font-size:var(--text-sm);color:var(--text2);margin-bottom:20px}
+
+/* Phase 4C — runtime AI sidebar. Distinct rt-* classes (rather
+   than reusing the legacy ss-ai-* prefix) so the runtime branch
+   never gets mistaken for the audit branch by a template grep
+   or a copy-pinned test. */
+.rt-ai-actions{display:inline-flex;gap:8px;align-items:center;margin-left:auto}
+.rt-ai-analyze-btn{padding:6px 14px;background:#1f6feb;color:#fff;border:1px solid var(--accent-border);border-radius:6px;font-size:var(--text-sm);cursor:pointer;font-weight:500;transition:background 0.15s}
+.rt-ai-analyze-btn:hover{background:#388bfd}
+.rt-ai-analyze-btn:disabled{opacity:0.6;cursor:wait}
+.rt-ai-disabled{font-size:var(--text-xs);color:var(--text3);font-style:italic}
+.rt-ai-panel{margin-top:24px;padding:18px 20px;background:var(--surface);border:1px solid var(--accent-border);border-radius:10px;position:relative}
+.rt-ai-panel::before{content:'';position:absolute;left:0;top:14px;bottom:14px;width:3px;background:var(--accent-light);border-radius:2px}
+.rt-ai-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;font-size:var(--text-sm);font-weight:600;color:var(--text)}
+.rt-ai-model{font-size:0.65rem;color:var(--text3);font-family:var(--mono);font-weight:400;padding:2px 8px;background:var(--surface2);border-radius:4px}
+.rt-ai-text{font-size:var(--text-sm);color:var(--text2);line-height:1.65;white-space:pre-wrap}
+.rt-ai-meta{display:flex;gap:12px;margin-top:12px;padding-top:12px;border-top:1px solid var(--border);font-size:0.68rem;color:var(--text3)}
 </style>
 
 <div class="page-header" style="margin-bottom:8px">
@@ -301,6 +317,15 @@ var runtimeSessionDetailTmpl = template.Must(template.New("runtime-session-detai
 <div class="rt-actions">
   <a href="{{.Detail.JSONExportURL}}">JSON</a>
   <a href="{{.Detail.CSVExportURL}}">CSV</a>
+  {{if .LLMEnabled}}
+    {{if .CanAnalyze}}
+    <span class="rt-ai-actions">
+      <button class="rt-ai-analyze-btn" id="rt-ai-analyze-btn" onclick="rtAnalyzeSession('{{.Detail.Session.SessionID}}')">{{if .SavedAnalysis}}Re-analyze with AI{{else}}Analyze with AI{{end}}</button>
+    </span>
+    {{else if .AnalysisDisabledReason}}
+    <span class="rt-ai-disabled">{{.AnalysisDisabledReason}}</span>
+    {{end}}
+  {{end}}
 </div>
 
 {{if .Detail.Session.IsHeartbeatOnly}}
@@ -377,4 +402,41 @@ var runtimeSessionDetailTmpl = template.Must(template.New("runtime-session-detai
   <div class="rt-empty">No hook events recorded for this session.</div>
   {{end}}
 </div>
+
+<div id="rt-ai-panel-slot">
+{{if .SavedAnalysis}}
+<div class="rt-ai-panel" id="rt-ai-panel">
+  <div class="rt-ai-hdr">
+    <span>Runtime AI assessment</span>
+    {{if .AnalysisModel}}<span class="rt-ai-model">{{.AnalysisModel}}</span>{{end}}
+  </div>
+  <div class="rt-ai-text">{{.SavedAnalysis}}</div>
+  {{if .AnalysisDate}}
+  <div class="rt-ai-meta">
+    <span>Analyzed: {{.AnalysisDate}}</span>
+  </div>
+  {{end}}
+</div>
+{{end}}
+</div>
+
+<script>
+function rtAnalyzeSession(sid) {
+  var btn = document.getElementById('rt-ai-analyze-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Analyzing...'; }
+  fetch('/dashboard/api/sessions/' + sid + '/analyze', {method: 'POST'})
+    .then(function(r) {
+      if (!r.ok) { return r.text().then(function(t){ throw new Error(t || r.statusText); }); }
+      return r.text();
+    })
+    .then(function() { window.location.reload(); })
+    .catch(function(e) {
+      if (btn) { btn.disabled = false; btn.textContent = 'Analyze with AI'; }
+      var slot = document.getElementById('rt-ai-panel-slot');
+      if (slot) {
+        slot.innerHTML = '<div class="rt-ai-panel" id="rt-ai-panel"><div class="rt-ai-hdr"><span>Runtime AI assessment</span></div><div class="rt-ai-text" style="color:var(--danger)">Analysis failed: ' + e.message + '</div></div>';
+      }
+    });
+}
+</script>
 ` + layoutFoot))

--- a/internal/dashboard/tmpl_session.go
+++ b/internal/dashboard/tmpl_session.go
@@ -410,7 +410,7 @@ var runtimeSessionDetailTmpl = template.Must(template.New("runtime-session-detai
     <span>Runtime AI assessment</span>
     {{if .AnalysisModel}}<span class="rt-ai-model">{{.AnalysisModel}}</span>{{end}}
   </div>
-  <div class="rt-ai-text">{{.SavedAnalysis}}</div>
+  <div class="rt-ai-text">{{mdToHTML .SavedAnalysis}}</div>
   {{if .AnalysisDate}}
   <div class="rt-ai-meta">
     <span>Analyzed: {{.AnalysisDate}}</span>
@@ -433,9 +433,24 @@ function rtAnalyzeSession(sid) {
     .catch(function(e) {
       if (btn) { btn.disabled = false; btn.textContent = 'Analyze with AI'; }
       var slot = document.getElementById('rt-ai-panel-slot');
-      if (slot) {
-        slot.innerHTML = '<div class="rt-ai-panel" id="rt-ai-panel"><div class="rt-ai-hdr"><span>Runtime AI assessment</span></div><div class="rt-ai-text" style="color:var(--danger)">Analysis failed: ' + e.message + '</div></div>';
-      }
+      if (!slot) return;
+      // textContent (not innerHTML) so a hostile upstream message can't inject markup.
+      while (slot.firstChild) { slot.removeChild(slot.firstChild); }
+      var panel = document.createElement('div');
+      panel.className = 'rt-ai-panel';
+      panel.id = 'rt-ai-panel';
+      var hdr = document.createElement('div');
+      hdr.className = 'rt-ai-hdr';
+      var hdrTitle = document.createElement('span');
+      hdrTitle.textContent = 'Runtime AI assessment';
+      hdr.appendChild(hdrTitle);
+      var txt = document.createElement('div');
+      txt.className = 'rt-ai-text';
+      txt.style.color = 'var(--danger)';
+      txt.textContent = 'Analysis failed: ' + e.message;
+      panel.appendChild(hdr);
+      panel.appendChild(txt);
+      slot.appendChild(panel);
     });
 }
 </script>


### PR DESCRIPTION
## Summary

Phase 3C hid the AI sidebar from runtime session detail because the runtime envelope and the audit-trace `SessionTrace` shape did not line up: forcing one into the other would either lie about roles (no `[HUMAN]`/`[AGENT]` split) or leak raw tool input. Phase 4C adds a runtime-native analysis path so the operator can use AI to investigate runtime sessions, without mixing audit and runtime evidence in either direction.

## Architecture

The legacy `session_analysis.go` path is unchanged. New `runtime_session_analysis.go` owns:

- **`runtimeSessionAnalysisEnvelope`** — read-only payload with only safe fields. Tool input/output are sha256 prefixes, file paths are tails, raw hook envelope JSON is dropped. `task_subject` is intentionally omitted because it can carry prompt-like content.
- **`buildRuntimeSessionAnalysisEnvelope`** — projects the runtime store rows. Drops heartbeat events; never reads `tool_input`.
- **`runtimeSessionAnalysisPrompt`** — distinct from the audit prompt. Frames inputs as runtime hook evidence, not raw conversation. States hashes/tails up front. Treats blocked / quarantined as Oktsec controls firing, NOT automatic verdicts on the agent. Restricts recommended actions to a whitelist.
- **`runtimeSessionAnalysisKey("runtime:" + sessionID)`** — saved analyses live in their own key namespace so a session id that exists in both audit and runtime never displays the audit analysis next to runtime evidence.
- **`analyzeRuntimeSession`** — same provider switch as the legacy analyser, reuses `callClaude` / `callOpenAI`.

## Handler wiring

`handleSessionAnalyze` tries runtime first. Heartbeat-only or zero-event envelope → 400 with a clear rejection reason; the LLM is never called. Otherwise → runtime analyse + save under `runtimeSessionAnalysisKey`. Audit fallback only fires when the runtime store has no row for the id; legacy `SessionTrace` path runs and saves under the bare `sessionID` exactly as before.

`handleSessionTrace` runtime branch loads the saved analysis from `runtimeSessionAnalysisKey(sessionID)`, computes `CanAnalyze` and `AnalysisDisabledReason`, and passes the full set to the template.

## Template

Distinct `rt-*` classes (`rt-ai-analyze-btn`, `rt-ai-panel`, `rt-ai-text`, ...) so a substring grep cannot mistake the runtime branch for the legacy audit branch. The button only renders when `LLMEnabled && CanAnalyze`. Heartbeat-only sessions keep the diagnostic banner; the disabled-reason copy renders inline when the session has zero events. The JS posts to the existing route and reloads on success.

## Tests

Eight new cases in `runtime_session_analysis_test.go` backed by a `fakeLLM` httptest server that records the OpenAI-compatible request body so each test can assert the prompt shape:

- `TestSessionDetail_RuntimeShowsAnalyzeButtonForRealActivity`
- `TestSessionDetail_RuntimeHidesAnalyzeButtonForHeartbeatOnly`
- `TestSessionAnalyze_RuntimeSessionDoesNotRequireAuditTrace`
- `TestSessionAnalyze_RuntimePromptUsesHashesNotRawPayload` — asserts seeded `SECRET_PAYLOAD_DO_NOT_LEAK_42` is absent from prompt; presence of `source: runtime`, `PreToolUse`, `sha256:` markers.
- `TestSessionAnalyze_RuntimeDoesNotDisplayLegacyAuditAnalysis` — saves both keys, asserts only the `runtime:` key renders.
- `TestSessionAnalyze_RuntimeSavedAnalysisRendersInDetail` — full round-trip.
- `TestSessionAnalyze_HeartbeatOnlyRuntimeSessionRejected` — 400 + LLM never called.
- `TestSessionAnalyze_AuditFallbackStillWorksForLegacySession` — audit-only id flows through legacy path; persisted under bare id, NOT under `runtime:` namespace.

Updated `TestSessionDetail_RuntimeTreeAndTimeline` to check the exact button id (`id="ai-analyze-btn"` / `id="rt-ai-analyze-btn"`) instead of the substring `"Analyze with AI"`, which now appears in the runtime JS error fallback even when the button is suppressed.

## Out of scope

LLM queue redesign, provider framework changes, streaming, raw payload analysis, JSON/CSV/SARIF export changes, graph-wide AI analysis, IdP/Okta/Auth0.

## Test plan

- [x] `go test ./internal/dashboard -run 'RuntimeSession|SessionAnalyze' -count=1`
- [x] `go test ./internal/dashboard ./internal/runtime -count=1`
- [x] `go build ./...`
- [x] `make vet`
- [x] `make lint`