### PR TITLE
Unify Claude Code runtime client lifecycle

### DIFF
--- a/cmd/oktsec/commands/claude_code_lifecycle.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle.go
@@ -147,17 +147,26 @@ func connectClaudeCodeRuntime(ctx context.Context, opts claudeCodeConnectOptions
 	// Gateway registration via `claude mcp add`. We always attempt it,
 	// even when the binary path is unresolvable, so the operator gets
 	// a clear failure mode.
+	//
+	// "Already present" is the repair case: the operator has run
+	// `connect claude-code` again because hooks are missing or stale.
+	// We treat it as idempotent success so the helper can continue
+	// into InstallV2 and fix the half-connected state.
 	result.GatewayAttempted = true
 	out, err := deps.runMCPAdd(ctx, port, endpoint)
 	result.GatewayOutput = string(out)
-	if err != nil {
+	switch {
+	case err == nil:
+		result.GatewayOK = true
+	case isClaudeMCPAlreadyPresent(out, err):
+		result.GatewayOK = true
+		result.Warnings = append(result.Warnings, "oktsec-gateway entry was already registered (continuing to verify hooks)")
+	default:
 		result.GatewayErr = fmt.Errorf("claude mcp add: %w (output: %s)", err, strings.TrimSpace(string(out)))
 		if opts.Mode == claudeConnectStrict {
 			return result, result.GatewayErr
 		}
 		result.Warnings = append(result.Warnings, result.GatewayErr.Error())
-	} else {
-		result.GatewayOK = true
 	}
 
 	// Hook manifest install via the shared V2 installer. The binary
@@ -207,16 +216,22 @@ func connectClaudeCodeRuntime(ctx context.Context, opts claudeCodeConnectOptions
 //
 // Hook uninstall always runs, even if `claude mcp remove` failed,
 // because a missing gateway entry must not block hook cleanup. The
-// caller renders warnings; a non-nil error is returned only when a
-// real mutation failed (a "no oktsec entries found" skip is success).
+// caller renders warnings; a non-nil error is returned when a real
+// mutation failed AND when the gateway state is unprovable. A "no
+// such oktsec entry" skip from the CLI is success; "we cannot run
+// the CLI at all" is partial-disconnect because the gateway entry
+// may still be registered.
 func disconnectClaudeCodeRuntime(ctx context.Context, opts claudeCodeDisconnectOptions, deps claudeCodeLifecycleDeps) (claudeCodeLifecycleResult, error) {
 	var result claudeCodeLifecycleResult
 
+	gatewayUnprovable := false
 	if !deps.hasClaudeCLI() {
-		// No CLI means we cannot remove the gateway entry, but we can
-		// still strip Oktsec-owned hooks from settings.json. Surface
-		// the missing CLI as a warning rather than a hard error.
-		result.Warnings = append(result.Warnings, "claude CLI not found on PATH; skipping `claude mcp remove`")
+		// No CLI means we cannot remove the gateway entry and we cannot
+		// verify whether one exists. We still strip Oktsec-owned hooks
+		// so the operator gets at least half the cleanup, but we must
+		// not claim a complete disconnect.
+		gatewayUnprovable = true
+		result.Warnings = append(result.Warnings, "claude CLI not found on PATH; cannot remove or verify oktsec-gateway entry")
 	} else {
 		result.GatewayAttempted = true
 		out, err := deps.runMCPRemove(ctx)
@@ -257,6 +272,9 @@ func disconnectClaudeCodeRuntime(ctx context.Context, opts claudeCodeDisconnectO
 	if result.HooksErr != nil {
 		return result, fmt.Errorf("partial disconnect: hook uninstall failed (%v); gateway entry was removed", result.HooksErr)
 	}
+	if gatewayUnprovable {
+		return result, fmt.Errorf("partial disconnect: claude CLI is not on PATH so the oktsec-gateway entry could not be removed or verified; install Claude Code or run `claude mcp remove oktsec-gateway` manually")
+	}
 	return result, nil
 }
 
@@ -273,4 +291,20 @@ func isClaudeMCPAlreadyAbsent(output []byte, err error) bool {
 	return strings.Contains(low, "not found") ||
 		strings.Contains(low, "no such mcp server") ||
 		strings.Contains(low, "is not configured")
+}
+
+// isClaudeMCPAlreadyPresent recognises the failure shape `claude mcp
+// add` returns when the named server is already registered. This is
+// the repair case: the operator runs `connect claude-code` again to
+// fix missing/stale hooks while the gateway entry already exists.
+// Treating it as idempotent success lets the helper continue into the
+// hook installer instead of refusing the repair.
+func isClaudeMCPAlreadyPresent(output []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	low := strings.ToLower(string(output))
+	return strings.Contains(low, "already exists") ||
+		strings.Contains(low, "already configured") ||
+		strings.Contains(low, "already registered")
 }

--- a/cmd/oktsec/commands/claude_code_lifecycle.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle.go
@@ -148,10 +148,15 @@ func connectClaudeCodeRuntime(ctx context.Context, opts claudeCodeConnectOptions
 	// even when the binary path is unresolvable, so the operator gets
 	// a clear failure mode.
 	//
-	// "Already present" is the repair case: the operator has run
-	// `connect claude-code` again because hooks are missing or stale.
-	// We treat it as idempotent success so the helper can continue
-	// into InstallV2 and fix the half-connected state.
+	// "Already present" is treated as a convergence target, not as
+	// idempotent success on its own: an existing oktsec-gateway entry
+	// proves a name match but says nothing about whether its URL,
+	// transport, header or scope match the desired port/endpoint. If
+	// the operator changed `gateway.port` or `gateway.endpoint_path`
+	// in oktsec.yaml, the stale entry would silently keep Claude Code
+	// pointing at the old URL while we install hooks for the new one.
+	// We collapse that risk by removing and re-adding so the resulting
+	// entry is the one this connect call describes.
 	result.GatewayAttempted = true
 	out, err := deps.runMCPAdd(ctx, port, endpoint)
 	result.GatewayOutput = string(out)
@@ -159,8 +164,19 @@ func connectClaudeCodeRuntime(ctx context.Context, opts claudeCodeConnectOptions
 	case err == nil:
 		result.GatewayOK = true
 	case isClaudeMCPAlreadyPresent(out, err):
-		result.GatewayOK = true
-		result.Warnings = append(result.Warnings, "oktsec-gateway entry was already registered (continuing to verify hooks)")
+		repointed, repointErr := repointClaudeMCPGateway(ctx, port, endpoint, deps)
+		result.GatewayOutput = string(repointed)
+		if repointErr != nil {
+			result.GatewayErr = repointErr
+			if opts.Mode == claudeConnectStrict {
+				return result, repointErr
+			}
+			result.Warnings = append(result.Warnings, repointErr.Error())
+		} else {
+			result.GatewayOK = true
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("oktsec-gateway entry already existed; re-pointed to http://127.0.0.1:%d%s", port, endpoint))
+		}
 	default:
 		result.GatewayErr = fmt.Errorf("claude mcp add: %w (output: %s)", err, strings.TrimSpace(string(out)))
 		if opts.Mode == claudeConnectStrict {
@@ -296,9 +312,10 @@ func isClaudeMCPAlreadyAbsent(output []byte, err error) bool {
 // isClaudeMCPAlreadyPresent recognises the failure shape `claude mcp
 // add` returns when the named server is already registered. This is
 // the repair case: the operator runs `connect claude-code` again to
-// fix missing/stale hooks while the gateway entry already exists.
-// Treating it as idempotent success lets the helper continue into the
-// hook installer instead of refusing the repair.
+// fix missing/stale hooks (or to re-point the gateway after changing
+// gateway.port / gateway.endpoint_path in oktsec.yaml). The caller
+// converges by removing and re-adding so the entry matches the
+// requested URL.
 func isClaudeMCPAlreadyPresent(output []byte, err error) bool {
 	if err == nil {
 		return false
@@ -307,4 +324,23 @@ func isClaudeMCPAlreadyPresent(output []byte, err error) bool {
 	return strings.Contains(low, "already exists") ||
 		strings.Contains(low, "already configured") ||
 		strings.Contains(low, "already registered")
+}
+
+// repointClaudeMCPGateway is the convergence path for an
+// already-present oktsec-gateway entry: remove it and re-add at the
+// caller's port/endpoint. We treat an already-absent remove as
+// success because the user (or another process) may have removed the
+// entry between our add and remove calls; the re-add is what
+// determines whether convergence actually happened. Returns the most
+// recent CLI output for context-sensitive error messages.
+func repointClaudeMCPGateway(ctx context.Context, port int, endpoint string, deps claudeCodeLifecycleDeps) ([]byte, error) {
+	rmOut, rmErr := deps.runMCPRemove(ctx)
+	if rmErr != nil && !isClaudeMCPAlreadyAbsent(rmOut, rmErr) {
+		return rmOut, fmt.Errorf("re-pointing gateway: claude mcp remove failed: %w (output: %s)", rmErr, strings.TrimSpace(string(rmOut)))
+	}
+	addOut, addErr := deps.runMCPAdd(ctx, port, endpoint)
+	if addErr != nil {
+		return addOut, fmt.Errorf("re-pointing gateway: claude mcp add after remove failed: %w (output: %s)", addErr, strings.TrimSpace(string(addOut)))
+	}
+	return addOut, nil
 }

--- a/cmd/oktsec/commands/claude_code_lifecycle.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle.go
@@ -1,0 +1,276 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+)
+
+// claudeCodeLifecycleDeps wraps the four external effects needed to
+// connect or disconnect Claude Code as an Oktsec runtime surface:
+//   - is the `claude` CLI on PATH;
+//   - run `claude mcp add` / `claude mcp remove` for the gateway entry;
+//   - install / uninstall the Phase 2 hook manifest via the shared
+//     claudecode connector package.
+//
+// All four are injected so the run, connect, and disconnect commands
+// can drive the same lifecycle path without invoking the real CLI or
+// mutating real ~/.claude state in tests.
+type claudeCodeLifecycleDeps struct {
+	hasClaudeCLI     func() bool
+	runMCPAdd        func(ctx context.Context, port int, endpoint string) ([]byte, error)
+	runMCPRemove     func(ctx context.Context) ([]byte, error)
+	installHooksV2   func(ctx context.Context, opts claudecode.InstallOptions) (claudecode.InstallResult, error)
+	uninstallHooksV2 func(ctx context.Context, opts claudecode.UninstallOptions) (claudecode.UninstallResult, error)
+	executable       func() (string, error)
+}
+
+func defaultClaudeCodeLifecycleDeps() claudeCodeLifecycleDeps {
+	return claudeCodeLifecycleDeps{
+		hasClaudeCLI: hasClaudeCLI,
+		runMCPAdd: func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+			url := fmt.Sprintf("http://127.0.0.1:%d%s", port, endpoint)
+			//nolint:gosec // args are not user-controlled
+			return exec.CommandContext(ctx,
+				"claude", "mcp", "add",
+				"--transport", "http",
+				"--header", "X-Oktsec-Agent: claude-code",
+				"--scope", "user",
+				"oktsec-gateway", url,
+			).CombinedOutput()
+		},
+		runMCPRemove: func(ctx context.Context) ([]byte, error) {
+			//nolint:gosec // args are not user-controlled
+			return exec.CommandContext(ctx, "claude", "mcp", "remove", "oktsec-gateway").CombinedOutput()
+		},
+		installHooksV2:   claudecode.InstallV2,
+		uninstallHooksV2: claudecode.UninstallV2,
+		executable:       os.Executable,
+	}
+}
+
+// claudeCodeConnectMode controls how connect failures are reported.
+//
+//   - claudeConnectBestEffort is used by `oktsec run` first-run setup:
+//     missing CLI, gateway-add failure and hook-install failure are all
+//     non-fatal but surfaced as warnings.
+//   - claudeConnectStrict is used by `oktsec connect claude-code`: any
+//     real failure (gateway add or hook install) returns a non-nil
+//     error so the operator knows the surface is not fully connected.
+type claudeCodeConnectMode int
+
+const (
+	claudeConnectBestEffort claudeCodeConnectMode = iota
+	claudeConnectStrict
+)
+
+type claudeCodeConnectOptions struct {
+	Port          int
+	Endpoint      string
+	Mode          claudeCodeConnectMode
+	FollowSymlink bool
+	DryRun        bool
+}
+
+type claudeCodeDisconnectOptions struct {
+	FollowSymlink bool
+	DryRun        bool
+}
+
+// claudeCodeLifecycleResult is the structured outcome of a connect or
+// disconnect attempt. The two callers use it to render human output
+// and to decide whether the operation should return an error.
+type claudeCodeLifecycleResult struct {
+	GatewayAttempted bool
+	GatewayOK        bool
+	GatewayErr       error
+	GatewayOutput    string
+
+	HooksAttempted  bool
+	HooksOK         bool
+	HooksErr        error
+	InstallResult   *claudecode.InstallResult
+	UninstallResult *claudecode.UninstallResult
+
+	Warnings []string
+}
+
+// Partial is true when exactly one side of the lifecycle (gateway or
+// hooks) succeeded. Both succeeded or both failed is not partial.
+func (r claudeCodeLifecycleResult) Partial() bool {
+	if !r.GatewayAttempted || !r.HooksAttempted {
+		return false
+	}
+	return r.GatewayOK != r.HooksOK
+}
+
+// Connected is true when the gateway entry and hook manifest are both
+// present (either freshly installed in this call or already in place).
+func (r claudeCodeLifecycleResult) Connected() bool {
+	return r.GatewayAttempted && r.GatewayOK && r.HooksAttempted && r.HooksOK
+}
+
+// connectClaudeCodeRuntime registers oktsec-gateway via `claude mcp
+// add` and installs the Phase 2 hook manifest via claudecode.InstallV2.
+//
+// In best-effort mode the function never returns a non-nil error; the
+// caller inspects the result to decide what to print. In strict mode
+// the function returns a non-nil error if either gateway registration
+// or hook install fails for a real reason (idempotent / already-present
+// outcomes still count as success).
+func connectClaudeCodeRuntime(ctx context.Context, opts claudeCodeConnectOptions, deps claudeCodeLifecycleDeps) (claudeCodeLifecycleResult, error) {
+	port := opts.Port
+	if port <= 0 {
+		port = 9090
+	}
+	endpoint := opts.Endpoint
+	if endpoint == "" {
+		endpoint = "/mcp"
+	}
+
+	var result claudeCodeLifecycleResult
+
+	if !deps.hasClaudeCLI() {
+		msg := "claude CLI not found on PATH; install Claude Code or run `claude --version`"
+		if opts.Mode == claudeConnectStrict {
+			return result, errors.New(msg)
+		}
+		result.Warnings = append(result.Warnings, msg)
+		return result, nil
+	}
+
+	// Gateway registration via `claude mcp add`. We always attempt it,
+	// even when the binary path is unresolvable, so the operator gets
+	// a clear failure mode.
+	result.GatewayAttempted = true
+	out, err := deps.runMCPAdd(ctx, port, endpoint)
+	result.GatewayOutput = string(out)
+	if err != nil {
+		result.GatewayErr = fmt.Errorf("claude mcp add: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		if opts.Mode == claudeConnectStrict {
+			return result, result.GatewayErr
+		}
+		result.Warnings = append(result.Warnings, result.GatewayErr.Error())
+	} else {
+		result.GatewayOK = true
+	}
+
+	// Hook manifest install via the shared V2 installer. The binary
+	// path is required so the manifest commands can call back into
+	// this binary.
+	exe, exeErr := deps.executable()
+	if exeErr != nil || exe == "" {
+		hookErr := fmt.Errorf("resolving oktsec binary path: %w", exeErr)
+		result.HooksAttempted = true
+		result.HooksErr = hookErr
+		if opts.Mode == claudeConnectStrict {
+			return result, hookErr
+		}
+		result.Warnings = append(result.Warnings, hookErr.Error())
+		return result, nil
+	}
+
+	result.HooksAttempted = true
+	installRes, installErr := deps.installHooksV2(ctx, claudecode.InstallOptions{
+		BinaryPath:    exe,
+		GatewayPort:   port,
+		FollowSymlink: opts.FollowSymlink,
+		DryRun:        opts.DryRun,
+	})
+	result.InstallResult = &installRes
+	if installErr != nil {
+		result.HooksErr = installErr
+		if opts.Mode == claudeConnectStrict {
+			return result, installErr
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("hook install: %s", installErr.Error()))
+		return result, nil
+	}
+	// Idempotent skip ("byte-identical to current file" or "dry-run") is
+	// still a success: the manifest is already in place.
+	result.HooksOK = true
+
+	if opts.Mode == claudeConnectStrict && result.Partial() {
+		return result, fmt.Errorf("partial connect: gateway=%t hooks=%t", result.GatewayOK, result.HooksOK)
+	}
+	return result, nil
+}
+
+// disconnectClaudeCodeRuntime removes the oktsec-gateway entry via
+// `claude mcp remove` and removes every Oktsec-owned hook entry (V2
+// plus legacy V1) via claudecode.UninstallV2.
+//
+// Hook uninstall always runs, even if `claude mcp remove` failed,
+// because a missing gateway entry must not block hook cleanup. The
+// caller renders warnings; a non-nil error is returned only when a
+// real mutation failed (a "no oktsec entries found" skip is success).
+func disconnectClaudeCodeRuntime(ctx context.Context, opts claudeCodeDisconnectOptions, deps claudeCodeLifecycleDeps) (claudeCodeLifecycleResult, error) {
+	var result claudeCodeLifecycleResult
+
+	if !deps.hasClaudeCLI() {
+		// No CLI means we cannot remove the gateway entry, but we can
+		// still strip Oktsec-owned hooks from settings.json. Surface
+		// the missing CLI as a warning rather than a hard error.
+		result.Warnings = append(result.Warnings, "claude CLI not found on PATH; skipping `claude mcp remove`")
+	} else {
+		result.GatewayAttempted = true
+		out, err := deps.runMCPRemove(ctx)
+		result.GatewayOutput = string(out)
+		switch {
+		case err == nil:
+			result.GatewayOK = true
+		case isClaudeMCPAlreadyAbsent(out, err):
+			// Already-absent is the success state for an idempotent
+			// disconnect: the operator's intent ("no oktsec gateway
+			// entry") already holds. Mark it OK and surface a warning.
+			result.GatewayOK = true
+			result.Warnings = append(result.Warnings, "oktsec-gateway entry was already absent")
+		default:
+			result.GatewayErr = fmt.Errorf("claude mcp remove: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	result.HooksAttempted = true
+	uninstallRes, uninstallErr := deps.uninstallHooksV2(ctx, claudecode.UninstallOptions{
+		FollowSymlink:   opts.FollowSymlink,
+		DryRun:          opts.DryRun,
+		IncludeLegacyV1: true,
+	})
+	result.UninstallResult = &uninstallRes
+	if uninstallErr != nil {
+		result.HooksErr = uninstallErr
+	} else {
+		result.HooksOK = true
+	}
+
+	if result.GatewayErr != nil && result.HooksErr != nil {
+		return result, fmt.Errorf("disconnect failed: gateway=%v; hooks=%v", result.GatewayErr, result.HooksErr)
+	}
+	if result.GatewayErr != nil {
+		return result, fmt.Errorf("partial disconnect: gateway removal failed (%v); hooks were uninstalled", result.GatewayErr)
+	}
+	if result.HooksErr != nil {
+		return result, fmt.Errorf("partial disconnect: hook uninstall failed (%v); gateway entry was removed", result.HooksErr)
+	}
+	return result, nil
+}
+
+// isClaudeMCPAlreadyAbsent recognises the failure shape `claude mcp
+// remove` returns when the named server was not registered. The CLI
+// emits messages like "MCP server \"oktsec-gateway\" not found" with a
+// non-zero exit code; we treat that as idempotent success rather than
+// blocking hook cleanup behind a CLI noop.
+func isClaudeMCPAlreadyAbsent(output []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	low := strings.ToLower(string(output))
+	return strings.Contains(low, "not found") ||
+		strings.Contains(low, "no such mcp server") ||
+		strings.Contains(low, "is not configured")
+}

--- a/cmd/oktsec/commands/claude_code_lifecycle_test.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle_test.go
@@ -234,6 +234,70 @@ func TestDisconnectClaudeCode_GatewayMissingStillAttemptsHookUninstall(t *testin
 	}
 }
 
+// TestConnectClaudeCode_GatewayAlreadyPresentIsRepairCase verifies that
+// when `claude mcp add` reports the entry already exists, the helper
+// treats it as idempotent success and continues into hook install.
+// This is the "repair connection" path: gateway present, hooks missing
+// or stale, operator runs `oktsec connect claude-code` again.
+func TestConnectClaudeCode_GatewayAlreadyPresentIsRepairCase(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:        true,
+		addOut:        []byte("Error: MCP server \"oktsec-gateway\" already exists"),
+		addErr:        errors.New("exit status 1"),
+		installResult: claudecode.InstallResult{Wrote: true},
+	}
+	res, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
+		stub.deps())
+	if err != nil {
+		t.Fatalf("strict connect must succeed when gateway already exists: %v", err)
+	}
+	if !res.GatewayOK {
+		t.Errorf("gateway should be marked OK on already-present; got %+v", res)
+	}
+	if !res.HooksOK {
+		t.Errorf("hooks must still install; got %+v", res)
+	}
+	if stub.installCalls != 1 {
+		t.Errorf("installHooksV2 must run after already-present gateway; calls=%d", stub.installCalls)
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected an informational warning about already-present gateway")
+	}
+}
+
+// TestDisconnectClaudeCode_MissingCLIReturnsPartialError pins the
+// stricter disconnect contract: when claude is not on PATH we cannot
+// remove or verify the gateway entry, so disconnect must report a
+// partial state even if hook uninstall succeeded.
+func TestDisconnectClaudeCode_MissingCLIReturnsPartialError(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:          false,
+		uninstallResult: claudecode.UninstallResult{Wrote: true, RemovedV2: 14},
+	}
+	res, err := disconnectClaudeCodeRuntime(context.Background(),
+		claudeCodeDisconnectOptions{},
+		stub.deps())
+	if err == nil {
+		t.Fatal("disconnect must return error when claude CLI is missing (gateway state is unprovable)")
+	}
+	if !strings.Contains(err.Error(), "claude CLI is not on PATH") {
+		t.Errorf("error should explain the missing CLI; got %v", err)
+	}
+	if res.GatewayAttempted {
+		t.Errorf("gateway must not be marked attempted when the CLI is missing")
+	}
+	if !res.HooksOK {
+		t.Errorf("hooks should still be cleaned up; got %+v", res)
+	}
+	if stub.uninstallCalls != 1 {
+		t.Errorf("hooks uninstall must still run; calls=%d", stub.uninstallCalls)
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected a warning about the missing CLI")
+	}
+}
+
 // TestPartialAndConnected_HelperContract pins the small predicate
 // methods on the lifecycle result so callers can rely on them.
 func TestPartialAndConnected_HelperContract(t *testing.T) {

--- a/cmd/oktsec/commands/claude_code_lifecycle_test.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle_test.go
@@ -234,35 +234,114 @@ func TestDisconnectClaudeCode_GatewayMissingStillAttemptsHookUninstall(t *testin
 	}
 }
 
-// TestConnectClaudeCode_GatewayAlreadyPresentIsRepairCase verifies that
-// when `claude mcp add` reports the entry already exists, the helper
-// treats it as idempotent success and continues into hook install.
-// This is the "repair connection" path: gateway present, hooks missing
-// or stale, operator runs `oktsec connect claude-code` again.
-func TestConnectClaudeCode_GatewayAlreadyPresentIsRepairCase(t *testing.T) {
+// addBehavior controls the runMCPAdd stub across calls. The first
+// call returns the configured initial output/err; subsequent calls
+// return the second output/err. Useful for the re-point convergence
+// path where the helper calls runMCPAdd twice (once to detect
+// already-present, again after remove).
+type addBehavior struct {
+	calls    int
+	first    []byte
+	firstErr error
+	second   []byte
+	secondEr error
+}
+
+// TestConnectClaudeCode_GatewayAlreadyPresentRepointsAndContinues
+// verifies the convergence contract: when `claude mcp add` reports
+// the entry already exists, the helper removes the stale entry and
+// re-adds at the caller's port/endpoint so the resulting Claude Code
+// runtime points where this connect call says it should. This is the
+// repair case (hooks missing or stale) AND the re-configure case
+// (operator changed gateway.port / gateway.endpoint_path).
+func TestConnectClaudeCode_GatewayAlreadyPresentRepointsAndContinues(t *testing.T) {
+	addBeh := &addBehavior{
+		first:    []byte("Error: MCP server \"oktsec-gateway\" already exists"),
+		firstErr: errors.New("exit status 1"),
+		second:   []byte("ok"),
+	}
 	stub := &stubLifecycleDeps{
 		hasCLI:        true,
-		addOut:        []byte("Error: MCP server \"oktsec-gateway\" already exists"),
-		addErr:        errors.New("exit status 1"),
 		installResult: claudecode.InstallResult{Wrote: true},
 	}
+	deps := stub.deps()
+	deps.runMCPAdd = func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+		stub.addCalls++
+		stub.addSeenPort = port
+		stub.addSeenEP = endpoint
+		addBeh.calls++
+		if addBeh.calls == 1 {
+			return addBeh.first, addBeh.firstErr
+		}
+		return addBeh.second, addBeh.secondEr
+	}
+
 	res, err := connectClaudeCodeRuntime(context.Background(),
-		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
-		stub.deps())
+		claudeCodeConnectOptions{Port: 9595, Endpoint: "/oktsec-mcp", Mode: claudeConnectStrict},
+		deps)
 	if err != nil {
-		t.Fatalf("strict connect must succeed when gateway already exists: %v", err)
+		t.Fatalf("strict connect must converge when gateway already exists: %v", err)
 	}
 	if !res.GatewayOK {
-		t.Errorf("gateway should be marked OK on already-present; got %+v", res)
+		t.Errorf("gateway should be marked OK after re-point; got %+v", res)
 	}
 	if !res.HooksOK {
 		t.Errorf("hooks must still install; got %+v", res)
 	}
-	if stub.installCalls != 1 {
-		t.Errorf("installHooksV2 must run after already-present gateway; calls=%d", stub.installCalls)
+	if stub.addCalls != 2 {
+		t.Errorf("runMCPAdd must run twice (initial + re-point); calls=%d", stub.addCalls)
 	}
-	if len(res.Warnings) == 0 {
-		t.Errorf("expected an informational warning about already-present gateway")
+	if stub.removeCalls != 1 {
+		t.Errorf("runMCPRemove must run once between the two adds; calls=%d", stub.removeCalls)
+	}
+	if stub.addSeenPort != 9595 || stub.addSeenEP != "/oktsec-mcp" {
+		t.Errorf("re-pointed entry must use the requested port/endpoint; got %d %q", stub.addSeenPort, stub.addSeenEP)
+	}
+	if stub.installCalls != 1 {
+		t.Errorf("installHooksV2 must run after gateway converges; calls=%d", stub.installCalls)
+	}
+	repointed := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "re-pointed") {
+			repointed = true
+			break
+		}
+	}
+	if !repointed {
+		t.Errorf("expected a warning describing the re-point; got %v", res.Warnings)
+	}
+}
+
+// TestConnectClaudeCode_GatewayAlreadyPresentRepointFailsReturnsError
+// guards strict mode against silent split-runtime states: if remove +
+// re-add cannot converge the gateway entry, we must return an error
+// rather than mark GatewayOK.
+func TestConnectClaudeCode_GatewayAlreadyPresentRepointFailsReturnsError(t *testing.T) {
+	addBeh := &addBehavior{
+		first:    []byte("Error: MCP server \"oktsec-gateway\" already exists"),
+		firstErr: errors.New("exit status 1"),
+		second:   []byte("Error: invalid URL"),
+		secondEr: errors.New("exit status 2"),
+	}
+	stub := &stubLifecycleDeps{hasCLI: true}
+	deps := stub.deps()
+	deps.runMCPAdd = func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+		addBeh.calls++
+		stub.addCalls++
+		if addBeh.calls == 1 {
+			return addBeh.first, addBeh.firstErr
+		}
+		return addBeh.second, addBeh.secondEr
+	}
+
+	_, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
+		deps)
+	if err == nil {
+		t.Fatal("strict connect must return error when re-point fails")
+	}
+	if !strings.Contains(err.Error(), "re-pointing gateway") {
+		t.Errorf("error should explain the re-point failure; got %v", err)
 	}
 }
 

--- a/cmd/oktsec/commands/claude_code_lifecycle_test.go
+++ b/cmd/oktsec/commands/claude_code_lifecycle_test.go
@@ -1,0 +1,287 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+)
+
+// stubLifecycleDeps records every external call the lifecycle helper
+// would make. Each callback can be overridden per test. Defaults match
+// the happy path: claude is on PATH, gateway add succeeds, install /
+// uninstall succeed.
+type stubLifecycleDeps struct {
+	hasCLI bool
+
+	addCalls    int
+	addOut      []byte
+	addErr      error
+	addSeenPort int
+	addSeenEP   string
+
+	removeCalls int
+	removeOut   []byte
+	removeErr   error
+
+	installCalls   int
+	installResult  claudecode.InstallResult
+	installErr     error
+	installSeenOpt claudecode.InstallOptions
+
+	uninstallCalls   int
+	uninstallResult  claudecode.UninstallResult
+	uninstallErr     error
+	uninstallSeenOpt claudecode.UninstallOptions
+
+	exePath string
+	exeErr  error
+}
+
+func (s *stubLifecycleDeps) deps() claudeCodeLifecycleDeps {
+	return claudeCodeLifecycleDeps{
+		hasClaudeCLI: func() bool { return s.hasCLI },
+		runMCPAdd: func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+			s.addCalls++
+			s.addSeenPort = port
+			s.addSeenEP = endpoint
+			return s.addOut, s.addErr
+		},
+		runMCPRemove: func(ctx context.Context) ([]byte, error) {
+			s.removeCalls++
+			return s.removeOut, s.removeErr
+		},
+		installHooksV2: func(ctx context.Context, opts claudecode.InstallOptions) (claudecode.InstallResult, error) {
+			s.installCalls++
+			s.installSeenOpt = opts
+			return s.installResult, s.installErr
+		},
+		uninstallHooksV2: func(ctx context.Context, opts claudecode.UninstallOptions) (claudecode.UninstallResult, error) {
+			s.uninstallCalls++
+			s.uninstallSeenOpt = opts
+			return s.uninstallResult, s.uninstallErr
+		},
+		executable: func() (string, error) {
+			if s.exePath == "" && s.exeErr == nil {
+				return "/usr/local/bin/oktsec", nil
+			}
+			return s.exePath, s.exeErr
+		},
+	}
+}
+
+// TestConnectClaudeCode_InstallsGatewayAndHooks verifies the strict
+// connect contract: `oktsec connect claude-code` registers the gateway
+// AND installs the V2 hook manifest. Both must succeed for the helper
+// to return success.
+func TestConnectClaudeCode_InstallsGatewayAndHooks(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:        true,
+		installResult: claudecode.InstallResult{Wrote: true},
+	}
+	res, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
+		stub.deps())
+	if err != nil {
+		t.Fatalf("connectClaudeCodeRuntime: %v", err)
+	}
+	if stub.addCalls != 1 {
+		t.Errorf("runMCPAdd calls = %d, want 1", stub.addCalls)
+	}
+	if stub.installCalls != 1 {
+		t.Errorf("installHooksV2 calls = %d, want 1", stub.installCalls)
+	}
+	if !res.Connected() {
+		t.Errorf("expected Connected() = true, got %+v", res)
+	}
+	if stub.installSeenOpt.GatewayPort != 9090 {
+		t.Errorf("install opts GatewayPort = %d, want 9090", stub.installSeenOpt.GatewayPort)
+	}
+}
+
+// TestConnectClaudeCode_HookFailureReturnsPartialError verifies strict
+// mode: gateway succeeds but hooks fail, so the helper returns a
+// non-nil error and the result records partial state.
+func TestConnectClaudeCode_HookFailureReturnsPartialError(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:     true,
+		installErr: errors.New("simulated install failure"),
+	}
+	res, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
+		stub.deps())
+	if err == nil {
+		t.Fatal("expected non-nil error in strict mode when hook install fails")
+	}
+	if res.GatewayOK == false {
+		t.Errorf("gateway should be OK; got %+v", res)
+	}
+	if res.HooksOK {
+		t.Errorf("hooks must not be OK when install failed")
+	}
+}
+
+// TestConnectClaudeCode_StrictMissingCLIErrors guards strict mode
+// against silently degrading when the user explicitly asked to connect.
+func TestConnectClaudeCode_StrictMissingCLIErrors(t *testing.T) {
+	stub := &stubLifecycleDeps{hasCLI: false}
+	_, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Mode: claudeConnectStrict},
+		stub.deps())
+	if err == nil {
+		t.Fatal("expected error when claude CLI is missing in strict mode")
+	}
+}
+
+// TestConnectClaudeCode_BestEffortMissingCLINoError ensures `oktsec run`
+// keeps its best-effort posture when claude is not installed.
+func TestConnectClaudeCode_BestEffortMissingCLINoError(t *testing.T) {
+	stub := &stubLifecycleDeps{hasCLI: false}
+	res, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Mode: claudeConnectBestEffort},
+		stub.deps())
+	if err != nil {
+		t.Fatalf("best-effort mode must not return error when CLI is missing: %v", err)
+	}
+	if res.GatewayAttempted || res.HooksAttempted {
+		t.Errorf("nothing should be attempted when CLI is missing")
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected a warning about the missing CLI")
+	}
+}
+
+// TestDisconnectClaudeCode_RemovesGatewayAndHooks verifies the
+// disconnect contract: gateway entry is removed AND every Oktsec-owned
+// hook (V2 plus legacy V1) is uninstalled.
+func TestDisconnectClaudeCode_RemovesGatewayAndHooks(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:          true,
+		uninstallResult: claudecode.UninstallResult{Wrote: true, RemovedV2: 12, RemovedV1: 2},
+	}
+	res, err := disconnectClaudeCodeRuntime(context.Background(),
+		claudeCodeDisconnectOptions{},
+		stub.deps())
+	if err != nil {
+		t.Fatalf("disconnectClaudeCodeRuntime: %v", err)
+	}
+	if stub.removeCalls != 1 {
+		t.Errorf("runMCPRemove calls = %d, want 1", stub.removeCalls)
+	}
+	if stub.uninstallCalls != 1 {
+		t.Errorf("uninstallHooksV2 calls = %d, want 1", stub.uninstallCalls)
+	}
+	if !stub.uninstallSeenOpt.IncludeLegacyV1 {
+		t.Errorf("uninstall must request IncludeLegacyV1 = true")
+	}
+	if !res.GatewayOK || !res.HooksOK {
+		t.Errorf("expected both sides OK; got %+v", res)
+	}
+}
+
+// TestDisconnectClaudeCode_HookUninstallFailureReturnsPartialError
+// verifies that when the gateway is removed but hook uninstall fails,
+// the operator gets a non-zero exit and a partial-state message.
+func TestDisconnectClaudeCode_HookUninstallFailureReturnsPartialError(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:       true,
+		uninstallErr: errors.New("simulated uninstall failure"),
+	}
+	_, err := disconnectClaudeCodeRuntime(context.Background(),
+		claudeCodeDisconnectOptions{},
+		stub.deps())
+	if err == nil {
+		t.Fatal("expected non-nil error when hook uninstall fails")
+	}
+	if !strings.Contains(err.Error(), "hook uninstall failed") {
+		t.Errorf("error should mention partial disconnect; got %v", err)
+	}
+}
+
+// TestDisconnectClaudeCode_GatewayMissingStillAttemptsHookUninstall
+// verifies that when `claude mcp remove` reports the entry is already
+// absent, hook uninstall still runs. Leaving Oktsec hooks behind after
+// a "disconnect" creates a confusing state for the operator.
+func TestDisconnectClaudeCode_GatewayMissingStillAttemptsHookUninstall(t *testing.T) {
+	stub := &stubLifecycleDeps{
+		hasCLI:    true,
+		removeOut: []byte("Error: MCP server \"oktsec-gateway\" not found"),
+		removeErr: errors.New("exit status 1"),
+		uninstallResult: claudecode.UninstallResult{
+			Wrote:     true,
+			RemovedV2: 14,
+		},
+	}
+	res, err := disconnectClaudeCodeRuntime(context.Background(),
+		claudeCodeDisconnectOptions{},
+		stub.deps())
+	if err != nil {
+		t.Fatalf("disconnect returned error when gateway was already absent: %v", err)
+	}
+	if stub.uninstallCalls != 1 {
+		t.Errorf("uninstallHooksV2 must run even if gateway removal reports absent; got %d", stub.uninstallCalls)
+	}
+	if !res.GatewayOK {
+		t.Errorf("already-absent should count as success")
+	}
+	if !res.HooksOK {
+		t.Errorf("hooks should be OK; got %+v", res)
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected an informational warning about already-absent gateway")
+	}
+}
+
+// TestPartialAndConnected_HelperContract pins the small predicate
+// methods on the lifecycle result so callers can rely on them.
+func TestPartialAndConnected_HelperContract(t *testing.T) {
+	cases := []struct {
+		name      string
+		res       claudeCodeLifecycleResult
+		partial   bool
+		connected bool
+	}{
+		{
+			name: "both ok",
+			res: claudeCodeLifecycleResult{
+				GatewayAttempted: true, GatewayOK: true,
+				HooksAttempted: true, HooksOK: true,
+			},
+			partial: false, connected: true,
+		},
+		{
+			name: "gateway only",
+			res: claudeCodeLifecycleResult{
+				GatewayAttempted: true, GatewayOK: true,
+				HooksAttempted: true, HooksOK: false,
+			},
+			partial: true, connected: false,
+		},
+		{
+			name: "hooks only",
+			res: claudeCodeLifecycleResult{
+				GatewayAttempted: true, GatewayOK: false,
+				HooksAttempted: true, HooksOK: true,
+			},
+			partial: true, connected: false,
+		},
+		{
+			name:      "nothing attempted",
+			res:       claudeCodeLifecycleResult{},
+			partial:   false,
+			connected: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.res.Partial(); got != tc.partial {
+				t.Errorf("Partial() = %t, want %t", got, tc.partial)
+			}
+			if got := tc.res.Connected(); got != tc.connected {
+				t.Errorf("Connected() = %t, want %t", got, tc.connected)
+			}
+		})
+	}
+}

