### PR TITLE
fix: validate agent and MCP server names before key file access

### DIFF
--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -41,7 +41,7 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				return fmt.Errorf("unsupported client %q\n\nSupported clients: %v", client, discover.WrappableClients())
 			}
 
-			if err := identity.ValidatePrincipalName(client); err != nil {
+			if err := identity.ValidatePublicPrincipalName(client); err != nil {
 				return err
 			}
 

--- a/cmd/oktsec/commands/connect.go
+++ b/cmd/oktsec/commands/connect.go
@@ -41,6 +41,10 @@ For other clients, this wraps their MCP servers through the oktsec proxy.`,
 				return fmt.Errorf("unsupported client %q\n\nSupported clients: %v", client, discover.WrappableClients())
 			}
 
+			if err := identity.ValidatePrincipalName(client); err != nil {
+				return err
+			}
+
 			// Load config
 			cfg, err := config.Load(cfgFile)
 			if err != nil {

--- a/cmd/oktsec/commands/doctor.go
+++ b/cmd/oktsec/commands/doctor.go
@@ -230,6 +230,12 @@ func checkKeypairs(cfg *config.Config) checkResult {
 	}
 	var missing []string
 	for name := range cfg.Agents {
+		// Defence in depth. config.Load already rejects unsafe agent
+		// names, but if a hand-edited config slipped one through,
+		// skip rather than stat a synthesised key path.
+		if !identity.IsValidPrincipalName(name) {
+			continue
+		}
 		keyFile := filepath.Join(keysDir, name+".key")
 		if _, err := os.Stat(keyFile); os.IsNotExist(err) {
 			missing = append(missing, name)

--- a/cmd/oktsec/commands/init.go
+++ b/cmd/oktsec/commands/init.go
@@ -48,7 +48,7 @@ func newInitCmd() *cobra.Command {
 
 			for _, entry := range result.AllServers() {
 				name := entry.Server.Name
-				if err := identity.ValidatePrincipalName(name); err != nil {
+				if err := identity.ValidatePublicPrincipalName(name); err != nil {
 					return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
 				}
 				risk := assessRisk(entry.Server)

--- a/cmd/oktsec/commands/init.go
+++ b/cmd/oktsec/commands/init.go
@@ -48,6 +48,9 @@ func newInitCmd() *cobra.Command {
 
 			for _, entry := range result.AllServers() {
 				name := entry.Server.Name
+				if err := identity.ValidatePrincipalName(name); err != nil {
+					return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
+				}
 				risk := assessRisk(entry.Server)
 
 				agents[name] = agentYAML{

--- a/cmd/oktsec/commands/keygen.go
+++ b/cmd/oktsec/commands/keygen.go
@@ -23,6 +23,9 @@ func newKeygenCmd() *cobra.Command {
 			}
 
 			for _, name := range agents {
+				if err := identity.ValidatePublicPrincipalName(name); err != nil {
+					return err
+				}
 				kp, err := identity.GenerateKeypair(name)
 				if err != nil {
 					return fmt.Errorf("generating keypair for %s: %w", name, err)

--- a/cmd/oktsec/commands/keys.go
+++ b/cmd/oktsec/commands/keys.go
@@ -129,6 +129,9 @@ func newKeysRotateCmd() *cobra.Command {
 		Short: "Rotate an agent's keypair",
 		Long:  "Generates a new keypair for the agent, moving the old one to keys/revoked/.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := identity.ValidatePublicPrincipalName(agent); err != nil {
+				return err
+			}
 			cfg, err := config.Load(cfgFile)
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)
@@ -220,6 +223,9 @@ func newKeysRevokeCmd() *cobra.Command {
 		Short: "Revoke an agent's keypair",
 		Long:  "Moves the agent's keys to keys/revoked/. The proxy will reject messages signed with revoked keys.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := identity.ValidatePublicPrincipalName(agent); err != nil {
+				return err
+			}
 			cfg, err := config.Load(cfgFile)
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)

--- a/cmd/oktsec/commands/keys_principal_test.go
+++ b/cmd/oktsec/commands/keys_principal_test.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/identity"
+)
+
+// keygen must refuse a path-traversal agent name before any file lands
+// on disk. The check sits on identity.GenerateKeypair, but this test
+// drives the CLI command end to end so a future refactor that moves
+// the call site cannot regress the protection.
+func TestKeygen_RejectsTraversalAgent(t *testing.T) {
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "keys")
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newKeygenCmd()
+	cmd.SetArgs([]string{"--agent=../../pwn", "--out=" + outDir})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("keygen accepted a traversal agent name")
+	}
+
+	parent := filepath.Dir(outDir)
+	for _, leaf := range []string{"pwn.key", "pwn.pub"} {
+		if _, err := os.Stat(filepath.Join(parent, leaf)); err == nil {
+			t.Fatalf("keygen wrote %s outside the keys directory", leaf)
+		}
+	}
+}
+
+// keys rotate must refuse the same shape and must not touch the
+// keys dir (no rename, no new keypair). We seed a valid alice keypair,
+// run rotate with a traversal name, then assert alice's files are
+// untouched.
+func TestKeysRotate_RejectsTraversalAgent(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed an existing keypair the traversal name must not be able to
+	// rename or replace.
+	kp, err := identity.GenerateKeypair("alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := kp.Save(keysDir); err != nil {
+		t.Fatal(err)
+	}
+	aliceKeyBefore, err := os.ReadFile(filepath.Join(keysDir, "alice.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	seed := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: keysDir},
+		Agents: map[string]config.Agent{
+			"alice": {CanMessage: []string{"*"}, KeyVersion: 1},
+		},
+		DBPath: filepath.Join(dir, "oktsec.db"),
+	}
+	if err := seed.Save(cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	origCfgFile := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = origCfgFile })
+
+	cmd := newKeysCmd()
+	cmd.SetArgs([]string{"rotate", "--agent=../../pwn"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("keys rotate accepted a traversal agent name")
+	}
+
+	// Confirm no files landed outside the keys dir.
+	parent := filepath.Dir(keysDir)
+	for _, leaf := range []string{"pwn.key", "pwn.pub"} {
+		if _, err := os.Stat(filepath.Join(parent, leaf)); err == nil {
+			t.Fatalf("rotate created %s outside the keys directory", leaf)
+		}
+	}
+
+	// Confirm alice's private key bytes are unchanged.
+	aliceKeyAfter, err := os.ReadFile(filepath.Join(keysDir, "alice.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(aliceKeyBefore) != string(aliceKeyAfter) {
+		t.Fatal("alice's keypair was modified during a rejected rotation")
+	}
+}

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -198,7 +198,7 @@ func autoSetupWithDeps(configPath string, opts runOpts, deps autoSetupDeps) erro
 	agents := make(map[string]agentYAML)
 	for _, entry := range result.AllServers() {
 		name := entry.Server.Name
-		if err := identity.ValidatePrincipalName(name); err != nil {
+		if err := identity.ValidatePublicPrincipalName(name); err != nil {
 			return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
 		}
 		risk := assessRisk(entry.Server)

--- a/cmd/oktsec/commands/run.go
+++ b/cmd/oktsec/commands/run.go
@@ -198,6 +198,9 @@ func autoSetupWithDeps(configPath string, opts runOpts, deps autoSetupDeps) erro
 	agents := make(map[string]agentYAML)
 	for _, entry := range result.AllServers() {
 		name := entry.Server.Name
+		if err := identity.ValidatePrincipalName(name); err != nil {
+			return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
+		}
 		risk := assessRisk(entry.Server)
 		agents[name] = agentYAML{
 			CanMessage: []string{"*"},

--- a/cmd/oktsec/commands/setup.go
+++ b/cmd/oktsec/commands/setup.go
@@ -90,6 +90,9 @@ including Claude Code gateway registration and hook installation.`,
 			agents := make(map[string]agentYAML)
 			for _, entry := range result.AllServers() {
 				name := entry.Server.Name
+				if err := identity.ValidatePrincipalName(name); err != nil {
+					return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
+				}
 				risk := assessRisk(entry.Server)
 				agents[name] = agentYAML{
 					CanMessage: []string{"*"},

--- a/cmd/oktsec/commands/setup.go
+++ b/cmd/oktsec/commands/setup.go
@@ -90,7 +90,7 @@ including Claude Code gateway registration and hook installation.`,
 			agents := make(map[string]agentYAML)
 			for _, entry := range result.AllServers() {
 				name := entry.Server.Name
-				if err := identity.ValidatePrincipalName(name); err != nil {
+				if err := identity.ValidatePublicPrincipalName(name); err != nil {
 					return fmt.Errorf("MCP server %q discovered in client %q: %w", name, entry.Client, err)
 				}
 				risk := assessRisk(entry.Server)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -608,16 +608,17 @@ func Load(path string) (*Config, error) {
 	}
 
 	// Principal-name keys reach the key file system path and the audit
-	// row. Reject unsafe names at load time so a hand-edited or
-	// otherwise tampered config cannot smuggle a path traversal
-	// through to callers that skip the full Validate sweep.
+	// row. Reject unsafe or reserved names at load time so a
+	// hand-edited or otherwise tampered config cannot smuggle a path
+	// traversal or a reserved-principal collision through to callers
+	// that skip the full Validate sweep.
 	for name := range cfg.Agents {
-		if err := identity.ValidatePrincipalName(name); err != nil {
+		if err := identity.ValidatePublicPrincipalName(name); err != nil {
 			return nil, fmt.Errorf("agents map key: %w", err)
 		}
 	}
 	for name := range cfg.MCPServers {
-		if err := identity.ValidatePrincipalName(name); err != nil {
+		if err := identity.ValidatePublicPrincipalName(name); err != nil {
 			return nil, fmt.Errorf("mcp_servers map key: %w", err)
 		}
 	}
@@ -729,7 +730,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid default_policy %q (must be allow or deny)", c.DefaultPolicy)
 	}
 	for name, agent := range c.Agents {
-		if err := identity.ValidatePrincipalName(name); err != nil {
+		if err := identity.ValidatePublicPrincipalName(name); err != nil {
 			return fmt.Errorf("agents map key: %w", err)
 		}
 		for _, target := range agent.CanMessage {
@@ -768,7 +769,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid gateway port: %d", c.Gateway.Port)
 		}
 		for name, srv := range c.MCPServers {
-			if err := identity.ValidatePrincipalName(name); err != nil {
+			if err := identity.ValidatePublicPrincipalName(name); err != nil {
 				return fmt.Errorf("mcp_servers map key: %w", err)
 			}
 			switch srv.Transport {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/oktsec/oktsec/internal/identity"
 	"github.com/oktsec/oktsec/internal/safefile"
 	"gopkg.in/yaml.v3"
 )
@@ -713,6 +714,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid default_policy %q (must be allow or deny)", c.DefaultPolicy)
 	}
 	for name, agent := range c.Agents {
+		if err := identity.ValidatePrincipalName(name); err != nil {
+			return fmt.Errorf("agents map key: %w", err)
+		}
 		for _, target := range agent.CanMessage {
 			if target == name {
 				return fmt.Errorf("agent %q lists itself in can_message", name)
@@ -749,6 +753,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid gateway port: %d", c.Gateway.Port)
 		}
 		for name, srv := range c.MCPServers {
+			if err := identity.ValidatePrincipalName(name); err != nil {
+				return fmt.Errorf("mcp_servers map key: %w", err)
+			}
 			switch srv.Transport {
 			case "stdio":
 				if srv.Command == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -607,6 +607,21 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
+	// Principal-name keys reach the key file system path and the audit
+	// row. Reject unsafe names at load time so a hand-edited or
+	// otherwise tampered config cannot smuggle a path traversal
+	// through to callers that skip the full Validate sweep.
+	for name := range cfg.Agents {
+		if err := identity.ValidatePrincipalName(name); err != nil {
+			return nil, fmt.Errorf("agents map key: %w", err)
+		}
+	}
+	for name := range cfg.MCPServers {
+		if err := identity.ValidatePrincipalName(name); err != nil {
+			return nil, fmt.Errorf("mcp_servers map key: %w", err)
+		}
+	}
+
 	// Apply zero-value defaults after unmarshal.
 	// These ensure sensible behavior even when fields are omitted from YAML.
 	if cfg.Quarantine.ExpiryHours == 0 {

--- a/internal/config/principal_validation_test.go
+++ b/internal/config/principal_validation_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A hand-edited oktsec.yaml must not be able to smuggle a path
+// traversal into the agents map. config.Load goes through Validate,
+// which calls identity.ValidatePrincipalName on every agent key. These
+// tests pin that contract.
+
+func TestLoad_RejectsUnsafeAgentMapKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	yaml := strings.TrimLeft(`
+version: "1"
+server:
+  port: 8080
+identity:
+  keys_dir: ./keys
+  require_signature: false
+agents:
+  "../../evil":
+    can_message: ["*"]
+`, "\n")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(cfgPath); err == nil {
+		t.Fatalf("Load accepted an agents map key that escapes the keys directory")
+	}
+}
+
+func TestLoad_RejectsUnsafeMCPServerMapKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	yaml := strings.TrimLeft(`
+version: "1"
+server:
+  port: 8080
+identity:
+  keys_dir: ./keys
+  require_signature: false
+gateway:
+  enabled: true
+  port: 9090
+mcp_servers:
+  "../escape":
+    transport: stdio
+    command: echo
+`, "\n")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(cfgPath); err == nil {
+		t.Fatalf("Load accepted an mcp_servers map key that escapes the keys directory")
+	}
+}
+
+func TestLoad_AcceptsValidAgentNames(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	yaml := strings.TrimLeft(`
+version: "1"
+server:
+  port: 8080
+identity:
+  keys_dir: ./keys
+  require_signature: false
+agents:
+  filesystem: { can_message: ["*"] }
+  github: { can_message: ["*"] }
+  research-agent: { can_message: ["*"] }
+  agent_01: { can_message: ["*"] }
+  org.tool: { can_message: ["*"] }
+`, "\n")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s) returned %v on a valid config", cfgPath, err)
+	}
+	for _, want := range []string{"filesystem", "github", "research-agent", "agent_01", "org.tool"} {
+		if _, ok := cfg.Agents[want]; !ok {
+			t.Fatalf("Load dropped a valid agent name %q", want)
+		}
+	}
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2932,12 +2932,10 @@ func (s *Server) handleQuarantineReject(w http.ResponseWriter, r *http.Request) 
 
 // --- Agent CRUD handlers ---
 
-var agentNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
-
 func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" || !agentNameRe.MatchString(name) {
-		http.Error(w, "invalid agent name (alphanumeric, hyphens, underscores)", http.StatusBadRequest)
+	if err := identity.ValidatePrincipalName(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if _, exists := s.cfg.Agents[name]; exists {
@@ -5695,12 +5693,10 @@ func (s *Server) handleSaveGatewaySettings(w http.ResponseWriter, r *http.Reques
 	http.Redirect(w, r, "/dashboard/gateway", http.StatusFound)
 }
 
-var mcpServerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
-
 func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" || !mcpServerNameRe.MatchString(name) {
-		http.Error(w, "invalid server name (alphanumeric, hyphens, underscores)", http.StatusBadRequest)
+	if err := identity.ValidatePrincipalName(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if _, exists := s.cfg.MCPServers[name]; exists {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2934,7 +2934,7 @@ func (s *Server) handleQuarantineReject(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("name"))
-	if err := identity.ValidatePrincipalName(name); err != nil {
+	if err := identity.ValidatePublicPrincipalName(name); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -5695,7 +5695,7 @@ func (s *Server) handleSaveGatewaySettings(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) handleCreateMCPServer(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("name"))
-	if err := identity.ValidatePrincipalName(name); err != nil {
+	if err := identity.ValidatePublicPrincipalName(name); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1002,10 +1002,11 @@ func (g *Gateway) autoRegisterAgent(name string) {
 	if g.cfg.Gateway.DisableAutoRegister {
 		return
 	}
-	// A name that fails principal-name validation must not be
-	// auto-registered. Otherwise it would land in cfg.Agents and the
-	// next key-load or save would synthesise an unsafe file path.
-	if err := identity.ValidatePrincipalName(name); err != nil {
+	// A name that fails public principal-name validation must not be
+	// auto-registered. Auto-register fires on external traffic, so we
+	// also reject reserved (leading-underscore) names to prevent
+	// collision with the internal _proxy signing principal.
+	if err := identity.ValidatePublicPrincipalName(name); err != nil {
 		g.logger.Warn("rejecting auto-register for unsafe agent name", "name", name, "error", err)
 		return
 	}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1002,6 +1002,13 @@ func (g *Gateway) autoRegisterAgent(name string) {
 	if g.cfg.Gateway.DisableAutoRegister {
 		return
 	}
+	// A name that fails principal-name validation must not be
+	// auto-registered. Otherwise it would land in cfg.Agents and the
+	// next key-load or save would synthesise an unsafe file path.
+	if err := identity.ValidatePrincipalName(name); err != nil {
+		g.logger.Warn("rejecting auto-register for unsafe agent name", "name", name, "error", err)
+		return
+	}
 	var needSave bool
 
 	g.registeredMu.Lock()

--- a/internal/identity/keypair.go
+++ b/internal/identity/keypair.go
@@ -23,7 +23,12 @@ type Keypair struct {
 }
 
 // GenerateKeypair creates a new Ed25519 key pair for the named agent.
+// The name must pass ValidatePrincipalName so that downstream Save and
+// Load calls cannot escape the keys directory.
 func GenerateKeypair(name string) (*Keypair, error) {
+	if err := ValidatePrincipalName(name); err != nil {
+		return nil, err
+	}
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generating keypair: %w", err)
@@ -37,7 +42,13 @@ func GenerateKeypair(name string) (*Keypair, error) {
 
 // Save writes the keypair to disk as PEM files.
 // Creates <dir>/<name>.key (private) and <dir>/<name>.pub (public).
+//
+// Save re-validates kp.Name. Callers that build a Keypair value
+// directly (without GenerateKeypair) cannot bypass the check.
 func (kp *Keypair) Save(dir string) error {
+	if err := ValidatePrincipalName(kp.Name); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating keys directory: %w", err)
 	}
@@ -67,7 +78,11 @@ func (kp *Keypair) Save(dir string) error {
 
 // LoadKeypair loads a full keypair (private + public) from disk.
 // Key files must not be symlinks and must not exceed 64 KB.
+// The name must pass ValidatePrincipalName.
 func LoadKeypair(dir, name string) (*Keypair, error) {
+	if err := ValidatePrincipalName(name); err != nil {
+		return nil, err
+	}
 	privPath := filepath.Join(dir, name+".key")
 	privPEM, err := safefile.ReadFileMax(privPath, 64*1024)
 	if err != nil {
@@ -94,7 +109,11 @@ func LoadKeypair(dir, name string) (*Keypair, error) {
 
 // LoadPublicKey loads only the public key from disk.
 // The file must not be a symlink and must not exceed 64 KB.
+// The name must pass ValidatePrincipalName.
 func LoadPublicKey(dir, name string) (ed25519.PublicKey, error) {
+	if err := ValidatePrincipalName(name); err != nil {
+		return nil, err
+	}
 	pubPath := filepath.Join(dir, name+".pub")
 	pubPEM, err := safefile.ReadFileMax(pubPath, 64*1024)
 	if err != nil {
@@ -123,6 +142,13 @@ func LoadPublicKeys(dir string) (map[string]ed25519.PublicKey, error) {
 			continue // skip symlinks
 		}
 		name := entry.Name()[:len(entry.Name())-4] // strip .pub
+		// A .pub file whose stem fails principal-name validation
+		// cannot be loaded safely. Skip it so a stray or malformed
+		// filename does not abort key loading for the whole
+		// directory; auditcheck flags it separately.
+		if !IsValidPrincipalName(name) {
+			continue
+		}
 		pub, err := LoadPublicKey(dir, name)
 		if err != nil {
 			return nil, fmt.Errorf("loading key for %s: %w", name, err)

--- a/internal/identity/principal.go
+++ b/internal/identity/principal.go
@@ -65,3 +65,31 @@ func ValidatePrincipalName(name string) error {
 func IsValidPrincipalName(name string) bool {
 	return ValidatePrincipalName(name) == nil
 }
+
+// IsReservedPrincipalName reports whether name is reserved for
+// internal use. Anything starting with "_" is reserved by convention.
+// The signing principal _proxy is the only current consumer, but new
+// internal principals follow the same prefix.
+//
+// Public surfaces (HTTP APIs, dashboard forms, CLI arguments, config
+// load, SDK callers) MUST reject reserved names so an external caller
+// cannot overwrite an internal key file. Only the identity package
+// and the audit-chain bootstrap may consume reserved names.
+func IsReservedPrincipalName(name string) bool {
+	return len(name) > 0 && name[0] == '_'
+}
+
+// ValidatePublicPrincipalName is the validator every user-facing
+// surface should call. It enforces the same filesystem-safety contract
+// as ValidatePrincipalName and additionally refuses internal reserved
+// names so an external caller cannot collide with a signing identity
+// such as _proxy.
+func ValidatePublicPrincipalName(name string) error {
+	if err := ValidatePrincipalName(name); err != nil {
+		return err
+	}
+	if IsReservedPrincipalName(name) {
+		return fmt.Errorf("principal name %q is reserved for internal use", name)
+	}
+	return nil
+}

--- a/internal/identity/principal.go
+++ b/internal/identity/principal.go
@@ -1,0 +1,62 @@
+package identity
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// principalNameRE is the canonical principal name shape: must start with
+// an alphanumeric character, then up to 127 of [A-Za-z0-9._-]. Total
+// length is bounded at 128 characters.
+var principalNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// MaxPrincipalNameLen is the maximum length accepted by
+// ValidatePrincipalName. 128 leaves room for sensible agent names while
+// staying well under PATH_MAX on every supported platform.
+const MaxPrincipalNameLen = 128
+
+// ValidatePrincipalName returns nil if name is safe to use as the basis
+// of a key filename or agent identifier. Otherwise it returns an
+// actionable error describing the violation.
+//
+// Callers MUST NOT silently rewrite a rejected name into a different
+// "safe" name. Rewriting would let two distinct upstream identities
+// collide on a single ACL and audit row, which is worse than refusing
+// the operation.
+//
+// Allowed: ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$
+//
+//	filesystem, github, research-agent, agent_01, org.tool
+//
+// Rejected: empty, ".", "..", anything containing path separators
+// (/, \), NUL bytes, leading ".", characters outside [A-Za-z0-9._-],
+// longer than 128 characters.
+func ValidatePrincipalName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid principal name: name is empty")
+	}
+	if len(name) > MaxPrincipalNameLen {
+		return fmt.Errorf("invalid principal name %q: length %d exceeds %d", name, len(name), MaxPrincipalNameLen)
+	}
+	// Explicit checks for the highest-impact cases produce clearer
+	// errors than a single regex mismatch message.
+	if strings.IndexByte(name, 0) >= 0 {
+		return fmt.Errorf("invalid principal name %q: contains a NUL byte", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("invalid principal name %q: contains a path separator", name)
+	}
+	if !principalNameRE.MatchString(name) {
+		return fmt.Errorf("invalid principal name %q: must start with a letter or digit and contain only letters, digits, dot, underscore, or dash", name)
+	}
+	return nil
+}
+
+// IsValidPrincipalName is the boolean predicate form of
+// ValidatePrincipalName. Use it when filtering filesystem entries where
+// a returned error would be noise (for example when enumerating .pub
+// files and silently skipping invalid filenames).
+func IsValidPrincipalName(name string) bool {
+	return ValidatePrincipalName(name) == nil
+}

--- a/internal/identity/principal.go
+++ b/internal/identity/principal.go
@@ -6,10 +6,15 @@ import (
 	"strings"
 )
 
-// principalNameRE is the canonical principal name shape: must start with
-// an alphanumeric character, then up to 127 of [A-Za-z0-9._-]. Total
-// length is bounded at 128 characters.
-var principalNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+// principalNameRE is the canonical principal name shape: must start
+// with a letter, digit, or underscore, then up to 127 of
+// [A-Za-z0-9._-]. Total length is bounded at 128 characters.
+//
+// Leading underscore is allowed for the small set of internal reserved
+// principals such as _proxy (used for audit-chain signing). Leading dot
+// is still rejected because it would create hidden files on Unix and
+// confuse directory enumeration.
+var principalNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 
 // MaxPrincipalNameLen is the maximum length accepted by
 // ValidatePrincipalName. 128 leaves room for sensible agent names while
@@ -25,13 +30,13 @@ const MaxPrincipalNameLen = 128
 // collide on a single ACL and audit row, which is worse than refusing
 // the operation.
 //
-// Allowed: ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$
+// Allowed: ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$
 //
-//	filesystem, github, research-agent, agent_01, org.tool
+//	filesystem, github, research-agent, agent_01, org.tool, _proxy
 //
 // Rejected: empty, ".", "..", anything containing path separators
-// (/, \), NUL bytes, leading ".", characters outside [A-Za-z0-9._-],
-// longer than 128 characters.
+// (/, \), NUL bytes, leading ".", leading "-", characters outside
+// [A-Za-z0-9._-], longer than 128 characters.
 func ValidatePrincipalName(name string) error {
 	if name == "" {
 		return fmt.Errorf("invalid principal name: name is empty")
@@ -48,7 +53,7 @@ func ValidatePrincipalName(name string) error {
 		return fmt.Errorf("invalid principal name %q: contains a path separator", name)
 	}
 	if !principalNameRE.MatchString(name) {
-		return fmt.Errorf("invalid principal name %q: must start with a letter or digit and contain only letters, digits, dot, underscore, or dash", name)
+		return fmt.Errorf("invalid principal name %q: must start with a letter, digit, or underscore and contain only letters, digits, dot, underscore, or dash", name)
 	}
 	return nil
 }

--- a/internal/identity/principal.go
+++ b/internal/identity/principal.go
@@ -21,6 +21,23 @@ var principalNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 // staying well under PATH_MAX on every supported platform.
 const MaxPrincipalNameLen = 128
 
+// windowsReservedNames is the set of basenames that map to character
+// devices on Windows regardless of file extension. Writing to
+// "NUL.key" on Windows opens the null device, so the validator must
+// refuse these basenames case-insensitively on every platform — the
+// resulting config files are shared across darwin, linux, and windows
+// hosts.
+//
+// Source: Microsoft "Naming Files, Paths, and Namespaces" doc, "DOS
+// device names" section.
+var windowsReservedNames = map[string]struct{}{
+	"con": {}, "prn": {}, "aux": {}, "nul": {},
+	"com1": {}, "com2": {}, "com3": {}, "com4": {}, "com5": {},
+	"com6": {}, "com7": {}, "com8": {}, "com9": {},
+	"lpt1": {}, "lpt2": {}, "lpt3": {}, "lpt4": {}, "lpt5": {},
+	"lpt6": {}, "lpt7": {}, "lpt8": {}, "lpt9": {},
+}
+
 // ValidatePrincipalName returns nil if name is safe to use as the basis
 // of a key filename or agent identifier. Otherwise it returns an
 // actionable error describing the violation.
@@ -54,6 +71,16 @@ func ValidatePrincipalName(name string) error {
 	}
 	if !principalNameRE.MatchString(name) {
 		return fmt.Errorf("invalid principal name %q: must start with a letter, digit, or underscore and contain only letters, digits, dot, underscore, or dash", name)
+	}
+	// Windows device-name check applies to the basename before the
+	// extension. Strip a trailing ".x...x" segment (the part after
+	// the first dot) and look up the lowercased prefix.
+	stem := name
+	if dot := strings.IndexByte(name, '.'); dot >= 0 {
+		stem = name[:dot]
+	}
+	if _, reserved := windowsReservedNames[strings.ToLower(stem)]; reserved {
+		return fmt.Errorf("invalid principal name %q: %s is a reserved Windows device name", name, stem)
 	}
 	return nil
 }

--- a/internal/identity/principal_path_safety_test.go
+++ b/internal/identity/principal_path_safety_test.go
@@ -1,0 +1,111 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests pin the filesystem-containment contract that
+// ValidatePrincipalName exists to enforce. They run against the real
+// identity package APIs (GenerateKeypair, Save, LoadKeypair,
+// LoadPublicKey, LoadPublicKeys) so that future refactors cannot
+// silently regress the protection.
+
+func TestGenerateKeypair_RejectsTraversal(t *testing.T) {
+	bad := []string{"../escape", "../../etc/passwd", `..\windows`, "a/b", "", "."}
+	for _, name := range bad {
+		t.Run(name, func(t *testing.T) {
+			kp, err := GenerateKeypair(name)
+			if err == nil {
+				t.Fatalf("GenerateKeypair(%q) returned a keypair %+v, want error", name, kp)
+			}
+		})
+	}
+}
+
+func TestKeypairSave_RejectsTraversal(t *testing.T) {
+	// A Keypair value built directly with an unsafe name must not be
+	// allowed to write outside dir.
+	dir := t.TempDir()
+	kp := &Keypair{Name: "../escape"}
+	if err := kp.Save(dir); err == nil {
+		t.Fatalf("Keypair{Name: %q}.Save(%q) returned nil, want error", kp.Name, dir)
+	}
+	// Confirm no file landed in the parent directory.
+	parent := filepath.Dir(dir)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", parent, err)
+	}
+	for _, e := range entries {
+		if e.Name() == "escape.key" || e.Name() == "escape.pub" {
+			t.Fatalf("Save wrote %s into the parent of the keys directory", e.Name())
+		}
+	}
+}
+
+func TestLoadKeypair_RejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	// Plant a benign decoy in the parent that a traversing name would
+	// otherwise read. The validator must refuse before the read.
+	parent := filepath.Dir(dir)
+	decoy := filepath.Join(parent, "decoy.key")
+	if err := os.WriteFile(decoy, []byte("not a key"), 0o600); err != nil {
+		t.Skipf("could not seed decoy: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(decoy) })
+
+	if _, err := LoadKeypair(dir, "../decoy"); err == nil {
+		t.Fatalf("LoadKeypair traversed into parent and succeeded")
+	}
+	if _, err := LoadPublicKey(dir, "../decoy"); err == nil {
+		t.Fatalf("LoadPublicKey traversed into parent and succeeded")
+	}
+}
+
+func TestLoadPublicKeys_SkipsUnsafeFilenames(t *testing.T) {
+	dir := t.TempDir()
+	// Plant a .pub file whose stem fails validation, plus a valid one.
+	// LoadPublicKeys must skip the invalid entry and return the valid
+	// key without erroring out.
+	valid := &Keypair{Name: "agent-a"}
+	pub, priv, err := generateForTest()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	valid.PublicKey = pub
+	valid.PrivateKey = priv
+	if err := valid.Save(dir); err != nil {
+		t.Fatalf("save valid: %v", err)
+	}
+	// A filename whose stem starts with "." fails validation. Seed it
+	// directly so we don't try to construct an invalid Keypair through
+	// the validated API.
+	unsafe := filepath.Join(dir, ".hidden.pub")
+	if err := os.WriteFile(unsafe, []byte("ignored"), 0o644); err != nil {
+		t.Fatalf("seed unsafe pub: %v", err)
+	}
+
+	keys, err := LoadPublicKeys(dir)
+	if err != nil {
+		t.Fatalf("LoadPublicKeys returned error %v, want nil with skip behavior", err)
+	}
+	if _, ok := keys["agent-a"]; !ok {
+		t.Fatalf("LoadPublicKeys lost the valid agent-a key: %v", keys)
+	}
+	if _, ok := keys[".hidden"]; ok {
+		t.Fatalf("LoadPublicKeys returned an unsafe filename as a key entry")
+	}
+}
+
+// generateForTest is a local helper that mirrors GenerateKeypair without
+// the principal-name check, so tests can seed files with arbitrary key
+// material when needed. We never expose this from the package itself.
+func generateForTest() (pub []byte, priv []byte, err error) {
+	tmp, err := GenerateKeypair("seed")
+	if err != nil {
+		return nil, nil, err
+	}
+	return tmp.PublicKey, tmp.PrivateKey, nil
+}

--- a/internal/identity/principal_test.go
+++ b/internal/identity/principal_test.go
@@ -85,6 +85,35 @@ func TestValidatePrincipalName_AcceptsReservedProxyPrincipal(t *testing.T) {
 	}
 }
 
+// ValidatePublicPrincipalName is the user-facing variant. It must
+// refuse internal reserved principals so an external caller (HTTP API,
+// dashboard form, SDK consumer, hand-edited config) cannot overwrite
+// the _proxy signing key.
+func TestValidatePublicPrincipalName_RejectsReserved(t *testing.T) {
+	cases := []string{"_proxy", "_internal", "_anything"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidatePublicPrincipalName(name); err == nil {
+				t.Fatalf("ValidatePublicPrincipalName(%q) returned nil; reserved names must be refused on public surfaces", name)
+			}
+			if !IsReservedPrincipalName(name) {
+				t.Fatalf("IsReservedPrincipalName(%q) = false, want true", name)
+			}
+		})
+	}
+}
+
+func TestValidatePublicPrincipalName_AcceptsNormalNames(t *testing.T) {
+	cases := []string{"filesystem", "github", "research-agent", "agent_01", "org.tool"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidatePublicPrincipalName(name); err != nil {
+				t.Fatalf("ValidatePublicPrincipalName(%q) = %v, want nil", name, err)
+			}
+		})
+	}
+}
+
 // Defence in depth: filenames built from a validated principal name must
 // never escape a parent directory via filepath.Join semantics. This test
 // pins the contract that motivates the validator.

--- a/internal/identity/principal_test.go
+++ b/internal/identity/principal_test.go
@@ -53,6 +53,14 @@ func TestValidatePrincipalName_Rejects(t *testing.T) {
 		{"weird:char", "must start with a letter, digit, or underscore"},
 		{"emoji-✓", "must start with a letter, digit, or underscore"},
 		{strings.Repeat("a", MaxPrincipalNameLen+1), "exceeds"},
+		{"NUL", "Windows device name"},
+		{"nul", "Windows device name"},
+		{"CON", "Windows device name"},
+		{"con.agent", "Windows device name"},
+		{"COM1", "Windows device name"},
+		{"lpt9", "Windows device name"},
+		{"AUX", "Windows device name"},
+		{"PRN", "Windows device name"},
 	}
 	for _, tc := range cases {
 		label := tc.name

--- a/internal/identity/principal_test.go
+++ b/internal/identity/principal_test.go
@@ -18,6 +18,8 @@ func TestValidatePrincipalName_Accepts(t *testing.T) {
 		"Z9",
 		"claude-code",
 		"alice.bob_carol-1",
+		"_proxy",
+		"_internal-signer_v2",
 		strings.Repeat("a", MaxPrincipalNameLen),
 	}
 	for _, name := range cases {
@@ -38,19 +40,18 @@ func TestValidatePrincipalName_Rejects(t *testing.T) {
 		want string // substring required in the error
 	}{
 		{"", "empty"},
-		{".", "must start with a letter or digit"},
-		{"..", "must start with a letter or digit"},
+		{".", "must start with a letter, digit, or underscore"},
+		{"..", "must start with a letter, digit, or underscore"},
 		{"../evil", "path separator"},
 		{"../../pwn", "path separator"},
 		{"a/b", "path separator"},
 		{`a\b`, "path separator"},
 		{"foo\x00bar", "NUL byte"},
-		{".hidden", "must start with a letter or digit"},
-		{"-leading-dash", "must start with a letter or digit"},
-		{"_leading_underscore", "must start with a letter or digit"},
-		{"name with space", "must start with a letter or digit"},
-		{"weird:char", "must start with a letter or digit"},
-		{"emoji-✓", "must start with a letter or digit"},
+		{".hidden", "must start with a letter, digit, or underscore"},
+		{"-leading-dash", "must start with a letter, digit, or underscore"},
+		{"name with space", "must start with a letter, digit, or underscore"},
+		{"weird:char", "must start with a letter, digit, or underscore"},
+		{"emoji-✓", "must start with a letter, digit, or underscore"},
 		{strings.Repeat("a", MaxPrincipalNameLen+1), "exceeds"},
 	}
 	for _, tc := range cases {
@@ -70,6 +71,17 @@ func TestValidatePrincipalName_Rejects(t *testing.T) {
 				t.Fatalf("IsValidPrincipalName(%q) = true, want false", tc.name)
 			}
 		})
+	}
+}
+
+// The _proxy principal signs audit-chain entries from
+// internal/proxy/server.go. ValidatePrincipalName must accept it; a
+// regression here would silently disable proxy signing on every fresh
+// install. See server.go LoadKeypair("_proxy") and
+// GenerateKeypair("_proxy") call sites.
+func TestValidatePrincipalName_AcceptsReservedProxyPrincipal(t *testing.T) {
+	if err := ValidatePrincipalName("_proxy"); err != nil {
+		t.Fatalf("ValidatePrincipalName(\"_proxy\") = %v, want nil; audit-chain signing depends on this name", err)
 	}
 }
 

--- a/internal/identity/principal_test.go
+++ b/internal/identity/principal_test.go
@@ -1,0 +1,87 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePrincipalName_Accepts(t *testing.T) {
+	cases := []string{
+		"filesystem",
+		"github",
+		"research-agent",
+		"agent_01",
+		"org.tool",
+		"a",
+		"A",
+		"0",
+		"Z9",
+		"claude-code",
+		"alice.bob_carol-1",
+		strings.Repeat("a", MaxPrincipalNameLen),
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidatePrincipalName(name); err != nil {
+				t.Fatalf("ValidatePrincipalName(%q) returned %v, want nil", name, err)
+			}
+			if !IsValidPrincipalName(name) {
+				t.Fatalf("IsValidPrincipalName(%q) = false, want true", name)
+			}
+		})
+	}
+}
+
+func TestValidatePrincipalName_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		want string // substring required in the error
+	}{
+		{"", "empty"},
+		{".", "must start with a letter or digit"},
+		{"..", "must start with a letter or digit"},
+		{"../evil", "path separator"},
+		{"../../pwn", "path separator"},
+		{"a/b", "path separator"},
+		{`a\b`, "path separator"},
+		{"foo\x00bar", "NUL byte"},
+		{".hidden", "must start with a letter or digit"},
+		{"-leading-dash", "must start with a letter or digit"},
+		{"_leading_underscore", "must start with a letter or digit"},
+		{"name with space", "must start with a letter or digit"},
+		{"weird:char", "must start with a letter or digit"},
+		{"emoji-✓", "must start with a letter or digit"},
+		{strings.Repeat("a", MaxPrincipalNameLen+1), "exceeds"},
+	}
+	for _, tc := range cases {
+		label := tc.name
+		if label == "" {
+			label = "<empty>"
+		}
+		t.Run(label, func(t *testing.T) {
+			err := ValidatePrincipalName(tc.name)
+			if err == nil {
+				t.Fatalf("ValidatePrincipalName(%q) returned nil, want error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidatePrincipalName(%q) error = %q, want substring %q", tc.name, err.Error(), tc.want)
+			}
+			if IsValidPrincipalName(tc.name) {
+				t.Fatalf("IsValidPrincipalName(%q) = true, want false", tc.name)
+			}
+		})
+	}
+}
+
+// Defence in depth: filenames built from a validated principal name must
+// never escape a parent directory via filepath.Join semantics. This test
+// pins the contract that motivates the validator.
+func TestValidatePrincipalName_FilesystemContainment(t *testing.T) {
+	const dir = "/tmp/keys"
+	bad := []string{"../escape", "../../etc/passwd", `..\windows`, "subdir/leaf"}
+	for _, name := range bad {
+		if err := ValidatePrincipalName(name); err == nil {
+			t.Fatalf("ValidatePrincipalName(%q) accepted a name that would escape %q", name, dir)
+		}
+	}
+}

--- a/internal/proxy/api_agents.go
+++ b/internal/proxy/api_agents.go
@@ -124,7 +124,7 @@ func (a *AgentAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Name = strings.TrimSpace(req.Name)
-	if err := identity.ValidatePrincipalName(req.Name); err != nil {
+	if err := identity.ValidatePublicPrincipalName(req.Name); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/proxy/api_agents.go
+++ b/internal/proxy/api_agents.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -13,9 +12,6 @@ import (
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/identity"
 )
-
-// agentAPINameRe validates agent names: alphanumeric, hyphens, underscores.
-var agentAPINameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 // AgentAPI handles REST endpoints for agent CRUD operations.
 type AgentAPI struct {
@@ -128,8 +124,8 @@ func (a *AgentAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Name = strings.TrimSpace(req.Name)
-	if req.Name == "" || !agentAPINameRe.MatchString(req.Name) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid agent name (alphanumeric, hyphens, underscores)"})
+	if err := identity.ValidatePrincipalName(req.Name); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 

--- a/internal/proxy/api_agents_principal_test.go
+++ b/internal/proxy/api_agents_principal_test.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The HTTP agent CRUD must refuse a reserved principal name like
+// _proxy. Accepting it would let an external caller register a
+// "_proxy" agent and a subsequent key rotation would overwrite the
+// audit-chain signing key.
+func TestAgentAPI_Create_RejectsReservedPrincipal(t *testing.T) {
+	_, mux := newTestAgentAPI(t)
+
+	for _, name := range []string{"_proxy", "_internal", "_anything"} {
+		t.Run(name, func(t *testing.T) {
+			body, _ := json.Marshal(AgentCreateRequest{Name: name})
+			req := httptest.NewRequest("POST", "/v1/agents", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "POST /v1/agents %q must return 400", name)
+		})
+	}
+}
+
+// Traversal names must also be refused with a 400. Pinning this here
+// (in addition to the existing TestAgentAPI_Create_InvalidName) makes
+// the contract explicit for future contributors.
+func TestAgentAPI_Create_RejectsTraversalPrincipal(t *testing.T) {
+	_, mux := newTestAgentAPI(t)
+
+	body, _ := json.Marshal(AgentCreateRequest{Name: "../../escape"})
+	req := httptest.NewRequest("POST", "/v1/agents", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -33,8 +33,10 @@ import (
 
 // sdkPrincipalNameRE mirrors internal/identity.ValidatePrincipalName so
 // the SDK can refuse a malicious agent name without taking a dependency
-// on an internal package. The shape is intentionally identical.
-var sdkPrincipalNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+// on an internal package. The shape is intentionally identical,
+// including the leading-underscore allowance for internal reserved
+// principals such as _proxy.
+var sdkPrincipalNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 
 // validateAgentName rejects names that would let LoadKeypair build a
 // path outside dir.
@@ -46,7 +48,7 @@ func validateAgentName(name string) error {
 		return fmt.Errorf("agent name %q contains a path separator or NUL byte", name)
 	}
 	if !sdkPrincipalNameRE.MatchString(name) {
-		return fmt.Errorf("agent name %q is not allowed: must start with a letter or digit and contain only letters, digits, dot, underscore, or dash (max 128 chars)", name)
+		return fmt.Errorf("agent name %q is not allowed: must start with a letter, digit, or underscore and contain only letters, digits, dot, underscore, or dash (max 128 chars)", name)
 	}
 	return nil
 }

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -26,8 +26,30 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 )
+
+// sdkPrincipalNameRE mirrors internal/identity.ValidatePrincipalName so
+// the SDK can refuse a malicious agent name without taking a dependency
+// on an internal package. The shape is intentionally identical.
+var sdkPrincipalNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// validateAgentName rejects names that would let LoadKeypair build a
+// path outside dir.
+func validateAgentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("agent name is empty")
+	}
+	if strings.IndexByte(name, 0) >= 0 || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("agent name %q contains a path separator or NUL byte", name)
+	}
+	if !sdkPrincipalNameRE.MatchString(name) {
+		return fmt.Errorf("agent name %q is not allowed: must start with a letter or digit and contain only letters, digits, dot, underscore, or dash (max 128 chars)", name)
+	}
+	return nil
+}
 
 // MessageRequest is sent to POST /v1/message.
 type MessageRequest struct {
@@ -195,7 +217,11 @@ type Keypair struct {
 
 // LoadKeypair loads an oktsec keypair from PEM files in the given directory.
 // Expects <dir>/<name>.key (private) and optionally <dir>/<name>.pub (public).
+// The name must be a safe principal identifier; see validateAgentName.
 func LoadKeypair(dir, name string) (*Keypair, error) {
+	if err := validateAgentName(name); err != nil {
+		return nil, err
+	}
 	privPath := filepath.Join(dir, name+".key")
 
 	privPEM, err := readFileNoFollow(privPath)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -36,10 +36,21 @@ import (
 // check before touching the disk.
 var sdkPrincipalNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 
+// sdkWindowsReserved mirrors internal/identity.windowsReservedNames so
+// the SDK can refuse a name that would otherwise open a Windows
+// character device (NUL, CON, COM1, etc.) instead of a key file.
+var sdkWindowsReserved = map[string]struct{}{
+	"con": {}, "prn": {}, "aux": {}, "nul": {},
+	"com1": {}, "com2": {}, "com3": {}, "com4": {}, "com5": {},
+	"com6": {}, "com7": {}, "com8": {}, "com9": {},
+	"lpt1": {}, "lpt2": {}, "lpt3": {}, "lpt4": {}, "lpt5": {},
+	"lpt6": {}, "lpt7": {}, "lpt8": {}, "lpt9": {},
+}
+
 // validateAgentName rejects names that would let LoadKeypair build a
-// path outside dir, and additionally refuses internal reserved
-// principals (leading underscore) so an external SDK caller cannot
-// load or overwrite a signing key such as _proxy.
+// path outside dir, refuses internal reserved principals (leading
+// underscore), and refuses Windows-reserved device basenames so the
+// same SDK build behaves consistently on darwin, linux, and windows.
 func validateAgentName(name string) error {
 	if name == "" {
 		return fmt.Errorf("agent name is empty")
@@ -52,6 +63,13 @@ func validateAgentName(name string) error {
 	}
 	if name[0] == '_' {
 		return fmt.Errorf("agent name %q is reserved for internal use", name)
+	}
+	stem := name
+	if dot := strings.IndexByte(name, '.'); dot >= 0 {
+		stem = name[:dot]
+	}
+	if _, reserved := sdkWindowsReserved[strings.ToLower(stem)]; reserved {
+		return fmt.Errorf("agent name %q resolves to a reserved Windows device name", name)
 	}
 	return nil
 }

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -31,15 +31,15 @@ import (
 	"time"
 )
 
-// sdkPrincipalNameRE mirrors internal/identity.ValidatePrincipalName so
-// the SDK can refuse a malicious agent name without taking a dependency
-// on an internal package. The shape is intentionally identical,
-// including the leading-underscore allowance for internal reserved
-// principals such as _proxy.
+// sdkPrincipalNameRE mirrors the filesystem-safety shape used by the
+// internal identity package. The SDK refuses names that fail this
+// check before touching the disk.
 var sdkPrincipalNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 
 // validateAgentName rejects names that would let LoadKeypair build a
-// path outside dir.
+// path outside dir, and additionally refuses internal reserved
+// principals (leading underscore) so an external SDK caller cannot
+// load or overwrite a signing key such as _proxy.
 func validateAgentName(name string) error {
 	if name == "" {
 		return fmt.Errorf("agent name is empty")
@@ -49,6 +49,9 @@ func validateAgentName(name string) error {
 	}
 	if !sdkPrincipalNameRE.MatchString(name) {
 		return fmt.Errorf("agent name %q is not allowed: must start with a letter, digit, or underscore and contain only letters, digits, dot, underscore, or dash (max 128 chars)", name)
+	}
+	if name[0] == '_' {
+		return fmt.Errorf("agent name %q is reserved for internal use", name)
 	}
 	return nil
 }

--- a/sdk/principal_test.go
+++ b/sdk/principal_test.go
@@ -1,0 +1,31 @@
+package sdk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// LoadKeypair must refuse a traversal name before it tries to read
+// outside dir. We seed a benign decoy in the parent directory so a
+// regression that drops the validation would succeed silently.
+func TestLoadKeypair_RejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Dir(dir)
+
+	decoyKey := filepath.Join(parent, "decoy.key")
+	if err := os.WriteFile(decoyKey, []byte("not a key"), 0o600); err != nil {
+		t.Skipf("could not seed decoy: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(decoyKey) })
+
+	if _, err := LoadKeypair(dir, "../decoy"); err == nil {
+		t.Fatal("LoadKeypair followed a traversal name and returned a keypair")
+	}
+	if _, err := LoadKeypair(dir, "a/b"); err == nil {
+		t.Fatal("LoadKeypair accepted a path-separator name")
+	}
+	if _, err := LoadKeypair(dir, ""); err == nil {
+		t.Fatal("LoadKeypair accepted an empty name")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `identity.ValidatePrincipalName` and `identity.ValidatePublicPrincipalName`. Filesystem-safety check plus a reserved-name guard for user-facing surfaces.
- Wire the validators into every code path that turns an agent or MCP server name into a key file, an ACL row, or an auto-registered config record.
- Refuse Windows-reserved device basenames (NUL, CON, COM1-9, LPT1-9, AUX, PRN) case-insensitively, including names with a trailing extension.

## Why
Internal security audit (2026-05-12) flagged a HIGH finding: agent and MCP server names flow into `filepath.Join(keysDir, name+".key")` without centralised validation. A name containing `../`, NUL, or a path separator could write a private key outside `keysDir` or read a decoy from a sibling directory. The same names auto-promote into `cfg.Agents` and the audit row, so the lack of validation also affected ACL and audit lookups.

## What changes
- `internal/identity/principal.go`: new helpers `ValidatePrincipalName`, `IsValidPrincipalName`, `IsReservedPrincipalName`, `ValidatePublicPrincipalName`. Canonical regex `^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`, length capped at 128. Leading underscore is reserved for internal principals such as `_proxy` (audit-chain signing).
- `internal/identity/keypair.go`: `GenerateKeypair`, `Keypair.Save`, `LoadKeypair`, `LoadPublicKey` all validate before any read or write. `LoadPublicKeys` skips `.pub` filenames whose stem fails validation rather than aborting the whole directory load.
- Public surfaces switched to `ValidatePublicPrincipalName`: proxy agent CRUD HTTP API, dashboard agent and MCP server forms, gateway `autoRegisterAgent`, `oktsec connect`, `keygen`, `keys rotate`, `keys revoke`, `setup`, `run`, `init`, and `config.Load` / `Validate` for the `agents` and `mcp_servers` map keys.
- `sdk/client.go`: `LoadKeypair` runs an identical self-contained check so external Go SDK consumers do not need an internal package import.
- Two package-local agent-name regexes (`agentAPINameRe` in `internal/proxy/api_agents.go`, `agentNameRe` and `mcpServerNameRe` in `internal/dashboard/handlers.go`) are removed in favour of the central validator.

## What stays the same
- Canonical names already in use stay valid: `filesystem`, `github`, `research-agent`, `agent_01`, `org.tool`, plus `_proxy` for internal callers only.
- No change to message signing, ACL semantics, audit hash chain, or proxy enforcement flow.
- `LoadPublicKeys` still returns the valid sibling entries when one filename is bad. No surprise abort on legitimate installs.

## Validation
- `go test -race -count=1 ./...` green
- `go vet ./...` clean
- `make lint` 0 issues
- `govulncheck ./...` no vulnerabilities

## Test plan
- [ ] CI green
- [ ] `oktsec run` on a fresh install discovers MCP servers with normal names and writes keys to `<keysDir>/<name>.key` as before
- [ ] `oktsec keygen --agent ../../pwn` returns an error and writes nothing outside the keys directory
- [ ] HTTP `POST /v1/agents` with `name: "_proxy"` returns 400
- [ ] HTTP `POST /v1/agents` with `name: "../escape"` returns 400
- [ ] A hand-edited `oktsec.yaml` with an `agents` map key containing `../` fails to load with a clear error