### PR TITLE
chore: bump Go toolchain to 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
 
       - name: Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/oktsec/oktsec
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0


### PR DESCRIPTION
## Summary
- Pin go.mod toolchain to go1.26.3.
- Pin GitHub Actions setup-go to "1.26.3" in CI and release.
- Picks up stdlib patches GO-2026-4918, GO-2026-4971, GO-2026-4980, GO-2026-4982.

## What stays the same
- Module language version stays at `go 1.26.0`.
- No application code changes.
- Same CI jobs, same release flow.

## Validation
- `go test ./...` green
- `go vet ./...` green
- `govulncheck ./...` reports no vulnerabilities
- `make build` succeeds
- `make lint` clean (0 issues)

## Test plan
- [ ] CI green on this PR
- [ ] Next release tag builds against go1.26.3