--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -1,16 +1,22 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/discover"
 	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/spf13/cobra"
 )
+
+// claudeCodeLifecycleDepsForCmd is overridable in tests so the connect /
+// disconnect commands can run without invoking the real claude CLI or
+// touching ~/.claude/settings.json. Production callers use the default.
+var claudeCodeLifecycleDepsForCmd = defaultClaudeCodeLifecycleDeps
 
 func newConnectCmd() *cobra.Command {
 	var keysDir string
@@ -128,7 +134,11 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 	return cmd
 }
 
-// connectClaudeCode runs `claude mcp add` to register the oktsec gateway as an HTTP MCP server.
+// connectClaudeCode registers the oktsec gateway entry and installs the V2
+// hook manifest through the shared Claude Code lifecycle helper. Strict mode:
+// gateway add failure or hook install failure both return a non-nil error so
+// the operator can trust that a successful return means Claude Code is fully
+// connected as a runtime surface.
 func connectClaudeCode(cfg *config.Config) error {
 	port := cfg.Gateway.Port
 	if port == 0 {
@@ -140,22 +150,37 @@ func connectClaudeCode(cfg *config.Config) error {
 	}
 
 	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, endpoint)
-
 	fmt.Printf("Connecting Claude Code to gateway at %s...\n", url)
 
-	//nolint:gosec // args are not user-controlled
-	out, err := exec.Command(
-		"claude", "mcp", "add",
-		"--transport", "http",
-		"--header", "X-Oktsec-Agent: claude-code",
-		"--scope", "user",
-		"oktsec-gateway", url,
-	).CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := connectClaudeCodeRuntime(ctx, claudeCodeConnectOptions{
+		Port:     port,
+		Endpoint: endpoint,
+		Mode:     claudeConnectStrict,
+	}, claudeCodeLifecycleDepsForCmd())
 	if err != nil {
-		return fmt.Errorf("running 'claude mcp add': %w\n%s", err, string(out))
+		fmt.Println()
+		fmt.Println("Connection incomplete. Run `oktsec doctor claude-code` for the full inventory.")
+		return err
 	}
 
-	fmt.Println("Claude Code configured with HTTP MCP transport.")
+	fmt.Println("Gateway entry added; HTTP MCP transport configured.")
+	if res.InstallResult != nil {
+		switch {
+		case res.InstallResult.Wrote:
+			fmt.Printf("Installed %d hook(s) via the V2 manifest installer.\n", len(res.InstallResult.Plan))
+			if res.InstallResult.UpgradedV1 > 0 {
+				fmt.Printf("Upgraded %d legacy V1 hook(s) in place.\n", res.InstallResult.UpgradedV1)
+			}
+			if res.InstallResult.BackupPath != "" {
+				fmt.Printf("Backup: %s\n", res.InstallResult.BackupPath)
+			}
+		case res.InstallResult.Skipped != "":
+			fmt.Printf("Hook manifest already in place (%s).\n", res.InstallResult.Skipped)
+		}
+	}
 	return nil
 }
 
