### PR TITLE
Phase 4E-0: provider-neutral identity context model

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,30 @@ type PrincipalConfig struct {
 	WorkspaceID     string                 `yaml:"workspace_id,omitempty"`
 	AllowedSurfaces []string               `yaml:"allowed_surfaces,omitempty"` // e.g. ["mcp_http", "http_egress_proxy"]
 	Tokens          []PrincipalTokenConfig `yaml:"tokens,omitempty"`
+	// Context carries provider-neutral identity enrichment. Optional;
+	// authorization is not driven by these fields. The YAML key is
+	// "context" on purpose — never "okta", "auth0", or "idp" — so no
+	// vendor name appears in the on-disk shape.
+	Context PrincipalContextConfig `yaml:"context,omitempty"`
+}
+
+// PrincipalContextConfig is the on-disk shape of provider-neutral
+// identity enrichment. Phase 4E-0 supports static config only; Provider
+// is display metadata and never branched on. A future PR may populate
+// these fields from verified OIDC claims.
+type PrincipalContextConfig struct {
+	Issuer     string   `yaml:"issuer,omitempty"`
+	Subject    string   `yaml:"subject,omitempty"`
+	Audience   string   `yaml:"audience,omitempty"`
+	ClientID   string   `yaml:"client_id,omitempty"`
+	TenantID   string   `yaml:"tenant_id,omitempty"`
+	Groups     []string `yaml:"groups,omitempty"`
+	Scopes     []string `yaml:"scopes,omitempty"`
+	Provider   string   `yaml:"provider,omitempty"`
+	Source     string   `yaml:"source,omitempty"`
+	Verified   bool     `yaml:"verified,omitempty"`
+	ExpiresAt  string   `yaml:"expires_at,omitempty"`
+	ClaimsHash string   `yaml:"claims_hash,omitempty"`
 }
 
 // PrincipalTokenConfig is one token bound to a Principal. The Hash field

