### PR TITLE
chore(ci): use installation token for Homebrew formula update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Mint a short-lived installation token for the Homebrew tap
+      # via the oktsec release GitHub App. The App is installed only
+      # on oktsec/homebrew-tap with Contents: read+write, so the
+      # token cannot reach any other repository even if the workflow
+      # is compromised. The token expires automatically (~1h) once
+      # the release run completes.
+      - id: homebrew-tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: oktsec
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
@@ -39,4 +53,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}


### PR DESCRIPTION
## Summary
GoReleaser writes the Homebrew formula into the project tap as part of the release run. This change wires the credential used for that write through `actions/create-github-app-token@v3.2.0` (SHA-pinned) instead of reading it from a workflow secret.

## What changes
- `.github/workflows/release.yml`: new step before `Run GoReleaser` produces an installation token scoped to a single repository. The token is wired into the GoReleaser env that the formula step already reads.

## What stays the same
- `.goreleaser.yaml` is untouched.
- GitHub Release creation, multi-arch binaries, Docker images, changelog generation continue on the same paths.
- No application code changes.

## Validation
- Workflow YAML structure verified.
- Action pinned to a 40-character SHA, matching the rest of the release pipeline.

## Test plan
- [ ] Merge this PR.
- [ ] Trigger the next release and confirm the tap formula update lands.