@@ -249,17 +274,42 @@ For other clients, this restores the original MCP config from backup.`,
 	return cmd
 }
 
-// disconnectClaudeCode runs `claude mcp remove` to unregister the oktsec gateway.
+// disconnectClaudeCode removes the oktsec-gateway entry and uninstalls every
+// Oktsec-owned hook (V2 plus legacy V1) through the shared Claude Code
+// lifecycle helper. Hook uninstall always runs even when gateway removal
+// reports the entry as already absent, so a partial state never leaves
+// Oktsec hook commands behind in settings.json.
 func disconnectClaudeCode() error {
-	fmt.Println("Removing oktsec-gateway from Claude Code...")
+	fmt.Println("Disconnecting Claude Code (gateway + Oktsec-owned hooks)...")
 
-	//nolint:gosec // args are not user-controlled
-	out, err := exec.Command("claude", "mcp", "remove", "oktsec-gateway").CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := disconnectClaudeCodeRuntime(ctx, claudeCodeDisconnectOptions{}, claudeCodeLifecycleDepsForCmd())
 	if err != nil {
-		return fmt.Errorf("running 'claude mcp remove': %w\n%s", err, string(out))
+		fmt.Println()
+		fmt.Println("Disconnect incomplete. Run `oktsec doctor claude-code` for the full inventory.")
+		return err
 	}
 
-	fmt.Println("Removed oktsec-gateway from Claude Code.")
+	if res.GatewayAttempted && res.GatewayOK {
+		fmt.Println("Removed oktsec-gateway entry.")
+	}
+	if res.UninstallResult != nil {
+		switch {
+		case res.UninstallResult.Wrote:
+			fmt.Printf("Removed %d V2 + %d legacy V1 hook(s).\n",
+				res.UninstallResult.RemovedV2, res.UninstallResult.RemovedV1)
+			if res.UninstallResult.BackupPath != "" {
+				fmt.Printf("Backup: %s\n", res.UninstallResult.BackupPath)
+			}
+		case res.UninstallResult.Skipped != "":
+			fmt.Printf("No Oktsec-owned hooks to remove (%s).\n", res.UninstallResult.Skipped)
+		}
+	}
+	for _, w := range res.Warnings {
+		fmt.Printf("warn: %s\n", w)
+	}
 	return nil
 }
 

--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -51,15 +51,25 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				cfg = config.Defaults()
 			}
 
-			// Check gateway is configured (required for claude-code HTTP transport)
-			if client == "claude-code" && !cfg.Gateway.Enabled {
-				fmt.Println("Note: Gateway is not enabled in config. Claude Code connects via HTTP MCP")
-				fmt.Println("transport, which requires the gateway. Enable it with:")
-				fmt.Println()
-				fmt.Printf("  gateway:\n    enabled: true\n    port: 9090\n")
-				fmt.Println()
-				fmt.Println("Proceeding with agent registration and key generation...")
-				fmt.Println()
+			// Claude Code routes through the gateway via HTTP MCP transport.
+			// `connect claude-code` is strict: a successful return must mean
+			// the runtime surface is actually usable. If the loaded config
+			// (or a legacy config) leaves the gateway disabled, we enable it
+			// here BEFORE mutating Claude Code state, with port/endpoint
+			// defaults filled in. Otherwise Claude Code would point at
+			// 127.0.0.1:9090/mcp while `oktsec run` / `oktsec serve` refused
+			// to start the gateway.
+			if client == "claude-code" {
+				if !cfg.Gateway.Enabled {
+					cfg.Gateway.Enabled = true
+					fmt.Println("Enabling gateway in config (required for Claude Code HTTP MCP transport).")
+				}
+				if cfg.Gateway.Port == 0 {
+					cfg.Gateway.Port = 9090
+				}
+				if cfg.Gateway.EndpointPath == "" {
+					cfg.Gateway.EndpointPath = "/mcp"
+				}
 			}
 
 			// Resolve keys directory from config or flag
@@ -103,6 +113,16 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				fmt.Printf("Keypair already exists at %s\n", keyPath)
 			}
 
+			// Persist config BEFORE mutating Claude Code state. If the
+			// strict connect fails partway through (gateway add OK but hook
+			// install fails, etc.) the operator still has an oktsec.yaml
+			// that matches the command's intent so `oktsec doctor
+			// claude-code` and a re-run of `connect` can repair the state.
+			if err := cfg.Save(cfgFile); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+			fmt.Printf("Config saved to %s\n", cfgFile)
+
 			// Connect the client
 			fmt.Println()
 			if client == "claude-code" {
@@ -114,12 +134,6 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 					return err
 				}
 			}
