### PR TITLE
chore: harden publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26.3"
 
@@ -21,7 +21,7 @@ jobs:
         run: make build
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.10.1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -33,7 +33,7 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,19 +7,24 @@ on:
 
 permissions:
   contents: read
+  # id-token is required for PyPI Trusted Publishing. The publish
+  # step exchanges this for a short-lived OIDC token that PyPI
+  # accepts when the project is configured to trust this repo and
+  # workflow. See RELEASE.md for the one-time PyPI side setup.
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: pip install build twine
+      - name: Install build tool
+        run: pip install build
 
       - name: Set version from tag
         working-directory: sdk/python
@@ -32,8 +37,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        working-directory: sdk/python
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: sdk/python/dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,15 +7,12 @@ on:
 
 permissions:
   contents: read
-  # id-token is required for PyPI Trusted Publishing. The publish
-  # step exchanges this for a short-lived OIDC token that PyPI
-  # accepts when the project is configured to trust this repo and
-  # workflow. See RELEASE.md for the one-time PyPI side setup.
-  id-token: write
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -36,7 +33,31 @@ jobs:
         working-directory: sdk/python
         run: python -m build
 
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-sdk-dist
+          path: sdk/python/dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      # The publish job is the only step that needs an OIDC token.
+      # Keeping id-token: write off the build job prevents
+      # PyPI-sourced build tooling from minting a publish credential
+      # before the artifact is final.
+      id-token: write
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-sdk-dist
+          path: dist
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          packages-dir: sdk/python/dist
+          packages-dir: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,27 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26.3"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+# Release process
+
+## Cutting a release
+
+```sh
+git pull --ff-only origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag push triggers parallel publish workflows that ship the
+multi-arch binaries, the Docker image, and the Python SDK.
+
+## Release authorisation
+
+Release-authorisation steps (credential model, repository protections,
+recurring rotation) are kept in the maintainer runbook outside this
+repository. Maintainers who need access to that runbook can request
+it from the project owner.


### PR DESCRIPTION
## Summary
- Pin every action referenced by CI, release, docs, and Python SDK publish workflows to a commit SHA. Version tags stay as trailing comments.
- Move the Python SDK publish step to the official PyPI publish action with OIDC. The publish credential exists only for the duration of the upload.
- Split the SDK publish workflow into separate build and publish jobs so OIDC token-mint capability is scoped to the publish job only.
- Add a short `RELEASE.md` covering the tag-and-publish flow. Operator-level release-authorisation details stay in maintainer-only notes outside the repository.

## Why
Internal security audit (2026-05-12) flagged the release path as a supply-chain priority. The previous workflows referenced upstream actions by mutable tag and depended on a long-lived publish credential held in repository secrets. Recent ecosystem incidents have shown both shapes to be live attack surface.

## What changes
- `.github/workflows/{ci,release,docs,pypi}.yml`: every action reference is now a 40-character commit SHA. The version tag is preserved as a trailing comment so the diff remains readable.
- `.github/workflows/pypi.yml`: replaces the previous credential-based upload with the official PyPI publish action. Build and publish are now separate jobs. The build job runs packaging tooling without any token-mint permission; the publish job downloads the built distribution as an artifact and is the only job that requests `id-token: write`.
- `RELEASE.md` (new): documents the recurring tag-and-publish flow. Operator-level release-authorisation steps are referenced as a maintainer-only runbook outside this repository.

## What stays the same
- `release.yml` continues to ship multi-arch binaries via GoReleaser and Docker images to GHCR.
- `docs.yml` continues to publish MkDocs to GitHub Pages.
- `ci.yml` continues to run build, lint, test, integration test, vet, and benchmark on every PR.
- No application code changes.

## Validation
- `go test -race -count=1 ./...` green
- `go vet ./...` clean
- `make lint` 0 issues
- `govulncheck ./...` no vulnerabilities
- Workflow file structure verified: every `uses:` references a 40-character SHA across all four workflows.

## Test plan
- [ ] CI green on this PR (the new pins run on this PR's own CI workflow)
- [ ] Next `v*` tag publishes the SDK through the new build-then-publish pipeline