### PR TITLE
chore: scope docs workflow permissions to the deploy job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -20,6 +18,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -40,6 +40,13 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      # Only the deploy job needs the Pages write + OIDC token-mint
+      # capability. Keeping these off the build job prevents
+      # PyPI-sourced packaging tooling (pip install mkdocs-material)
+      # from running with deploy credentials available.
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Move `pages: write` and `id-token: write` from workflow scope to the deploy job in `.github/workflows/docs.yml`.
- The build job, which runs `pip install mkdocs-material`, no longer executes with deploy credentials available.

## Why
Final review on the 2026-05-12 hardening round flagged the docs workflow as the same anti-pattern closed earlier on the SDK publish workflow: workflow-level permissions included token-mint and Pages-write capability, and the build step runs ecosystem-fetched packaging tooling in that scope. Scoping permissions per job removes the implicit credential exposure.

## What changes
- `.github/workflows/docs.yml`:
  - Workflow-level `permissions` reduces to `contents: read`.
  - `build` job declares `permissions: contents: read` explicitly.
  - `deploy` job carries `pages: write` + `id-token: write`. It is the only job that needs them.

## What stays the same
- Same actions at the same pinned SHAs.
- Same MkDocs build + GitHub Pages deploy target.
- Same trigger (push to `main` on `documentation/**` / `mkdocs.yml`, plus `workflow_dispatch`).

## Validation
- `go test -race -count=1 ./...` green (no app changes)
- `make lint` 0 issues
- `go vet ./...` clean

## Test plan
- [ ] CI green on this PR
- [ ] Next push to `main` touching `documentation/**` deploys to GitHub Pages as before