-
-			// Save config
-			if err := cfg.Save(cfgFile); err != nil {
-				return fmt.Errorf("saving config: %w", err)
-			}
-			fmt.Printf("\nConfig saved to %s\n", cfgFile)
 
 			// Instructions
 			fmt.Println()

--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -113,19 +113,26 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				fmt.Printf("Keypair already exists at %s\n", keyPath)
 			}
 
-			// Persist config BEFORE mutating Claude Code state. If the
-			// strict connect fails partway through (gateway add OK but hook
-			// install fails, etc.) the operator still has an oktsec.yaml
-			// that matches the command's intent so `oktsec doctor
-			// claude-code` and a re-run of `connect` can repair the state.
-			if err := cfg.Save(cfgFile); err != nil {
-				return fmt.Errorf("saving config: %w", err)
-			}
-			fmt.Printf("Config saved to %s\n", cfgFile)
-
-			// Connect the client
+			// Connect the client.
+			//
+			// claude-code: persist config BEFORE mutating Claude Code
+			// state. The strict lifecycle helper can fail partway through
+			// (gateway add converges but hook install fails, etc.); having
+			// the saved config match the command's intent lets `oktsec
+			// doctor claude-code` and a re-run of `connect` repair the
+			// state without re-deriving the gateway/agent block.
+			//
+			// Other clients keep the previous order: wrap first, save
+			// only after wrap succeeded. Pre-saving for stdio clients
+			// would leave a phantom registered agent in oktsec.yaml when
+			// wrapping fails (missing client config, broken backup, etc.).
 			fmt.Println()
 			if client == "claude-code" {
+				if err := cfg.Save(cfgFile); err != nil {
+					return fmt.Errorf("saving config: %w", err)
+				}
+				fmt.Printf("Config saved to %s\n", cfgFile)
+				fmt.Println()
 				if err := connectClaudeCode(cfg); err != nil {
 					return err
 				}
@@ -133,6 +140,10 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				if err := connectStdioClient(client); err != nil {
 					return err
 				}
+				if err := cfg.Save(cfgFile); err != nil {
+					return fmt.Errorf("saving config: %w", err)
+				}
+				fmt.Printf("\nConfig saved to %s\n", cfgFile)
 			}
 
 			// Instructions

