### PR TITLE
release: v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.1] - 2026-05-13
+
+### Maintenance
+
+- Republish the release pipeline to align all distribution channels for the v0.16 line. No code changes from v0.16.0.
+
 ## [0.16.0] - 2026-05-13
 
 ### Added


### PR DESCRIPTION
## Summary
Maintenance release. Republishes the v0.16 line through the release pipeline so all distribution channels carry consistent artifacts. No code changes from v0.16.0.

## What changes
- `CHANGELOG.md`: adds the `v0.16.1` entry.

## Post-merge sequence
1. `git pull --ff-only origin main`
2. `git tag v0.16.1`
3. `git push origin v0.16.1`
4. Watch the release pipeline complete.