### PR TITLE
fix: enforce egress sandbox env precedence in MCP gateway

### DIFF
--- a/internal/gateway/backend.go
+++ b/internal/gateway/backend.go
@@ -101,34 +101,7 @@ func (b *Backend) createSession(ctx context.Context) (MCPSession, error) {
 	case "stdio":
 		args := b.Config.Args
 		cmd := exec.CommandContext(ctx, b.Config.Command, args...)
-
-		// Egress sandbox: inject proxy env vars so all HTTP traffic from the
-		// child process routes through oktsec's forward proxy where egress
-		// policies (domain allow/block, content scanning) are enforced.
-		if b.Config.EgressSandbox {
-			port := b.proxyPort
-			if port == 0 {
-				port = 8083 // default forward proxy port
-			}
-			proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", port)
-			// Start with host env so child has PATH, HOME, etc.
-			cmd.Env = os.Environ()
-			cmd.Env = setEnv(cmd.Env, "HTTP_PROXY", proxyAddr)
-			cmd.Env = setEnv(cmd.Env, "HTTPS_PROXY", proxyAddr)
-			cmd.Env = setEnv(cmd.Env, "http_proxy", proxyAddr)
-			cmd.Env = setEnv(cmd.Env, "https_proxy", proxyAddr)
-			cmd.Env = setEnv(cmd.Env, "NO_PROXY", "")
-			cmd.Env = setEnv(cmd.Env, "no_proxy", "")
-			b.logger.Info("egress sandbox active", "server", b.Name, "proxy", proxyAddr)
-		}
-
-		// Apply user's custom env vars (overrides sandbox vars if set)
-		for k, v := range b.Config.Env {
-			if cmd.Env == nil {
-				cmd.Env = os.Environ()
-			}
-			cmd.Env = setEnv(cmd.Env, k, v)
-		}
+		cmd.Env = b.buildChildEnv(os.Environ())
 		transport = &mcp.CommandTransport{Command: cmd}
 
 	case "http":
@@ -143,6 +116,82 @@ func (b *Backend) createSession(ctx context.Context) (MCPSession, error) {
 		return nil, fmt.Errorf("connecting: %w", err)
 	}
 	return session, nil
+}
+
+// buildChildEnv assembles the env slice that a stdio backend's child
+// process inherits. baseEnv is typically os.Environ(); tests pass a
+// fixed slice for deterministic assertions.
+//
+// Layering:
+//
+//  1. baseEnv (host environment, copied so we never mutate it).
+//  2. Egress-sandbox proxy env, when EgressSandbox is true. This
+//     forces HTTP_PROXY / HTTPS_PROXY / ALL_PROXY (and lowercase
+//     variants) to point at Oktsec's forward proxy and clears
+//     NO_PROXY so nothing bypasses the sandbox.
+//  3. Backend Env from the config. When the sandbox is active,
+//     reserved proxy keys are dropped here with a warning so a
+//     hostile or buggy backend config cannot redirect or disable
+//     the sandbox. Non-proxy keys (NODE_OPTIONS, custom tokens,
+//     etc.) still pass through.
+func (b *Backend) buildChildEnv(baseEnv []string) []string {
+	env := make([]string, len(baseEnv))
+	copy(env, baseEnv)
+
+	sandbox := b.Config.EgressSandbox
+	if sandbox {
+		port := b.proxyPort
+		if port == 0 {
+			port = 8083 // default forward proxy port
+		}
+		proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", port)
+		env = setEnv(env, "HTTP_PROXY", proxyAddr)
+		env = setEnv(env, "HTTPS_PROXY", proxyAddr)
+		env = setEnv(env, "ALL_PROXY", proxyAddr)
+		env = setEnv(env, "http_proxy", proxyAddr)
+		env = setEnv(env, "https_proxy", proxyAddr)
+		env = setEnv(env, "all_proxy", proxyAddr)
+		env = setEnv(env, "NO_PROXY", "")
+		env = setEnv(env, "no_proxy", "")
+		b.logger.Info("egress sandbox active", "server", b.Name, "proxy", proxyAddr)
+	}
+
+	for k, v := range b.Config.Env {
+		if sandbox && isReservedProxyEnvKey(k) {
+			b.logger.Warn("egress sandbox ignored reserved proxy env from backend config",
+				"server", b.Name, "key", k)
+			continue
+		}
+		env = setEnv(env, k, v)
+	}
+	return env
+}
+
+// reservedProxyEnvKeys are the environment variable names through
+// which a child process selects its outbound HTTP proxy. When the
+// egress sandbox is active, Oktsec sets these to route traffic
+// through the forward proxy; backend config must not override them.
+//
+// Net/http honours both upper and lower case forms, and many
+// language runtimes (Python requests, Node fetch, curl) follow the
+// same convention, so we treat each variant as a distinct reserved
+// key.
+var reservedProxyEnvKeys = map[string]struct{}{
+	"HTTP_PROXY":  {},
+	"HTTPS_PROXY": {},
+	"ALL_PROXY":   {},
+	"NO_PROXY":    {},
+	"http_proxy":  {},
+	"https_proxy": {},
+	"all_proxy":   {},
+	"no_proxy":    {},
+}
+
+// isReservedProxyEnvKey reports whether key controls outbound proxy
+// behaviour in the child process.
+func isReservedProxyEnvKey(key string) bool {
+	_, ok := reservedProxyEnvKeys[key]
+	return ok
 }
 
 // setEnv sets a key=value pair in an env slice, replacing an existing entry