--- a/internal/config/principal_context_test.go
+++ b/internal/config/principal_context_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// principal_context_test.go covers Phase 4E-0 config parsing for the
+// provider-neutral PrincipalContextConfig. The YAML key must be
+// `context` (never `okta`/`auth0`/`idp`) and Save+Load must round
+// trip every field declared on the struct so a future change can't
+// silently drop a value.
+
+const principalContextYAML = `
+version: "1"
+server:
+  port: 9090
+identity:
+  keys_dir: ./test-keys
+  require_signature: true
+  principals:
+    - id: claude-code
+      display_name: Claude Code
+      kind: agent
+      workspace_id: local
+      context:
+        issuer: https://issuer.example.com/
+        subject: agent/claude-code
+        audience: oktsec
+        client_id: claude-code-local
+        tenant_id: local-dev
+        groups: ["ai-agents"]
+        scopes: ["mcp:tools", "hooks:events"]
+        provider: custom_oidc
+        source: static_config
+        verified: true
+        expires_at: 2099-01-01T00:00:00Z
+        claims_hash: deadbeef
+`
+
+func writePrincipalContextConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(principalContextYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestPrincipalContext_LoadParsesAllFields — every YAML field listed
+// in the spec lands on the parsed PrincipalContextConfig.
+func TestPrincipalContext_LoadParsesAllFields(t *testing.T) {
+	cfg, err := Load(writePrincipalContextConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Identity.Principals) != 1 {
+		t.Fatalf("principals = %d, want 1", len(cfg.Identity.Principals))
+	}
+	got := cfg.Identity.Principals[0].Context
+	want := PrincipalContextConfig{
+		Issuer:     "https://issuer.example.com/",
+		Subject:    "agent/claude-code",
+		Audience:   "oktsec",
+		ClientID:   "claude-code-local",
+		TenantID:   "local-dev",
+		Groups:     []string{"ai-agents"},
+		Scopes:     []string{"mcp:tools", "hooks:events"},
+		Provider:   "custom_oidc",
+		Source:     "static_config",
+		Verified:   true,
+		ExpiresAt:  "2099-01-01T00:00:00Z",
+		ClaimsHash: "deadbeef",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("context mismatch:\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+// TestPrincipalContext_YAMLKeyIsContextNotVendorName — the on-disk
+// key must be exactly `context`. Mistyped vendor-named keys must not
+// silently bind to PrincipalContextConfig.
+func TestPrincipalContext_YAMLKeyIsContextNotVendorName(t *testing.T) {
+	for _, key := range []string{"okta", "auth0", "idp", "oidc"} {
+		body := strings.Replace(principalContextYAML, "      context:", "      "+key+":", 1)
+		dir := t.TempDir()
+		path := filepath.Join(dir, "oktsec.yaml")
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load with key %q: %v", key, err)
+		}
+		if len(cfg.Identity.Principals) != 1 {
+			t.Fatalf("key %q: principals = %d", key, len(cfg.Identity.Principals))
+		}
+		if !principalContextConfigEmpty(cfg.Identity.Principals[0].Context) {
+			t.Errorf("YAML key %q populated PrincipalContext; only `context` is the supported key", key)
+		}
+	}
+}
+
+// TestPrincipalContext_OmittedYieldsZero — a principal without a
+// `context:` block must produce an empty PrincipalContextConfig (the
+// "External identity context not configured" case).
+func TestPrincipalContext_OmittedYieldsZero(t *testing.T) {
+	body := `
+version: "1"
+identity:
+  keys_dir: ./test-keys
+  require_signature: true
+  principals:
+    - id: claude-code
+      display_name: Claude Code
+      kind: agent
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !principalContextConfigEmpty(cfg.Identity.Principals[0].Context) {
+		t.Errorf("missing context block produced non-empty PrincipalContextConfig: %#v", cfg.Identity.Principals[0].Context)
+	}
+}
+
+// TestPrincipalContext_SaveLoadRoundTrip — Save followed by Load
+// preserves every field. Guards against a missed YAML tag or a future
+// field added without serialization support.
+func TestPrincipalContext_SaveLoadRoundTrip(t *testing.T) {
+	cfg, err := Load(writePrincipalContextConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "out.yaml")
+	if err := cfg.Save(out); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := Load(out)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.Identity.Principals[0].Context, cfg2.Identity.Principals[0].Context) {
+		t.Errorf("round-trip mismatch:\n in=%#v\nout=%#v",
+			cfg.Identity.Principals[0].Context, cfg2.Identity.Principals[0].Context)
+	}
+}
+
+func principalContextConfigEmpty(c PrincipalContextConfig) bool {
+	return c.Issuer == "" && c.Subject == "" && c.Audience == "" &&
+		c.ClientID == "" && c.TenantID == "" && c.Provider == "" &&
+		c.Source == "" && c.ExpiresAt == "" && c.ClaimsHash == "" &&
+		!c.Verified && len(c.Groups) == 0 && len(c.Scopes) == 0
+}

--- a/internal/dashboard/runtime_posture.go
+++ b/internal/dashboard/runtime_posture.go
@@ -430,18 +430,54 @@ func buildIdentityContextDimension(in PostureInputs) RuntimePostureDimension {
 		ID:    PostureDimIdentityContext,
 		Label: "Identity context",
 	}
-	if in.Identity.RequireSignature {
-		dim.Status = PostureCellOK
+	if !in.Identity.RequireSignature {
+		// Signature gate is the floor. Even a fully populated identity
+		// context cannot promote this state — context is enrichment,
+		// not authority. This must keep warning users that signed
+		// identity is off.
+		dim.Status = PostureCellWarn
+		dim.Summary = "Signature is not required. Local development mode."
+		dim.Evidence = "Set identity.require_signature=true to enforce signed identity on every request."
+		return dim
+	}
+	dim.Status = PostureCellOK
+	contextMapped := identityContextMapped(in)
+	switch {
+	case contextMapped && in.Identity.RequireDelegation:
+		dim.Summary = "Signed identity, delegation enforced, external context mapped."
+	case contextMapped:
+		dim.Summary = "Signed identity with external context mapped. Delegation not enforced."
+	default:
 		dim.Summary = "Local signed identity required (Ed25519)."
 		if in.Identity.RequireDelegation {
 			dim.Summary += " Delegation chain enforced."
 		}
-	} else {
-		dim.Status = PostureCellWarn
-		dim.Summary = "Signature is not required. Local development mode."
-		dim.Evidence = "Set identity.require_signature=true to enforce signed identity on every request."
+		dim.Summary += " External identity context not configured."
 	}
 	return dim
+}
+
+// identityContextMapped reports whether any configured Principal carries
+// non-empty PrincipalContextConfig. The check stays vendor-neutral on
+// purpose: it asks "is there any external context at all" not "which
+// IdP is in use". Provider is display metadata only — never branched on.
+func identityContextMapped(in PostureInputs) bool {
+	if in.Cfg == nil {
+		return false
+	}
+	for _, p := range in.Cfg.Identity.Principals {
+		if !principalContextEmpty(p.Context) {
+			return true
+		}
+	}
+	return false
+}
+
+func principalContextEmpty(c config.PrincipalContextConfig) bool {
+	return c.Issuer == "" && c.Subject == "" && c.Audience == "" &&
+		c.ClientID == "" && c.TenantID == "" && c.Provider == "" &&
+		c.Source == "" && c.ExpiresAt == "" && c.ClaimsHash == "" &&
+		!c.Verified && len(c.Groups) == 0 && len(c.Scopes) == 0
 }
 
 func buildEvidenceDimension(in PostureInputs) RuntimePostureDimension {

--- a/internal/dashboard/runtime_posture_identity_context_test.go
+++ b/internal/dashboard/runtime_posture_identity_context_test.go
@@ -1,0 +1,138 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// runtime_posture_identity_context_test.go covers Phase 4E-0 posture
+// behavior: the identity_context dimension must surface the mapped
+// state when any configured Principal carries a non-empty context,
+// keep saying "External identity context not configured" otherwise,
+// stay silent on vendor names, and never let context promote a
+// signature-disabled state to OK.
+
+func principalsWithContext() []config.PrincipalConfig {
+	return []config.PrincipalConfig{{
+		ID:          "claude-code",
+		DisplayName: "Claude Code",
+		Kind:        "agent",
+		WorkspaceID: "local",
+		Context: config.PrincipalContextConfig{
+			Issuer:   "https://issuer.example.com/",
+			Subject:  "agent/claude-code",
+			Audience: "oktsec",
+			Provider: "custom_oidc",
+			Source:   "static_config",
+			Verified: true,
+		},
+	}}
+}
+
+// TestRuntimePosture_IdentityContextMappedWithSignature — sig
+// required + context present -> OK + "external context mapped".
+func TestRuntimePosture_IdentityContextMappedWithSignature(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = true
+	in.Cfg.Identity.Principals = principalsWithContext()
+
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+
+	if id.Status != PostureCellOK {
+		t.Errorf("Status = %q, want ok", id.Status)
+	}
+	if !strings.Contains(strings.ToLower(id.Summary), "external context mapped") {
+		t.Errorf("Summary should advertise mapped context: %q", id.Summary)
+	}
+	if strings.Contains(strings.ToLower(id.Summary), "not configured") {
+		t.Errorf("Summary still says not configured even though context is mapped: %q", id.Summary)
+	}
+	for _, vendor := range []string{"okta", "auth0", "entra"} {
+		if strings.Contains(strings.ToLower(id.Summary+id.Evidence), vendor) {
+			t.Errorf("identity_context mentions vendor %q: summary=%q evidence=%q", vendor, id.Summary, id.Evidence)
+		}
+	}
+}
+
+// TestRuntimePosture_IdentityContextMappedWithDelegation — sig + ctx
+// + delegation -> single-line summary that names all three.
+func TestRuntimePosture_IdentityContextMappedWithDelegation(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = true
+	in.Identity.RequireDelegation = true
+	in.Cfg.Identity.Principals = principalsWithContext()
+
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+
+	if id.Status != PostureCellOK {
+		t.Errorf("Status = %q, want ok", id.Status)
+	}
+	for _, want := range []string{"signed", "delegation", "external context mapped"} {
+		if !strings.Contains(strings.ToLower(id.Summary), want) {
+			t.Errorf("Summary missing %q: %q", want, id.Summary)
+		}
+	}
+}
+
+// TestRuntimePosture_IdentityContextMappedWithoutDelegationCallsItOut —
+// when context is present but delegation is not enforced, the page
+// should not silently imply delegation is active. The summary must
+// say "Delegation not enforced." so the operator sees the gap.
+func TestRuntimePosture_IdentityContextMappedWithoutDelegationCallsItOut(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = true
+	in.Identity.RequireDelegation = false
+	in.Cfg.Identity.Principals = principalsWithContext()
+
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+
+	if !strings.Contains(strings.ToLower(id.Summary), "delegation not enforced") {
+		t.Errorf("Summary should call out missing delegation: %q", id.Summary)
+	}
+}
+
+// TestRuntimePosture_IdentityContextAbsentSaysNotConfigured — sig
+// required + no context -> existing local-signed copy plus the new
+// "External identity context not configured." trailer.
+func TestRuntimePosture_IdentityContextAbsentSaysNotConfigured(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = true
+	// in.Cfg has no principals -> no context mapped
+
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+
+	if id.Status != PostureCellOK {
+		t.Errorf("Status = %q, want ok", id.Status)
+	}
+	if !strings.Contains(strings.ToLower(id.Summary), "local signed identity required") {
+		t.Errorf("Summary missing local signed copy: %q", id.Summary)
+	}
+	if !strings.Contains(strings.ToLower(id.Summary), "external identity context not configured") {
+		t.Errorf("Summary missing 'not configured' trailer: %q", id.Summary)
+	}
+}
+
+// TestRuntimePosture_SignatureDisabledStillWarnsEvenWithContext —
+// context never promotes the dimension when signature is off. The
+// page must keep the warning so the operator sees the gating issue.
+func TestRuntimePosture_SignatureDisabledStillWarnsEvenWithContext(t *testing.T) {
+	in := baseInputsWithConnection(fixtureProtectedConnection())
+	in.Identity.RequireSignature = false
+	in.Cfg.Identity.Principals = principalsWithContext()
+
+	snap := buildRuntimePostureSnapshot(in)
+	id := findDimension(t, snap, PostureDimIdentityContext)
+
+	if id.Status != PostureCellWarn {
+		t.Errorf("Status = %q, want warn (context cannot promote sig-disabled state)", id.Status)
+	}
+	if !strings.Contains(strings.ToLower(id.Summary), "signature is not required") {
+		t.Errorf("Summary changed away from signature-disabled warning: %q", id.Summary)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -230,10 +230,30 @@ func configPrincipalsFor(cfg *config.Config) []resolve.ConfigPrincipal {
 		out = append(out, resolve.ConfigPrincipal{
 			ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
 			WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
-			Tokens: toks,
+			Tokens:  toks,
+			Context: configPrincipalContext(p.Context),
 		})
 	}
 	return out
+}
+
+// configPrincipalContext lifts the YAML PrincipalContextConfig into the
+// resolver-side neutral context. Empty in, empty out.
+func configPrincipalContext(c config.PrincipalContextConfig) resolve.ConfigPrincipalContext {
+	return resolve.ConfigPrincipalContext{
+		Issuer:     c.Issuer,
+		Subject:    c.Subject,
+		Audience:   c.Audience,
+		ClientID:   c.ClientID,
+		TenantID:   c.TenantID,
+		Groups:     c.Groups,
+		Scopes:     c.Scopes,
+		Provider:   c.Provider,
+		Source:     c.Source,
+		Verified:   c.Verified,
+		ExpiresAt:  c.ExpiresAt,
+		ClaimsHash: c.ClaimsHash,
+	}
 }
 
 // buildResolver constructs the resolver/store the gateway uses for every

--- a/internal/hooks/handler.go
+++ b/internal/hooks/handler.go
@@ -52,7 +52,8 @@ func buildHooksIdentity(cfg *config.Config) (resolve.Resolver, resolve.Config, b
 			principals = append(principals, resolve.ConfigPrincipal{
 				ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
 				WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
-				Tokens: toks,
+				Tokens:  toks,
+				Context: configPrincipalContextHooks(p.Context),
 			})
 		}
 	}
@@ -1018,4 +1019,25 @@ func truncateStr(s string, max int) string {
 		return s
 	}
 	return s[:max]
+}
+
+// configPrincipalContextHooks lifts the YAML PrincipalContextConfig
+// into the resolver-side neutral context. Empty in, empty out. Mirrors
+// the helpers in gateway and forward proxy; lives here so the resolver
+// stays independent of internal/config.
+func configPrincipalContextHooks(c config.PrincipalContextConfig) resolve.ConfigPrincipalContext {
+	return resolve.ConfigPrincipalContext{
+		Issuer:     c.Issuer,
+		Subject:    c.Subject,
+		Audience:   c.Audience,
+		ClientID:   c.ClientID,
+		TenantID:   c.TenantID,
+		Groups:     c.Groups,
+		Scopes:     c.Scopes,
+		Provider:   c.Provider,
+		Source:     c.Source,
+		Verified:   c.Verified,
+		ExpiresAt:  c.ExpiresAt,
+		ClaimsHash: c.ClaimsHash,
+	}
 }

--- a/internal/identity/resolve/configbridge.go
+++ b/internal/identity/resolve/configbridge.go
@@ -90,29 +90,14 @@ func PrincipalsFromConfig(in []ConfigPrincipal) []PrincipalRecord {
 	return out
 }
 
-// principalContextFromConfig copies the neutral context fields. Slice
-// fields are length-preserving copies so the resolver record cannot be
-// mutated through the original config slice.
+// principalContextFromConfig copies the neutral context fields. The
+// PrincipalContext(c) conversion documents that the two structs are
+// intentionally parallel — a future divergence forces this line to
+// fail to compile, which is the right signal. Slice fields are
+// deep-copied via clonePrincipalContext so a later mutation on either
+// side cannot reach the other.
 func principalContextFromConfig(c ConfigPrincipalContext) PrincipalContext {
-	out := PrincipalContext{
-		Issuer:     c.Issuer,
-		Subject:    c.Subject,
-		Audience:   c.Audience,
-		ClientID:   c.ClientID,
-		TenantID:   c.TenantID,
-		Provider:   c.Provider,
-		Source:     c.Source,
-		Verified:   c.Verified,
-		ExpiresAt:  c.ExpiresAt,
-		ClaimsHash: c.ClaimsHash,
-	}
-	if len(c.Groups) > 0 {
-		out.Groups = append([]string(nil), c.Groups...)
-	}
-	if len(c.Scopes) > 0 {
-		out.Scopes = append([]string(nil), c.Scopes...)
-	}
-	return out
+	return clonePrincipalContext(PrincipalContext(c))
 }
 
 func tokenTypeFromString(s string) (TokenType, bool) {

--- a/internal/identity/resolve/configbridge.go
+++ b/internal/identity/resolve/configbridge.go
@@ -15,6 +15,25 @@ type ConfigPrincipal struct {
 	WorkspaceID     string
 	AllowedSurfaces []string
 	Tokens          []ConfigToken
+	Context         ConfigPrincipalContext
+}
+
+// ConfigPrincipalContext mirrors config.PrincipalContextConfig but stays
+// free of YAML tags so resolve does not import config. Empty values
+// translate to a zero PrincipalContext (no enrichment).
+type ConfigPrincipalContext struct {
+	Issuer     string
+	Subject    string
+	Audience   string
+	ClientID   string
+	TenantID   string
+	Groups     []string
+	Scopes     []string
+	Provider   string
+	Source     string
+	Verified   bool
+	ExpiresAt  string
+	ClaimsHash string
 }
 
 // ConfigToken mirrors config.PrincipalTokenConfig but stays free of YAML
@@ -65,7 +84,33 @@ func PrincipalsFromConfig(in []ConfigPrincipal) []PrincipalRecord {
 			WorkspaceID:     p.WorkspaceID,
 			AllowedSurfaces: surfaces,
 			Tokens:          tokens,
+			Context:         principalContextFromConfig(p.Context),
 		})
+	}
+	return out
+}
+
+// principalContextFromConfig copies the neutral context fields. Slice
+// fields are length-preserving copies so the resolver record cannot be
+// mutated through the original config slice.
+func principalContextFromConfig(c ConfigPrincipalContext) PrincipalContext {
+	out := PrincipalContext{
+		Issuer:     c.Issuer,
+		Subject:    c.Subject,
+		Audience:   c.Audience,
+		ClientID:   c.ClientID,
+		TenantID:   c.TenantID,
+		Provider:   c.Provider,
+		Source:     c.Source,
+		Verified:   c.Verified,
+		ExpiresAt:  c.ExpiresAt,
+		ClaimsHash: c.ClaimsHash,
+	}
+	if len(c.Groups) > 0 {
+		out.Groups = append([]string(nil), c.Groups...)
+	}
+	if len(c.Scopes) > 0 {
+		out.Scopes = append([]string(nil), c.Scopes...)
 	}
 	return out
 }

--- a/internal/identity/resolve/principal_context_test.go
+++ b/internal/identity/resolve/principal_context_test.go
@@ -1,0 +1,207 @@
+package resolve
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// principal_context_test.go covers Phase 4E-0: the provider-neutral
+// PrincipalContext model. The tests pin three contracts:
+//
+//  1. Context propagates from config -> resolver record -> Result.
+//  2. Behavior is identical regardless of Provider string (no vendor
+//     branching anywhere in the resolve stack).
+//  3. Adding/removing context never changes the Principal fields ACL
+//     and delegation read (ID, AuthMethod, TrustLevel, WorkspaceID).
+//
+// Plus a structural guard that no field on PrincipalContext could
+// hold raw JWTs or raw claims JSON.
+
+// fixtureConfigContext is the example context the spec §6.5 YAML
+// shows. Reused across cases so each test focuses on the contract,
+// not the field bag.
+func fixtureConfigContext() ConfigPrincipalContext {
+	return ConfigPrincipalContext{
+		Issuer:    "https://issuer.example.com/",
+		Subject:   "agent/claude-code",
+		Audience:  "oktsec",
+		ClientID:  "claude-code-local",
+		TenantID:  "local-dev",
+		Groups:    []string{"ai-agents"},
+		Scopes:    []string{"mcp:tools", "hooks:events"},
+		Provider:  "custom_oidc",
+		Source:    "static_config",
+		Verified:  true,
+		ExpiresAt: "2099-01-01T00:00:00Z",
+	}
+}
+
+// resolveWithContext builds a token-authenticated resolve and returns
+// the Principal so each test can assert on the post-resolve shape.
+func resolveWithContext(t *testing.T, principalID string, ctx ConfigPrincipalContext) Principal {
+	t.Helper()
+	raw, hash, err := GenerateRawToken(TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	cp := ConfigPrincipal{
+		ID:          principalID,
+		DisplayName: principalID,
+		Kind:        string(PrincipalKindAgent),
+		WorkspaceID: "wks-1",
+		Tokens: []ConfigToken{{
+			ID:        principalID + "-tok",
+			Type:      "gateway_bearer",
+			Hash:      hash,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		}},
+		Context: ctx,
+	}
+	store := NewMemoryTokenStoreWithClock(PrincipalsFromConfig([]ConfigPrincipal{cp}), nil)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+	got, err := r.Resolve(context.Background(), Config{
+		Profile:           ProfileLocal,
+		AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+	}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return got.Principal
+}
+
+// TestPrincipalContext_PropagatedThroughTokenLookup — config carries
+// context, token-authenticated resolve must surface it on the
+// resolved Principal.
+func TestPrincipalContext_PropagatedThroughTokenLookup(t *testing.T) {
+	p := resolveWithContext(t, "claude-code", fixtureConfigContext())
+
+	if p.Context.IsZero() {
+		t.Fatal("Principal.Context is zero after token lookup; propagation broken")
+	}
+	if p.Context.Issuer != "https://issuer.example.com/" {
+		t.Errorf("Issuer = %q", p.Context.Issuer)
+	}
+	if p.Context.Subject != "agent/claude-code" {
+		t.Errorf("Subject = %q", p.Context.Subject)
+	}
+	if got, want := p.Context.Groups, []string{"ai-agents"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Groups = %v, want %v", got, want)
+	}
+	if got, want := p.Context.Scopes, []string{"mcp:tools", "hooks:events"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Scopes = %v, want %v", got, want)
+	}
+	if !p.Context.Verified {
+		t.Errorf("Verified = false; static_config marked verified must round-trip")
+	}
+}
+
+// TestPrincipalContext_LookupWithoutContextReturnsZero — empty config
+// context must round-trip as a zero PrincipalContext (the absence
+// case the dashboard renders as "External identity context not
+// configured").
+func TestPrincipalContext_LookupWithoutContextReturnsZero(t *testing.T) {
+	p := resolveWithContext(t, "no-context-agent", ConfigPrincipalContext{})
+	if !p.Context.IsZero() {
+		t.Errorf("Principal.Context = %#v, want zero", p.Context)
+	}
+}
+
+// TestPrincipalContext_VendorNeutralBehavior — two principals that
+// differ only in Provider ("okta" vs "custom_oidc") must produce
+// identical Principal shape apart from Context.Provider. No code
+// path may branch on a vendor string.
+func TestPrincipalContext_VendorNeutralBehavior(t *testing.T) {
+	okta := fixtureConfigContext()
+	okta.Provider = "okta"
+	custom := fixtureConfigContext()
+	custom.Provider = "custom_oidc"
+
+	pOkta := resolveWithContext(t, "p-okta", okta)
+	pCustom := resolveWithContext(t, "p-custom", custom)
+
+	// Strip the only field allowed to differ, then compare every
+	// other Principal field — including the rest of Context.
+	pOkta.ID = ""
+	pCustom.ID = ""
+	pOkta.DisplayName = ""
+	pCustom.DisplayName = ""
+	pOkta.TokenID = ""
+	pCustom.TokenID = ""
+	pOkta.Context.Provider = ""
+	pCustom.Context.Provider = ""
+
+	if !reflect.DeepEqual(pOkta, pCustom) {
+		t.Errorf("Principal differs across providers beyond display fields:\n okta=%#v\n custom=%#v", pOkta, pCustom)
+	}
+}
+
+// TestPrincipalContext_DoesNotChangeAuthorityFields — adding or
+// removing context never mutates the Principal fields the policy
+// stack actually consumes (ID, AuthMethod, TrustLevel, WorkspaceID).
+// This locks in "context is enrichment, not authority".
+func TestPrincipalContext_DoesNotChangeAuthorityFields(t *testing.T) {
+	pBare := resolveWithContext(t, "claude-code", ConfigPrincipalContext{})
+	pCtx := resolveWithContext(t, "claude-code", fixtureConfigContext())
+
+	if pBare.ID != pCtx.ID {
+		t.Errorf("ID changed by context: %q vs %q", pBare.ID, pCtx.ID)
+	}
+	if pBare.AuthMethod != pCtx.AuthMethod {
+		t.Errorf("AuthMethod changed by context: %q vs %q", pBare.AuthMethod, pCtx.AuthMethod)
+	}
+	if pBare.TrustLevel != pCtx.TrustLevel {
+		t.Errorf("TrustLevel changed by context: %q vs %q", pBare.TrustLevel, pCtx.TrustLevel)
+	}
+	if pBare.WorkspaceID != pCtx.WorkspaceID {
+		t.Errorf("WorkspaceID changed by context: %q vs %q", pBare.WorkspaceID, pCtx.WorkspaceID)
+	}
+	if pBare.Kind != pCtx.Kind {
+		t.Errorf("Kind changed by context: %q vs %q", pBare.Kind, pCtx.Kind)
+	}
+}
+
+// TestPrincipalContext_NoRawClaimsField — structural guard: no field
+// on PrincipalContext may hold a raw JWT or raw claims JSON. Only
+// ClaimsHash (a digest) is permitted. A future PR that adds
+// "RawJWT" or "Claims" must update this list deliberately.
+func TestPrincipalContext_NoRawClaimsField(t *testing.T) {
+	rt := reflect.TypeOf(PrincipalContext{})
+	for i := 0; i < rt.NumField(); i++ {
+		name := strings.ToLower(rt.Field(i).Name)
+		switch name {
+		case "claimshash":
+			// hash, not the claims themselves — allowed
+		default:
+			if strings.Contains(name, "jwt") || strings.Contains(name, "rawclaim") || name == "claims" {
+				t.Errorf("PrincipalContext field %q would surface raw claims/JWT; not allowed", rt.Field(i).Name)
+			}
+		}
+	}
+}
+
+// TestPrincipalContext_DeepCopiedSlices — the resolver record must
+// not share Groups/Scopes backing arrays with the inbound config so
+// a later mutation on the config side cannot reach principal state.
+func TestPrincipalContext_DeepCopiedSlices(t *testing.T) {
+	cfg := fixtureConfigContext()
+	records := PrincipalsFromConfig([]ConfigPrincipal{{
+		ID: "x", Tokens: nil, Context: cfg,
+	}})
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if len(records[0].Context.Groups) != 1 {
+		t.Fatalf("Groups not copied")
+	}
+	cfg.Groups[0] = "MUTATED"
+	if records[0].Context.Groups[0] == "MUTATED" {
+		t.Errorf("config slice mutation reached resolver record (shared backing array)")
+	}
+}

--- a/internal/identity/resolve/principal_context_test.go
+++ b/internal/identity/resolve/principal_context_test.go
@@ -205,3 +205,78 @@ func TestPrincipalContext_DeepCopiedSlices(t *testing.T) {
 		t.Errorf("config slice mutation reached resolver record (shared backing array)")
 	}
 }
+
+// TestPrincipalContext_ResolverReturnSlicesAreIsolated — review #175
+// P2 regression. resolve once, mutate the returned Context.Groups and
+// Context.Scopes, resolve again, and assert the second resolution is
+// untouched. Without the clonePrincipalContext guard at every outward
+// boundary (resolver buildResult, MemoryTokenStore.Lookup,
+// PrincipalByID), the first resolution's slice headers shared backing
+// arrays with the store-backed PrincipalRecord and a caller could
+// poison every later resolution.
+func TestPrincipalContext_ResolverReturnSlicesAreIsolated(t *testing.T) {
+	const principalID = "claude-code"
+	raw, hash, err := GenerateRawToken(TokenTypeGatewayBearer)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	cp := ConfigPrincipal{
+		ID:          principalID,
+		DisplayName: principalID,
+		Kind:        string(PrincipalKindAgent),
+		Tokens: []ConfigToken{{
+			ID: principalID + "-tok", Type: "gateway_bearer", Hash: hash,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		}},
+		Context: fixtureConfigContext(),
+	}
+	store := NewMemoryTokenStoreWithClock(PrincipalsFromConfig([]ConfigPrincipal{cp}), nil)
+	r := NewDefaultResolver(store, nil)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+raw)
+	doResolve := func() Principal {
+		got, err := r.Resolve(context.Background(), Config{
+			Profile:           ProfileLocal,
+			AllowedTokenTypes: []TokenType{TokenTypeGatewayBearer},
+		}, Evidence{Surface: SurfaceMCPHTTP, Header: hdr, RemoteAddr: "127.0.0.1:1"})
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		return got.Principal
+	}
+
+	first := doResolve()
+	if len(first.Context.Groups) != 1 || first.Context.Groups[0] != "ai-agents" {
+		t.Fatalf("first.Context.Groups = %v, want [ai-agents]", first.Context.Groups)
+	}
+	if len(first.Context.Scopes) != 2 {
+		t.Fatalf("first.Context.Scopes = %v, want length 2", first.Context.Scopes)
+	}
+
+	first.Context.Groups[0] = "ATTACKER-GROUPS"
+	first.Context.Scopes[0] = "ATTACKER-SCOPE"
+
+	second := doResolve()
+	if got := second.Context.Groups[0]; got != "ai-agents" {
+		t.Errorf("second.Context.Groups[0] = %q; mutation on first resolution reached store-backed state", got)
+	}
+	if got := second.Context.Scopes[0]; got != "mcp:tools" {
+		t.Errorf("second.Context.Scopes[0] = %q; mutation on first resolution reached store-backed state", got)
+	}
+
+	// PrincipalByID is the other outward boundary — same isolation contract.
+	rec, ok := store.PrincipalByID(principalID)
+	if !ok {
+		t.Fatal("PrincipalByID miss")
+	}
+	rec.Context.Groups[0] = "ATTACKER-PBID"
+	rec.Context.Scopes[0] = "ATTACKER-PBID-SCOPE"
+	rec2, _ := store.PrincipalByID(principalID)
+	if got := rec2.Context.Groups[0]; got != "ai-agents" {
+		t.Errorf("PrincipalByID Groups leaked: %q", got)
+	}
+	if got := rec2.Context.Scopes[0]; got != "mcp:tools" {
+		t.Errorf("PrincipalByID Scopes leaked: %q", got)
+	}
+}

--- a/internal/identity/resolve/resolver.go
+++ b/internal/identity/resolve/resolver.go
@@ -152,6 +152,7 @@ func (r *DefaultResolver) buildResult(p PrincipalRecord, tok TokenRecord, eviden
 			TrustLevel:  TrustAuthenticated,
 			TokenID:     tok.ID,
 			WorkspaceID: p.WorkspaceID,
+			Context:     p.Context,
 		},
 		ReportedActor: extractReportedActor(evidence, cfg),
 	}

--- a/internal/identity/resolve/resolver.go
+++ b/internal/identity/resolve/resolver.go
@@ -152,7 +152,7 @@ func (r *DefaultResolver) buildResult(p PrincipalRecord, tok TokenRecord, eviden
 			TrustLevel:  TrustAuthenticated,
 			TokenID:     tok.ID,
 			WorkspaceID: p.WorkspaceID,
-			Context:     p.Context,
+			Context:     clonePrincipalContext(p.Context),
 		},
 		ReportedActor: extractReportedActor(evidence, cfg),
 	}

--- a/internal/identity/resolve/tokens.go
+++ b/internal/identity/resolve/tokens.go
@@ -75,12 +75,13 @@ func (r TokenRecord) Active(now time.Time) bool {
 // the Principal because lookups always start from a token and resolve to
 // the owning Principal.
 type PrincipalRecord struct {
-	ID              string        `yaml:"id" json:"id"`
-	DisplayName     string        `yaml:"display_name,omitempty" json:"display_name,omitempty"`
-	Kind            PrincipalKind `yaml:"kind,omitempty" json:"kind,omitempty"`
-	WorkspaceID     string        `yaml:"workspace_id,omitempty" json:"workspace_id,omitempty"`
-	Tokens          []TokenRecord `yaml:"tokens,omitempty" json:"tokens,omitempty"`
-	AllowedSurfaces []Surface     `yaml:"allowed_surfaces,omitempty" json:"allowed_surfaces,omitempty"`
+	ID              string           `yaml:"id" json:"id"`
+	DisplayName     string           `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Kind            PrincipalKind    `yaml:"kind,omitempty" json:"kind,omitempty"`
+	WorkspaceID     string           `yaml:"workspace_id,omitempty" json:"workspace_id,omitempty"`
+	Tokens          []TokenRecord    `yaml:"tokens,omitempty" json:"tokens,omitempty"`
+	AllowedSurfaces []Surface        `yaml:"allowed_surfaces,omitempty" json:"allowed_surfaces,omitempty"`
+	Context         PrincipalContext `yaml:"context,omitempty" json:"context,omitempty"`
 }
 
 // TokenStore looks up tokens by ID and, given a candidate raw secret,

--- a/internal/identity/resolve/tokens.go
+++ b/internal/identity/resolve/tokens.go
@@ -201,6 +201,9 @@ func (s *MemoryTokenStore) Lookup(t TokenType, raw string) (PrincipalRecord, Tok
 		s.mu.RLock()
 		principal := s.byID[idx.principalID]
 		s.mu.RUnlock()
+		// Clone Context so a caller mutating returned Groups/Scopes
+		// cannot reach into store-backed state and affect later lookups.
+		principal.Context = clonePrincipalContext(principal.Context)
 		for _, tok := range principal.Tokens {
 			if tok.ID == tokID {
 				return principal, tok, nil
@@ -228,12 +231,18 @@ func indexActive(idx tokenIndex, now time.Time) bool {
 	return now.Before(exp)
 }
 
-// PrincipalByID returns the principal record by ID.
+// PrincipalByID returns the principal record by ID. Context slices are
+// deep-copied before returning so a caller mutating Groups/Scopes
+// cannot reach into store-backed state and affect later resolutions.
 func (s *MemoryTokenStore) PrincipalByID(id string) (PrincipalRecord, bool) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	p, ok := s.byID[id]
-	return p, ok
+	s.mu.RUnlock()
+	if !ok {
+		return PrincipalRecord{}, false
+	}
+	p.Context = clonePrincipalContext(p.Context)
+	return p, true
 }
 
 // GenerateRawToken returns a freshly generated raw token (with type prefix)

--- a/internal/identity/resolve/types.go
+++ b/internal/identity/resolve/types.go
@@ -149,6 +149,26 @@ func (c PrincipalContext) IsZero() bool {
 		!c.Verified && len(c.Groups) == 0 && len(c.Scopes) == 0
 }
 
+// clonePrincipalContext returns a deep copy of c so a caller cannot
+// mutate the resolver-side stored context through the returned slice
+// headers. Used at every outward boundary that hands a context to a
+// caller (resolver buildResult, MemoryTokenStore.Lookup, PrincipalByID,
+// and the config -> resolver bridge in PrincipalsFromConfig).
+func clonePrincipalContext(c PrincipalContext) PrincipalContext {
+	out := c
+	if len(c.Groups) > 0 {
+		out.Groups = append([]string(nil), c.Groups...)
+	} else {
+		out.Groups = nil
+	}
+	if len(c.Scopes) > 0 {
+		out.Scopes = append([]string(nil), c.Scopes...)
+	} else {
+		out.Scopes = nil
+	}
+	return out
+}
+
 // ReportedActor is display/audit metadata supplied by the surface (header,
 // payload, hook body) or inferred by correlation. It is rendered in the UI
 // alongside the Principal, but never used for policy.

--- a/internal/identity/resolve/types.go
+++ b/internal/identity/resolve/types.go
@@ -113,6 +113,40 @@ type Principal struct {
 	TrustLevel  TrustLevel
 	TokenID     string // empty when auth method is not token-based
 	WorkspaceID string
+	// Context is provider-neutral identity enrichment. Empty is valid
+	// and means no external identity context is configured. It is
+	// metadata only — authorization stays driven by ID, AuthMethod,
+	// TrustLevel, delegation, suspension, ACL, and runtime policy.
+	Context PrincipalContext
+}
+
+// PrincipalContext is the provider-neutral identity context model.
+// Phase 4E-0 wires it as static enrichment carried through config; a
+// later phase may populate it from verified OIDC/JWT claims, but no
+// code path may branch on Provider — it is display metadata only.
+type PrincipalContext struct {
+	Issuer     string
+	Subject    string
+	Audience   string
+	ClientID   string
+	TenantID   string
+	Groups     []string
+	Scopes     []string
+	Provider   string // display-only label, e.g. "custom_oidc"
+	Source     string // "static_config" in 4E-0; "oidc_jwt" reserved for 4E-1
+	Verified   bool
+	ExpiresAt  string
+	ClaimsHash string // optional short hash if raw claims existed upstream
+}
+
+// IsZero reports whether the context carries no enrichment. Used by
+// the posture builder and by tests to decide whether to render the
+// "external context mapped" copy or the local-only fallback.
+func (c PrincipalContext) IsZero() bool {
+	return c.Issuer == "" && c.Subject == "" && c.Audience == "" &&
+		c.ClientID == "" && c.TenantID == "" && c.Provider == "" &&
+		c.Source == "" && c.ExpiresAt == "" && c.ClaimsHash == "" &&
+		!c.Verified && len(c.Groups) == 0 && len(c.Scopes) == 0
 }
 
 // ReportedActor is display/audit metadata supplied by the surface (header,

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -158,7 +158,8 @@ func buildForwardProxyIdentity(cfg *config.ForwardProxyConfig, fullCfg *config.C
 			principals = append(principals, resolve.ConfigPrincipal{
 				ID: p.ID, DisplayName: p.DisplayName, Kind: p.Kind,
 				WorkspaceID: p.WorkspaceID, AllowedSurfaces: p.AllowedSurfaces,
-				Tokens: toks,
+				Tokens:  toks,
+				Context: configPrincipalContextForward(p.Context),
 			})
 		}
 	}
@@ -735,5 +736,26 @@ func copyWithDeadline(dst, src net.Conn, idle time.Duration) (int64, error) {
 		if err != nil {
 			return total, err
 		}
+	}
+}
+
+// configPrincipalContextForward lifts the YAML PrincipalContextConfig
+// into the resolver-side neutral context. Empty in, empty out. Mirrors
+// the helpers in gateway and hooks; lives here to keep the resolver
+// independent of internal/config.
+func configPrincipalContextForward(c config.PrincipalContextConfig) resolve.ConfigPrincipalContext {
+	return resolve.ConfigPrincipalContext{
+		Issuer:     c.Issuer,
+		Subject:    c.Subject,
+		Audience:   c.Audience,
+		ClientID:   c.ClientID,
+		TenantID:   c.TenantID,
+		Groups:     c.Groups,
+		Scopes:     c.Scopes,
+		Provider:   c.Provider,
+		Source:     c.Source,
+		Verified:   c.Verified,
+		ExpiresAt:  c.ExpiresAt,
+		ClaimsHash: c.ClaimsHash,
 	}
 }


### PR DESCRIPTION
## Scope

This is **Phase 4E-0: static / provider-neutral identity context model**.

- **No** OIDC/JWKS verification.
- **No** IdP-specific adapter.
- **No** authorization behavior change.
- **No** production dependency on Okta/Auth0.

Identity context is enrichment, not authority. Authorization stays driven by principal ID, AuthMethod, TrustLevel, delegation chain (Phase 4B), suspension, ACL, and runtime policy. None of those code paths read context fields.

## Model

`internal/identity/resolve.PrincipalContext`:

```go
type PrincipalContext struct {
    Issuer     string
    Subject    string
    Audience   string
    ClientID   string
    TenantID   string
    Groups     []string
    Scopes     []string
    Provider   string // display-only label, e.g. "custom_oidc"
    Source     string // "static_config" in 4E-0; "oidc_jwt" reserved for 4E-1
    Verified   bool
    ExpiresAt  string
    ClaimsHash string // optional short hash if raw claims existed upstream
}
```

Threaded through `PrincipalRecord` -> `Principal` -> `Result`. Slice fields (`Groups`, `Scopes`) are deep-copied through `PrincipalsFromConfig` so a later mutation on the config side cannot reach principal state.

## Config

New `config.PrincipalContextConfig` carried under YAML key `context`. The key is exactly `context` — never `okta`, `auth0`, or `idp` — and a vendor-named key does **not** bind to the field (regression test asserts this).

```yaml
identity:
  principals:
    - id: claude-code
      display_name: Claude Code
      kind: agent
      workspace_id: local
      context:
        issuer: https://issuer.example.com/
        subject: agent/claude-code
        audience: oktsec
        client_id: claude-code-local
        tenant_id: local-dev
        groups: ["ai-agents"]
        scopes: ["mcp:tools", "hooks:events"]
        provider: custom_oidc
        source: static_config
        verified: true
```

Empty `context:` block is valid and round-trips as a zero `PrincipalContext`. Each surface adapter (gateway, forward proxy, hooks) has a small helper that lifts the YAML struct onto `resolve.ConfigPrincipalContext`; the resolver itself stays free of any `internal/config` import to avoid the cycle.

## Posture

`buildIdentityContextDimension` now reads the configured Principals and renders one of three OK summaries when signature is required:

| State | Summary |
| --- | --- |
| sig + ctx + delegation | "Signed identity, delegation enforced, external context mapped." |
| sig + ctx, no delegation | "Signed identity with external context mapped. Delegation not enforced." |
| sig + no context | "Local signed identity required (Ed25519). [Delegation chain enforced.] External identity context not configured." |
| signature disabled | existing warning, unchanged even when context is mapped |

Vendor names never appear in the dimension copy.

## Tests

- **Config parsing** (`internal/config/principal_context_test.go`): every field loads; vendor-named YAML keys (`okta`, `auth0`, `idp`, `oidc`) do not bind; missing block yields zero; Save+Load round-trip preserves all fields.
- **Resolver propagation** (`internal/identity/resolve/principal_context_test.go`): token lookup returns `Result.Principal.Context` populated; absent context returns `IsZero`.
- **Provider neutrality**: two principals differing only in `Provider` (`okta` vs `custom_oidc`) produce identical `Principal` shape apart from `Context.Provider`.
- **Policy non-interference**: adding/removing context does not change `ID`, `AuthMethod`, `TrustLevel`, `WorkspaceID`, or `Kind`.
- **Structural guard**: `PrincipalContext` has no field that could carry a raw JWT or raw claims JSON (only `ClaimsHash` is permitted; a future struct change to add a `RawJWT`/`Claims` field fails this test on purpose).
- **Slice isolation**: mutating the inbound config slice does not reach the resolver record.
- **Posture** (`internal/dashboard/runtime_posture_identity_context_test.go`): four cases above, plus a vendor-name guard on the rendered copy.

## Validation

```
go test ./internal/config ./internal/identity/resolve ./internal/dashboard ./internal/proxy -count=1   # ok
go test ./... -count=1                                                                                  # full suite green
go build ./...                                                                                          # ok
make lint                                                                                               # 0 issues
make vet                                                                                                # ok
```

## Out of scope (deferred to Phase 4E-1 or later)

OIDC/JWKS verification, JWT parsing, issuer/audience runtime checks, JWKS cache, network fetches, Okta/Auth0/Entra-specific adapters, dashboard SSO/RBAC, group-based ACL, runtime DB migration for raw claims, marketing copy changes.