### PR TITLE
Phase 4D: deterministic runtime evidence write path

### DIFF
--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -260,12 +260,35 @@ func openStore(dbPath string, logger *slog.Logger, readOnly bool, retentionDays 
 		}
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
 	if err != nil {
 		return nil, fmt.Errorf("opening audit db: %w", err)
 	}
 
 	return newStore(db, SQLiteDialect{}, logger, retentionDays, readOnly)
+}
+
+// sqliteDSN appends per-connection PRAGMAs to the path so every
+// connection in the database/sql pool inherits busy_timeout, WAL,
+// and synchronous=NORMAL. Without this only the connection that
+// ran db.Exec("PRAGMA ...") was configured; later pool connections
+// came up clean and returned SQLITE_BUSY immediately under
+// contention between the audit batch, runtime tx, and activity
+// insert. :memory: is left untouched because each connection there
+// is a separate database — appending a query string would not help
+// and would break existing tests.
+func sqliteDSN(dbPath string) string {
+	if dbPath == ":memory:" {
+		return dbPath
+	}
+	sep := "?"
+	if strings.ContainsRune(dbPath, '?') {
+		sep = "&"
+	}
+	return dbPath + sep +
+		"_pragma=busy_timeout(5000)" +
+		"&_pragma=journal_mode(WAL)" +
+		"&_pragma=synchronous(NORMAL)"
 }
 
 // NewStoreWithDB creates an audit store from an existing *sql.DB connection

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -230,6 +230,11 @@ type Handler struct {
 	// when activity migration failed at startup.
 	activity activityWriter
 
+	// activityWG tracks in-flight async activity inserts so tests (and
+	// shutdown paths) can drain them deterministically via FlushActivity.
+	// Production cost is one Add/Done per hook event.
+	activityWG sync.WaitGroup
+
 	// runtime captures the durable session/actor/event substrate added
 	// in Phase 3A. Same nil-safety contract as activity: a missing
 	// store means the dashboard's runtime APIs (added in 3C) read from
@@ -238,6 +243,12 @@ type Handler struct {
 	// committed — runtime is evidence projection, not policy.
 	runtime *runtime.Store
 }
+
+// FlushActivity blocks until every async activity insert spawned by
+// emitHookActivity has returned. Tests use this after the audit
+// store's Flush so they can query activity_events without polling
+// for a deadline that masks contention bugs.
+func (h *Handler) FlushActivity() { h.activityWG.Wait() }
 
 // NewHandler creates a hooks handler wired to the security pipeline.
 func NewHandler(scanner *engine.Scanner, store HookStore, cfg *config.Config, logger *slog.Logger) *Handler {
@@ -403,7 +414,9 @@ func (h *Handler) emitHookActivity(activityID, msgID string, authResult resolve.
 		ResourceLabel:       ev.ToolName,
 		ResourceID:          ev.ToolName,
 	}
+	h.activityWG.Add(1)
 	go func() {
+		defer h.activityWG.Done()
 		// Detached context: the request context can be cancelled by the
 		// time the goroutine runs, and activity should still land if the
 		// DB is reachable.

--- a/internal/hooks/runtime_integration_test.go
+++ b/internal/hooks/runtime_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/oktsec/oktsec/internal/activity"
 	"github.com/oktsec/oktsec/internal/audit"
@@ -56,11 +55,12 @@ func newRuntimeWiredHandler(t *testing.T) (*Handler, *runtime.Store, *sql.DB, fu
 	}
 }
 
-// post helper sends a hook event, drains the audit batch, and
-// returns the response body. Drains are necessary because the
-// runtime store + audit batch + activity insert all write to one
-// SQLite file; without serialising on Flush() between posts a
-// burst can lose runtime/audit rows to SQLITE_BUSY contention.
+// post helper sends a hook event and deterministically drains both
+// the audit batch and the async activity insert before returning.
+// Without this drain, downstream queries against activity_events or
+// audit_log race the writeLoop / activity goroutine and tests pass
+// or fail based on Go scheduler timing under -race + full-suite
+// concurrency.
 func post(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/hooks/event", bytes.NewReader([]byte(body)))
@@ -72,6 +72,7 @@ func post(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
 	if dbs, ok := h.store.(interface{ Flush() }); ok {
 		dbs.Flush()
 	}
+	h.FlushActivity()
 	return w
 }
 
@@ -297,24 +298,12 @@ func TestServeHTTP_ActivityIDMatchesRuntimeRow(t *testing.T) {
 	}
 	runtimeActivityID := events[0].ActivityEventID
 
-	// Wait for the async activity insert to land. The activity
-	// insert is bounded by activityInsertTimeout (2s) but the race
-	// detector under a full-suite run can push the goroutine past
-	// that window; SQLite write lock contention with the runtime
-	// tx and the audit batch loop can stretch the wait to ~5-8s
-	// under load. 10s gives generous slack before declaring the
-	// cross-reference broken.
-	deadline := time.Now().Add(10 * time.Second)
+	// post() drains audit + activity before returning, so a single
+	// SELECT is enough — no polling deadline can mask a real race.
 	var activityRowID string
-	for time.Now().Before(deadline) {
-		row := db.QueryRow(`SELECT id FROM activity_events WHERE session_id = ?`, "sess-3b-xref")
-		if err := row.Scan(&activityRowID); err == nil && activityRowID != "" {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if activityRowID == "" {
-		t.Fatal("activity_events row never landed within 5s")
+	row := db.QueryRow(`SELECT id FROM activity_events WHERE session_id = ?`, "sess-3b-xref")
+	if err := row.Scan(&activityRowID); err != nil {
+		t.Fatalf("activity_events row missing for sess-3b-xref: %v", err)
 	}
 	if activityRowID != runtimeActivityID {
 		t.Errorf("activity_events.id = %q, runtime row's activity_event_id = %q (must match)", activityRowID, runtimeActivityID)
@@ -442,6 +431,67 @@ func TestServeHTTP_GenericEventFormatLandsRuntimeRow(t *testing.T) {
 	}
 	if events[0].HookEventName != "PreToolUse" {
 		t.Errorf("HookEventName = %q, want PreToolUse (canonicalized from pre_tool_use)", events[0].HookEventName)
+	}
+}
+
+// TestServeHTTP_ActivityRuntimeCrossRefsSurviveRepeatedPosts —
+// Phase 4D regression. Sends a burst of hook posts through the
+// shared post() helper and asserts that every runtime row whose
+// ActivityEventID is non-empty maps to exactly one activity_events
+// row with the same id. The historic flake was that, under
+// SQLITE_BUSY contention between the audit batch, runtime tx, and
+// activity insert, a runtime row could land while its activity row
+// was lost — leaving a dangling cross-reference. With the
+// per-connection pragma fix and the deterministic FlushActivity in
+// post(), the contract holds for every row in the burst.
+func TestServeHTTP_ActivityRuntimeCrossRefsSurviveRepeatedPosts(t *testing.T) {
+	h, store, db, cleanup := newRuntimeWiredHandler(t)
+	defer cleanup()
+
+	const sessionID = "sess-4d-burst"
+	bodies := []string{
+		`{"hook_event_name":"SessionStart","session_id":"` + sessionID + `"}`,
+		`{"hook_event_name":"PreToolUse","session_id":"` + sessionID + `","tool_name":"Read","tool_input":{"path":"/etc/hosts"}}`,
+		`{"hook_event_name":"PostToolUse","session_id":"` + sessionID + `","tool_name":"Read","tool_response":"ok"}`,
+		`{"hook_event_name":"PreToolUse","session_id":"` + sessionID + `","tool_name":"Bash","tool_input":{"command":"ls"}}`,
+		`{"hook_event_name":"PostToolUse","session_id":"` + sessionID + `","tool_name":"Bash","tool_response":"a b c"}`,
+		`{"hook_event_name":"PreToolUse","session_id":"` + sessionID + `","tool_name":"Write","tool_input":{"path":"/tmp/x"}}`,
+		`{"hook_event_name":"PostToolUse","session_id":"` + sessionID + `","tool_name":"Write","tool_response":"ok"}`,
+		`{"hook_event_name":"SessionEnd","session_id":"` + sessionID + `"}`,
+	}
+	for _, body := range bodies {
+		w := post(t, h, body)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d for body=%s; body=%s", w.Code, body, w.Body.String())
+		}
+	}
+
+	events, err := store.QueryEvents(context.Background(), runtime.EventQuery{SessionID: sessionID, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != len(bodies) {
+		t.Fatalf("runtime event count = %d, want %d (lost rows under contention)", len(events), len(bodies))
+	}
+
+	for _, ev := range events {
+		if ev.ActivityEventID == "" {
+			// SessionStart/SessionEnd intentionally do not emit activity
+			// events from the hooks handler today; they upsert the
+			// runtime session row but skip emitHookActivity. The contract
+			// here is "if a runtime row carries an activity ref, that ref
+			// must resolve" — empty refs are a no-op for this test.
+			continue
+		}
+		var got string
+		row := db.QueryRow(`SELECT id FROM activity_events WHERE id = ?`, ev.ActivityEventID)
+		if err := row.Scan(&got); err != nil {
+			t.Errorf("dangling cross-ref: runtime event %s -> activity %s missing: %v", ev.HookEventName, ev.ActivityEventID, err)
+			continue
+		}
+		if got != ev.ActivityEventID {
+			t.Errorf("activity_events.id = %q, runtime activity_event_id = %q (must match)", got, ev.ActivityEventID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Root cause

`PRAGMA busy_timeout=5000` was set once via `db.Exec` after `sql.Open`, so only the connection that ran it was configured. Every other connection in the `database/sql` pool — the audit batch tx, the runtime tx, the activity insert — came up clean and returned `SQLITE_BUSY` immediately on contention. Under `-race` in the full suite this surfaced as the recurring `audit write failed ... database is locked (5)` / `activity_events row never landed within 5s` flake in `internal/hooks`.

The activity insert was also fire-and-forget with no test-visible drain, so even after the busy issue cleared, tests raced the goroutine.

## Why the fix is deterministic

1. **`internal/audit/store.go`**: `openStore` now appends `_pragma=busy_timeout(5000)`, `_pragma=journal_mode(WAL)`, and `_pragma=synchronous(NORMAL)` to the DSN. The `modernc.org/sqlite` driver applies query-string pragmas on every new connection (verified at `modernc.org/sqlite@v1.46.1/conn.go:75`), so the entire pool inherits them. The audit batch, the runtime tx, and the activity insert all wait the configured 5s before any of them ever returns `SQLITE_BUSY` again. `:memory:` paths are left alone — separate-DB-per-connection semantics make the pragma irrelevant there and existing tests continue to work unchanged.
2. **`internal/hooks/handler.go`**: `Handler` tracks in-flight async activity inserts on a `sync.WaitGroup`. `FlushActivity()` blocks until every spawned goroutine has returned. Production cost: one `Add(1)` / `Done()` per hook event.
3. **`internal/hooks/runtime_integration_test.go`**: `post()` helper now drains both audit (`Flush`) and activity (`FlushActivity`) before returning. The polling loop in `TestServeHTTP_ActivityIDMatchesRuntimeRow` collapses to a single `SELECT` — no deadline can mask a real race.

## Preserved assertions

- `TestServeHTTP_ActivityIDMatchesRuntimeRow` still asserts: runtime event exists, `runtime_hook_events.activity_event_id` is non-empty, the matching `activity_events` row exists, and the IDs are equal.
- Spec rule honoured: the test was not removed, the equality assertion was not lowered, no flaky tag was added, no sleeps were extended to mask contention.
- New regression `TestServeHTTP_ActivityRuntimeCrossRefsSurviveRepeatedPosts` bursts eight hook posts (SessionStart -> 3x Pre/Post tool pairs -> SessionEnd), then asserts every runtime row with a non-empty `ActivityEventID` resolves to a real `activity_events` row.

## Commands run

```
go test ./internal/hooks -run TestServeHTTP_ActivityIDMatchesRuntimeRow -count=20 -race   # 8.96s, ok
go test ./internal/hooks -count=10 -race                                                  # 97.10s, ok
go test ./internal/runtime ./internal/audit ./internal/dashboard -count=1 -race           # ok
go build ./...                                                                            # ok
make lint                                                                                 # 0 issues
make vet                                                                                  # ok
go test ./... -count=1                                                                    # ok (full suite green)
```

## Suite status

Full suite passed. Previously-known `SQLITE_BUSY` flake in `internal/hooks/TestServeHTTP_ActivityIDMatchesRuntimeRow` is gone.

## Remaining known flakes

None observed during this validation run.