--- a/internal/gateway/egress_sandbox_test.go
+++ b/internal/gateway/egress_sandbox_test.go
@@ -136,22 +136,89 @@ func TestBuildSandboxEnv(t *testing.T) {
 	assert.Equal(t, "secret123", envMap["MY_TOKEN"])
 }
 
-// TestCustomEnvOverridesSandbox verifies that user-specified Env can override
-// the sandbox proxy vars (e.g., to point at a different proxy).
-func TestCustomEnvOverridesSandbox(t *testing.T) {
-	proxyAddr := "http://127.0.0.1:8083"
-	customProxy := "http://custom-proxy:9090"
+// When EgressSandbox is true, backend Env entries naming a reserved
+// proxy key are ignored. A backend config that sets NO_PROXY=* or
+// HTTPS_PROXY=http://evil could otherwise disable or redirect the
+// sandbox; the merged child env must point at the Oktsec forward
+// proxy regardless of backend config.
+func TestBuildChildEnv_SandboxRejectsBackendProxyOverride(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := NewBackend("test", config.MCPServerConfig{
+		Transport:     "stdio",
+		Command:       "echo",
+		EgressSandbox: true,
+		Env: map[string]string{
+			"HTTP_PROXY":  "http://evil:1",
+			"HTTPS_PROXY": "http://evil:2",
+			"ALL_PROXY":   "http://evil:3",
+			"NO_PROXY":    "*",
+			"http_proxy":  "http://evil:4",
+			"https_proxy": "http://evil:5",
+			"all_proxy":   "http://evil:6",
+			"no_proxy":    "*",
+		},
+	}, logger)
+	b.SetProxyPort(8083)
 
-	env := []string{"HOME=/home/user"}
-	env = setEnv(env, "HTTP_PROXY", proxyAddr)
-	env = setEnv(env, "HTTPS_PROXY", proxyAddr)
-
-	// User overrides HTTP_PROXY
-	env = setEnv(env, "HTTP_PROXY", customProxy)
-
+	env := b.buildChildEnv([]string{"HOME=/home/user", "PATH=/usr/bin"})
 	envMap := envToMap(env)
-	assert.Equal(t, customProxy, envMap["HTTP_PROXY"], "user Env should override sandbox proxy")
-	assert.Equal(t, proxyAddr, envMap["HTTPS_PROXY"], "non-overridden proxy var should remain")
+
+	const proxyAddr = "http://127.0.0.1:8083"
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"} {
+		assert.Equal(t, proxyAddr, envMap[key], "%s must point at the Oktsec sandbox proxy", key)
+	}
+	assert.Equal(t, "", envMap["NO_PROXY"], "NO_PROXY must be empty so nothing bypasses the sandbox")
+	assert.Equal(t, "", envMap["no_proxy"], "no_proxy must be empty so nothing bypasses the sandbox")
+}
+
+// Non-proxy backend env still passes through under the sandbox.
+// Application-specific config (NODE_OPTIONS, MY_TOKEN, etc.) is not
+// affected by the precedence rule.
+func TestBuildChildEnv_SandboxPassesThroughNonProxyEnv(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := NewBackend("test", config.MCPServerConfig{
+		Transport:     "stdio",
+		Command:       "echo",
+		EgressSandbox: true,
+		Env: map[string]string{
+			"NODE_OPTIONS":   "--max-old-space-size=4096",
+			"APP_API_TOKEN":  "secret-123",
+			"FEATURE_FLAG":   "on",
+			"HTTPS_PROXY":    "http://evil:9",
+		},
+	}, logger)
+	b.SetProxyPort(8083)
+
+	env := b.buildChildEnv([]string{"HOME=/home/user"})
+	envMap := envToMap(env)
+
+	assert.Equal(t, "--max-old-space-size=4096", envMap["NODE_OPTIONS"])
+	assert.Equal(t, "secret-123", envMap["APP_API_TOKEN"])
+	assert.Equal(t, "on", envMap["FEATURE_FLAG"])
+	assert.Equal(t, "http://127.0.0.1:8083", envMap["HTTPS_PROXY"], "sandbox still wins for proxy keys")
+}
+
+// With the sandbox disabled, backend Env still passes through as
+// before. This preserves the legacy behaviour: an operator who
+// chooses to route a backend through a custom HTTP proxy without
+// Oktsec sandboxing keeps that ability.
+func TestBuildChildEnv_NoSandboxKeepsBackendEnvUnchanged(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := NewBackend("test", config.MCPServerConfig{
+		Transport:     "stdio",
+		Command:       "echo",
+		EgressSandbox: false,
+		Env: map[string]string{
+			"HTTPS_PROXY": "http://custom-proxy:9090",
+			"NO_PROXY":    "localhost",
+		},
+	}, logger)
+
+	env := b.buildChildEnv([]string{"HOME=/home/user"})
+	envMap := envToMap(env)
+
+	assert.Equal(t, "http://custom-proxy:9090", envMap["HTTPS_PROXY"], "without sandbox, backend env still controls proxy")
+	assert.Equal(t, "localhost", envMap["NO_PROXY"])
 }
 
 func TestDefaultProxyPort_FallbackTo8083(t *testing.T) {


### PR DESCRIPTION
## Summary
- When `EgressSandbox=true`, reserved proxy environment keys from backend config are dropped with a warning. The Oktsec-set values for `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, and their lowercase variants win.
- `ALL_PROXY` and `all_proxy` join the sandbox injection set alongside the existing `HTTP_PROXY` / `HTTPS_PROXY` pair.
- Env-building logic moves into a `Backend.buildChildEnv` method so the precedence contract is testable without spawning a child process.
- Three regression tests replace `TestCustomEnvOverridesSandbox`, which documented the bug ("user Env should override sandbox proxy").

## Why
Internal security audit (2026-05-12) flagged a MEDIUM finding: `internal/gateway/backend.go` set the sandbox proxy env first, then applied backend `Env` on top. A backend config that set `HTTPS_PROXY=http://evil` or `NO_PROXY=*` could redirect or bypass the sandbox entirely, and the forward proxy was the only place egress policies (domain allow/block, content scanning) ran. Disabling the sandbox also disabled those.

## What changes
- `internal/gateway/backend.go`:
  - New `Backend.buildChildEnv(baseEnv []string) []string` method assembles the child env in three layers (host env, sandbox proxy injection, backend env). `createSession` now calls it once.
  - `reservedProxyEnvKeys` is a fixed set of 8 names (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` + lowercase variants). The runtimes that honour proxy env (Go `net/http`, Python `urllib`, Node, curl) treat upper and lower case as distinct keys, so both shapes are reserved.
  - When `EgressSandbox=true`, backend env entries naming a reserved key are skipped and the dropped key is logged at warn.
- `internal/gateway/egress_sandbox_test.go`:
  - `TestCustomEnvOverridesSandbox` is removed.
  - `TestBuildChildEnv_SandboxRejectsBackendProxyOverride`: backend config that sets `HTTP_PROXY=http://evil:1`, `NO_PROXY=*`, etc. across all 8 keys produces a child env where every proxy key points at the Oktsec sandbox and both `NO_PROXY` forms are empty.
  - `TestBuildChildEnv_SandboxPassesThroughNonProxyEnv`: non-proxy backend env (`NODE_OPTIONS`, `APP_API_TOKEN`, custom flags) still passes through unchanged.
  - `TestBuildChildEnv_NoSandboxKeepsBackendEnvUnchanged`: when `EgressSandbox=false`, backend `HTTPS_PROXY` and `NO_PROXY` are honoured. The legacy path is preserved.

## What stays the same
- `EgressSandbox=false` continues to let backend env control proxy selection. Operators routing a backend through a non-Oktsec proxy keep that ability.
- Non-proxy env keys (`PATH`, `NODE_OPTIONS`, application tokens, etc.) still flow through backend config in both modes.
- No change to the `setEnv` helper, the forward proxy itself, or any other gateway code path.

## Validation
- `go test -race -count=1 ./...` green
- `go vet ./...` clean
- `make lint` 0 issues
- `govulncheck ./...` no vulnerabilities

## Test plan
- [ ] CI green
- [ ] A backend with `egress_sandbox: true` and `env: { HTTPS_PROXY: http://evil }` routes through Oktsec, with a warning logged for the dropped key
- [ ] A backend with `egress_sandbox: false` and `env: { HTTPS_PROXY: http://custom }` routes through `http://custom`
- [ ] A backend with `egress_sandbox: true` and `env: { NODE_OPTIONS: ... }` keeps `NODE_OPTIONS` in the child process