--- a/cmd/oktsec/commands/connect_claude_code_test.go
+++ b/cmd/oktsec/commands/connect_claude_code_test.go
@@ -128,6 +128,48 @@ func TestConnectClaudeCode_PersistsConfigBeforeMutatingClaude(t *testing.T) {
 	}
 }
 
+// TestConnectStdioClient_NoConfigSavedWhenWrapFails protects the
+// non-Claude path from the pre-save ordering fix that ships with
+// `connect claude-code`. Stdio clients must keep the previous order:
+// wrap first, save oktsec.yaml only after wrapping succeeded.
+// Otherwise a failed `connect cursor` (no client config to wrap)
+// would leave a phantom cursor agent in oktsec.yaml. Use a temp HOME
+// so the discover scanner cannot find a real cursor config from the
+// developer machine running the test.
+func TestConnectStdioClient_NoConfigSavedWhenWrapFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	keysDir := filepath.Join(dir, "keys")
+
+	seed := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: keysDir},
+	}
+	if err := seed.Save(cfgPath); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	prevCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = prevCfg })
+
+	cmd := newConnectCmd()
+	cmd.SetArgs([]string{"cursor"})
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("connect cursor must fail when no cursor config exists")
+	}
+
+	saved, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load saved config: %v", err)
+	}
+	if _, exists := saved.Agents["cursor"]; exists {
+		t.Errorf("cursor agent must not be persisted when wrap failed; got %+v", saved.Agents)
+	}
+}
+
 // TestConnectClaudeCode_LegacyConfigKeepsCustomGatewayPort ensures we
 // only fill blanks: an operator who set a custom port stays on it.
 func TestConnectClaudeCode_LegacyConfigKeepsCustomGatewayPort(t *testing.T) {

--- a/cmd/oktsec/commands/connect_claude_code_test.go
+++ b/cmd/oktsec/commands/connect_claude_code_test.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
+)
+
+// TestConnectClaudeCode_EnablesGatewayInSavedConfig pins the contract
+// that `oktsec connect claude-code` is strict in the runtime sense: a
+// successful return means the operator can run `oktsec run` / `oktsec
+// serve` and the gateway will actually accept Claude Code's HTTP MCP
+// transport. Before this fix, a legacy or default config with
+// gateway.enabled: false left Claude Code pointing at 127.0.0.1:9090
+// but the gateway never started.
+func TestConnectClaudeCode_EnablesGatewayInSavedConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	keysDir := filepath.Join(dir, "keys")
+
+	// Seed a config with gateway disabled, the same shape an operator
+	// would have after editing oktsec.yaml by hand or carrying over
+	// from a pre-Phase-4F install.
+	seed := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: keysDir},
+		Gateway: config.GatewayConfig{
+			Enabled: false,
+		},
+	}
+	if err := seed.Save(cfgPath); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Stub the lifecycle deps so the test never invokes the real claude
+	// CLI or mutates ~/.claude/settings.json.
+	prevDeps := claudeCodeLifecycleDepsForCmd
+	claudeCodeLifecycleDepsForCmd = func() claudeCodeLifecycleDeps {
+		stub := &stubLifecycleDeps{
+			hasCLI:        true,
+			installResult: claudecode.InstallResult{Wrote: true},
+		}
+		return stub.deps()
+	}
+	t.Cleanup(func() { claudeCodeLifecycleDepsForCmd = prevDeps })
+
+	prevCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = prevCfg })
+
+	cmd := newConnectCmd()
+	cmd.SetArgs([]string{"claude-code"})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("connect claude-code: %v", err)
+	}
+
+	saved, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load saved config: %v", err)
+	}
+	if !saved.Gateway.Enabled {
+		t.Errorf("connect claude-code must leave gateway.enabled = true; got %+v", saved.Gateway)
+	}
+	if saved.Gateway.Port != 9090 {
+		t.Errorf("connect must default Gateway.Port to 9090 when blank; got %d", saved.Gateway.Port)
+	}
+	if saved.Gateway.EndpointPath != "/mcp" {
+		t.Errorf("connect must default Gateway.EndpointPath to /mcp when blank; got %q", saved.Gateway.EndpointPath)
+	}
+	if _, exists := saved.Agents["claude-code"]; !exists {
+		t.Errorf("connect must register the claude-code agent in saved config")
+	}
+}
+
+// TestConnectClaudeCode_PersistsConfigBeforeMutatingClaude protects
+// the ordering decision: strict connect saves oktsec.yaml first, then
+// runs the lifecycle helper. If the lifecycle fails partway through,
+// the operator at least has a config that matches the intent so
+// `oktsec doctor claude-code` and a re-run can repair it.
+func TestConnectClaudeCode_PersistsConfigBeforeMutatingClaude(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	keysDir := filepath.Join(dir, "keys")
+
+	seed := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: keysDir},
+		Gateway:  config.GatewayConfig{Enabled: false},
+	}
+	if err := seed.Save(cfgPath); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Track whether config was already saved by the time the lifecycle
+	// stub runs. We read it from disk inside the stub.
+	gatewayEnabledAtMutationTime := false
+
+	prevDeps := claudeCodeLifecycleDepsForCmd
+	claudeCodeLifecycleDepsForCmd = func() claudeCodeLifecycleDeps {
+		base := stubLifecycleDeps{hasCLI: true}
+		d := base.deps()
+		realAdd := d.runMCPAdd
+		d.runMCPAdd = func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+			if loaded, err := config.Load(cfgPath); err == nil && loaded.Gateway.Enabled {
+				gatewayEnabledAtMutationTime = true
+			}
+			return realAdd(ctx, port, endpoint)
+		}
+		return d
+	}
+	t.Cleanup(func() { claudeCodeLifecycleDepsForCmd = prevDeps })
+
+	prevCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = prevCfg })
+
+	cmd := newConnectCmd()
+	cmd.SetArgs([]string{"claude-code"})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("connect claude-code: %v", err)
+	}
+
+	if !gatewayEnabledAtMutationTime {
+		t.Errorf("config must be persisted with gateway enabled BEFORE Claude Code mutation runs")
+	}
+}
+
+// TestConnectClaudeCode_LegacyConfigKeepsCustomGatewayPort ensures we
+// only fill blanks: an operator who set a custom port stays on it.
+func TestConnectClaudeCode_LegacyConfigKeepsCustomGatewayPort(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	keysDir := filepath.Join(dir, "keys")
+
+	seed := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: keysDir},
+		Gateway: config.GatewayConfig{
+			Enabled:      false,
+			Port:         9595,
+			EndpointPath: "/oktsec-mcp",
+		},
+	}
+	if err := seed.Save(cfgPath); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	prevDeps := claudeCodeLifecycleDepsForCmd
+	claudeCodeLifecycleDepsForCmd = func() claudeCodeLifecycleDeps {
+		stub := &stubLifecycleDeps{
+			hasCLI:        true,
+			installResult: claudecode.InstallResult{Wrote: true},
+		}
+		return stub.deps()
+	}
+	t.Cleanup(func() { claudeCodeLifecycleDepsForCmd = prevDeps })
+
+	prevCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = prevCfg })
+
+	cmd := newConnectCmd()
+	cmd.SetArgs([]string{"claude-code"})
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	saved, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !saved.Gateway.Enabled {
+		t.Errorf("gateway must end up enabled")
+	}
+	if saved.Gateway.Port != 9595 {
+		t.Errorf("custom port must be preserved; got %d, want 9595", saved.Gateway.Port)
+	}
+	if saved.Gateway.EndpointPath != "/oktsec-mcp" {
+		t.Errorf("custom endpoint must be preserved; got %q", saved.Gateway.EndpointPath)
+	}
+}
+

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -98,22 +97,30 @@ func executeRun(opts runOpts) error {
 }
 
 // autoSetupDeps lets tests substitute the external effects of first-run setup
-// (MCP discovery, Claude CLI presence check, Claude Code gateway connection,
-// generic client wrapping) without invoking real CLIs or mutating real
-// ~/.claude/settings.json.
+// (MCP discovery, Claude Code runtime lifecycle, generic client wrapping)
+// without invoking real CLIs or mutating real ~/.claude/settings.json.
+//
+// connectClaudeCode runs the shared Claude Code lifecycle (gateway entry plus
+// V2 hook manifest) in best-effort mode. Idempotent and "already in place"
+// outcomes still count as success; warnings are surfaced through the result.
 type autoSetupDeps struct {
 	scan              func() (*discover.Result, error)
-	hasClaudeCLI      func() bool
-	connectClaudeCode func(port int, endpoint string) error
+	connectClaudeCode func(ctx context.Context, port int, endpoint string) (claudeCodeLifecycleResult, error)
 	wrapClient        func(client string, opts discover.WrapOpts) (int, error)
 }
 
 func defaultAutoSetupDeps() autoSetupDeps {
+	lifecycle := defaultClaudeCodeLifecycleDeps()
 	return autoSetupDeps{
-		scan:              discover.Scan,
-		hasClaudeCLI:      hasClaudeCLI,
-		connectClaudeCode: autoConnectClaudeCode,
-		wrapClient:        discover.WrapClient,
+		scan: discover.Scan,
+		connectClaudeCode: func(ctx context.Context, port int, endpoint string) (claudeCodeLifecycleResult, error) {
+			return connectClaudeCodeRuntime(ctx, claudeCodeConnectOptions{
+				Port:     port,
+				Endpoint: endpoint,
+				Mode:     claudeConnectBestEffort,
+			}, lifecycle)
+		},
+		wrapClient: discover.WrapClient,
 	}
 }
 
@@ -314,10 +321,10 @@ func autoSetupWithDeps(configPath string, opts runOpts, deps autoSetupDeps) erro
 }
 
 // connectMCPClients runs the client-bootstrap phase shared by both empty and
