### PR TITLE
Fix oktsec run Claude Code bootstrap when discovery is empty

### DIFF
--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -97,7 +97,31 @@ func executeRun(opts runOpts) error {
 	return startServer(configPath, opts)
 }
 
+// autoSetupDeps lets tests substitute the external effects of first-run setup
+// (MCP discovery, Claude CLI presence check, Claude Code gateway connection,
+// generic client wrapping) without invoking real CLIs or mutating real
+// ~/.claude/settings.json.
+type autoSetupDeps struct {
+	scan              func() (*discover.Result, error)
+	hasClaudeCLI      func() bool
+	connectClaudeCode func(port int, endpoint string) error
+	wrapClient        func(client string, opts discover.WrapOpts) (int, error)
+}
+
+func defaultAutoSetupDeps() autoSetupDeps {
+	return autoSetupDeps{
+		scan:              discover.Scan,
+		hasClaudeCLI:      hasClaudeCLI,
+		connectClaudeCode: autoConnectClaudeCode,
+		wrapClient:        discover.WrapClient,
+	}
+}
+
 func autoSetup(configPath string, opts runOpts) error {
+	return autoSetupWithDeps(configPath, opts, defaultAutoSetupDeps())
+}
+
+func autoSetupWithDeps(configPath string, opts runOpts, deps autoSetupDeps) error {
 	// Ensure parent directory exists (e.g. ~/.oktsec/)
 	if dir := filepath.Dir(configPath); dir != "." {
 		_ = os.MkdirAll(dir, 0o700)
@@ -105,7 +129,7 @@ func autoSetup(configPath string, opts runOpts) error {
 
 	// Step 1: Discover
 	fmt.Printf("  %s\n", color.New(color.Bold).Sprint("Scanning for MCP servers..."))
-	result, err := discover.Scan()
+	result, err := deps.scan()
 	if err != nil {
 		return err
 	}
@@ -119,7 +143,24 @@ func autoSetup(configPath string, opts runOpts) error {
 		if err := writeMinimalConfig(configPath); err != nil {
 			return err
 		}
-		return ensureSecrets(configPath)
+		if err := ensureSecrets(configPath); err != nil {
+			return err
+		}
+
+		absConfig, err := filepath.Abs(configPath)
+		if err != nil {
+			absConfig = configPath
+		}
+
+		// Discovery answers "did we find backend MCP servers to import?".
+		// Claude Code bootstrap answers "can we register oktsec as a runtime
+		// surface and install hooks?". Empty discovery must not skip the
+		// second question.
+		connectMCPClients(result, absConfig, opts, 9090, "/mcp", deps)
+
+		fmt.Println("  " + color.GreenString("Setup complete.") + " Starting server...")
+		fmt.Println()
+		return nil
 	}
 
 	fmt.Printf("  Found %s across %d client(s):\n\n", color.GreenString("%d server(s)", result.TotalServers()), result.TotalClients())
@@ -265,52 +306,65 @@ func autoSetup(configPath string, opts runOpts) error {
 	}
 
 	// Step 4: Connect clients
-	if !opts.skipWrap {
-		fmt.Println("  Connecting MCP clients...")
-
-		totalConnected := 0
-
-		// Claude Code: register gateway via HTTP MCP transport (preferred over wrapping)
-		if hasClaudeCLI() {
-			if err := autoConnectClaudeCode(9090, "/mcp"); err != nil {
-				fmt.Printf("    %-16s  error: %s\n", "Claude Code", err)
-			} else {
-				fmt.Printf("    %-16s  connected via gateway\n", "Claude Code")
-				totalConnected++
-			}
-		}
-
-		// Other clients: wrap stdio servers through oktsec proxy
-		wrapOpts := discover.WrapOpts{
-			Enforce:    opts.enforce,
-			ConfigPath: absConfig,
-		}
-		for _, cr := range result.Clients {
-			// Skip claude-code (handled above via gateway)
-			if cr.Client == "claude-code" || !discover.IsWrappable(cr.Client) || len(cr.Servers) == 0 {
-				continue
-			}
-			wrapped, err := discover.WrapClient(cr.Client, wrapOpts)
-			name := discover.ClientDisplayName(cr.Client)
-			if err != nil {
-				fmt.Printf("    %-16s  error: %s\n", name, err)
-				continue
-			}
-			if wrapped > 0 {
-				fmt.Printf("    %-16s  %d server(s) wrapped\n", name, wrapped)
-				totalConnected += wrapped
-			}
-		}
-
-		if totalConnected > 0 {
-			fmt.Printf("\n    %d client(s) now routing through oktsec.\n", totalConnected)
-		}
-		fmt.Println()
-	}
+	connectMCPClients(result, absConfig, opts, 9090, "/mcp", deps)
 
 	fmt.Println("  " + color.GreenString("Setup complete.") + " Starting server...")
 	fmt.Println()
 	return nil
+}
+
+// connectMCPClients runs the client-bootstrap phase shared by both empty and
+// non-empty discovery paths: register Claude Code via the gateway when the
+// `claude` CLI is available, and wrap any other supported clients with at
+// least one discovered MCP server. --skip-wrap is the opt-out for any
+// external client mutation.
+func connectMCPClients(result *discover.Result, absConfig string, opts runOpts, gatewayPort int, endpoint string, deps autoSetupDeps) {
+	if opts.skipWrap {
+		return
+	}
+
+	fmt.Println("  Connecting MCP clients...")
+
+	totalConnected := 0
+
+	// Claude Code: register gateway via HTTP MCP transport (preferred over wrapping).
+	// This runs even when discovery is empty so first-run setup still installs the
+	// gateway entry and PreToolUse/PostToolUse hooks.
+	if deps.hasClaudeCLI() {
+		if err := deps.connectClaudeCode(gatewayPort, endpoint); err != nil {
+			fmt.Printf("    %-16s  error: %s\n", "Claude Code", err)
+		} else {
+			fmt.Printf("    %-16s  connected via gateway\n", "Claude Code")
+			totalConnected++
+		}
+	}
+
+	// Other clients: wrap stdio servers through oktsec proxy. Skipped when
+	// discovery is empty because there are no servers to wrap.
+	wrapOpts := discover.WrapOpts{
+		Enforce:    opts.enforce,
+		ConfigPath: absConfig,
+	}
+	for _, cr := range result.Clients {
+		if cr.Client == "claude-code" || !discover.IsWrappable(cr.Client) || len(cr.Servers) == 0 {
+			continue
+		}
+		wrapped, err := deps.wrapClient(cr.Client, wrapOpts)
+		name := discover.ClientDisplayName(cr.Client)
+		if err != nil {
+			fmt.Printf("    %-16s  error: %s\n", name, err)
+			continue
+		}
+		if wrapped > 0 {
+			fmt.Printf("    %-16s  %d server(s) wrapped\n", name, wrapped)
+			totalConnected += wrapped
+		}
+	}
+
+	if totalConnected > 0 {
+		fmt.Printf("\n    %d client(s) now routing through oktsec.\n", totalConnected)
+	}
+	fmt.Println()
 }
 
 

--- a/cmd/oktsec/commands/run_setup_test.go
+++ b/cmd/oktsec/commands/run_setup_test.go
@@ -1,0 +1,303 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/discover"
+)
+
+// stubDeps records what autoSetupWithDeps invoked and lets each test override
+// individual hooks. Defaults are deliberately strict — anything not opted in
+// fails the test.
+type stubDeps struct {
+	scanResult *discover.Result
+	scanErr    error
+
+	hasClaude bool
+
+	connectErr   error
+	connectCalls []connectCall
+
+	wrapResult int
+	wrapErr    error
+	wrapCalls  []wrapCall
+}
+
+type connectCall struct {
+	port     int
+	endpoint string
+}
+
+type wrapCall struct {
+	client string
+	opts   discover.WrapOpts
+}
+
+func (s *stubDeps) deps() autoSetupDeps {
+	return autoSetupDeps{
+		scan: func() (*discover.Result, error) {
+			if s.scanResult == nil && s.scanErr == nil {
+				return &discover.Result{}, nil
+			}
+			return s.scanResult, s.scanErr
+		},
+		hasClaudeCLI: func() bool { return s.hasClaude },
+		connectClaudeCode: func(port int, endpoint string) error {
+			s.connectCalls = append(s.connectCalls, connectCall{port: port, endpoint: endpoint})
+			return s.connectErr
+		},
+		wrapClient: func(client string, opts discover.WrapOpts) (int, error) {
+			s.wrapCalls = append(s.wrapCalls, wrapCall{client: client, opts: opts})
+			return s.wrapResult, s.wrapErr
+		},
+	}
+}
+
+// scrubKeysDir registers a cleanup that removes any keypair files written for
+// the given agent names. It is a defensive net for the non-empty-discovery
+// test: if HomeDir() was already memoized to the real user directory before
+// the test ran, the agent keypair lands there. We clean up regardless of
+// where it lands.
+func scrubKeysDir(t *testing.T, agents ...string) {
+	t.Helper()
+	keysDir := config.DefaultKeysDir()
+	t.Cleanup(func() {
+		for _, name := range agents {
+			_ = os.Remove(filepath.Join(keysDir, name+".priv"))
+			_ = os.Remove(filepath.Join(keysDir, name+".pub"))
+		}
+	})
+}
+
+// readConfig returns the contents of the generated oktsec.yaml as a string.
+func readConfig(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	return string(data)
+}
+
+// TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway is the direct
+// regression test for issue #176. When discovery finds zero MCP servers and
+// the `claude` CLI is available, oktsec run must still register the gateway
+// and install hooks.
+func TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubDeps{hasClaude: true}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
+		t.Fatalf(".env not created: %v", err)
+	}
+
+	if got := len(stub.connectCalls); got != 1 {
+		t.Fatalf("connectClaudeCode call count = %d, want 1", got)
+	}
+	got := stub.connectCalls[0]
+	if got.port != 9090 {
+		t.Errorf("connectClaudeCode port = %d, want 9090", got.port)
+	}
+	if got.endpoint != "/mcp" {
+		t.Errorf("connectClaudeCode endpoint = %q, want %q", got.endpoint, "/mcp")
+	}
+}
+
+// TestAutoSetup_EmptyDiscoverySkipWrapDoesNotConnectClaudeCode protects the
+// --skip-wrap opt-out: even when claude is on PATH, no external client
+// configuration should be mutated.
+func TestAutoSetup_EmptyDiscoverySkipWrapDoesNotConnectClaudeCode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubDeps{hasClaude: true}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{skipWrap: true}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
+		t.Fatalf(".env not created: %v", err)
+	}
+	if len(stub.connectCalls) != 0 {
+		t.Fatalf("connectClaudeCode called %d time(s) under --skip-wrap, want 0", len(stub.connectCalls))
+	}
+	if len(stub.wrapCalls) != 0 {
+		t.Fatalf("wrapClient called %d time(s) under --skip-wrap, want 0", len(stub.wrapCalls))
+	}
+}
+
+// TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes verifies that
+// first-run setup still succeeds when the `claude` CLI is not installed.
+// Missing claude is non-fatal: setup completes silently without a connection
+// attempt.
+func TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubDeps{hasClaude: false}
+	deps := stub.deps()
+	deps.connectClaudeCode = func(port int, endpoint string) error {
+		t.Fatalf("connectClaudeCode must not be called when claude CLI is missing (got port=%d endpoint=%q)", port, endpoint)
+		return nil
+	}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, deps); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
+		t.Fatalf(".env not created: %v", err)
+	}
+	if len(stub.connectCalls) != 0 {
+		t.Fatalf("connectClaudeCode called %d time(s) without claude CLI, want 0", len(stub.connectCalls))
+	}
+}
+
+// TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal preserves the
+// existing Step 4 behaviour: a `claude mcp add` failure must not abort
+// first-run setup.
+func TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubDeps{
+		hasClaude:  true,
+		connectErr: errors.New("simulated claude mcp add failure"),
+	}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps must not return error when connect fails: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
+		t.Fatalf(".env not created: %v", err)
+	}
+	if got := len(stub.connectCalls); got != 1 {
+		t.Fatalf("connectClaudeCode call count = %d, want 1 (must still attempt once)", got)
+	}
+}
+
+// TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway protects the
+// non-empty-discovery path. The bug fix routes both paths through the shared
+// helper; this test pins the original behaviour so the helper does not
+// regress it.
+func TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	const agent = "okt-test-disc-server"
+	scrubKeysDir(t, agent)
+
+	stub := &stubDeps{
+		hasClaude:  true,
+		wrapResult: 1,
+		scanResult: &discover.Result{
+			Clients: []discover.ClientResult{
+				{
+					Client: "cursor",
+					Path:   "/fake/cursor.json",
+					Servers: []discover.MCPServer{
+						{Name: agent, Command: "/bin/echo", Args: []string{"hi"}},
+					},
+				},
+			},
+		},
+	}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config not created: %v", err)
+	}
+
+	if got := len(stub.connectCalls); got != 1 {
+		t.Fatalf("connectClaudeCode call count = %d, want 1", got)
+	}
+
+	if got := len(stub.wrapCalls); got != 1 {
+		t.Fatalf("wrapClient call count = %d, want 1", got)
+	}
+	if stub.wrapCalls[0].client != "cursor" {
+		t.Errorf("wrapClient called with client = %q, want cursor", stub.wrapCalls[0].client)
+	}
+
+	cfgYAML := readConfig(t, cfgPath)
+	if !strings.Contains(cfgYAML, "mcp_servers:") {
+		t.Errorf("config missing mcp_servers block:\n%s", cfgYAML)
+	}
+	if !strings.Contains(cfgYAML, agent) {
+		t.Errorf("config missing discovered agent %q in mcp_servers:\n%s", agent, cfgYAML)
+	}
+}
+
+// TestAutoSetup_EmptyDiscoveryWritesGatewayConfig is a small belt-and-braces
+// check that the minimal config still enables the gateway (the gateway must
+// be running for Claude Code's HTTP MCP transport to connect).
+func TestAutoSetup_EmptyDiscoveryWritesGatewayConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubDeps{hasClaude: false}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	cfgYAML := readConfig(t, cfgPath)
+	wantSubstrings := []string{
+		"gateway:",
+		"enabled: true",
+		"port: 9090",
+		fmt.Sprintf("endpoint_path: %s", `/mcp`),
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(cfgYAML, s) {
+			t.Errorf("minimal config missing %q:\n%s", s, cfgYAML)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- make first-run setup continue into client bootstrap when MCP discovery finds zero servers
- register Claude Code gateway and install hooks in the empty-discovery case when `claude` is available
- preserve `--skip-wrap`, missing-CLI and connection-error semantics

Closes #176.

Discovery answers "did we find backend MCP servers to import?". Claude Code bootstrap answers "can we register oktsec as a runtime surface and install hooks?". Before this change, `autoSetup` collapsed those two questions: when discovery returned zero servers, it wrote a minimal config and returned without ever calling `autoConnectClaudeCode`, so neither the `oktsec-gateway` HTTP MCP entry nor the PreToolUse/PostToolUse hooks were installed.

The fix extracts the client-connection step into a shared `connectMCPClients` helper and routes both the empty and non-empty discovery paths through it. External effects (MCP discovery, `claude` CLI presence, gateway registration, generic client wrapping) are injected through an `autoSetupDeps` struct so the new behavior can be exercised in tests without invoking the real `claude` CLI or mutating `~/.claude/settings.json`.

`--skip-wrap` still short-circuits any external client mutation. Missing `claude` CLI and a failing `claude mcp add` both remain non-fatal.

## Test plan

- [x] `go test ./cmd/oktsec/commands`
- [x] `go test ./internal/discover`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `make build`
- [x] `make lint`

New tests added in `cmd/oktsec/commands/run_setup_test.go`:

- `TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway` — direct regression for the reported issue
- `TestAutoSetup_EmptyDiscoverySkipWrapDoesNotConnectClaudeCode` — preserves the `--skip-wrap` opt-out
- `TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes` — missing CLI stays non-fatal
- `TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal` — failed `claude mcp add` stays non-fatal
- `TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway` — non-empty path keeps wrapping non-Claude clients and still bootstraps Claude Code
- `TestAutoSetup_EmptyDiscoveryWritesGatewayConfig` — minimal config still enables the gateway on port 9090 at `/mcp`