-// non-empty discovery paths: register Claude Code via the gateway when the
-// `claude` CLI is available, and wrap any other supported clients with at
-// least one discovered MCP server. --skip-wrap is the opt-out for any
-// external client mutation.
+// non-empty discovery paths: register Claude Code via the shared lifecycle
+// helper (gateway entry plus V2 hook manifest), and wrap any other supported
+// clients with at least one discovered MCP server. --skip-wrap is the opt-out
+// for any external client mutation.
 func connectMCPClients(result *discover.Result, absConfig string, opts runOpts, gatewayPort int, endpoint string, deps autoSetupDeps) {
 	if opts.skipWrap {
 		return
@@ -327,15 +334,27 @@ func connectMCPClients(result *discover.Result, absConfig string, opts runOpts, 
 
 	totalConnected := 0
 
-	// Claude Code: register gateway via HTTP MCP transport (preferred over wrapping).
-	// This runs even when discovery is empty so first-run setup still installs the
-	// gateway entry and PreToolUse/PostToolUse hooks.
-	if deps.hasClaudeCLI() {
-		if err := deps.connectClaudeCode(gatewayPort, endpoint); err != nil {
-			fmt.Printf("    %-16s  error: %s\n", "Claude Code", err)
-		} else {
-			fmt.Printf("    %-16s  connected via gateway\n", "Claude Code")
-			totalConnected++
+	// Claude Code: register gateway and install V2 hooks. Best-effort:
+	// missing CLI, gateway add failure and hook install failure are all
+	// surfaced as warnings but do not abort first-run setup.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := deps.connectClaudeCode(ctx, gatewayPort, endpoint)
+	switch {
+	case err != nil:
+		fmt.Printf("    %-16s  error: %s\n", "Claude Code", err)
+	case res.Connected():
+		fmt.Printf("    %-16s  gateway + hooks installed\n", "Claude Code")
+		totalConnected++
+	case res.Partial():
+		fmt.Printf("    %-16s  partial: gateway=%t hooks=%t\n", "Claude Code", res.GatewayOK, res.HooksOK)
+		for _, w := range res.Warnings {
+			fmt.Printf("                      warn: %s\n", w)
+		}
+	default:
+		// Neither attempted (no claude CLI on PATH) or both failed best-effort.
+		for _, w := range res.Warnings {
+			fmt.Printf("    %-16s  %s\n", "Claude Code", w)
 		}
 	}
 
@@ -349,10 +368,10 @@ func connectMCPClients(result *discover.Result, absConfig string, opts runOpts, 
 		if cr.Client == "claude-code" || !discover.IsWrappable(cr.Client) || len(cr.Servers) == 0 {
 			continue
 		}
-		wrapped, err := deps.wrapClient(cr.Client, wrapOpts)
+		wrapped, werr := deps.wrapClient(cr.Client, wrapOpts)
 		name := discover.ClientDisplayName(cr.Client)
-		if err != nil {
-			fmt.Printf("    %-16s  error: %s\n", name, err)
+		if werr != nil {
+			fmt.Printf("    %-16s  error: %s\n", name, werr)
 			continue
 		}
 		if wrapped > 0 {
@@ -369,90 +388,10 @@ func connectMCPClients(result *discover.Result, absConfig string, opts runOpts, 
 
 
 // hasClaudeCLI checks if the `claude` CLI is available on the system.
+// Used by the shared Claude Code lifecycle helper.
 func hasClaudeCLI() bool {
 	_, err := exec.LookPath("claude")
 	return err == nil
-}
-
-// autoConnectClaudeCode registers the oktsec gateway as an HTTP MCP server in Claude Code
-// and configures hooks to capture all tool-call telemetry.
-func autoConnectClaudeCode(port int, endpoint string) error {
-	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, endpoint)
-
-	//nolint:gosec // args are not user-controlled
-	out, err := exec.Command(
-		"claude", "mcp", "add",
-		"--transport", "http",
-		"--header", "X-Oktsec-Agent: claude-code",
-		"--scope", "user",
-		"oktsec-gateway", url,
-	).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("claude mcp add: %w\n%s", err, string(out))
-	}
-
-	// Configure hooks to capture all tool-call telemetry.
-	if err := configureClaudeCodeHooks(port); err != nil {
-		// Non-fatal: gateway still works without hooks.
-		fmt.Printf("    %-16s  hooks: %s\n", "", err)
-	}
-
-	return nil
-}
-
-// configureClaudeCodeHooks writes PreToolUse/PostToolUse hooks to Claude Code's
-// user settings so all tool calls are forwarded to the oktsec gateway.
-func configureClaudeCodeHooks(gatewayPort int) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-
-	// Read existing settings (or start fresh).
-	var settings map[string]any
-	if data, err := os.ReadFile(settingsPath); err == nil {
-		_ = json.Unmarshal(data, &settings)
-	}
-	if settings == nil {
-		settings = make(map[string]any)
-	}
-
-	// Use a command hook instead of HTTP so that if oktsec is not running,
-	// the hook exits silently with code 0 — no error shown to the user.
-	exe, _ := os.Executable()
-	if exe == "" {
-		exe = "oktsec" // fallback to PATH lookup
-	}
-
-	hookEntry := []any{
-		map[string]any{
-			"matcher": ".*",
-			"hooks": []any{
-				map[string]any{
-					"type":    "command",
-					"command": fmt.Sprintf("%s hook --port %d", exe, gatewayPort),
-				},
-			},
-		},
-	}
-
-	hooksMap, _ := settings["hooks"].(map[string]any)
-	if hooksMap == nil {
-		hooksMap = make(map[string]any)
-	}
-	hooksMap["PreToolUse"] = hookEntry
-	hooksMap["PostToolUse"] = hookEntry
-	settings["hooks"] = hooksMap
-
-	// Ensure directory exists.
-	_ = os.MkdirAll(filepath.Dir(settingsPath), 0o700)
-
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(settingsPath, append(data, '\n'), 0o600)
 }
 
 // ensureSecrets creates the .env file with auto-generated secrets if it doesn't exist.

--- a/cmd/oktsec/commands/run_setup_test.go
+++ b/cmd/oktsec/commands/run_setup_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,20 +10,24 @@ import (
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/connectors/claudecode"
 	"github.com/oktsec/oktsec/internal/discover"
 )
 
-// stubDeps records what autoSetupWithDeps invoked and lets each test override
-// individual hooks. Defaults are deliberately strict — anything not opted in
-// fails the test.
-type stubDeps struct {
+// stubAutoSetupDeps records what autoSetupWithDeps invoked. The Claude
+// Code lifecycle is collapsed into a single connectClaudeCode callback
+// that returns a claudeCodeLifecycleResult, mirroring how the helper
+// behaves in production. wrapClient is recorded the same way.
+type stubAutoSetupDeps struct {
 	scanResult *discover.Result
 	scanErr    error
 
-	hasClaude bool
-
-	connectErr   error
-	connectCalls []connectCall
+	// connectResult / connectErr are returned by the connectClaudeCode
+	// stub. Tests that want to simulate a missing CLI leave both at
+	// their zero values (no GatewayAttempted, no HooksAttempted).
+	connectResult claudeCodeLifecycleResult
+	connectErr    error
+	connectCalls  []connectCall
 
 	wrapResult int
 	wrapErr    error
@@ -39,7 +44,7 @@ type wrapCall struct {
 	opts   discover.WrapOpts
 }
 
-func (s *stubDeps) deps() autoSetupDeps {
+func (s *stubAutoSetupDeps) deps() autoSetupDeps {
 	return autoSetupDeps{
 		scan: func() (*discover.Result, error) {
 			if s.scanResult == nil && s.scanErr == nil {
@@ -47,10 +52,9 @@ func (s *stubDeps) deps() autoSetupDeps {
 			}
 			return s.scanResult, s.scanErr
 		},
-		hasClaudeCLI: func() bool { return s.hasClaude },
-		connectClaudeCode: func(port int, endpoint string) error {
+		connectClaudeCode: func(ctx context.Context, port int, endpoint string) (claudeCodeLifecycleResult, error) {
 			s.connectCalls = append(s.connectCalls, connectCall{port: port, endpoint: endpoint})
-			return s.connectErr
+			return s.connectResult, s.connectErr
 		},
 		wrapClient: func(client string, opts discover.WrapOpts) (int, error) {
 			s.wrapCalls = append(s.wrapCalls, wrapCall{client: client, opts: opts})
@@ -60,10 +64,8 @@ func (s *stubDeps) deps() autoSetupDeps {
 }
 
 // scrubKeysDir registers a cleanup that removes any keypair files written for
-// the given agent names. It is a defensive net for the non-empty-discovery
-// test: if HomeDir() was already memoized to the real user directory before
-// the test ran, the agent keypair lands there. We clean up regardless of
-// where it lands.
+// the given agent names. Defensive net for the non-empty discovery test in
+// case config.HomeDir() was already memoized to the real user directory.
 func scrubKeysDir(t *testing.T, agents ...string) {
 	t.Helper()
 	keysDir := config.DefaultKeysDir()
@@ -75,7 +77,6 @@ func scrubKeysDir(t *testing.T, agents ...string) {
 	})
 }
 
-// readConfig returns the contents of the generated oktsec.yaml as a string.
 func readConfig(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -85,18 +86,35 @@ func readConfig(t *testing.T, path string) string {
 	return string(data)
 }
 
-// TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway is the direct
-// regression test for issue #176. When discovery finds zero MCP servers and
-// the `claude` CLI is available, oktsec run must still register the gateway
-// and install hooks.
-func TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway(t *testing.T) {
+// connectedResult builds a stub lifecycle result that mirrors a successful
+// connect: gateway entry was added and the hook manifest was installed.
+func connectedResult() claudeCodeLifecycleResult {
+	plan := []claudecode.PlannedHookEntry{{Event: "PreToolUse"}}
+	return claudeCodeLifecycleResult{
+		GatewayAttempted: true,
+		GatewayOK:        true,
+		HooksAttempted:   true,
+		HooksOK:          true,
+		InstallResult: &claudecode.InstallResult{
+			SettingsPath: "/tmp/fake-settings.json",
+			Plan:         plan,
+			Wrote:        true,
+		},
+	}
+}
+
+// TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGatewayAndHooks is the
+// regression test for issue #176 plus the Phase 4F-0 contract: zero-discovery
+// first-run setup must register the gateway entry AND install the V2 hook
+// manifest when claude is available.
+func TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGatewayAndHooks(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
 
-	stub := &stubDeps{hasClaude: true}
+	stub := &stubAutoSetupDeps{connectResult: connectedResult()}
 
 	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
 		t.Fatalf("autoSetupWithDeps returned error: %v", err)
@@ -108,53 +126,79 @@ func TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGateway(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
 		t.Fatalf(".env not created: %v", err)
 	}
-
 	if got := len(stub.connectCalls); got != 1 {
 		t.Fatalf("connectClaudeCode call count = %d, want 1", got)
 	}
-	got := stub.connectCalls[0]
-	if got.port != 9090 {
-		t.Errorf("connectClaudeCode port = %d, want 9090", got.port)
-	}
-	if got.endpoint != "/mcp" {
-		t.Errorf("connectClaudeCode endpoint = %q, want %q", got.endpoint, "/mcp")
+	if got := stub.connectCalls[0]; got.port != 9090 || got.endpoint != "/mcp" {
+		t.Errorf("connectClaudeCode called with port=%d endpoint=%q, want 9090 /mcp", got.port, got.endpoint)
 	}
 }
 
-// TestAutoSetup_EmptyDiscoverySkipWrapDoesNotConnectClaudeCode protects the
-// --skip-wrap opt-out: even when claude is on PATH, no external client
-// configuration should be mutated.
-func TestAutoSetup_EmptyDiscoverySkipWrapDoesNotConnectClaudeCode(t *testing.T) {
+// TestAutoSetup_EmptyDiscoveryHookFailureIsNonFatal pins the best-effort
+// contract for `oktsec run`: a hook install failure must not abort first-run
+// setup, but it must still surface as a partial state in the result.
+func TestAutoSetup_EmptyDiscoveryHookFailureIsNonFatal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
 
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
 
-	stub := &stubDeps{hasClaude: true}
+	partial := claudeCodeLifecycleResult{
+		GatewayAttempted: true,
+		GatewayOK:        true,
+		HooksAttempted:   true,
+		HooksOK:          false,
+		HooksErr:         errors.New("simulated hook install failure"),
+		Warnings:         []string{"hook install: simulated hook install failure"},
+	}
+	stub := &stubAutoSetupDeps{connectResult: partial}
 
-	if err := autoSetupWithDeps(cfgPath, runOpts{skipWrap: true}, stub.deps()); err != nil {
-		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps must not return error when hook install fails: %v", err)
 	}
 
 	if _, err := os.Stat(cfgPath); err != nil {
 		t.Fatalf("config not created: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
-		t.Fatalf(".env not created: %v", err)
+	if got := len(stub.connectCalls); got != 1 {
+		t.Fatalf("connectClaudeCode call count = %d, want 1", got)
 	}
-	if len(stub.connectCalls) != 0 {
-		t.Fatalf("connectClaudeCode called %d time(s) under --skip-wrap, want 0", len(stub.connectCalls))
+	if !partial.Partial() {
+		t.Fatalf("partial fixture must report Partial() = true")
 	}
 	if len(stub.wrapCalls) != 0 {
-		t.Fatalf("wrapClient called %d time(s) under --skip-wrap, want 0", len(stub.wrapCalls))
+		t.Errorf("wrapClient must not be called for empty discovery, got %d calls", len(stub.wrapCalls))
 	}
 }
 
-// TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes verifies that
-// first-run setup still succeeds when the `claude` CLI is not installed.
-// Missing claude is non-fatal: setup completes silently without a connection
-// attempt.
+// TestAutoSetup_SkipWrapSkipsGatewayAndHooks pins the --skip-wrap opt-out:
+// no gateway, no hooks, no stdio wrap, even when the lifecycle helper would
+// otherwise have something to do.
+func TestAutoSetup_SkipWrapSkipsGatewayAndHooks(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+
+	stub := &stubAutoSetupDeps{connectResult: connectedResult()}
+
+	if err := autoSetupWithDeps(cfgPath, runOpts{skipWrap: true}, stub.deps()); err != nil {
+		t.Fatalf("autoSetupWithDeps returned error: %v", err)
+	}
+
+	if len(stub.connectCalls) != 0 {
+		t.Errorf("connectClaudeCode called %d time(s) under --skip-wrap, want 0", len(stub.connectCalls))
+	}
+	if len(stub.wrapCalls) != 0 {
+		t.Errorf("wrapClient called %d time(s) under --skip-wrap, want 0", len(stub.wrapCalls))
+	}
+}
+
+// TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes verifies missing
+// claude CLI stays non-fatal. The lifecycle helper returns a result with
+// nothing attempted; the run code path keeps going.
 func TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
@@ -162,31 +206,23 @@ func TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
 
-	stub := &stubDeps{hasClaude: false}
-	deps := stub.deps()
-	deps.connectClaudeCode = func(port int, endpoint string) error {
-		t.Fatalf("connectClaudeCode must not be called when claude CLI is missing (got port=%d endpoint=%q)", port, endpoint)
-		return nil
+	missingCLI := claudeCodeLifecycleResult{
+		Warnings: []string{"claude CLI not found on PATH; install Claude Code or run `claude --version`"},
 	}
+	stub := &stubAutoSetupDeps{connectResult: missingCLI}
 
-	if err := autoSetupWithDeps(cfgPath, runOpts{}, deps); err != nil {
+	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
 		t.Fatalf("autoSetupWithDeps returned error: %v", err)
 	}
-
-	if _, err := os.Stat(cfgPath); err != nil {
-		t.Fatalf("config not created: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
-		t.Fatalf(".env not created: %v", err)
-	}
-	if len(stub.connectCalls) != 0 {
-		t.Fatalf("connectClaudeCode called %d time(s) without claude CLI, want 0", len(stub.connectCalls))
+	if got := len(stub.connectCalls); got != 1 {
+		t.Fatalf("connectClaudeCode call count = %d, want 1 (must still attempt)", got)
 	}
 }
 
 // TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal preserves the
-// existing Step 4 behaviour: a `claude mcp add` failure must not abort
-// first-run setup.
+// existing best-effort contract: a connect error returned to the caller
+// (rare path, since the helper normally swallows best-effort errors as
+// warnings) must not abort first-run setup.
 func TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
@@ -194,31 +230,22 @@ func TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
 
-	stub := &stubDeps{
-		hasClaude:  true,
-		connectErr: errors.New("simulated claude mcp add failure"),
+	stub := &stubAutoSetupDeps{
+		connectErr: errors.New("simulated lifecycle error"),
 	}
 
 	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
-		t.Fatalf("autoSetupWithDeps must not return error when connect fails: %v", err)
-	}
-
-	if _, err := os.Stat(cfgPath); err != nil {
-		t.Fatalf("config not created: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".env")); err != nil {
-		t.Fatalf(".env not created: %v", err)
+		t.Fatalf("autoSetupWithDeps must not return error when lifecycle fails: %v", err)
 	}
 	if got := len(stub.connectCalls); got != 1 {
 		t.Fatalf("connectClaudeCode call count = %d, want 1 (must still attempt once)", got)
 	}
 }
 
-// TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway protects the
-// non-empty-discovery path. The bug fix routes both paths through the shared
-// helper; this test pins the original behaviour so the helper does not
-// regress it.
-func TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway(t *testing.T) {
+// TestAutoSetup_DiscoveredServersUseSameClaudeLifecycle protects the
+// non-empty discovery path. Both paths must share the lifecycle helper:
+// gateway + V2 hooks for Claude Code, stdio wrapping for other clients.
+func TestAutoSetup_DiscoveredServersUseSameClaudeLifecycle(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
 
@@ -228,9 +255,9 @@ func TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway(t *testing.T) 
 	const agent = "okt-test-disc-server"
 	scrubKeysDir(t, agent)
 
-	stub := &stubDeps{
-		hasClaude:  true,
-		wrapResult: 1,
+	stub := &stubAutoSetupDeps{
+		connectResult: connectedResult(),
+		wrapResult:    1,
 		scanResult: &discover.Result{
 			Clients: []discover.ClientResult{
 				{
@@ -248,14 +275,9 @@ func TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway(t *testing.T) 
 		t.Fatalf("autoSetupWithDeps returned error: %v", err)
 	}
 
-	if _, err := os.Stat(cfgPath); err != nil {
-		t.Fatalf("config not created: %v", err)
-	}
-
 	if got := len(stub.connectCalls); got != 1 {
 		t.Fatalf("connectClaudeCode call count = %d, want 1", got)
 	}
-
 	if got := len(stub.wrapCalls); got != 1 {
 		t.Fatalf("wrapClient call count = %d, want 1", got)
 	}
@@ -268,13 +290,13 @@ func TestAutoSetup_DiscoveredServersStillConnectClaudeCodeGateway(t *testing.T) 
 		t.Errorf("config missing mcp_servers block:\n%s", cfgYAML)
 	}
 	if !strings.Contains(cfgYAML, agent) {
-		t.Errorf("config missing discovered agent %q in mcp_servers:\n%s", agent, cfgYAML)
+		t.Errorf("config missing discovered agent %q:\n%s", agent, cfgYAML)
 	}
 }
 
 // TestAutoSetup_EmptyDiscoveryWritesGatewayConfig is a small belt-and-braces
-// check that the minimal config still enables the gateway (the gateway must
-// be running for Claude Code's HTTP MCP transport to connect).
+// check that the minimal config still enables the gateway. The gateway must
+// be running for Claude Code's HTTP MCP transport to connect.
 func TestAutoSetup_EmptyDiscoveryWritesGatewayConfig(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PATH", "")
@@ -282,22 +304,64 @@ func TestAutoSetup_EmptyDiscoveryWritesGatewayConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
 
-	stub := &stubDeps{hasClaude: false}
+	stub := &stubAutoSetupDeps{}
 
 	if err := autoSetupWithDeps(cfgPath, runOpts{}, stub.deps()); err != nil {
 		t.Fatalf("autoSetupWithDeps returned error: %v", err)
 	}
 
 	cfgYAML := readConfig(t, cfgPath)
-	wantSubstrings := []string{
-		"gateway:",
-		"enabled: true",
-		"port: 9090",
-		fmt.Sprintf("endpoint_path: %s", `/mcp`),
-	}
-	for _, s := range wantSubstrings {
+	want := []string{"gateway:", "enabled: true", "port: 9090", fmt.Sprintf("endpoint_path: %s", `/mcp`)}
+	for _, s := range want {
 		if !strings.Contains(cfgYAML, s) {
 			t.Errorf("minimal config missing %q:\n%s", s, cfgYAML)
 		}
+	}
+}
+
+// TestRunClaudeCodeUsesManifestV2Installer pins the V2 manifest parity
+// invariant: when the default lifecycle deps are wired to the real
+// claudecode.InstallV2 against a temp HOME, the resulting settings.json
+// carries the V2 manifest marker. This test fails if any future change
+// reintroduces a hand-written PreToolUse/PostToolUse-only writer.
+func TestRunClaudeCodeUsesManifestV2Installer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	deps := claudeCodeLifecycleDeps{
+		// Pretend claude is available and that `claude mcp add` succeeds.
+		hasClaudeCLI: func() bool { return true },
+		runMCPAdd: func(ctx context.Context, port int, endpoint string) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+		runMCPRemove: func(ctx context.Context) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+		// Use the real installer so we exercise the V2 manifest writer.
+		installHooksV2:   claudecode.InstallV2,
+		uninstallHooksV2: claudecode.UninstallV2,
+		executable: func() (string, error) {
+			return "/usr/local/bin/oktsec", nil
+		},
+	}
+
+	res, err := connectClaudeCodeRuntime(context.Background(),
+		claudeCodeConnectOptions{Port: 9090, Endpoint: "/mcp", Mode: claudeConnectStrict},
+		deps)
+	if err != nil {
+		t.Fatalf("connectClaudeCodeRuntime: %v", err)
+	}
+	if !res.HooksOK {
+		t.Fatalf("hooks did not install successfully: %+v", res)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	body, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if !strings.Contains(string(body), claudecode.ManifestV2Marker) {
+		t.Errorf("expected ManifestV2Marker %q in settings.json:\n%s",
+			claudecode.ManifestV2Marker, string(body))
 	}
 }

--- a/cmd/oktsec/commands/setup.go
+++ b/cmd/oktsec/commands/setup.go
@@ -25,20 +25,23 @@ func newSetupCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Discover, configure, and protect all MCP servers in one step",
-		Long: `Runs the full onboarding flow:
-  1. Discovers all MCP clients and servers on this machine
-  2. Generates oktsec.yaml with sensible defaults
-  3. Generates Ed25519 keypairs for each agent
-  4. Wraps all discovered MCP servers through oktsec proxy
-  5. Shows what's protected and how to start the dashboard`,
-		Example: `  oktsec setup
+		Short: "(deprecated) MCP-discovery-only onboarding; use `oktsec run`",
+		Long: `Deprecated. Use ` + "`oktsec run`" + ` for current runtime client setup.
+
+This legacy command only handles MCP-server discovery and stdio wrapping. It
+does not register Claude Code as a runtime surface and does not install the
+V2 hook manifest. ` + "`oktsec run`" + ` performs the full first-run flow,
+including Claude Code gateway registration and hook installation.`,
+		Example: `  oktsec setup           # legacy MCP-only onboarding
   oktsec setup --enforce
   oktsec setup --skip-wrap`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println()
-			fmt.Println("  oktsec setup")
+			fmt.Println("  oktsec setup (deprecated)")
 			fmt.Println("  ────────────────────────────────────────")
+			fmt.Println("  Use `oktsec run` for current runtime client setup.")
+			fmt.Println("  This command only handles MCP discovery and stdio wrapping;")
+			fmt.Println("  it does not register Claude Code or install hooks.")
 			fmt.Println()
 
 			// Step 1: Discover
@@ -52,10 +55,9 @@ func newSetupCmd() *cobra.Command {
 				fmt.Println()
 				fmt.Println("  No MCP servers found on this machine.")
 				fmt.Println()
-				fmt.Println("  Checked 17 clients: Claude Desktop, Cursor, VS Code, Cline,")
-				fmt.Println("  Windsurf, Claude Code, Roo Code, and more.")
-				fmt.Println()
-				fmt.Println("  Install an MCP server first, then run 'oktsec setup' again.")
+				fmt.Println("  This legacy command exits here because it only configures")
+				fmt.Println("  discovered MCP servers. Use `oktsec run` to set up Claude Code")
+				fmt.Println("  as a runtime surface even when no MCP servers are installed.")
 				return nil
 			}
 

--- a/cmd/oktsec/commands/setup_deprecated_test.go
+++ b/cmd/oktsec/commands/setup_deprecated_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSetupDeprecatedZeroDiscoveryPointsToRun pins the Phase 4F-0 copy
+// contract for the deprecated `oktsec setup` command. The previous
+// "Install an MCP server first, then run 'oktsec setup' again" line
+// led users into a stale onboarding path that ignored Claude Code
+// runtime client surfaces. This test fails if that copy ever reappears
+// or if the new "Use `oktsec run`" line goes missing.
+func TestSetupDeprecatedZeroDiscoveryPointsToRun(t *testing.T) {
+	body := readSetupSource(t)
+
+	for _, banned := range []string{
+		// The dead-end copy: this implied installing an MCP server was a
+		// prerequisite for Oktsec, even though `oktsec run` can register
+		// Claude Code without one.
+		"Install an MCP server first",
+		"run 'oktsec setup' again",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("setup.go contains banned phrase %q", banned)
+		}
+	}
+
+	for _, required := range []string{
+		// Deprecation must point users to the current onboarding path.
+		"Use `oktsec run`",
+		"runtime client setup",
+	} {
+		if !strings.Contains(body, required) {
+			t.Errorf("setup.go missing required phrase %q", required)
+		}
+	}
+}
+
+// TestSetupCmd_LongAdvertisesDeprecation makes sure the help text users
+// see when they run `oktsec setup --help` is honest about which command
+// is the current onboarding path.
+func TestSetupCmd_LongAdvertisesDeprecation(t *testing.T) {
+	cmd := newSetupCmd()
+	if !strings.Contains(strings.ToLower(cmd.Short), "deprecated") {
+		t.Errorf("Short = %q, want it to contain 'deprecated'", cmd.Short)
+	}
+	if !strings.Contains(cmd.Long, "`oktsec run`") {
+		t.Errorf("Long must point users at `oktsec run`; got %q", cmd.Long)
+	}
+}
+
+// readSetupSource locates setup.go from the test's source path so the
+// test does not depend on the working directory `go test` was launched
+// from. setup.go lives next to this test file.
+func readSetupSource(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate setup.go")
+	}
+	path := filepath.Join(filepath.Dir(thisFile), "setup.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read setup.go: %v", err)
+	}
+	return string(data)
+}

--- a/documentation/guides/openclaw.md
+++ b/documentation/guides/openclaw.md
@@ -327,7 +327,7 @@ Content scanning takes ~8ms per tool call. Rate limiting and ACL checks are sub-
 
 **Can I use oktsec with other MCP clients at the same time?**
 
-Yes. Run `oktsec setup` to auto-wrap Claude Desktop, Cursor, VS Code, etc. Those use stdio proxy mode. OpenClaw uses gateway mode. Both share the same dashboard and audit trail.
+Yes. Run `oktsec run` to auto-wrap Claude Desktop, Cursor, VS Code, etc., and to register Claude Code through the gateway with V2 hooks. Stdio clients use proxy mode. OpenClaw uses gateway mode. Both share the same dashboard and audit trail.
 
 **What happens when a tool call is blocked?**
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -66,9 +66,7 @@ Checks:
 ### `setup` (deprecated)
 
 !!! warning "Deprecated"
-    Use `oktsec run` instead. The `setup` command still works but prints a deprecation notice.
-
-One-command onboarding: discover all MCP servers, generate config and keypairs, wrap everything.
+    Use `oktsec run` instead. `setup` is a legacy MCP-discovery-only path: it does not register Claude Code as a runtime surface and does not install the V2 hook manifest. `oktsec run` performs the full first-run flow.
 
 ```bash
 oktsec setup
@@ -83,13 +81,7 @@ oktsec setup --skip-wrap
 | `--enforce` | bool | `false` | Start in enforcement mode (block malicious requests) |
 | `--skip-wrap` | bool | `false` | Generate config only, don't modify client configs |
 
-What `setup` does:
-
-1. Scans for MCP clients on the machine
-2. Generates `oktsec.yaml` with one agent per MCP server
-3. Generates Ed25519 keypairs for each agent
-4. Wraps all MCP servers through `oktsec proxy`
-5. Prints next steps
+`setup` only handles MCP-server discovery and stdio wrapping. When discovery returns zero servers, the command exits without configuring anything else; use `oktsec run` to set up Claude Code as a runtime surface even on a machine with no installed MCP servers.
 
 ### `discover`
 

--- a/documentation/use-cases/index.md
+++ b/documentation/use-cases/index.md
@@ -72,11 +72,10 @@ You run OpenClaw agents with MCP tools. You need to control which agents call wh
 === "Development"
 
     ```bash
-    oktsec setup
-    oktsec serve
+    oktsec run
     ```
 
-    Zero config. Discovers your MCP servers, wraps them, starts in **observe mode**. Review activity in the dashboard before enabling enforcement.
+    Zero config. Discovers MCP servers, registers Claude Code through the gateway, installs hooks, starts in **observe mode**. Review activity in the dashboard before enabling enforcement.
 
 === "Staging"
 

--- a/documentation/use-cases/mcp-hardening.md
+++ b/documentation/use-cases/mcp-hardening.md
@@ -52,7 +52,7 @@ oktsec proxy --enforce --agent filesystem -- npx @mcp/server-filesystem /data
 Or wrap all MCP clients at once:
 
 ```bash
-oktsec setup           # discovers + wraps everything
+oktsec run                    # discovers + wraps everything (current onboarding path)
 oktsec wrap --enforce --all   # enable enforcement for all
 ```
 


### PR DESCRIPTION
## Summary

- routes `run`, `connect claude-code` and `disconnect claude-code` through one Claude Code lifecycle helper
- replaces the `run` ad-hoc hook writer with the Phase 2 V2 hook manifest installer
- makes explicit `connect`/`disconnect` cover both gateway MCP registration and Oktsec-owned hooks
- keeps `run` best-effort while making `connect claude-code` strict
- updates deprecated `setup` and the live docs that presented it as the primary onboarding path

## Context

PR #177 fixed the symptom: empty MCP discovery skipped Claude Code gateway registration and hook installation in `oktsec run`. The root cause was that lifecycle state lived in fragments across `run`, `connect`, `disconnect`, the discovery scanner and the local hook writer, with no single contract for "connected", "partial" or "disconnected".

This PR unifies that lifecycle. Discovery answers "did we find backend MCP servers to import?". Client bootstrap answers "can Oktsec register itself as a runtime surface and install hooks?". The two questions are independent.

## What changed

**New shared helper** (`cmd/oktsec/commands/claude_code_lifecycle.go`):
- `connectClaudeCodeRuntime` — registers `oktsec-gateway` via `claude mcp add` and installs the V2 hook manifest via `claudecode.InstallV2`. Best-effort vs strict mode controls how failures are reported.
- `disconnectClaudeCodeRuntime` — removes the gateway entry and uninstalls every Oktsec-owned hook (V2 plus legacy V1). Hook uninstall always runs even when `claude mcp remove` reports the entry already absent.
- `claudeCodeLifecycleDeps` injects the four external effects so tests never need to invoke the real `claude` CLI or mutate `~/.claude/settings.json`.

**`oktsec run`**: best-effort. `autoSetupDeps.connectClaudeCode` is now backed by the shared helper. The local `configureClaudeCodeHooks` ad-hoc writer is deleted. Empty and non-empty discovery paths share the same lifecycle.

**`oktsec connect claude-code`**: strict. Returns a non-zero error if either gateway registration or hook install fails. Points the operator at `oktsec doctor claude-code` for a full inventory on partial state.

**`oktsec disconnect claude-code`**: now removes Oktsec-owned hooks via `UninstallV2` with `IncludeLegacyV1: true`. Already-absent gateway entries no longer block hook cleanup.

**`oktsec setup` (deprecated)**: no longer tells users to install an MCP server first when discovery is empty. Points explicitly at `oktsec run`. Long help advertises the deprecation.

**Live docs updated** to remove `oktsec setup` as the primary onboarding path:
- `documentation/reference/cli.md`
- `documentation/use-cases/index.md`
- `documentation/use-cases/mcp-hardening.md`
- `documentation/guides/openclaw.md`

## Test plan

- [x] `go test ./cmd/oktsec/commands`
- [x] `go test ./internal/connectors/claudecode`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `make build`
- [x] `make lint`

New tests:

Run lifecycle (`run_setup_test.go`):
- `TestAutoSetup_EmptyDiscoveryConnectsClaudeCodeGatewayAndHooks` — regression for #176 with V2 hook contract
- `TestAutoSetup_EmptyDiscoveryHookFailureIsNonFatal` — best-effort partial state
- `TestAutoSetup_SkipWrapSkipsGatewayAndHooks` — `--skip-wrap` opt-out
- `TestAutoSetup_EmptyDiscoveryMissingClaudeCLICompletes` — missing CLI non-fatal
- `TestAutoSetup_EmptyDiscoveryClaudeConnectErrorIsNonFatal` — lifecycle error non-fatal
- `TestAutoSetup_DiscoveredServersUseSameClaudeLifecycle` — non-empty path uses the same helper
- `TestAutoSetup_EmptyDiscoveryWritesGatewayConfig` — minimal config still enables the gateway
- `TestRunClaudeCodeUsesManifestV2Installer` — real-installer parity producing the V2 manifest marker against a temp HOME

Connect / disconnect lifecycle (`claude_code_lifecycle_test.go`):
- `TestConnectClaudeCode_InstallsGatewayAndHooks`
- `TestConnectClaudeCode_HookFailureReturnsPartialError`
- `TestConnectClaudeCode_StrictMissingCLIErrors`
- `TestConnectClaudeCode_BestEffortMissingCLINoError`
- `TestDisconnectClaudeCode_RemovesGatewayAndHooks`
- `TestDisconnectClaudeCode_HookUninstallFailureReturnsPartialError`
- `TestDisconnectClaudeCode_GatewayMissingStillAttemptsHookUninstall`
- `TestPartialAndConnected_HelperContract`

Deprecated setup (`setup_deprecated_test.go`):
- `TestSetupDeprecatedZeroDiscoveryPointsToRun`
- `TestSetupCmd_LongAdvertisesDeprecation`