### PR TITLE
Add local node identity and read-only snapshot

### DIFF
--- a/cmd/oktsec/commands/node.go
+++ b/cmd/oktsec/commands/node.go
@@ -1,0 +1,311 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/node"
+	"github.com/spf13/cobra"
+)
+
+// newNodeCmd builds the `oktsec node` command group. Order 1 ships
+// three subcommands: init / status / snapshot. All are additive and
+// read-only with respect to existing oktsec runtime state.
+func newNodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "Manage the local Oktsec node identity and snapshot",
+		Long: "Node commands manage this Oktsec install as a single protected runtime node. " +
+			"Identity is local-only; snapshot is read-only and reports what this node sees, " +
+			"controls, and can prove.",
+	}
+	cmd.AddCommand(newNodeInitCmd())
+	cmd.AddCommand(newNodeStatusCmd())
+	cmd.AddCommand(newNodeSnapshotCmd())
+	return cmd
+}
+
+// newNodeInitCmd creates or confirms the local node identity.
+func newNodeInitCmd() *cobra.Command {
+	var (
+		profile    string
+		jsonOutput bool
+	)
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create the local node identity (idempotent)",
+		Example: "  oktsec node init\n" +
+			"  oktsec node init --profile enterprise\n" +
+			"  oktsec node init --json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := nodeStoreForTest()
+			id, err := store.Init(profile)
+			if err != nil {
+				return fmt.Errorf("init node identity: %w", err)
+			}
+			out := cmd.OutOrStdout()
+			if jsonOutput {
+				return writeIndentedJSON(out, node.IdentityStatus{
+					Status:   "present",
+					Identity: id,
+				})
+			}
+			fmt.Fprintf(out, "Node identity ready\n")
+			fmt.Fprintf(out, "  node_id:        %s\n", id.NodeID)
+			fmt.Fprintf(out, "  fingerprint:    %s\n", truncateNodeFingerprint(id.PublicKeyFingerprint))
+			fmt.Fprintf(out, "  profile:        %s\n", id.InstallProfile)
+			fmt.Fprintf(out, "  directory:      %s\n", store.Dir)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&profile, "profile", "local", "install profile: local | enterprise")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
+}
+
+// newNodeStatusCmd reports identity presence without modifying it.
+func newNodeStatusCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show local node identity status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := nodeStoreForTest()
+			status := store.Status()
+			out := cmd.OutOrStdout()
+			if jsonOutput {
+				if err := writeIndentedJSON(out, status); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintf(out, "Node identity: %s\n", status.Status)
+				if status.Identity != nil {
+					fmt.Fprintf(out, "  node_id:      %s\n", status.Identity.NodeID)
+					fmt.Fprintf(out, "  fingerprint:  %s\n", truncateNodeFingerprint(status.Identity.PublicKeyFingerprint))
+					fmt.Fprintf(out, "  profile:      %s\n", status.Identity.InstallProfile)
+					fmt.Fprintf(out, "  created_at:   %s\n", status.Identity.CreatedAt)
+				}
+				for _, w := range status.Warnings {
+					fmt.Fprintf(out, "  warning [%s]: %s\n", w.Code, w.Message)
+				}
+			}
+			if status.Status == "invalid" {
+				return errInvalidNodeIdentity
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	return cmd
+}
+
+// newNodeSnapshotCmd produces a read-only JSON snapshot of what this
+// node sees, controls, and can prove.
+func newNodeSnapshotCmd() *cobra.Command {
+	var (
+		since            string
+		until            string
+		outputPath       string
+		jsonOutput       bool
+		includeDiscovery bool
+	)
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Emit a read-only snapshot of this node's coverage and evidence",
+		Long: "Reports configured surfaces, inventory, posture, and audit evidence as JSON. " +
+			"Read-only: no databases are created, no migrations run, no external clients are touched.",
+		Example: "  oktsec node snapshot --json\n" +
+			"  oktsec node snapshot --since 24h --output /tmp/node.json\n" +
+			"  oktsec node snapshot --since 2026-05-20T00:00:00Z --json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sinceT, err := parseSnapshotSince(since)
+			if err != nil {
+				return err
+			}
+			untilT, err := parseSnapshotUntil(until)
+			if err != nil {
+				return err
+			}
+			opts := node.Options{
+				ConfigPath:       cfgFile,
+				DBPath:           nodeSnapshotDBPathOverride,
+				IdentityStore:    nodeStoreForTest(),
+				Since:            sinceT,
+				Until:            untilT,
+				IncludeDiscovery: includeDiscovery,
+				OktsecVersion:    version,
+				OktsecCommit:     commit,
+			}
+			snap, err := node.Build(context.Background(), opts)
+			if err != nil {
+				return fmt.Errorf("building snapshot: %w", err)
+			}
+			data, err := node.MarshalSnapshot(snap)
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if outputPath != "" {
+				if err := writeSnapshotFile(outputPath, data); err != nil {
+					return err
+				}
+				if !jsonOutput {
+					fmt.Fprintf(out, "Wrote node snapshot to %s\n", outputPath)
+				}
+				return nil
+			}
+			if _, err := out.Write(data); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "24h", "snapshot range floor (Go duration or RFC3339)")
+	cmd.Flags().StringVar(&until, "until", "", "snapshot range ceiling (RFC3339; default: now)")
+	cmd.Flags().StringVar(&outputPath, "output", "", "write snapshot to this path instead of stdout")
+	cmd.Flags().BoolVar(&jsonOutput, "json", true, "emit JSON (always true in Order 1)")
+	cmd.Flags().BoolVar(&includeDiscovery, "include-discovery", false, "request MCP client discovery (Order 1: not supported, warns)")
+	return cmd
+}
+
+// parseSnapshotSince accepts a Go duration (e.g. "24h") or an
+// RFC3339 timestamp. The duration form is the common case; absolute
+// timestamps let operators pin a snapshot to a known event window.
+func parseSnapshotSince(in string) (time.Time, error) {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return time.Time{}, nil
+	}
+	if d, err := time.ParseDuration(in); err == nil {
+		if d < 0 {
+			d = -d
+		}
+		return time.Now().UTC().Add(-d), nil
+	}
+	if t, err := time.Parse(time.RFC3339, in); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("--since must be a Go duration (e.g. 24h) or RFC3339 timestamp")
+}
+
+// parseSnapshotUntil accepts only RFC3339 (and empty = now). Duration
+// would be ambiguous here ("24h ago" vs "24h from now") so it's not
+// supported.
+func parseSnapshotUntil(in string) (time.Time, error) {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, in)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("--until must be RFC3339")
+	}
+	return t.UTC(), nil
+}
+
+// writeSnapshotFile writes data atomically to path, refusing to
+// follow symlinks at the destination so a malicious link in
+// /tmp/node.json cannot redirect the write elsewhere.
+func writeSnapshotFile(path string, data []byte) error {
+	if path == "" {
+		return errors.New("--output path is required")
+	}
+	// Reject symlinked destination so a planted symlink cannot
+	// be used to overwrite an unrelated file.
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through a symlink: %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat output path: %w", err)
+	}
+	// Reject symlinked parent for the same reason.
+	parent := filepath.Dir(path)
+	if info, err := os.Lstat(parent); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write into a symlinked directory: %s", parent)
+		}
+	}
+	tmp, err := os.CreateTemp(parent, ".node-snapshot-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// writeIndentedJSON renders v as indented JSON to w.
+func writeIndentedJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// errInvalidNodeIdentity is returned by `node status` when the on-disk
+// identity exists but cannot be parsed. Cobra surfaces it as a
+// non-zero exit code, matching the spec's exit contract.
+var errInvalidNodeIdentity = errors.New("node identity is invalid")
+
+// truncateNodeFingerprint shrinks a "sha256:<hex>" fingerprint for
+// terminal display while keeping enough characters to be useful for
+// confirmation.
+func truncateNodeFingerprint(fp string) string {
+	if fp == "" {
+		return "(none)"
+	}
+	hex := fp
+	if i := strings.Index(fp, ":"); i >= 0 {
+		hex = fp[i+1:]
+	}
+	if len(hex) <= 12 {
+		return fp
+	}
+	prefix := ""
+	if i := strings.Index(fp, ":"); i >= 0 {
+		prefix = fp[:i+1]
+	}
+	return prefix + hex[:8] + "…" + hex[len(hex)-4:]
+}
+
+// nodeStoreForTest is a hook tests use to override the default
+// identity directory without rerouting config.HomeDir() (which is
+// cached via sync.Once and cannot be reset). Production code never
+// touches it.
+var nodeStoreForTest = func() node.IdentityStore { return node.DefaultIdentityStore() }
+
+// nodeSnapshotDBPathOverride pins the DB path used by the snapshot
+// command. Empty (the default) lets node.Build resolve via config
+// and the default home. Tests set this to a temp path so they
+// never reach the developer's real audit DB.
+var nodeSnapshotDBPathOverride string

--- a/cmd/oktsec/commands/node_test.go
+++ b/cmd/oktsec/commands/node_test.go
@@ -1,0 +1,196 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/node"
+)
+
+// withTestNodeStore swaps nodeStoreForTest for the duration of the test
+// so the CLI never reaches the real ~/.oktsec/node.
+func withTestNodeStore(t *testing.T) node.IdentityStore {
+	t.Helper()
+	store := node.IdentityStore{Dir: filepath.Join(t.TempDir(), "node")}
+	prev := nodeStoreForTest
+	nodeStoreForTest = func() node.IdentityStore { return store }
+	t.Cleanup(func() { nodeStoreForTest = prev })
+	return store
+}
+
+// withTestCfgFile sets cfgFile to a temp path so commands resolve
+// against test fixtures instead of the operator's real config.
+func withTestCfgFile(t *testing.T, path string) {
+	t.Helper()
+	prev := cfgFile
+	cfgFile = path
+	t.Cleanup(func() { cfgFile = prev })
+}
+
+// withTestSnapshotDBPath pins the DB path the snapshot command
+// reads so it never reaches the developer's real audit DB.
+func withTestSnapshotDBPath(t *testing.T, path string) {
+	t.Helper()
+	prev := nodeSnapshotDBPathOverride
+	nodeSnapshotDBPathOverride = path
+	t.Cleanup(func() { nodeSnapshotDBPathOverride = prev })
+}
+
+func TestNodeCmdRegistered(t *testing.T) {
+	root := NewRoot()
+	found := false
+	for _, c := range root.Commands() {
+		if c.Name() == "node" {
+			found = true
+			subs := map[string]bool{}
+			for _, sc := range c.Commands() {
+				subs[sc.Name()] = true
+			}
+			for _, want := range []string{"init", "status", "snapshot"} {
+				if !subs[want] {
+					t.Errorf("node command missing subcommand %q", want)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("oktsec node command should be registered on root")
+	}
+}
+
+func TestNodeInit_CreatesIdentity(t *testing.T) {
+	store := withTestNodeStore(t)
+	cmd := newNodeInitCmd()
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var got node.IdentityStatus
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out.String())
+	}
+	if got.Status != "present" || got.Identity == nil {
+		t.Fatalf("expected present + identity, got %+v", got)
+	}
+	if _, err := os.Stat(filepath.Join(store.Dir, "identity.json")); err != nil {
+		t.Fatalf("identity.json missing: %v", err)
+	}
+}
+
+func TestNodeStatus_Missing(t *testing.T) {
+	_ = withTestNodeStore(t)
+	cmd := newNodeStatusCmd()
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var got node.IdentityStatus
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out.String())
+	}
+	if got.Status != "missing" {
+		t.Fatalf("expected missing, got %q", got.Status)
+	}
+}
+
+func TestNodeSnapshot_NoConfig(t *testing.T) {
+	_ = withTestNodeStore(t)
+	withTestCfgFile(t, filepath.Join(t.TempDir(), "missing.yaml"))
+	withTestSnapshotDBPath(t, filepath.Join(t.TempDir(), "missing.db"))
+	cmd := newNodeSnapshotCmd()
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var snap node.Snapshot
+	if err := json.Unmarshal(out.Bytes(), &snap); err != nil {
+		t.Fatalf("decode snapshot: %v\n%s", err, out.String())
+	}
+	if snap.SchemaVersion != node.SchemaSnapshot {
+		t.Fatalf("schema version: %q", snap.SchemaVersion)
+	}
+	if !strings.HasPrefix(snap.Node.OktsecVersion, "") {
+		t.Fatalf("version field unexpectedly absent")
+	}
+}
+
+func TestNodeSnapshot_OutputFile(t *testing.T) {
+	_ = withTestNodeStore(t)
+	withTestCfgFile(t, filepath.Join(t.TempDir(), "missing.yaml"))
+	withTestSnapshotDBPath(t, filepath.Join(t.TempDir(), "missing.db"))
+	outPath := filepath.Join(t.TempDir(), "snap.json")
+	cmd := newNodeSnapshotCmd()
+	cmd.SetArgs([]string{"--output", outPath})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read snapshot file: %v", err)
+	}
+	var snap node.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("decode: %v\n%s", err, string(data))
+	}
+	if snap.SchemaVersion != node.SchemaSnapshot {
+		t.Fatalf("schema version: %q", snap.SchemaVersion)
+	}
+}
+
+func TestNodeSnapshot_InvalidSinceFails(t *testing.T) {
+	_ = withTestNodeStore(t)
+	withTestSnapshotDBPath(t, filepath.Join(t.TempDir(), "missing.db"))
+	cmd := newNodeSnapshotCmd()
+	cmd.SetArgs([]string{"--since", "not-a-duration"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error on invalid --since")
+	}
+}
+
+func TestNodeSnapshot_DoesNotCreateDB(t *testing.T) {
+	_ = withTestNodeStore(t)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: dir},
+		Server:   config.ServerConfig{Port: 8080, LogLevel: "info"},
+		DBPath:   filepath.Join(dir, "should-not-be-created.db"),
+	}
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	withTestCfgFile(t, cfgPath)
+	withTestSnapshotDBPath(t, cfg.DBPath)
+	cmd := newNodeSnapshotCmd()
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if _, err := os.Stat(cfg.DBPath); err == nil {
+		t.Fatalf("snapshot must not create the audit DB")
+	}
+}

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -82,6 +82,7 @@ func NewRoot() *cobra.Command {
 		newDisconnectCmd(),
 		newScanOpenClawCmd(),
 		newTokensCmd(),
+		newNodeCmd(),
 	)
 
 	// Internal/advanced commands — hidden from help

--- a/internal/node/dbinspect.go
+++ b/internal/node/dbinspect.go
@@ -1,0 +1,482 @@
+package node
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/safefile"
+	_ "modernc.org/sqlite"
+)
+
+// dbAvailability reports whether a SQLite DB file is reachable and
+// safe to open read-only. Used by the snapshot builder to short-
+// circuit inspection without ever running CREATE statements.
+type dbAvailability struct {
+	Path      string
+	Available bool
+	// Reason is set when Available is false; one of:
+	//   "missing"      — file does not exist
+	//   "unreachable"  — symlink, permission denied, etc.
+	Reason string
+}
+
+// inspectSQLiteAvailability checks whether path can be opened. It
+// never creates the file. A non-existent path is reported as
+// missing, not as an error.
+func inspectSQLiteAvailability(path string) dbAvailability {
+	if path == "" {
+		return dbAvailability{Available: false, Reason: "missing"}
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return dbAvailability{Path: path, Available: false, Reason: "missing"}
+		}
+		return dbAvailability{Path: path, Available: false, Reason: "unreachable"}
+	}
+	if err := safefile.RejectSymlink(path); err != nil {
+		return dbAvailability{Path: path, Available: false, Reason: "unreachable"}
+	}
+	// Refuse a symlinked parent so directory swaps cannot redirect a
+	// later inspection at a different DB.
+	parent := filepath.Dir(path)
+	if info, err := os.Lstat(parent); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return dbAvailability{Path: path, Available: false, Reason: "unreachable"}
+		}
+	}
+	return dbAvailability{Path: path, Available: true}
+}
+
+// openSQLiteReadOnly opens an existing SQLite database without
+// creating it and without running any migrations. The DSN forces
+// SQLite's read-only mode (mode=ro) and PRAGMA query_only=ON guards
+// the connection at the engine level. The caller is responsible for
+// closing the returned *sql.DB.
+//
+// The DSN is built through net/url so a filesystem path containing
+// '?', '#' or other URI-sensitive characters is properly escaped.
+// Without escaping, "/tmp/path?weird.db" would have ?weird.db
+// silently parsed as a query string and SQLite would open a
+// different (and possibly creatable) file — that violates the
+// "snapshot never creates DB files" contract.
+func openSQLiteReadOnly(path string) (*sql.DB, error) {
+	if path == "" {
+		return nil, errors.New("node: empty db path")
+	}
+	dsn := buildSQLiteReadOnlyDSN(path)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("node: opening sqlite ro: %w", err)
+	}
+	// Make sure the engine refuses any write we might accidentally
+	// issue (defence in depth on top of mode=ro).
+	if _, err := db.Exec("PRAGMA query_only=ON"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("node: sqlite query_only: %w", err)
+	}
+	// Cap connections so the inspector never holds more than one
+	// file handle on the live DB.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(30 * time.Second)
+	return db, nil
+}
+
+// buildSQLiteReadOnlyDSN constructs a `file:` URI that opens path
+// in mode=ro with a short busy_timeout. The path is encoded so
+// reserved URI characters do not collapse into the query string.
+//
+// Absolute POSIX paths produce "file:/abs/path?mode=ro&..."; relative
+// paths produce "file:./relative/path?mode=ro&..." so they cannot be
+// confused with a host segment. Windows paths get a leading slash so
+// "C:\\Users\\foo.db" -> "file:/C:/Users/foo.db".
+func buildSQLiteReadOnlyDSN(path string) string {
+	// Convert to a slash-separated path for URI use; backslashes
+	// are not legal URI path characters in modernc.org/sqlite's
+	// parser on either platform.
+	slashed := filepath.ToSlash(path)
+	if !strings.HasPrefix(slashed, "/") {
+		// Either a Windows drive ("C:/...") or a relative path.
+		// Prefix "/" so the result is "file:/C:/..." or
+		// "file:/relative/...", which the URI parser treats as
+		// a path-rooted reference rather than a host.
+		slashed = "/" + slashed
+	}
+	u := &url.URL{
+		Scheme: "file",
+		Path:   slashed,
+	}
+	q := u.Query()
+	q.Set("mode", "ro")
+	q.Add("_pragma", "busy_timeout(2000)")
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// sqliteTableExists reports whether the named table is present.
+// Read-only safe.
+func sqliteTableExists(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	var found string
+	err := db.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1`, name,
+	).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return found == name, nil
+}
+
+// auditDBInspection holds the read-only audit aggregates the snapshot
+// needs. Counts are bounded by range; chain verification reads up to
+// chainLimit rows.
+type auditDBInspection struct {
+	Available           bool
+	Entries             int
+	Allowed             int
+	Flagged             int
+	Quarantined         int
+	Blocked             int
+	Rejected            int
+	OldestAt            string
+	NewestAt            string
+	ChainAvailable      bool
+	ChainHead           string
+	ChainVerified       bool
+	ChainScope          string
+	ChainEntriesChecked int
+}
+
+// inspectAuditSQLite computes the audit aggregates inside [since,until].
+// `until` zero means "now". Always read-only; never alters rows.
+func inspectAuditSQLite(ctx context.Context, db *sql.DB, since, until time.Time, chainLimit int) (auditDBInspection, error) {
+	out := auditDBInspection{}
+	exists, err := sqliteTableExists(ctx, db, "audit_log")
+	if err != nil {
+		return out, fmt.Errorf("audit table check: %w", err)
+	}
+	if !exists {
+		return out, nil
+	}
+	out.Available = true
+
+	sinceStr := since.UTC().Format(time.RFC3339)
+	untilStr := ""
+	if !until.IsZero() {
+		untilStr = until.UTC().Format(time.RFC3339)
+	}
+
+	whereRange, args := buildRangeClause("timestamp", sinceStr, untilStr)
+
+	// Total entries in range.
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM audit_log "+whereRange, args...,
+	).Scan(&out.Entries); err != nil {
+		return out, fmt.Errorf("audit count: %w", err)
+	}
+
+	// Decisions are reported by policy_decision first, because
+	// status alone undercounts important signals: a content_flagged
+	// row writes status="delivered" and policy_decision="content_flagged",
+	// which would otherwise be hidden inside "allowed". Group by
+	// the (status, policy_decision) pair so legacy rows that only
+	// populated status still classify correctly.
+	rows, err := db.QueryContext(ctx,
+		`SELECT COALESCE(status,''), COALESCE(policy_decision,''), COUNT(*) FROM audit_log `+whereRange+
+			` GROUP BY status, policy_decision`, args...,
+	)
+	if err != nil {
+		return out, fmt.Errorf("audit group: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var status, decision string
+		var count int
+		if err := rows.Scan(&status, &decision, &count); err != nil {
+			return out, fmt.Errorf("audit scan: %w", err)
+		}
+		switch classifyDecision(status, decision) {
+		case "allowed":
+			out.Allowed += count
+		case "flagged":
+			out.Flagged += count
+		case "quarantined":
+			out.Quarantined += count
+		case "blocked":
+			out.Blocked += count
+		case "rejected":
+			out.Rejected += count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("audit rows err: %w", err)
+	}
+
+	// Oldest/newest in the same range.
+	if out.Entries > 0 {
+		if err := db.QueryRowContext(ctx,
+			"SELECT MIN(timestamp), MAX(timestamp) FROM audit_log "+whereRange, args...,
+		).Scan(&out.OldestAt, &out.NewestAt); err != nil {
+			return out, fmt.Errorf("audit range: %w", err)
+		}
+	}
+	return out, nil
+}
+
+// runtimeDBInspection holds runtime_* table aggregates.
+type runtimeDBInspection struct {
+	Available        bool
+	Sessions         int
+	Events           int
+	ToolEvents       int
+	BlockEvents      int
+	LastRealEventAt  string
+	LastHeartbeatAt  string
+	HasFreshRealEvent  bool
+	HasRecentHeartbeat bool
+}
+
+// inspectRuntimeSQLite reads the runtime_* tables in read-only mode.
+// "Fresh" thresholds match the dashboard surface card semantics:
+// real event within 1 hour, heartbeat within 5 minutes.
+func inspectRuntimeSQLite(ctx context.Context, db *sql.DB, since, until time.Time) (runtimeDBInspection, error) {
+	out := runtimeDBInspection{}
+	hasSessions, err := sqliteTableExists(ctx, db, "runtime_sessions")
+	if err != nil {
+		return out, err
+	}
+	hasEvents, err := sqliteTableExists(ctx, db, "runtime_hook_events")
+	if err != nil {
+		return out, err
+	}
+	if !hasSessions && !hasEvents {
+		return out, nil
+	}
+	out.Available = true
+
+	sinceStr := since.UTC().Format(time.RFC3339)
+	untilStr := ""
+	if !until.IsZero() {
+		untilStr = until.UTC().Format(time.RFC3339)
+	}
+
+	if hasSessions {
+		whereRange, args := buildRangeClause("last_seen_at", sinceStr, untilStr)
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM runtime_sessions "+whereRange, args...,
+		).Scan(&out.Sessions); err != nil {
+			return out, fmt.Errorf("runtime sessions: %w", err)
+		}
+	}
+
+	if hasEvents {
+		whereRange, args := buildRangeClause("timestamp", sinceStr, untilStr)
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM runtime_hook_events "+whereRange, args...,
+		).Scan(&out.Events); err != nil {
+			return out, fmt.Errorf("runtime events: %w", err)
+		}
+		// Tool events. Use tool_name != '' as a proxy for tool-call lifecycle.
+		toolWhere := whereRange
+		toolArgs := append([]any(nil), args...)
+		if toolWhere == "" {
+			toolWhere = "WHERE tool_name <> ''"
+		} else {
+			toolWhere += " AND tool_name <> ''"
+		}
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM runtime_hook_events "+toolWhere, toolArgs...,
+		).Scan(&out.ToolEvents); err != nil {
+			return out, fmt.Errorf("runtime tool events: %w", err)
+		}
+		blockWhere := whereRange
+		blockArgs := append([]any(nil), args...)
+		if blockWhere == "" {
+			blockWhere = "WHERE policy_decision IN ('block','quarantine')"
+		} else {
+			blockWhere += " AND policy_decision IN ('block','quarantine')"
+		}
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM runtime_hook_events "+blockWhere, blockArgs...,
+		).Scan(&out.BlockEvents); err != nil {
+			return out, fmt.Errorf("runtime block events: %w", err)
+		}
+
+		// Freshness signals — bounded by the snapshot window so the
+		// snapshot does not paint a stale install as healthy.
+		var lastRealStr sql.NullString
+		realWhere := whereRange
+		realArgs := append([]any(nil), args...)
+		if realWhere == "" {
+			realWhere = "WHERE session_id NOT LIKE 'heartbeat-%'"
+		} else {
+			realWhere += " AND session_id NOT LIKE 'heartbeat-%'"
+		}
+		if err := db.QueryRowContext(ctx,
+			"SELECT MAX(timestamp) FROM runtime_hook_events "+realWhere, realArgs...,
+		).Scan(&lastRealStr); err != nil {
+			return out, fmt.Errorf("runtime last real: %w", err)
+		}
+		if lastRealStr.Valid {
+			out.LastRealEventAt = lastRealStr.String
+		}
+		var lastHBStr sql.NullString
+		if err := db.QueryRowContext(ctx,
+			"SELECT MAX(last_heartbeat_at) FROM runtime_sessions",
+		).Scan(&lastHBStr); err == nil && lastHBStr.Valid {
+			out.LastHeartbeatAt = lastHBStr.String
+		}
+
+		now := time.Now().UTC()
+		if t, err := time.Parse(time.RFC3339, out.LastRealEventAt); err == nil {
+			out.HasFreshRealEvent = now.Sub(t) <= time.Hour
+		}
+		if t, err := time.Parse(time.RFC3339, out.LastHeartbeatAt); err == nil {
+			out.HasRecentHeartbeat = now.Sub(t) <= 5*time.Minute
+		}
+	}
+	return out, nil
+}
+
+// activityDBInspection holds activity_events aggregates.
+type activityDBInspection struct {
+	Available bool
+	Events    int
+}
+
+func inspectActivitySQLite(ctx context.Context, db *sql.DB, since, until time.Time) (activityDBInspection, error) {
+	out := activityDBInspection{}
+	exists, err := sqliteTableExists(ctx, db, "activity_events")
+	if err != nil {
+		return out, err
+	}
+	if !exists {
+		return out, nil
+	}
+	out.Available = true
+	sinceStr := since.UTC().Format(time.RFC3339)
+	untilStr := ""
+	if !until.IsZero() {
+		untilStr = until.UTC().Format(time.RFC3339)
+	}
+	whereRange, args := buildRangeClause("timestamp", sinceStr, untilStr)
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM activity_events "+whereRange, args...,
+	).Scan(&out.Events); err != nil {
+		return out, fmt.Errorf("activity count: %w", err)
+	}
+	return out, nil
+}
+
+// distinctActivePrincipalsSQLite counts active principal_ids observed
+// in any of the three tables inside the window. Best-effort: missing
+// tables are skipped silently because availability is already reported
+// in the snapshot.
+func distinctActivePrincipalsSQLite(ctx context.Context, db *sql.DB, since, until time.Time) (int, error) {
+	sinceStr := since.UTC().Format(time.RFC3339)
+	untilStr := ""
+	if !until.IsZero() {
+		untilStr = until.UTC().Format(time.RFC3339)
+	}
+	set := map[string]struct{}{}
+	for _, q := range []struct{ table, col string }{
+		{"runtime_sessions", "last_seen_at"},
+		{"runtime_hook_events", "timestamp"},
+		{"activity_events", "timestamp"},
+	} {
+		exists, err := sqliteTableExists(ctx, db, q.table)
+		if err != nil {
+			return 0, err
+		}
+		if !exists {
+			continue
+		}
+		whereRange, args := buildRangeClause(q.col, sinceStr, untilStr)
+		query := "SELECT DISTINCT principal_id FROM " + q.table + " " + whereRange
+		// Cap the scan so a giant table cannot stall the snapshot.
+		query += " LIMIT 10000"
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return 0, fmt.Errorf("distinct principals from %s: %w", q.table, err)
+		}
+		for rows.Next() {
+			var p string
+			if err := rows.Scan(&p); err != nil {
+				_ = rows.Close()
+				return 0, err
+			}
+			if p != "" {
+				set[p] = struct{}{}
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return 0, err
+		}
+	}
+	return len(set), nil
+}
+
+// classifyDecision maps an audit row's (status, policy_decision) pair
+// to the bucket the snapshot reports. policy_decision is consulted
+// first so a "delivered + content_flagged" row counts as flagged
+// instead of being silently rolled into allowed. Status alone is the
+// fallback for legacy rows from versions that did not populate
+// policy_decision.
+func classifyDecision(status, decision string) string {
+	d := strings.ToLower(strings.TrimSpace(decision))
+	switch d {
+	case "content_flagged":
+		return "flagged"
+	case "content_blocked", "rate_limited", "tool_not_allowed",
+		"constraint_violated", "concurrency_exceeded",
+		"delegation_invalid", "delegation_scope_violation",
+		"delegation_depth_exceeded":
+		return "blocked"
+	case "content_quarantined":
+		return "quarantined"
+	case "acl_denied", "agent_suspended", "recipient_suspended",
+		"identity_rejected", "signature_required",
+		"delegation_required", "scan_error":
+		return "rejected"
+	case "allow":
+		return "allowed"
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "delivered", "allowed", "clean":
+		return "allowed"
+	case "flagged", "flag":
+		return "flagged"
+	case "quarantined":
+		return "quarantined"
+	case "blocked":
+		return "blocked"
+	case "rejected":
+		return "rejected"
+	}
+	return ""
+}
+
+// buildRangeClause builds a "WHERE col >= ? AND col <= ?" fragment.
+// Empty until omits the upper bound. Returns "" with empty args when
+// both bounds are empty.
+func buildRangeClause(col, since, until string) (string, []any) {
+	switch {
+	case since == "" && until == "":
+		return "", nil
+	case since != "" && until == "":
+		return "WHERE " + col + " >= ?", []any{since}
+	case since == "" && until != "":
+		return "WHERE " + col + " <= ?", []any{until}
+	default:
+		return "WHERE " + col + " >= ? AND " + col + " <= ?", []any{since, until}
+	}
+}

--- a/internal/node/dbinspect_test.go
+++ b/internal/node/dbinspect_test.go
@@ -1,0 +1,317 @@
+package node
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestInspectAvailabilityMissing(t *testing.T) {
+	av := inspectSQLiteAvailability(filepath.Join(t.TempDir(), "missing.db"))
+	if av.Available {
+		t.Fatal("non-existent file must report missing")
+	}
+	if av.Reason != "missing" {
+		t.Fatalf("expected missing, got %q", av.Reason)
+	}
+}
+
+func TestInspectAvailabilityEmptyPath(t *testing.T) {
+	av := inspectSQLiteAvailability("")
+	if av.Available || av.Reason != "missing" {
+		t.Fatalf("empty path should be missing, got %+v", av)
+	}
+}
+
+func TestSqliteTableExists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oktsec.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE present (a INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = db.Close()
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	got, err := sqliteTableExists(context.Background(), ro, "present")
+	if err != nil || !got {
+		t.Fatalf("expected present table, got %v %v", got, err)
+	}
+	got, err = sqliteTableExists(context.Background(), ro, "absent")
+	if err != nil || got {
+		t.Fatalf("expected absent missing, got %v %v", got, err)
+	}
+}
+
+func TestOpenSQLiteReadOnlyRefusesWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oktsec.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE t (a INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = db.Close()
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	if _, err := ro.Exec("INSERT INTO t VALUES (1)"); err == nil {
+		t.Fatal("read-only DB must refuse INSERT")
+	}
+}
+
+func TestInspectAuditOnMissingTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oktsec.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE marker (x INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = db.Close()
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	got, err := inspectAuditSQLite(context.Background(), ro, time.Time{}, time.Time{}, 100)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if got.Available {
+		t.Fatalf("expected audit table missing")
+	}
+}
+
+func TestInspectActivityAndRuntimeOnMissingTables(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oktsec.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE marker (x INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = db.Close()
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	act, err := inspectActivitySQLite(context.Background(), ro, time.Time{}, time.Time{})
+	if err != nil || act.Available {
+		t.Fatalf("expected activity missing: %v %+v", err, act)
+	}
+	rt, err := inspectRuntimeSQLite(context.Background(), ro, time.Time{}, time.Time{})
+	if err != nil || rt.Available {
+		t.Fatalf("expected runtime missing: %v %+v", err, rt)
+	}
+}
+
+func TestClassifyDecision(t *testing.T) {
+	cases := []struct {
+		status, decision, want string
+	}{
+		{"delivered", "allow", "allowed"},
+		{"delivered", "content_flagged", "flagged"},
+		{"blocked", "content_blocked", "blocked"},
+		{"blocked", "rate_limited", "blocked"},
+		{"quarantined", "content_quarantined", "quarantined"},
+		{"rejected", "identity_rejected", "rejected"},
+		{"delivered", "", "allowed"},     // legacy: status only
+		{"flagged", "", "flagged"},        // legacy: status only
+		{"", "", ""},                       // unknown
+	}
+	for _, c := range cases {
+		if got := classifyDecision(c.status, c.decision); got != c.want {
+			t.Errorf("classifyDecision(%q,%q) = %q, want %q", c.status, c.decision, got, c.want)
+		}
+	}
+}
+
+func TestInspectAuditFlaggedNotCountedAsAllowed(t *testing.T) {
+	// Regression: a delivered + content_flagged row must surface as
+	// flagged in the snapshot. Grouping by status alone would hide
+	// it under allowed.
+	path := filepath.Join(t.TempDir(), "audit.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		status TEXT NOT NULL,
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER,
+		signature_verified INTEGER,
+		prev_hash TEXT DEFAULT '',
+		entry_hash TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	base := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	rows := []struct{ status, decision string }{
+		{"delivered", "allow"},
+		{"delivered", "content_flagged"},
+		{"delivered", "content_flagged"},
+		{"blocked", "content_blocked"},
+	}
+	for i, r := range rows {
+		if _, err := db.Exec(`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, content_hash, status, policy_decision, latency_ms, signature_verified)
+			VALUES (?, ?, 'a', 'b', 'h', ?, ?, 1, 1)`,
+			"row-"+r.status+"-"+r.decision+"-"+time.Duration(i).String(),
+			base.Add(time.Duration(i)*time.Minute).Format(time.RFC3339),
+			r.status, r.decision,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	_ = db.Close()
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	got, err := inspectAuditSQLite(context.Background(), ro, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), time.Time{}, 100)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if got.Flagged != 2 {
+		t.Errorf("expected 2 flagged decisions, got %d", got.Flagged)
+	}
+	if got.Allowed != 1 {
+		t.Errorf("expected 1 allowed decision, got %d", got.Allowed)
+	}
+	if got.Blocked != 1 {
+		t.Errorf("expected 1 blocked decision, got %d", got.Blocked)
+	}
+}
+
+func TestBuildRangeClause(t *testing.T) {
+	cases := []struct {
+		since, until string
+		want         string
+		argsLen      int
+	}{
+		{"", "", "", 0},
+		{"2026-01-01T00:00:00Z", "", "WHERE timestamp >= ?", 1},
+		{"", "2026-01-01T00:00:00Z", "WHERE timestamp <= ?", 1},
+		{"2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "WHERE timestamp >= ? AND timestamp <= ?", 2},
+	}
+	for _, c := range cases {
+		gotWhere, gotArgs := buildRangeClause("timestamp", c.since, c.until)
+		if gotWhere != c.want {
+			t.Errorf("buildRangeClause(%q,%q) where = %q, want %q", c.since, c.until, gotWhere, c.want)
+		}
+		if len(gotArgs) != c.argsLen {
+			t.Errorf("buildRangeClause(%q,%q) args len = %d, want %d", c.since, c.until, len(gotArgs), c.argsLen)
+		}
+	}
+}
+
+func TestBuildSQLiteReadOnlyDSN_EscapesPath(t *testing.T) {
+	dsn := buildSQLiteReadOnlyDSN("/tmp/has?weird#chars.db")
+	if strings.Count(dsn, "?") != 1 {
+		t.Fatalf("DSN should have exactly one '?' (query separator), got %q", dsn)
+	}
+	if !strings.Contains(dsn, "mode=ro") {
+		t.Fatalf("DSN missing mode=ro: %q", dsn)
+	}
+	if !strings.Contains(dsn, "busy_timeout") {
+		t.Fatalf("DSN missing busy_timeout pragma: %q", dsn)
+	}
+	// Original path with the literal '?' must not survive raw.
+	if strings.Contains(dsn, "has?weird") {
+		t.Fatalf("DSN must escape literal '?' inside the path, got %q", dsn)
+	}
+}
+
+func TestOpenSQLiteReadOnly_PathWithQuestionMark(t *testing.T) {
+	// Regression: a filesystem path containing '?' (legal on POSIX)
+	// must be opened by SQLite as-is. Without URI escaping the part
+	// after '?' would be parsed as DSN parameters and SQLite could
+	// silently open or create a different file.
+	if runtime.GOOS == "windows" {
+		t.Skip("'?' is not a legal filename character on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "has?weird.db")
+	// Seed via a properly escaped URI so the DB really lands at the
+	// path-with-? on disk. Plain sql.Open("sqlite", path) would hit
+	// the same DSN-parsing bug this test exists to lock down.
+	seedDSN := buildSQLiteReadOnlyDSN(path)
+	seedDSN = strings.Replace(seedDSN, "mode=ro", "mode=rwc", 1)
+	db, err := sql.Open("sqlite", seedDSN)
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE marker(x INT)"); err != nil {
+		t.Fatalf("create marker: %v", err)
+	}
+	_ = db.Close()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s, got %v", path, err)
+	}
+	ro, err := openSQLiteReadOnly(path)
+	if err != nil {
+		t.Fatalf("ro open: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	exists, err := sqliteTableExists(context.Background(), ro, "marker")
+	if err != nil {
+		t.Fatalf("table check: %v", err)
+	}
+	if !exists {
+		t.Fatalf("read-only inspector opened the wrong file: marker table not found")
+	}
+	// And — critically — no decoy "has" file landed beside the
+	// real DB. If the inspector had treated "?weird.db" as a query
+	// string we would see one.
+	if _, err := os.Stat(filepath.Join(dir, "has")); err == nil {
+		t.Fatalf("DSN unescaping created a decoy file at %s/has", dir)
+	}
+}
+
+func TestInspectAvailabilityRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.db")
+	link := filepath.Join(dir, "linked.db")
+	db, err := sql.Open("sqlite", real)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE t (x INT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = db.Close()
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	av := inspectSQLiteAvailability(link)
+	if av.Available {
+		t.Fatal("symlinked DB path must be refused")
+	}
+}

--- a/internal/node/errors.go
+++ b/internal/node/errors.go
@@ -1,0 +1,40 @@
+// Package node implements the local node identity and read-only
+// snapshot contract for Phase 5 Order 1. Community owns the local
+// runtime node; Enterprise will consume the JSON artifacts this
+// package emits without importing internal/ Go code.
+//
+// Everything in this package must remain additive and read-only.
+// Snapshot must not create databases, run migrations, install hooks,
+// touch external client config, or modify oktsec.yaml. Node identity
+// lives under config.HomeDir()/node/ so it stays separate from agent
+// keys and from the YAML config.
+package node
+
+// Warning is a structured non-fatal diagnostic emitted by the snapshot
+// builder when partial state is observed. The Code is a stable
+// snake_case identifier consumers can branch on; Message is a short
+// human-readable description.
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Stable warning codes. New codes may be appended; existing codes must
+// not change spelling, because Enterprise consumers and Order 2 evidence
+// checkpoints branch on them.
+const (
+	WarnNodeIdentityMissing      = "node_identity_missing"
+	WarnNodeIdentityInvalid      = "node_identity_invalid"
+	WarnConfigMissing            = "config_missing"
+	WarnConfigInvalid            = "config_invalid"
+	WarnDBMissing                = "db_missing"
+	WarnDBUnreachable            = "db_unreachable"
+	WarnAuditTableMissing        = "audit_table_missing"
+	WarnRuntimeTableMissing      = "runtime_table_missing"
+	WarnActivityTableMissing     = "activity_table_missing"
+	WarnAuditChainUnavailable          = "audit_chain_unavailable"
+	WarnAuditChainSignaturesNotChecked = "audit_chain_signatures_not_checked"
+	WarnAuditChainSignaturesPartial    = "audit_chain_signatures_partial"
+	WarnClientDiscoveryNotIncluded     = "client_discovery_not_included"
+	WarnPostgresSnapshotLimited        = "postgres_snapshot_limited"
+)

--- a/internal/node/identity.go
+++ b/internal/node/identity.go
@@ -1,0 +1,106 @@
+package node
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// PEM block types for the node identity keypair. Intentionally distinct
+// from agent/principal keys ("OKTSEC ED25519 PRIVATE KEY") so a node
+// key cannot be mistaken for, or loaded as, an agent key by the
+// identity package.
+const (
+	NodePrivateKeyPEMType = "OKTSEC NODE ED25519 PRIVATE KEY"
+	NodePublicKeyPEMType  = "OKTSEC NODE ED25519 PUBLIC KEY"
+)
+
+// File names inside the node identity directory.
+const (
+	identityFileName  = "identity.json"
+	privateKeyFile    = "node.key"
+	publicKeyFile     = "node.pub"
+	maxIdentityBytes  = 64 * 1024
+	maxKeyBytes       = 64 * 1024
+	nodeIDRandomBytes = 18 // 24 base32 chars after encoding
+)
+
+// Signature is the result of NodeIdentity.Sign. The Base64 field is
+// the raw 64-byte Ed25519 signature std-base64-encoded.
+type Signature struct {
+	Base64 string
+}
+
+// errIdentityMissing is returned when no identity files are present.
+// Callers convert this into structured warnings via Status; CLI uses
+// it to decide between exit codes.
+var errIdentityMissing = errors.New("node identity missing")
+
+// IsErrIdentityMissing reports whether err is the canonical
+// "identity files not present" error.
+func IsErrIdentityMissing(err error) bool {
+	return errors.Is(err, errIdentityMissing)
+}
+
+// newNodeID generates a non-secret, stable, random node ID with a
+// "node_" prefix. The body is base32-without-padding so it is URL-safe
+// and avoids ambiguous characters; nothing in the ID is derived from
+// hostname, username, or path.
+func newNodeID() (string, error) {
+	buf := make([]byte, nodeIDRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("node id rand: %w", err)
+	}
+	// Lowercase hex keeps the ID short and avoids confusion with the
+	// hashed fingerprints, which are sha256-prefixed.
+	return "node_" + hex.EncodeToString(buf), nil
+}
+
+// computeHostFingerprint hashes coarse, non-secret host facts.
+// Hostname is intentionally NOT used directly to avoid leaking
+// machine names; we hash hostname + OS + arch together so the result
+// is opaque but stable across runs on the same machine.
+func computeHostFingerprint() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = ""
+	}
+	// Lowercase so case-insensitive macOS hostnames produce a stable
+	// fingerprint across reboots.
+	hostname = strings.ToLower(hostname)
+	payload := hostname + "|" + runtime.GOOS + "|" + runtime.GOARCH
+	sum := sha256.Sum256([]byte(payload))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// fingerprintPublicKey returns "sha256:<hex>" for an Ed25519 public
+// key. Mirrors identity.Fingerprint's hash but with the "sha256:"
+// prefix so callers can tell hash families apart in JSON output.
+func fingerprintPublicKey(pub ed25519.PublicKey) string {
+	if len(pub) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(pub)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// signWithKey produces an Ed25519 signature over payload using priv.
+func signWithKey(priv ed25519.PrivateKey, payload []byte) Signature {
+	sig := ed25519.Sign(priv, payload)
+	return Signature{Base64: base64.StdEncoding.EncodeToString(sig)}
+}
+
+// nowUTCRFC3339 returns the current time as an RFC3339 UTC string.
+// Wrapped so tests can avoid passing time.Now everywhere; the
+// snapshot/identity flows always want UTC.
+func nowUTCRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}

--- a/internal/node/identity_store.go
+++ b/internal/node/identity_store.go
@@ -1,0 +1,418 @@
+package node
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/safefile"
+)
+
+// IdentityStore is the file-backed local node identity. The directory
+// holds:
+//
+//	identity.json   metadata + public-key fingerprint
+//	node.key        Ed25519 private key (PEM, 0600)
+//	node.pub        Ed25519 public key  (PEM, 0644)
+//
+// Init/Load/Sign all refuse symlinked files and refuse to follow
+// symlinks for the directory itself.
+type IdentityStore struct {
+	Dir string
+}
+
+// DefaultIdentityStore returns the canonical node identity store at
+// config.HomeDir()/node/.
+func DefaultIdentityStore() IdentityStore {
+	return IdentityStore{Dir: filepath.Join(config.HomeDir(), "node")}
+}
+
+// Status reports whether the local identity is present, missing, or
+// invalid. Always non-nil even for missing identity so the CLI can
+// JSON-serialize the result without a special case.
+func (s IdentityStore) Status() IdentityStatus {
+	id, err := s.Load()
+	switch {
+	case err == nil:
+		return IdentityStatus{Status: "present", Identity: id}
+	case IsErrIdentityMissing(err):
+		return IdentityStatus{
+			Status: "missing",
+			Warnings: []Warning{{
+				Code:    WarnNodeIdentityMissing,
+				Message: "Run `oktsec node init` to sign future checkpoints.",
+			}},
+		}
+	default:
+		return IdentityStatus{
+			Status: "invalid",
+			Warnings: []Warning{{
+				Code:    WarnNodeIdentityInvalid,
+				Message: err.Error(),
+			}},
+		}
+	}
+}
+
+// Init creates the identity directory and writes identity.json,
+// node.key, node.pub. Idempotent: if a valid identity already exists,
+// the loaded identity is returned unchanged. The InstallProfile field
+// is updated on re-init only if it differs (the rest of the record
+// is preserved).
+//
+// Init refuses symlinked target paths. Files are written with
+// 0o600/0o644 modes and the directory is 0o700.
+func (s IdentityStore) Init(profile string) (*Identity, error) {
+	if s.Dir == "" {
+		return nil, errors.New("node: identity store dir is empty")
+	}
+	if profile == "" {
+		profile = ProfileLocal
+	}
+
+	if err := ensureDirSafe(s.Dir); err != nil {
+		return nil, err
+	}
+
+	// Idempotency: a complete identity stays; we never rotate the
+	// keypair from Init. force-rotate is intentionally not in Order 1.
+	if existing, err := s.Load(); err == nil {
+		if profile != "" && existing.InstallProfile != profile {
+			existing.InstallProfile = profile
+			if err := s.writeIdentity(existing); err != nil {
+				return nil, err
+			}
+		}
+		return existing, nil
+	} else if !IsErrIdentityMissing(err) {
+		// A partial/corrupt identity is a refuse-to-overwrite case.
+		// The operator must `oktsec node init --force-rotate` (future)
+		// or manually remove the file. We never silently destroy keys.
+		return nil, fmt.Errorf("node identity present but invalid (refusing to overwrite): %w", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating node keypair: %w", err)
+	}
+
+	if err := writePEMSafe(filepath.Join(s.Dir, privateKeyFile), NodePrivateKeyPEMType, priv, 0o600); err != nil {
+		return nil, err
+	}
+	if err := writePEMSafe(filepath.Join(s.Dir, publicKeyFile), NodePublicKeyPEMType, pub, 0o644); err != nil {
+		return nil, err
+	}
+
+	nodeID, err := newNodeID()
+	if err != nil {
+		return nil, err
+	}
+	id := &Identity{
+		SchemaVersion:        SchemaIdentity,
+		NodeID:               nodeID,
+		CreatedAt:            nowUTCRFC3339(),
+		PublicKeyFingerprint: fingerprintPublicKey(pub),
+		HostFingerprint:      computeHostFingerprint(),
+		InstallProfile:       profile,
+	}
+	if err := s.writeIdentity(id); err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+// Load reads identity.json AND verifies that node.key + node.pub
+// exist and are consistent with the fingerprint in identity.json.
+//
+// The signed-checkpoint contract that future Enterprise depends on
+// requires all three to be usable together: identity.json on its own
+// (without keys, or with mismatched keys) must not be reported as
+// present. If only identity.json exists, Load returns a real error
+// — not errIdentityMissing — so the CLI marks the install "invalid"
+// rather than "missing" (which would imply a clean uninitialized
+// node).
+//
+// Treatment of the three files:
+//
+//	all three absent          -> errIdentityMissing (status: missing)
+//	identity.json only        -> error                (status: invalid)
+//	identity.json + keys but
+//	      fingerprint mismatch -> error                (status: invalid)
+//	all three present, valid  -> *Identity, nil       (status: present)
+func (s IdentityStore) Load() (*Identity, error) {
+	idPath := filepath.Join(s.Dir, identityFileName)
+	privPath := filepath.Join(s.Dir, privateKeyFile)
+	pubPath := filepath.Join(s.Dir, publicKeyFile)
+
+	idExists := fileExists(idPath)
+	privExists := fileExists(privPath)
+	pubExists := fileExists(pubPath)
+	if !idExists && !privExists && !pubExists {
+		return nil, errIdentityMissing
+	}
+
+	if !idExists {
+		return nil, fmt.Errorf("node key files present but identity.json missing")
+	}
+	data, err := safefile.ReadFileMax(idPath, maxIdentityBytes)
+	if err != nil {
+		return nil, fmt.Errorf("reading node identity: %w", err)
+	}
+
+	var id Identity
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("parsing node identity: %w", err)
+	}
+	if id.NodeID == "" || id.SchemaVersion == "" {
+		return nil, fmt.Errorf("node identity missing required fields")
+	}
+	if id.SchemaVersion != SchemaIdentity {
+		return nil, fmt.Errorf("unsupported node identity schema %q", id.SchemaVersion)
+	}
+	if id.InstallProfile == "" {
+		id.InstallProfile = ProfileLocal
+	}
+
+	// Keys must both exist and match the fingerprint in identity.json.
+	// Anything else means the install cannot sign checkpoints and must
+	// be reported as invalid, not present.
+	if !privExists {
+		return nil, fmt.Errorf("node private key missing at %s", privateKeyFile)
+	}
+	if !pubExists {
+		return nil, fmt.Errorf("node public key missing at %s", publicKeyFile)
+	}
+	priv, err := readPrivateKey(privPath)
+	if err != nil {
+		return nil, fmt.Errorf("node identity unusable: %w", err)
+	}
+	pub, err := readPublicKey(pubPath)
+	if err != nil {
+		return nil, fmt.Errorf("node identity unusable: %w", err)
+	}
+	// Cross-check: the private key's derived public half must match
+	// the on-disk public key and the fingerprint recorded earlier.
+	derived, ok := priv.Public().(ed25519.PublicKey)
+	if !ok || !pubKeysEqual(derived, pub) {
+		return nil, fmt.Errorf("node identity unusable: public key does not match private key")
+	}
+	if id.PublicKeyFingerprint != "" && fingerprintPublicKey(pub) != id.PublicKeyFingerprint {
+		return nil, fmt.Errorf("node identity unusable: public key fingerprint mismatch")
+	}
+	return &id, nil
+}
+
+// fileExists reports whether path exists as a non-symlink file.
+// Symlinks are treated as "does not exist" so a planted link never
+// causes Load to read content through it; the symlink-rejecting
+// readers further down still cover the read path.
+func fileExists(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// pubKeysEqual compares two Ed25519 public keys byte-by-byte.
+func pubKeysEqual(a, b ed25519.PublicKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// PublicKey loads and returns the node's Ed25519 public key.
+func (s IdentityStore) PublicKey() (ed25519.PublicKey, error) {
+	return readPublicKey(filepath.Join(s.Dir, publicKeyFile))
+}
+
+// Sign produces an Ed25519 signature over payload using the on-disk
+// private key. Returns an error if the identity is missing or the key
+// file is unreadable. The private key is loaded fresh on every call so
+// the store does not have to keep secret material in memory; callers
+// that sign in tight loops should batch payloads upstream.
+func (s IdentityStore) Sign(payload []byte) (Signature, error) {
+	priv, err := readPrivateKey(filepath.Join(s.Dir, privateKeyFile))
+	if err != nil {
+		return Signature{}, err
+	}
+	return signWithKey(priv, payload), nil
+}
+
+// writeIdentity serializes id as JSON and writes it under
+// identity.json with 0o600 perms via an atomic rename.
+func (s IdentityStore) writeIdentity(id *Identity) error {
+	data, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding node identity: %w", err)
+	}
+	// json.MarshalIndent omits the trailing newline; most tools
+	// expect one. Adding it here keeps the file editor-friendly
+	// without changing the parsed value.
+	data = append(data, '\n')
+	return writeFileSafe(filepath.Join(s.Dir, identityFileName), data, 0o600)
+}
+
+// readPrivateKey loads the Ed25519 private key PEM and validates the
+// PEM type so an agent key cannot stand in for the node key.
+func readPrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := safefile.ReadFileMax(path, maxKeyBytes)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errIdentityMissing
+		}
+		return nil, fmt.Errorf("reading node private key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("node private key: invalid PEM in %s", path)
+	}
+	if block.Type != NodePrivateKeyPEMType {
+		return nil, fmt.Errorf("node private key: unexpected PEM type %q", block.Type)
+	}
+	if len(block.Bytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("node private key: wrong size (%d)", len(block.Bytes))
+	}
+	return ed25519.PrivateKey(block.Bytes), nil
+}
+
+// readPublicKey loads the Ed25519 public key PEM and validates the
+// PEM type so an agent key cannot stand in for the node key.
+func readPublicKey(path string) (ed25519.PublicKey, error) {
+	data, err := safefile.ReadFileMax(path, maxKeyBytes)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errIdentityMissing
+		}
+		return nil, fmt.Errorf("reading node public key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("node public key: invalid PEM in %s", path)
+	}
+	if block.Type != NodePublicKeyPEMType {
+		return nil, fmt.Errorf("node public key: unexpected PEM type %q", block.Type)
+	}
+	if len(block.Bytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("node public key: wrong size (%d)", len(block.Bytes))
+	}
+	return ed25519.PublicKey(block.Bytes), nil
+}
+
+// ensureDirSafe creates dir with 0o700 if it does not exist and
+// refuses to proceed if dir (or its parent) is a symlink. Existing
+// directories keep their mode.
+func ensureDirSafe(dir string) error {
+	if dir == "" {
+		return errors.New("node: empty directory")
+	}
+	// Reject a symlinked parent (so an attacker can't redirect
+	// future writes by swapping ~/.oktsec for a link).
+	parent := filepath.Dir(dir)
+	if parent != "." && parent != "" {
+		if info, err := os.Lstat(parent); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("node: parent directory is a symlink: %s", parent)
+			}
+		}
+	}
+	info, err := os.Lstat(dir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return os.MkdirAll(dir, 0o700)
+	case err != nil:
+		return fmt.Errorf("node: stat %s: %w", dir, err)
+	default:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("node: identity directory is a symlink: %s", dir)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("node: %s exists and is not a directory", dir)
+		}
+		return nil
+	}
+}
+
+// writeFileSafe writes data to path atomically. It refuses to write to
+// an existing symlink and uses rename(2) to avoid partial writes.
+// File perms are applied via chmod after the rename so the umask does
+// not weaken them.
+func writeFileSafe(path string, data []byte, perm os.FileMode) error {
+	if err := refuseExistingSymlink(path); err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := ensureDirSafe(dir); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".node-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("node: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("node: write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		// Sync failures are non-fatal on some filesystems; log via
+		// the returned error chain so tests can see them but do not
+		// block the write — Order 1 does not require fsync semantics.
+		_ = tmp.Close()
+		return fmt.Errorf("node: sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("node: close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("node: chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("node: rename: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// writePEMSafe wraps writeFileSafe with PEM encoding.
+func writePEMSafe(path, pemType string, body []byte, perm os.FileMode) error {
+	block := &pem.Block{Type: pemType, Bytes: body}
+	return writeFileSafe(path, pem.EncodeToMemory(block), perm)
+}
+
+// refuseExistingSymlink returns an error if path exists AND is a
+// symlink. A non-existent path is fine — Init expects that.
+func refuseExistingSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("node: stat %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("node: refusing to overwrite symlink: %s", path)
+	}
+	return nil
+}

--- a/internal/node/identity_test.go
+++ b/internal/node/identity_test.go
@@ -1,0 +1,316 @@
+package node
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// newTempStore returns an IdentityStore rooted in a fresh temp dir.
+// Tests must never touch the real ~/.oktsec/node.
+func newTempStore(t *testing.T) IdentityStore {
+	t.Helper()
+	return IdentityStore{Dir: filepath.Join(t.TempDir(), "node")}
+}
+
+func TestIdentityStore_StatusMissing(t *testing.T) {
+	store := newTempStore(t)
+	got := store.Status()
+	if got.Status != "missing" {
+		t.Fatalf("expected missing, got %q", got.Status)
+	}
+	if got.Identity != nil {
+		t.Fatal("expected nil identity for missing status")
+	}
+	if len(got.Warnings) == 0 || got.Warnings[0].Code != WarnNodeIdentityMissing {
+		t.Fatalf("expected node_identity_missing warning, got %#v", got.Warnings)
+	}
+}
+
+func TestIdentityStore_InitCreatesFiles(t *testing.T) {
+	store := newTempStore(t)
+	id, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if id.NodeID == "" || !strings.HasPrefix(id.NodeID, "node_") {
+		t.Fatalf("node_id should be non-empty with node_ prefix, got %q", id.NodeID)
+	}
+	if id.SchemaVersion != SchemaIdentity {
+		t.Fatalf("schema_version mismatch: %q", id.SchemaVersion)
+	}
+	if id.InstallProfile != ProfileLocal {
+		t.Fatalf("profile mismatch: %q", id.InstallProfile)
+	}
+	if !strings.HasPrefix(id.PublicKeyFingerprint, "sha256:") {
+		t.Fatalf("public key fingerprint must be sha256-prefixed, got %q", id.PublicKeyFingerprint)
+	}
+	if !strings.HasPrefix(id.HostFingerprint, "sha256:") {
+		t.Fatalf("host fingerprint must be sha256-prefixed, got %q", id.HostFingerprint)
+	}
+	for _, name := range []string{identityFileName, privateKeyFile, publicKeyFile} {
+		path := filepath.Join(store.Dir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected file %s, got %v", name, err)
+		}
+	}
+}
+
+func TestIdentityStore_InitIsIdempotent(t *testing.T) {
+	store := newTempStore(t)
+	first, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	second, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	if first.NodeID != second.NodeID {
+		t.Fatalf("idempotent init produced new node id: %q vs %q", first.NodeID, second.NodeID)
+	}
+}
+
+func TestIdentityStore_InitUpdatesProfileOnly(t *testing.T) {
+	store := newTempStore(t)
+	first, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	second, err := store.Init(ProfileEnterprise)
+	if err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	if second.NodeID != first.NodeID {
+		t.Fatalf("profile change must not rotate node id")
+	}
+	if second.InstallProfile != ProfileEnterprise {
+		t.Fatalf("expected enterprise profile after re-init, got %q", second.InstallProfile)
+	}
+}
+
+func TestIdentityStore_PrivateKeyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics do not apply on Windows")
+	}
+	store := newTempStore(t)
+	if _, err := store.Init(ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(store.Dir, privateKeyFile))
+	if err != nil {
+		t.Fatalf("stat private key: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("private key must be 0600, got %o", mode)
+	}
+	info, err = os.Stat(filepath.Join(store.Dir, publicKeyFile))
+	if err != nil {
+		t.Fatalf("stat public key: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o644 {
+		t.Fatalf("public key should be 0644, got %o", mode)
+	}
+	info, err = os.Stat(store.Dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("identity dir should be 0700, got %o", mode)
+	}
+}
+
+func TestIdentityStore_IdentityJSONHasNoSecret(t *testing.T) {
+	store := newTempStore(t)
+	if _, err := store.Init(ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(store.Dir, identityFileName))
+	if err != nil {
+		t.Fatalf("read identity.json: %v", err)
+	}
+	// Decode as raw map so we don't pre-restrict the fields.
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("identity.json must be valid JSON: %v", err)
+	}
+	// Reject any field that looks key-shaped.
+	for k := range raw {
+		lower := strings.ToLower(k)
+		if strings.Contains(lower, "private") || lower == "secret" || lower == "key" {
+			t.Fatalf("identity.json must not contain private/secret material: %s", k)
+		}
+	}
+	if strings.Contains(string(data), "BEGIN") {
+		t.Fatalf("identity.json must not contain PEM blocks")
+	}
+}
+
+func TestIdentityStore_SignVerify(t *testing.T) {
+	store := newTempStore(t)
+	id, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	pub, err := store.PublicKey()
+	if err != nil {
+		t.Fatalf("public key: %v", err)
+	}
+	if fingerprintPublicKey(pub) != id.PublicKeyFingerprint {
+		t.Fatalf("fingerprint mismatch between identity.json and on-disk key")
+	}
+	payload := []byte("hello-node-snapshot")
+	sig, err := store.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw := decodeBase64OrFail(t, sig.Base64)
+	if !ed25519.Verify(pub, payload, raw) {
+		t.Fatalf("signature did not verify against the stored public key")
+	}
+}
+
+func TestIdentityStore_RejectsSymlinkedIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	store := newTempStore(t)
+	if err := os.MkdirAll(store.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Plant a symlink at identity.json pointing at a real file
+	// elsewhere; Load() must refuse to read it.
+	other := filepath.Join(t.TempDir(), "decoy.json")
+	if err := os.WriteFile(other, []byte(`{"node_id":"node_x","schema_version":"node_identity.v1","install_profile":"local"}`), 0o600); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	if err := os.Symlink(other, filepath.Join(store.Dir, identityFileName)); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := store.Load(); err == nil {
+		t.Fatal("Load() should reject symlinked identity.json")
+	}
+}
+
+func TestIdentityStore_RejectsSymlinkedNodeDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	parent := t.TempDir()
+	real := filepath.Join(parent, "real")
+	if err := os.MkdirAll(real, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	linkDir := filepath.Join(parent, "linked")
+	if err := os.Symlink(real, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	store := IdentityStore{Dir: linkDir}
+	if _, err := store.Init(ProfileLocal); err == nil {
+		t.Fatal("Init must refuse symlinked node directory")
+	}
+}
+
+func TestIdentityStore_IdentityJSONOnlyIsInvalid(t *testing.T) {
+	// Regression: future Enterprise relies on signed checkpoints.
+	// An identity.json without the corresponding node.key/node.pub
+	// must report as invalid, not present, otherwise `node status`
+	// lies about whether this node can sign anything.
+	store := newTempStore(t)
+	if err := os.MkdirAll(store.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{
+		"schema_version": "node_identity.v1",
+		"node_id": "node_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"created_at": "2026-05-21T00:00:00Z",
+		"public_key_fingerprint": "sha256:deadbeef",
+		"host_fingerprint": "sha256:cafebabe",
+		"install_profile": "local"
+	}`
+	if err := os.WriteFile(filepath.Join(store.Dir, identityFileName), []byte(body), 0o600); err != nil {
+		t.Fatalf("write identity.json: %v", err)
+	}
+	got := store.Status()
+	if got.Status != "invalid" {
+		t.Fatalf("identity.json without keys must be invalid, got %q", got.Status)
+	}
+	if got.Identity != nil {
+		t.Fatalf("invalid identity should not expose identity payload")
+	}
+}
+
+func TestIdentityStore_MismatchedKeyIsInvalid(t *testing.T) {
+	// Regression: identity.json fingerprint must match the actual
+	// public key on disk. A mismatched pair cannot sign anything.
+	store := newTempStore(t)
+	if _, err := store.Init(ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Replace the public key with a different one — the fingerprint
+	// in identity.json will no longer match.
+	otherStore := newTempStore(t)
+	if _, err := otherStore.Init(ProfileLocal); err != nil {
+		t.Fatalf("init other: %v", err)
+	}
+	otherPub, err := os.ReadFile(filepath.Join(otherStore.Dir, publicKeyFile))
+	if err != nil {
+		t.Fatalf("read other pub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Dir, publicKeyFile), otherPub, 0o644); err != nil {
+		t.Fatalf("overwrite pub: %v", err)
+	}
+	got := store.Status()
+	if got.Status != "invalid" {
+		t.Fatalf("mismatched pub/priv must be invalid, got %q", got.Status)
+	}
+}
+
+func TestIdentityStore_MissingPrivateKeyIsInvalid(t *testing.T) {
+	store := newTempStore(t)
+	if _, err := store.Init(ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := os.Remove(filepath.Join(store.Dir, privateKeyFile)); err != nil {
+		t.Fatalf("remove private: %v", err)
+	}
+	got := store.Status()
+	if got.Status != "invalid" {
+		t.Fatalf("missing private key must be invalid, got %q", got.Status)
+	}
+}
+
+func TestIdentityStore_LoadRejectsAgentPEM(t *testing.T) {
+	// A node store must never accept a key written by the agent
+	// identity package (which uses "OKTSEC ED25519 PRIVATE KEY"
+	// without the NODE qualifier).
+	store := newTempStore(t)
+	if err := os.MkdirAll(store.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bad := "-----BEGIN OKTSEC ED25519 PRIVATE KEY-----\nAAAA\n-----END OKTSEC ED25519 PRIVATE KEY-----\n"
+	if err := os.WriteFile(filepath.Join(store.Dir, privateKeyFile), []byte(bad), 0o600); err != nil {
+		t.Fatalf("write bad key: %v", err)
+	}
+	if _, err := readPrivateKey(filepath.Join(store.Dir, privateKeyFile)); err == nil {
+		t.Fatal("expected agent-PEM key to be refused")
+	}
+}
+
+// decodeBase64OrFail uses the std library and t.Fatal on error.
+func decodeBase64OrFail(t *testing.T, s string) []byte {
+	t.Helper()
+	out, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if len(out) != ed25519.SignatureSize {
+		t.Fatalf("unexpected sig length %d", len(out))
+	}
+	return out
+}

--- a/internal/node/redact.go
+++ b/internal/node/redact.go
@@ -1,0 +1,114 @@
+package node
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// HashString returns "sha256:<hex>" for s. Empty input returns "".
+func HashString(s string) string {
+	if s == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(s))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// PathTail returns the last segment of a filesystem path. It accepts
+// both POSIX and Windows-style separators so the same redaction works
+// on every platform the binary runs on.
+//
+// Examples:
+//
+//	"/Users/a/b/file.txt" -> "file.txt"
+//	"/Users/a/project"     -> "project"
+//	"C:\\Users\\a\\b.txt"  -> "b.txt"
+func PathTail(path string) string {
+	if path == "" {
+		return ""
+	}
+	// Normalize both separators so Windows-style paths shrink
+	// correctly on Unix-built binaries (and vice versa).
+	p := strings.TrimRight(path, "/\\")
+	if p == "" {
+		// Path was only separators ("/", "\\\\", etc).
+		return ""
+	}
+	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
+		return p[i+1:]
+	}
+	// No separator at all; use filepath.Base for OS-specific edge
+	// cases (e.g. Windows volume names like "C:").
+	return filepath.Base(p)
+}
+
+// PathHash returns HashString of the path. Used so two snapshots from
+// the same node can correlate config/db locations without leaking the
+// absolute filesystem layout.
+func PathHash(path string) string {
+	return HashString(path)
+}
+
+// CommandTail returns the basename of a command string (the binary
+// name without args). Empty input returns "".
+//
+// The MCPServerConfig contract keeps args in a separate field, so
+// CommandTail treats the first whitespace-delimited token as the
+// executable. Operators with binary paths that contain spaces should
+// keep the path quoted or move flags into Args — without that
+// contract a "/Program Files/node.exe --flag" string is ambiguous.
+func CommandTail(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return ""
+	}
+	if idx := strings.IndexAny(cmd, " \t"); idx >= 0 {
+		cmd = cmd[:idx]
+	}
+	return PathTail(cmd)
+}
+
+// URLHostHash returns HashString of the URL's host (without
+// userinfo or port). If parsing fails, returns "". Query strings,
+// credentials, and paths are never hashed.
+func URLHostHash(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
+	return HashString(strings.ToLower(host))
+}
+
+// RedactMCPServerConfig converts an MCPServerConfig into a redacted
+// InventoryMCPServer. Raw command paths, URL credentials, args, env
+// values, and full URLs are stripped.
+func RedactMCPServerConfig(name string, in config.MCPServerConfig) InventoryMCPServer {
+	out := InventoryMCPServer{
+		Name:      name,
+		Transport: in.Transport,
+		EnvCount:  len(in.Env),
+	}
+	if in.Command != "" {
+		out.CommandTail = CommandTail(in.Command)
+	}
+	if len(in.Args) > 0 {
+		out.ArgsCount = len(in.Args)
+	}
+	if in.URL != "" {
+		out.URLHostHash = URLHostHash(in.URL)
+	}
+	return out
+}

--- a/internal/node/redact_test.go
+++ b/internal/node/redact_test.go
@@ -1,0 +1,103 @@
+package node
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+func TestPathTail(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/", ""},
+		{"file.txt", "file.txt"},
+		{"/Users/dev/secret/file.txt", "file.txt"},
+		{"/Users/dev/project", "project"},
+		{`C:\Users\dev\b.txt`, "b.txt"},
+		{`\\share\folder\file.txt`, "file.txt"},
+		{"/Users/dev/project/", "project"},
+	}
+	for _, c := range cases {
+		if got := PathTail(c.in); got != c.want {
+			t.Errorf("PathTail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestHashStringStable(t *testing.T) {
+	if HashString("") != "" {
+		t.Fatal("empty input should hash to empty string")
+	}
+	got := HashString("hello")
+	if !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("HashString output should be sha256-prefixed, got %q", got)
+	}
+	if got != HashString("hello") {
+		t.Fatal("HashString must be deterministic")
+	}
+}
+
+func TestURLHostHashRedactsCreds(t *testing.T) {
+	in := "https://user:password@example.com/sub?token=abc"
+	got := URLHostHash(in)
+	if got == "" {
+		t.Fatal("URLHostHash returned empty for parsable URL")
+	}
+	// Must not contain any plaintext from the URL.
+	for _, banned := range []string{"user", "password", "sub", "token", "abc", "example.com"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("URLHostHash leaked %q", banned)
+		}
+	}
+	// Identical hosts (case + creds invariant) must hash equally.
+	if URLHostHash("https://EXAMPLE.com") != got {
+		t.Errorf("URLHostHash should be case-insensitive on host")
+	}
+}
+
+func TestCommandTailStripsArgs(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"/usr/local/bin/npx --secret abc", "npx"},
+		{"npx", "npx"},
+		{`C:\Users\dev\node.exe`, "node.exe"},
+	}
+	for _, c := range cases {
+		if got := CommandTail(c.in); got != c.want {
+			t.Errorf("CommandTail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRedactMCPServerConfig(t *testing.T) {
+	in := config.MCPServerConfig{
+		Transport: "stdio",
+		Command:   "/usr/bin/npx",
+		Args:      []string{"--token", "secret-value", "/Users/dev/path"},
+		URL:       "https://user:pw@mcp.example.com/foo?k=v",
+		Env:       map[string]string{"SECRET_KEY": "should-not-leak"},
+	}
+	got := RedactMCPServerConfig("backend", in)
+	if got.Name != "backend" || got.Transport != "stdio" {
+		t.Fatalf("expected name/transport preserved")
+	}
+	if got.CommandTail != "npx" {
+		t.Errorf("expected command tail npx, got %q", got.CommandTail)
+	}
+	if got.ArgsCount != 3 {
+		t.Errorf("expected args count 3, got %d", got.ArgsCount)
+	}
+	if got.EnvCount != 1 {
+		t.Errorf("expected env count 1, got %d", got.EnvCount)
+	}
+	// Make sure nothing leaked into the marshalled redaction.
+	raw, _ := toJSON(got)
+	for _, banned := range []string{"secret-value", "should-not-leak", "pw", "user", "Users", "dev/path"} {
+		if strings.Contains(raw, banned) {
+			t.Errorf("redacted output leaked %q", banned)
+		}
+	}
+}

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -1,0 +1,271 @@
+package node
+
+// Stable schema versions emitted in JSON output. Bumping a version is a
+// breaking-change signal to Enterprise consumers and must be done in a
+// dedicated PR with a migration note.
+const (
+	SchemaIdentity = "node_identity.v1"
+	SchemaSnapshot = "node_snapshot.v1"
+)
+
+// Install profile values for node identity. Display/planning only;
+// nothing in the policy hot path branches on this field.
+const (
+	ProfileLocal      = "local"
+	ProfileEnterprise = "enterprise"
+)
+
+// Identity is the on-disk and JSON-emitted shape of the local node
+// identity record. NodeID is non-secret, stable, and randomly
+// generated; host/public-key fingerprints are SHA-256 hashes that
+// must never expose raw hostname or username material.
+type Identity struct {
+	SchemaVersion        string            `json:"schema_version"`
+	NodeID               string            `json:"node_id"`
+	CreatedAt            string            `json:"created_at"`
+	PublicKeyFingerprint string            `json:"public_key_fingerprint"`
+	HostFingerprint      string            `json:"host_fingerprint"`
+	InstallProfile       string            `json:"install_profile"`
+	Labels               map[string]string `json:"labels,omitempty"`
+}
+
+// IdentityStatus is the JSON envelope returned by `oktsec node status`.
+// Status is one of "present", "missing", "invalid"; Identity is set
+// only when Status is "present". Warnings are non-fatal.
+type IdentityStatus struct {
+	Status   string    `json:"status"`
+	Identity *Identity `json:"identity,omitempty"`
+	Warnings []Warning `json:"warnings,omitempty"`
+}
+
+// Snapshot is the top-level JSON shape emitted by
+// `oktsec node snapshot --json`. Sections are populated on a best-effort
+// basis; partial state is reported via Warnings instead of failing.
+type Snapshot struct {
+	SchemaVersion string           `json:"schema_version"`
+	GeneratedAt   string           `json:"generated_at"`
+	Range         SnapshotRange    `json:"range"`
+	Node          SnapshotNode     `json:"node"`
+	Config        SnapshotConfig   `json:"config"`
+	Surfaces      SnapshotSurfaces `json:"surfaces"`
+	Inventory     SnapshotInventory `json:"inventory"`
+	Posture       SnapshotPosture  `json:"posture"`
+	Evidence      SnapshotEvidence `json:"evidence"`
+	Warnings      []Warning        `json:"warnings"`
+}
+
+// SnapshotRange describes the time window the snapshot was computed
+// over. Both bounds are RFC3339 strings; Until empty means "now".
+type SnapshotRange struct {
+	Since string `json:"since"`
+	Until string `json:"until"`
+}
+
+// SnapshotNode summarizes the local Oktsec runtime that produced this
+// snapshot. IdentityStatus mirrors IdentityStatus.Status above so the
+// section is self-describing when identity is missing.
+type SnapshotNode struct {
+	NodeID               string `json:"node_id,omitempty"`
+	IdentityStatus       string `json:"identity_status"`
+	HostFingerprint      string `json:"host_fingerprint,omitempty"`
+	PublicKeyFingerprint string `json:"public_key_fingerprint,omitempty"`
+	OktsecVersion        string `json:"oktsec_version,omitempty"`
+	Commit               string `json:"commit,omitempty"`
+	GOOS                 string `json:"goos"`
+	GOARCH               string `json:"goarch"`
+	Profile              string `json:"profile,omitempty"`
+}
+
+// SnapshotConfig reports the state of oktsec.yaml without exposing
+// secrets or full paths. ConfigHash is SHA-256 of the raw file bytes;
+// PathHash is SHA-256 of the absolute path.
+type SnapshotConfig struct {
+	Status              string `json:"status"`
+	PathTail            string `json:"path_tail,omitempty"`
+	PathHash            string `json:"path_hash,omitempty"`
+	ConfigHash          string `json:"config_hash,omitempty"`
+	DefaultPolicy       string `json:"default_policy,omitempty"`
+	SignatureRequired   bool   `json:"signature_required"`
+	DelegationRequired  bool   `json:"delegation_required"`
+	DBBackend           string `json:"db_backend,omitempty"`
+	DBAvailable         bool   `json:"db_available"`
+}
+
+// SnapshotSurfaces is the per-surface configured/observed view used by
+// the dashboard coverage matrix and by the planned Enterprise fleet
+// report. Booleans are conservative: false when the section cannot
+// prove the affirmative.
+type SnapshotSurfaces struct {
+	MCPGateway      SurfaceGateway  `json:"mcp_gateway"`
+	StdioProxy      SurfaceStdio    `json:"stdio_proxy"`
+	Hooks           SurfaceHooks    `json:"hooks"`
+	EgressProxy     SurfaceEgress   `json:"egress_proxy"`
+	AgentMessageAPI SurfaceAgentMsg `json:"agent_message_api"`
+}
+
+// SurfaceGateway summarizes the MCP gateway surface.
+type SurfaceGateway struct {
+	Configured     bool `json:"configured"`
+	Enabled        bool `json:"enabled"`
+	AuthRequired   bool `json:"auth_required"`
+	BackendCount   int  `json:"backend_count"`
+	ScanResponses  bool `json:"scan_responses"`
+}
+
+// SurfaceStdio summarizes the stdio proxy surface. Source is
+// "config_only" in Order 1; future orders may add "discovered".
+type SurfaceStdio struct {
+	Configured         bool   `json:"configured"`
+	WrappedClientCount int    `json:"wrapped_client_count"`
+	Source             string `json:"source"`
+}
+
+// SurfaceHooks summarizes the hook ingestion surface.
+type SurfaceHooks struct {
+	Configured      bool `json:"configured"`
+	AuthRequired    bool `json:"auth_required"`
+	FreshRealEvent  bool `json:"fresh_real_event"`
+	HeartbeatRecent bool `json:"heartbeat_recent"`
+}
+
+// SurfaceEgress summarizes the HTTP egress proxy surface.
+type SurfaceEgress struct {
+	Configured          bool `json:"configured"`
+	Enabled             bool `json:"enabled"`
+	AuthRequired        bool `json:"auth_required"`
+	AllowedDomainCount  int  `json:"allowed_domain_count"`
+	BlockedDomainCount  int  `json:"blocked_domain_count"`
+}
+
+// SurfaceAgentMsg summarizes the inter-agent message API surface.
+type SurfaceAgentMsg struct {
+	Configured         bool `json:"configured"`
+	SignatureRequired  bool `json:"signature_required"`
+	DelegationRequired bool `json:"delegation_required"`
+}
+
+// SnapshotInventory enumerates what this node is configured to protect.
+// Arrays are sorted by stable id so diff tooling is stable across runs.
+type SnapshotInventory struct {
+	Agents     []InventoryAgent     `json:"agents"`
+	Principals []InventoryPrincipal `json:"principals"`
+	MCPServers []InventoryMCPServer `json:"mcp_servers"`
+	Tools      []InventoryTool      `json:"tools"`
+	Clients    []InventoryClient    `json:"clients"`
+}
+
+// InventoryAgent is a redacted projection of config.Agent.
+type InventoryAgent struct {
+	ID        string   `json:"id"`
+	Suspended bool     `json:"suspended"`
+	Tags      []string `json:"tags,omitempty"`
+}
+
+// InventoryPrincipal is a redacted projection of config.PrincipalConfig.
+type InventoryPrincipal struct {
+	ID              string   `json:"id"`
+	Kind            string   `json:"kind,omitempty"`
+	WorkspaceIDHash string   `json:"workspace_id_hash,omitempty"`
+	Surfaces        []string `json:"surfaces,omitempty"`
+}
+
+// InventoryMCPServer is a redacted projection of config.MCPServerConfig.
+// Command paths and URLs are reduced to tail + host so secrets in args
+// or query strings never appear in the snapshot.
+type InventoryMCPServer struct {
+	Name        string `json:"name"`
+	Transport   string `json:"transport"`
+	CommandTail string `json:"command_tail,omitempty"`
+	ArgsCount   int    `json:"args_count,omitempty"`
+	URLHostHash string `json:"url_host_hash,omitempty"`
+	EnvCount    int    `json:"env_count"`
+}
+
+// InventoryTool is a tool the node knows about. Source is one of
+// "runtime" (observed via runtime_hook_events) or "config"; in Order 1
+// the inventory comes primarily from runtime when available.
+type InventoryTool struct {
+	Name            string `json:"name"`
+	Source          string `json:"source"`
+	Server          string `json:"server,omitempty"`
+	SchemaHash      string `json:"schema_hash,omitempty"`
+	DescriptionHash string `json:"description_hash,omitempty"`
+}
+
+// InventoryClient is a discovered AI client (Claude Desktop, Cursor,
+// etc.). Order 1 emits an empty array with a `client_discovery_not_included`
+// warning; later orders populate this when --include-discovery is set.
+type InventoryClient struct {
+	Name string `json:"name"`
+	Kind string `json:"kind,omitempty"`
+}
+
+// SnapshotPosture summarizes the node's protection coverage using the
+// same vocabulary as the dashboard coverage matrix. Overall is one of
+// protected/observing/blind/setup_pending/degraded.
+type SnapshotPosture struct {
+	Overall            string         `json:"overall"`
+	SurfaceCounts      PostureCounts  `json:"surface_counts"`
+	RuntimeSessions    int            `json:"runtime_sessions"`
+	ActivePrincipals   int            `json:"active_principals"`
+	BlockedActions     int            `json:"blocked_actions"`
+	QuarantinedActions int            `json:"quarantined_actions"`
+}
+
+// PostureCounts breaks down configured surfaces by coverage state.
+type PostureCounts struct {
+	Protected     int `json:"protected"`
+	Observed      int `json:"observed"`
+	Blind         int `json:"blind"`
+	Stale         int `json:"stale"`
+	NotConfigured int `json:"not_configured"`
+}
+
+// SnapshotEvidence reports aggregate counts and chain-verification
+// results from the audit/runtime/activity tables. Counts respect the
+// snapshot range; chain verification is bounded by a fixed limit and
+// the entry-count scope is reported in AuditChainVerificationScope.
+//
+// AuditChainVerified is the overall result under the checks the
+// snapshot was able to run. It is false if hash links break OR if
+// any signature that *was* checked against the configured proxy key
+// failed. It is true only when every applicable check passed.
+//
+// AuditChainSignaturesChecked is the stronger signature claim:
+// true only when every entry in the verified scope carried a
+// proxy_signature AND every one of those signatures verified
+// against the configured proxy public key. Anything weaker —
+// no key reachable, no signed rows, or mixed signed/unsigned
+// coverage — leaves this field false. Enterprise compliance
+// evidence must read both fields together: AuditChainVerified
+// tells you nothing tampered; AuditChainSignaturesChecked tells
+// you the proxy actually signed every row in scope.
+type SnapshotEvidence struct {
+	AuditAvailable               bool             `json:"audit_available"`
+	AuditEntries                 int              `json:"audit_entries"`
+	AuditChainHead               string           `json:"audit_chain_head,omitempty"`
+	AuditChainVerified           bool             `json:"audit_chain_verified"`
+	AuditChainVerificationScope  string           `json:"audit_chain_verification_scope,omitempty"`
+	AuditChainSignaturesChecked  bool             `json:"audit_chain_signatures_checked"`
+	AuditChainKeyFingerprint     string           `json:"audit_chain_key_fingerprint,omitempty"`
+	AuditOldestAt                string           `json:"audit_oldest_at,omitempty"`
+	AuditNewestAt                string           `json:"audit_newest_at,omitempty"`
+	RuntimeAvailable             bool             `json:"runtime_available"`
+	RuntimeSessions              int              `json:"runtime_sessions"`
+	RuntimeEvents                int              `json:"runtime_events"`
+	RuntimeToolEvents            int              `json:"runtime_tool_events"`
+	ActivityAvailable            bool             `json:"activity_available"`
+	ActivityEvents               int              `json:"activity_events"`
+	Decisions                    DecisionCounts   `json:"decisions"`
+}
+
+// DecisionCounts breaks audit entries down by policy_decision /
+// status. Reported as plain integers so dashboards and dashboards-of-
+// dashboards can diff snapshots field-by-field.
+type DecisionCounts struct {
+	Allowed     int `json:"allowed"`
+	Flagged     int `json:"flagged"`
+	Quarantined int `json:"quarantined"`
+	Blocked     int `json:"blocked"`
+	Rejected    int `json:"rejected"`
+}

--- a/internal/node/snapshot.go
+++ b/internal/node/snapshot.go
@@ -1,0 +1,750 @@
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/safefile"
+)
+
+// Options controls SnapshotBuilder.Build. All fields are optional;
+// zero values fall back to sensible defaults.
+type Options struct {
+	// ConfigPath is the path to oktsec.yaml. Empty means "use
+	// config.ResolveConfigPath with no flag".
+	ConfigPath string
+
+	// DBPath overrides the resolved audit-database path. When
+	// empty, the snapshot uses cfg.DBPath if available and falls
+	// back to config.DefaultDBPath. Tests pin this so the snapshot
+	// never reaches the operator's real ~/.oktsec/oktsec.db.
+	DBPath string
+
+	// IdentityStore is the node identity store to consult. Zero
+	// value uses DefaultIdentityStore.
+	IdentityStore IdentityStore
+
+	// Since/Until define the snapshot range. Zero Since defaults
+	// to 24h ago; zero Until means "now".
+	Since time.Time
+	Until time.Time
+
+	// IncludeDiscovery requests MCP client discovery in the
+	// inventory. Order 1 ignores this flag and emits a
+	// client_discovery_not_included warning instead.
+	IncludeDiscovery bool
+
+	// OktsecVersion / OktsecCommit override the version stamped
+	// into the snapshot. CLI fills these from version.go; tests
+	// pin them so golden output stays deterministic.
+	OktsecVersion string
+	OktsecCommit  string
+
+	// Now overrides time.Now for the GeneratedAt field. Used by
+	// tests; production callers leave it zero.
+	Now time.Time
+}
+
+// chainScanLimit caps the number of chain entries the snapshot
+// reads. Verification runs over a bounded window so a 50M-row audit
+// log cannot stall a snapshot.
+const chainScanLimit = 5000
+
+// defaultSince is the default range floor when Options.Since is zero.
+const defaultSince = 24 * time.Hour
+
+// Build assembles the full Snapshot. It is read-only by construction:
+// no DB is created, no migrations run, and no external client is
+// queried. Partial state is reported via warnings.
+func Build(ctx context.Context, opts Options) (Snapshot, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	since := opts.Since
+	if since.IsZero() {
+		since = now.Add(-defaultSince)
+	}
+	until := opts.Until
+	if !until.IsZero() {
+		until = until.UTC()
+	}
+
+	snap := Snapshot{
+		SchemaVersion: SchemaSnapshot,
+		GeneratedAt:   now.UTC().Format(time.RFC3339),
+		Range: SnapshotRange{
+			Since: since.UTC().Format(time.RFC3339),
+		},
+		Node: SnapshotNode{
+			IdentityStatus: "missing",
+			GOOS:           runtime.GOOS,
+			GOARCH:         runtime.GOARCH,
+			OktsecVersion:  opts.OktsecVersion,
+			Commit:         opts.OktsecCommit,
+			Profile:        ProfileLocal,
+		},
+		Config: SnapshotConfig{Status: "missing"},
+		Inventory: SnapshotInventory{
+			Agents:     []InventoryAgent{},
+			Principals: []InventoryPrincipal{},
+			MCPServers: []InventoryMCPServer{},
+			Tools:      []InventoryTool{},
+			Clients:    []InventoryClient{},
+		},
+	}
+	if !until.IsZero() {
+		snap.Range.Until = until.Format(time.RFC3339)
+	}
+
+	idStore := opts.IdentityStore
+	if idStore.Dir == "" {
+		idStore = DefaultIdentityStore()
+	}
+	idStatus := idStore.Status()
+	snap.Node.IdentityStatus = idStatus.Status
+	if idStatus.Identity != nil {
+		snap.Node.NodeID = idStatus.Identity.NodeID
+		snap.Node.HostFingerprint = idStatus.Identity.HostFingerprint
+		snap.Node.PublicKeyFingerprint = idStatus.Identity.PublicKeyFingerprint
+		if idStatus.Identity.InstallProfile != "" {
+			snap.Node.Profile = idStatus.Identity.InstallProfile
+		}
+	}
+	snap.Warnings = append(snap.Warnings, idStatus.Warnings...)
+
+	cfg, cfgPath, cfgWarnings := loadConfigForSnapshot(opts.ConfigPath)
+	snap.Warnings = append(snap.Warnings, cfgWarnings...)
+	populateConfigSection(&snap, cfg, cfgPath)
+	populateSurfacesSection(&snap, cfg)
+	populateInventorySection(&snap, cfg, opts.IncludeDiscovery)
+
+	// Postgres-backed installs must not be inspected as if they
+	// were SQLite — that would silently report stale ~/.oktsec/oktsec.db
+	// contents (or any leftover from a prior local run) as the
+	// authoritative audit evidence and ship false positives to a
+	// future fleet report. Order 1 emits a structured warning and
+	// stops short of opening any DB handle.
+	if cfg != nil && strings.EqualFold(cfg.DBBackend, "postgres") {
+		snap.Config.DBAvailable = false
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnPostgresSnapshotLimited,
+			Message: "Postgres-backed installs are not inspected in Order 1; audit/runtime/activity counts are omitted.",
+		})
+		snap.Posture = computePosture(cfg, runtimeDBInspection{}, auditDBInspection{}, snap.Surfaces)
+		return snap, nil
+	}
+
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = resolveSnapshotDBPath(cfg)
+	}
+	avail := inspectSQLiteAvailability(dbPath)
+	snap.Config.DBAvailable = avail.Available
+	if !avail.Available {
+		switch avail.Reason {
+		case "missing":
+			snap.Warnings = append(snap.Warnings, Warning{
+				Code:    WarnDBMissing,
+				Message: "Audit database has not been created yet.",
+			})
+		default:
+			snap.Warnings = append(snap.Warnings, Warning{
+				Code:    WarnDBUnreachable,
+				Message: "Audit database is not safe to open read-only.",
+			})
+		}
+		snap.Posture = computePosture(cfg, runtimeDBInspection{}, auditDBInspection{}, snap.Surfaces)
+		return snap, nil
+	}
+
+	db, err := openSQLiteReadOnly(dbPath)
+	if err != nil {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnDBUnreachable,
+			Message: "Could not open audit database read-only: " + err.Error(),
+		})
+		snap.Config.DBAvailable = false
+		snap.Posture = computePosture(cfg, runtimeDBInspection{}, auditDBInspection{}, snap.Surfaces)
+		return snap, nil
+	}
+	defer func() { _ = db.Close() }()
+
+	auditInfo, err := inspectAuditSQLite(ctx, db, since, until, chainScanLimit)
+	if err != nil {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnAuditTableMissing,
+			Message: err.Error(),
+		})
+	} else if !auditInfo.Available {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnAuditTableMissing,
+			Message: "audit_log table is not present.",
+		})
+	}
+	runtimeInfo, err := inspectRuntimeSQLite(ctx, db, since, until)
+	if err != nil {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnRuntimeTableMissing,
+			Message: err.Error(),
+		})
+	} else if !runtimeInfo.Available {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnRuntimeTableMissing,
+			Message: "runtime_* tables are not present.",
+		})
+	}
+	activityInfo, err := inspectActivitySQLite(ctx, db, since, until)
+	if err != nil {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnActivityTableMissing,
+			Message: err.Error(),
+		})
+	} else if !activityInfo.Available {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnActivityTableMissing,
+			Message: "activity_events table is not present.",
+		})
+	}
+
+	chain := verifyAuditChainBounded(ctx, db, auditInfo.Available, chainScanLimit, configuredKeysDir(cfg))
+	if !chain.Available && auditInfo.Available {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnAuditChainUnavailable,
+			Message: chain.Reason,
+		})
+	}
+	if auditInfo.Available && auditInfo.Entries > 0 && !chain.SignaturesChecked {
+		// Two distinct failure modes that both end at
+		// SignaturesChecked=false:
+		//
+		//   partial coverage: at least one row carries a
+		//   signature, but the scope also contains unsigned rows.
+		//   Calling this "signed" would overclaim — Enterprise
+		//   evidence needs a separate code so the consumer can
+		//   distinguish "no key reachable" from "mixed coverage".
+		//
+		//   no signed evidence: either proxy.pub could not be
+		//   located or every row in scope is unsigned. Either
+		//   way the snapshot only proved hashes.
+		//
+		// The chain may still have failed for a non-signature
+		// reason (broken hash link); audit_chain_verified is the
+		// definitive overall result and consumers must read it
+		// alongside this warning.
+		if chain.SignedEntries > 0 && chain.UnsignedEntries > 0 {
+			snap.Warnings = append(snap.Warnings, Warning{
+				Code:    WarnAuditChainSignaturesPartial,
+				Message: "Some audit entries in scope carry proxy signatures and others do not; full-range Ed25519 verification NOT proven. See audit_chain_verified for the hash/overall result.",
+			})
+		} else {
+			snap.Warnings = append(snap.Warnings, Warning{
+				Code:    WarnAuditChainSignaturesNotChecked,
+				Message: "Ed25519 proxy signatures were NOT verified (no reachable proxy public key or no signed entries in scope). See audit_chain_verified for the hash/overall result.",
+			})
+		}
+	}
+
+	activePrincipals, err := distinctActivePrincipalsSQLite(ctx, db, since, until)
+	if err != nil {
+		activePrincipals = 0
+	}
+
+	snap.Evidence = SnapshotEvidence{
+		AuditAvailable:              auditInfo.Available,
+		AuditEntries:                auditInfo.Entries,
+		AuditChainHead:              chain.Head,
+		AuditChainVerified:          chain.Verified,
+		AuditChainVerificationScope: chain.Scope,
+		AuditChainSignaturesChecked: chain.SignaturesChecked,
+		AuditChainKeyFingerprint:    chain.KeyFingerprint,
+		AuditOldestAt:               auditInfo.OldestAt,
+		AuditNewestAt:               auditInfo.NewestAt,
+		RuntimeAvailable:            runtimeInfo.Available,
+		RuntimeSessions:             runtimeInfo.Sessions,
+		RuntimeEvents:               runtimeInfo.Events,
+		RuntimeToolEvents:           runtimeInfo.ToolEvents,
+		ActivityAvailable:           activityInfo.Available,
+		ActivityEvents:              activityInfo.Events,
+		Decisions: DecisionCounts{
+			Allowed:     auditInfo.Allowed,
+			Flagged:     auditInfo.Flagged,
+			Quarantined: auditInfo.Quarantined,
+			Blocked:     auditInfo.Blocked,
+			Rejected:    auditInfo.Rejected,
+		},
+	}
+
+	// Wire hook-surface freshness from runtime info into the
+	// surfaces section now that the DB has been inspected.
+	snap.Surfaces.Hooks.FreshRealEvent = runtimeInfo.HasFreshRealEvent
+	snap.Surfaces.Hooks.HeartbeatRecent = runtimeInfo.HasRecentHeartbeat
+
+	snap.Posture = computePosture(cfg, runtimeInfo, auditInfo, snap.Surfaces)
+	snap.Posture.RuntimeSessions = runtimeInfo.Sessions
+	snap.Posture.ActivePrincipals = activePrincipals
+	snap.Posture.BlockedActions = auditInfo.Blocked
+	snap.Posture.QuarantinedActions = auditInfo.Quarantined
+
+	return snap, nil
+}
+
+// loadConfigForSnapshot resolves the config path (falling back to the
+// default resolver) and loads the file. Failures are turned into
+// warnings rather than fatal errors so a missing config still emits a
+// usable snapshot.
+func loadConfigForSnapshot(explicit string) (*config.Config, string, []Warning) {
+	path := explicit
+	if path == "" {
+		path, _ = config.ResolveConfigPath("", false)
+	}
+	if path == "" {
+		return nil, "", []Warning{{Code: WarnConfigMissing, Message: "No config path could be resolved."}}
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, path, []Warning{{Code: WarnConfigMissing, Message: "Config file does not exist: " + PathTail(path)}}
+		}
+		return nil, path, []Warning{{Code: WarnConfigInvalid, Message: "Could not stat config: " + err.Error()}}
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		return nil, path, []Warning{{Code: WarnConfigInvalid, Message: "Config did not load: " + err.Error()}}
+	}
+	return cfg, path, nil
+}
+
+// populateConfigSection fills snap.Config from the loaded config.
+// path may be set even when cfg is nil (e.g. parse failure or
+// not-yet-created file). Status disambiguates the two: a path that
+// does not exist on disk is "missing"; a path whose contents could
+// not be parsed is "invalid".
+func populateConfigSection(snap *Snapshot, cfg *config.Config, path string) {
+	if cfg == nil {
+		if path != "" {
+			snap.Config.PathTail = PathTail(path)
+			snap.Config.PathHash = PathHash(path)
+			if _, err := os.Stat(path); err == nil {
+				snap.Config.Status = "invalid"
+				snap.Config.ConfigHash = hashFileBytes(path)
+			} else {
+				snap.Config.Status = "missing"
+			}
+		}
+		return
+	}
+	snap.Config.Status = "present"
+	snap.Config.PathTail = PathTail(path)
+	snap.Config.PathHash = PathHash(path)
+	snap.Config.ConfigHash = hashFileBytes(path)
+	snap.Config.DefaultPolicy = cfg.DefaultPolicy
+	if snap.Config.DefaultPolicy == "" {
+		snap.Config.DefaultPolicy = "allow"
+	}
+	snap.Config.SignatureRequired = cfg.Identity.RequireSignature
+	snap.Config.DelegationRequired = cfg.Identity.RequireDelegation
+	snap.Config.DBBackend = cfg.DBBackend
+	if snap.Config.DBBackend == "" {
+		snap.Config.DBBackend = "sqlite"
+	}
+	if cfg.Deployment.Profile != "" {
+		snap.Node.Profile = cfg.Deployment.Profile
+	}
+}
+
+// populateSurfacesSection derives configured/enabled booleans from
+// cfg. Runtime freshness (FreshRealEvent, HeartbeatRecent) is added
+// later once the DB has been inspected.
+func populateSurfacesSection(snap *Snapshot, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	snap.Surfaces.MCPGateway = SurfaceGateway{
+		Configured:    cfg.Gateway.Port != 0 || cfg.Gateway.Enabled || len(cfg.MCPServers) > 0,
+		Enabled:       cfg.Gateway.Enabled,
+		AuthRequired:  requireAuthBool(cfg.Gateway.SurfaceAuthConfig, cfg.Deployment.Profile),
+		BackendCount:  len(cfg.MCPServers),
+		ScanResponses: cfg.Gateway.ScanResponses,
+	}
+	snap.Surfaces.StdioProxy = SurfaceStdio{
+		Configured: len(cfg.MCPServers) > 0,
+		Source:     "config_only",
+	}
+	snap.Surfaces.Hooks = SurfaceHooks{
+		Configured:   true, // hooks endpoint is always wired when oktsec runs
+		AuthRequired: requireAuthBool(cfg.Hooks.SurfaceAuthConfig, cfg.Deployment.Profile),
+	}
+	snap.Surfaces.EgressProxy = SurfaceEgress{
+		Configured:         cfg.ForwardProxy.Port != 0 || cfg.ForwardProxy.Enabled,
+		Enabled:            cfg.ForwardProxy.Enabled,
+		AuthRequired:       requireAuthBool(cfg.ForwardProxy.SurfaceAuthConfig, cfg.Deployment.Profile),
+		AllowedDomainCount: len(cfg.ForwardProxy.AllowedDomains),
+		BlockedDomainCount: len(cfg.ForwardProxy.BlockedDomains),
+	}
+	snap.Surfaces.AgentMessageAPI = SurfaceAgentMsg{
+		Configured:         len(cfg.Agents) > 0 || cfg.Server.Port != 0,
+		SignatureRequired:  cfg.Identity.RequireSignature,
+		DelegationRequired: cfg.Identity.RequireDelegation,
+	}
+}
+
+// requireAuthBool resolves the surface auth knob to a concrete bool
+// for snapshot reporting. "auto" follows the deployment profile.
+func requireAuthBool(s config.SurfaceAuthConfig, profile string) bool {
+	switch strings.ToLower(s.RequireAuth) {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		return strings.ToLower(profile) == ProfileEnterprise
+	}
+}
+
+// populateInventorySection fills the inventory arrays from cfg. All
+// arrays are returned sorted so two snapshots diff cleanly.
+func populateInventorySection(snap *Snapshot, cfg *config.Config, includeDiscovery bool) {
+	if cfg == nil {
+		return
+	}
+	for name, agent := range cfg.Agents {
+		ia := InventoryAgent{
+			ID:        name,
+			Suspended: agent.Suspended,
+		}
+		if len(agent.Tags) > 0 {
+			ia.Tags = append([]string(nil), agent.Tags...)
+			sort.Strings(ia.Tags)
+		}
+		snap.Inventory.Agents = append(snap.Inventory.Agents, ia)
+	}
+	sort.Slice(snap.Inventory.Agents, func(i, j int) bool {
+		return snap.Inventory.Agents[i].ID < snap.Inventory.Agents[j].ID
+	})
+
+	for _, p := range cfg.Identity.Principals {
+		ip := InventoryPrincipal{
+			ID:              p.ID,
+			Kind:            p.Kind,
+			WorkspaceIDHash: HashString(p.WorkspaceID),
+			Surfaces:        append([]string(nil), p.AllowedSurfaces...),
+		}
+		sort.Strings(ip.Surfaces)
+		snap.Inventory.Principals = append(snap.Inventory.Principals, ip)
+	}
+	sort.Slice(snap.Inventory.Principals, func(i, j int) bool {
+		return snap.Inventory.Principals[i].ID < snap.Inventory.Principals[j].ID
+	})
+
+	for name, server := range cfg.MCPServers {
+		snap.Inventory.MCPServers = append(snap.Inventory.MCPServers, RedactMCPServerConfig(name, server))
+	}
+	sort.Slice(snap.Inventory.MCPServers, func(i, j int) bool {
+		return snap.Inventory.MCPServers[i].Name < snap.Inventory.MCPServers[j].Name
+	})
+
+	// Tools and Clients are runtime-derived; Order 1 keeps them as
+	// empty arrays plus a warning when discovery was requested.
+	if includeDiscovery {
+		snap.Warnings = append(snap.Warnings, Warning{
+			Code:    WarnClientDiscoveryNotIncluded,
+			Message: "Client discovery is not included in this Oktsec version's node snapshot.",
+		})
+	}
+}
+
+// chainResult is the bounded chain verification result wired into
+// SnapshotEvidence.
+//
+//	Available           false => "we did not run the verifier"
+//	                    (table missing, query error, etc).
+//	Verified            overall pass under available checks
+//	                    (hash chain links AND any signature that
+//	                    was checked).
+//	SignaturesChecked   STRICT: true only when every entry in the
+//	                    verified scope had a proxy_signature and
+//	                    every signature verified against the
+//	                    configured key. Mixed signed/unsigned
+//	                    coverage leaves this false.
+//	SignedEntries /     diagnostic counters for the partial-coverage
+//	  UnsignedEntries   warning path; consumers can derive coverage
+//	                    ratio without re-querying audit_log.
+type chainResult struct {
+	Available         bool
+	Verified          bool
+	SignaturesChecked bool
+	SignedEntries     int
+	UnsignedEntries   int
+	KeyFingerprint    string
+	Head              string
+	Scope             string
+	Reason            string
+}
+
+// verifyAuditChainBounded reads up to limit chain rows and runs
+// audit.VerifyChain. The proxy public key is loaded from the
+// keysDir argument (the operator's configured identity.keys_dir,
+// not the default) so a custom-keys deployment is verified against
+// the actual signing key. If no key is locatable, the chain hash
+// portion is still verified and SignaturesChecked is reported as
+// false.
+func verifyAuditChainBounded(ctx context.Context, db *sql.DB, auditAvailable bool, limit int, keysDir string) chainResult {
+	if !auditAvailable {
+		return chainResult{Reason: "audit_log table is not present"}
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT id, timestamp, from_agent, to_agent, content_hash, status,
+		 COALESCE(policy_decision,''), COALESCE(rules_triggered,''), COALESCE(signature_verified,0),
+		 COALESCE(prev_hash,''), COALESCE(entry_hash,''), COALESCE(proxy_signature,'')
+		 FROM audit_log WHERE entry_hash != '' ORDER BY timestamp ASC LIMIT ?`, limit,
+	)
+	if err != nil {
+		return chainResult{Reason: "chain query failed: " + err.Error()}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []audit.ChainEntry
+	for rows.Next() {
+		var ce audit.ChainEntry
+		if err := rows.Scan(&ce.ID, &ce.Timestamp, &ce.FromAgent, &ce.ToAgent,
+			&ce.ContentHash, &ce.Status,
+			&ce.PolicyDecision, &ce.RulesTriggered, &ce.SignatureVerified,
+			&ce.PrevHash, &ce.EntryHash, &ce.ProxySignature); err != nil {
+			return chainResult{Reason: "chain scan failed: " + err.Error()}
+		}
+		entries = append(entries, ce)
+	}
+	if err := rows.Err(); err != nil {
+		return chainResult{Reason: "chain rows err: " + err.Error()}
+	}
+	if len(entries) == 0 {
+		return chainResult{Available: true, Verified: true, Scope: "empty"}
+	}
+
+	proxyPub, keyFP := loadProxyPubKeyForSnapshot(keysDir)
+	res := audit.VerifyChain(entries, proxyPub)
+	scope := "bounded"
+	if len(entries) < limit {
+		scope = "all"
+	}
+
+	// Count signed vs unsigned entries so the strict
+	// SignaturesChecked claim only fires when the full scope is
+	// covered. audit.VerifyChain only verifies non-empty
+	// proxy_signature values; a chain of 5000 rows with one
+	// signature would otherwise let consumers misread the result
+	// as "the range was signed".
+	var signed, unsigned int
+	for _, e := range entries {
+		if e.ProxySignature != "" {
+			signed++
+		} else {
+			unsigned++
+		}
+	}
+	sigChecked := proxyPub != nil && unsigned == 0 && signed > 0 && res.Valid
+
+	return chainResult{
+		Available:         true,
+		Verified:          res.Valid,
+		SignaturesChecked: sigChecked,
+		SignedEntries:     signed,
+		UnsignedEntries:   unsigned,
+		KeyFingerprint:    keyFP,
+		Head:              entries[len(entries)-1].EntryHash,
+		Scope:             scope,
+	}
+}
+
+// loadProxyPubKeyForSnapshot reads proxy.pub from keysDir first and
+// falls back to config.DefaultKeysDir only if keysDir is empty or
+// the configured file does not exist. Returns nil + "" when no key
+// is reachable so chain verification proceeds hash-only.
+//
+// Falling back to the default keys dir when keysDir was specified
+// but missing the proxy key would let a misconfigured node silently
+// verify against the wrong key, so that path explicitly errors out
+// (returns nil + "") instead of substituting the default.
+func loadProxyPubKeyForSnapshot(keysDir string) (ed25519.PublicKey, string) {
+	candidates := []string{}
+	switch keysDir {
+	case "":
+		candidates = append(candidates, filepath.Join(config.DefaultKeysDir(), "proxy.pub"))
+	default:
+		// Only look at the configured location. Refusing to fall
+		// back is intentional: a custom keys_dir without proxy.pub
+		// is a misconfiguration, not a license to verify against
+		// some unrelated default-dir key.
+		candidates = append(candidates, filepath.Join(keysDir, "proxy.pub"))
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		data, err := safefile.ReadFileMax(candidate, maxKeyBytes)
+		if err != nil {
+			continue
+		}
+		pub, ok := parseEd25519PublicKeyPEM(data)
+		if !ok {
+			continue
+		}
+		return pub, fingerprintPublicKey(pub)
+	}
+	return nil, ""
+}
+
+// configuredKeysDir returns the operator-configured identity.keys_dir
+// (empty string when no config is present, which signals the default
+// keys dir to loadProxyPubKeyForSnapshot).
+func configuredKeysDir(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Identity.KeysDir
+}
+
+// resolveSnapshotDBPath mirrors the CLI's defaultDBPath logic but
+// without consulting cfgFile (we already loaded the config above).
+func resolveSnapshotDBPath(cfg *config.Config) string {
+	if cfg != nil && cfg.DBPath != "" {
+		return cfg.DBPath
+	}
+	return config.DefaultDBPath()
+}
+
+// hashFileBytes reads up to 1MB of path and returns "sha256:<hex>".
+// Returns "" on any failure (used for diagnostic-only ConfigHash).
+func hashFileBytes(path string) string {
+	data, err := safefile.ReadFileMax(path, 1<<20)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// computePosture turns the surfaces / runtime / audit observations
+// into the dashboard coverage vocabulary. The logic is conservative:
+// only call a surface protected when we have concrete *real* runtime
+// evidence within the snapshot window. Heartbeats are diagnostic
+// only — they prove the hook ingestion endpoint is reachable but do
+// not prove a single real action was inspected. Treating them as
+// protection would let an idle install masquerade as locked down.
+// Each configured surface is counted exactly once across protected
+// / observed / blind / stale; surfaces that are not configured go
+// to NotConfigured.
+func computePosture(cfg *config.Config, rt runtimeDBInspection, aud auditDBInspection, sf SnapshotSurfaces) SnapshotPosture {
+	labels := []string{
+		classifySurfaceCoverage(sf.MCPGateway.Configured, sf.MCPGateway.Enabled, rt.HasFreshRealEvent, rt.Events > 0 || aud.Entries > 0),
+		classifySurfaceCoverage(sf.Hooks.Configured, true, sf.Hooks.FreshRealEvent, sf.Hooks.HeartbeatRecent || rt.Events > 0),
+		classifySurfaceCoverage(sf.EgressProxy.Configured, sf.EgressProxy.Enabled, false, aud.Entries > 0),
+		classifySurfaceCoverage(sf.AgentMessageAPI.Configured, true, false, aud.Entries > 0),
+		classifySurfaceCoverage(sf.StdioProxy.Configured, false, false, aud.Entries > 0),
+	}
+	var counts PostureCounts
+	for _, c := range labels {
+		switch c {
+		case "protected":
+			counts.Protected++
+		case "observed":
+			counts.Observed++
+		case "blind":
+			counts.Blind++
+		case "stale":
+			counts.Stale++
+		case "not_configured":
+			counts.NotConfigured++
+		}
+	}
+
+	overall := "blind"
+	switch {
+	case cfg == nil:
+		overall = "setup_pending"
+	case counts.Protected > 0:
+		overall = "protected"
+	case counts.Observed > 0:
+		overall = "observing"
+	case counts.Blind > 0 || counts.NotConfigured > 0:
+		overall = "blind"
+	}
+	if !aud.Available && cfg != nil && counts.Protected == 0 && counts.Observed == 0 {
+		overall = "blind"
+	}
+	return SnapshotPosture{
+		Overall:       overall,
+		SurfaceCounts: counts,
+	}
+}
+
+// classifySurfaceCoverage returns a coverage label for a single
+// surface from a few cheap signals.
+//
+//	configured = surface is wired up in oktsec.yaml
+//	enabled    = surface is on (gateway.enabled, forward_proxy.enabled, etc.)
+//	freshReal  = a real action was observed in the snapshot window
+//	             — heartbeats and keepalives do NOT count
+//	observed   = any diagnostic evidence (heartbeat, audit row,
+//	             post-action telemetry) was seen in the window
+//
+// Only freshReal AND enabled can produce "protected"; anything weaker
+// is at most "observed" so an idle install never overclaims.
+func classifySurfaceCoverage(configured, enabled, freshReal, observed bool) string {
+	if !configured {
+		return "not_configured"
+	}
+	if freshReal && enabled {
+		return "protected"
+	}
+	if observed {
+		return "observed"
+	}
+	return "blind"
+}
+
+// parseEd25519PublicKeyPEM decodes a PEM-wrapped Ed25519 public key
+// (32 raw bytes) and returns it along with an ok flag. Accepts any
+// PEM type so the proxy key file produced by either internal/identity
+// or older fixtures is readable; raw-binary fallback covers test data.
+func parseEd25519PublicKeyPEM(data []byte) (ed25519.PublicKey, bool) {
+	if block, _ := pem.Decode(data); block != nil {
+		if len(block.Bytes) == ed25519.PublicKeySize {
+			return ed25519.PublicKey(append([]byte(nil), block.Bytes...)), true
+		}
+	}
+	if len(data) == ed25519.PublicKeySize {
+		return ed25519.PublicKey(append([]byte(nil), data...)), true
+	}
+	return nil, false
+}
+
+// MarshalSnapshot is a small helper so callers don't repeat the
+// indented json.Marshal dance.
+func MarshalSnapshot(s Snapshot) ([]byte, error) {
+	buf, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal snapshot: %w", err)
+	}
+	return append(buf, '\n'), nil
+}

--- a/internal/node/snapshot_test.go
+++ b/internal/node/snapshot_test.go
@@ -1,0 +1,828 @@
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+	_ "modernc.org/sqlite"
+)
+
+// buildAt is a convenience wrapper that pins the snapshot's
+// generated_at, IdentityStore directory and DBPath to the test temp
+// space so no test ever reaches the real ~/.oktsec.
+func buildAt(t *testing.T, opts Options) Snapshot {
+	t.Helper()
+	if opts.IdentityStore.Dir == "" {
+		opts.IdentityStore = IdentityStore{Dir: filepath.Join(t.TempDir(), "node")}
+	}
+	if opts.DBPath == "" {
+		// Pin to a guaranteed-missing path so we never leak into the
+		// developer's ~/.oktsec/oktsec.db. Tests that need a real DB
+		// set DBPath explicitly.
+		opts.DBPath = filepath.Join(t.TempDir(), "node-test-default.db")
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	}
+	snap, err := Build(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return snap
+}
+
+func TestSnapshot_NoConfigNoDB(t *testing.T) {
+	snap := buildAt(t, Options{ConfigPath: filepath.Join(t.TempDir(), "missing.yaml")})
+	if snap.SchemaVersion != SchemaSnapshot {
+		t.Fatalf("schema version: %q", snap.SchemaVersion)
+	}
+	if snap.Node.IdentityStatus != "missing" {
+		t.Fatalf("identity status: %q", snap.Node.IdentityStatus)
+	}
+	if snap.Config.Status != "missing" {
+		t.Fatalf("config status: %q", snap.Config.Status)
+	}
+	if snap.Config.DBAvailable {
+		t.Fatalf("db should not be available")
+	}
+	if snap.Posture.Overall != "setup_pending" {
+		t.Fatalf("posture should be setup_pending without config, got %q", snap.Posture.Overall)
+	}
+	if !hasWarning(snap.Warnings, WarnConfigMissing) {
+		t.Fatalf("expected config_missing warning, got %#v", snap.Warnings)
+	}
+	if !hasWarning(snap.Warnings, WarnNodeIdentityMissing) {
+		t.Fatalf("expected node_identity_missing warning, got %#v", snap.Warnings)
+	}
+}
+
+func TestSnapshot_ConfigPresentDBMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.DBPath = filepath.Join(dir, "does-not-exist.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	snap := buildAt(t, Options{ConfigPath: cfgPath, DBPath: cfg.DBPath})
+	if snap.Config.Status != "present" {
+		t.Fatalf("expected config present, got %q", snap.Config.Status)
+	}
+	if snap.Config.DBAvailable {
+		t.Fatalf("db must not be available")
+	}
+	if _, err := os.Stat(cfg.DBPath); err == nil {
+		t.Fatalf("snapshot must not create the audit DB at %s", cfg.DBPath)
+	}
+	if !hasWarning(snap.Warnings, WarnDBMissing) {
+		t.Fatalf("expected db_missing warning, got %#v", snap.Warnings)
+	}
+}
+
+func TestSnapshot_RuntimeTablesMissingAreReported(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save cfg: %v", err)
+	}
+	// Create an empty SQLite DB without any tables. Snapshot must
+	// observe it and report missing tables.
+	db, err := sql.Open("sqlite", cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE marker(x INT)"); err != nil {
+		t.Fatalf("create marker: %v", err)
+	}
+	_ = db.Close()
+	snap := buildAt(t, Options{ConfigPath: cfgPath, DBPath: cfg.DBPath})
+	if !snap.Config.DBAvailable {
+		t.Fatalf("db should be available")
+	}
+	if !hasWarning(snap.Warnings, WarnAuditTableMissing) {
+		t.Fatalf("expected audit_table_missing warning")
+	}
+	if !hasWarning(snap.Warnings, WarnRuntimeTableMissing) {
+		t.Fatalf("expected runtime_table_missing warning")
+	}
+	if !hasWarning(snap.Warnings, WarnActivityTableMissing) {
+		t.Fatalf("expected activity_table_missing warning")
+	}
+	if snap.Evidence.AuditAvailable || snap.Evidence.RuntimeAvailable || snap.Evidence.ActivityAvailable {
+		t.Fatalf("availability flags should be false when tables are missing")
+	}
+}
+
+func TestSnapshot_WithAuditRows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	seedAuditDB(t, cfg.DBPath, 3, 1)
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !snap.Evidence.AuditAvailable {
+		t.Fatalf("audit should be available")
+	}
+	if snap.Evidence.AuditEntries < 4 {
+		t.Fatalf("expected at least 4 audit entries, got %d", snap.Evidence.AuditEntries)
+	}
+	if snap.Evidence.Decisions.Blocked != 1 {
+		t.Fatalf("expected 1 blocked decision, got %d", snap.Evidence.Decisions.Blocked)
+	}
+	if snap.Evidence.AuditChainHead == "" {
+		t.Fatalf("audit chain head should be populated")
+	}
+}
+
+func TestSnapshot_InventoryRedacted(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.Agents = map[string]config.Agent{
+		"researcher": {Suspended: false, Tags: []string{"alpha"}},
+		"analyst":    {Suspended: true},
+	}
+	cfg.Identity.Principals = []config.PrincipalConfig{
+		{ID: "researcher", Kind: "agent", WorkspaceID: "ws-123", AllowedSurfaces: []string{"mcp_http"}},
+	}
+	cfg.MCPServers = map[string]config.MCPServerConfig{
+		"filesystem": {Transport: "stdio", Command: "/usr/bin/npx", Args: []string{"--workdir", "/Users/dev/secret"}, Env: map[string]string{"K": "v"}},
+		"remote":     {Transport: "http", URL: "https://user:pw@mcp.example.com/api?token=topsecret"},
+	}
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	snap := buildAt(t, Options{ConfigPath: cfgPath})
+	raw := requireJSON(t, snap)
+	// Banned strings the redaction must keep out of the JSON.
+	banned := []string{
+		"/usr/bin/npx",
+		"/Users/dev/secret",
+		"user:pw@",
+		"topsecret",
+		"ws-123",
+	}
+	for _, b := range banned {
+		if strings.Contains(raw, b) {
+			t.Errorf("snapshot leaked %q", b)
+		}
+	}
+	if len(snap.Inventory.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(snap.Inventory.Agents))
+	}
+	// Sorted by id.
+	if snap.Inventory.Agents[0].ID != "analyst" || snap.Inventory.Agents[1].ID != "researcher" {
+		t.Fatalf("agents not sorted: %v", snap.Inventory.Agents)
+	}
+	if len(snap.Inventory.MCPServers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(snap.Inventory.MCPServers))
+	}
+}
+
+func TestSnapshot_RejectsSymlinkedDB(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	real := filepath.Join(dir, "real.db")
+	link := filepath.Join(dir, "linked.db")
+	seedAuditDB(t, real, 1, 0)
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	cfg.DBPath = link
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	snap := buildAt(t, Options{ConfigPath: cfgPath, DBPath: cfg.DBPath})
+	if snap.Config.DBAvailable {
+		t.Fatalf("snapshot must refuse symlinked DB path")
+	}
+	if !hasWarning(snap.Warnings, WarnDBUnreachable) {
+		t.Fatalf("expected db_unreachable warning, got %#v", snap.Warnings)
+	}
+}
+
+func TestPosture_HeartbeatNeverProtects(t *testing.T) {
+	// Regression: heartbeats are diagnostic only. A recent heartbeat
+	// proves the hook endpoint is reachable, not that any real
+	// action was inspected. Posture must not flip to protected from
+	// heartbeat evidence alone.
+	cfg := minimalCfg()
+	surfaces := SnapshotSurfaces{
+		MCPGateway:      SurfaceGateway{Configured: true, Enabled: true},
+		Hooks:           SurfaceHooks{Configured: true, HeartbeatRecent: true, FreshRealEvent: false},
+		EgressProxy:     SurfaceEgress{Configured: true, Enabled: true},
+		AgentMessageAPI: SurfaceAgentMsg{Configured: true},
+		StdioProxy:      SurfaceStdio{Configured: true},
+	}
+	got := computePosture(cfg, runtimeDBInspection{HasRecentHeartbeat: true}, auditDBInspection{Available: true}, surfaces)
+	if got.SurfaceCounts.Protected != 0 {
+		t.Fatalf("heartbeat alone must not mark any surface protected, got Protected=%d", got.SurfaceCounts.Protected)
+	}
+	if got.Overall == "protected" {
+		t.Fatalf("overall posture must not be protected from heartbeat alone, got %q", got.Overall)
+	}
+}
+
+func TestPosture_StaleRuntimeEventsAreObservedNotProtected(t *testing.T) {
+	// Regression: a runtime_hook_events row in the window but
+	// outside the freshness threshold counts as observed, not
+	// protected. Without this distinction an install that ran one
+	// real action 23h ago looks just as protected as one that
+	// gated a tool call moments ago.
+	cfg := minimalCfg()
+	surfaces := SnapshotSurfaces{
+		MCPGateway:      SurfaceGateway{Configured: true, Enabled: true},
+		Hooks:           SurfaceHooks{Configured: true},
+		EgressProxy:     SurfaceEgress{Configured: true, Enabled: true},
+		AgentMessageAPI: SurfaceAgentMsg{Configured: true},
+		StdioProxy:      SurfaceStdio{Configured: true},
+	}
+	rt := runtimeDBInspection{
+		Available:         true,
+		Events:            4, // in window, but stale (no HasFreshRealEvent)
+		HasFreshRealEvent: false,
+	}
+	got := computePosture(cfg, rt, auditDBInspection{Available: true, Entries: 1}, surfaces)
+	if got.SurfaceCounts.Protected != 0 {
+		t.Fatalf("stale runtime events must not mark surfaces protected, got Protected=%d", got.SurfaceCounts.Protected)
+	}
+	if got.SurfaceCounts.Observed == 0 {
+		t.Fatalf("stale runtime events must show up as observed, got %+v", got.SurfaceCounts)
+	}
+}
+
+func TestPosture_FreshRealEventCanProtect(t *testing.T) {
+	cfg := minimalCfg()
+	surfaces := SnapshotSurfaces{
+		MCPGateway:      SurfaceGateway{Configured: true, Enabled: true},
+		Hooks:           SurfaceHooks{Configured: true, FreshRealEvent: true},
+		EgressProxy:     SurfaceEgress{Configured: false},
+		AgentMessageAPI: SurfaceAgentMsg{Configured: false},
+		StdioProxy:      SurfaceStdio{Configured: false},
+	}
+	rt := runtimeDBInspection{Available: true, Events: 4, HasFreshRealEvent: true}
+	got := computePosture(cfg, rt, auditDBInspection{Available: true, Entries: 5}, surfaces)
+	if got.SurfaceCounts.Protected == 0 {
+		t.Fatalf("fresh real evidence must support protected, got %+v", got.SurfaceCounts)
+	}
+	if got.Overall != "protected" {
+		t.Fatalf("overall should be protected, got %q", got.Overall)
+	}
+}
+
+func TestSnapshot_PostgresBackendSkipsSQLiteInspection(t *testing.T) {
+	// Regression: a stale local SQLite file must not be counted as
+	// Postgres audit evidence. Snapshot must emit
+	// postgres_snapshot_limited and leave audit/runtime/activity
+	// availability false even if the local DB exists and contains
+	// rows.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	stalePath := filepath.Join(dir, "stale-local.db")
+	seedAuditDB(t, stalePath, 5, 2)
+	cfg := minimalCfg()
+	cfg.DBBackend = "postgres"
+	// DBPath here mimics a stale local SQLite the operator forgot
+	// to delete after migrating to Postgres.
+	cfg.DBPath = stalePath
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	snap := buildAt(t, Options{ConfigPath: cfgPath, DBPath: stalePath})
+	if !hasWarning(snap.Warnings, WarnPostgresSnapshotLimited) {
+		t.Fatalf("expected postgres_snapshot_limited warning, got %#v", snap.Warnings)
+	}
+	if snap.Evidence.AuditAvailable || snap.Evidence.RuntimeAvailable || snap.Evidence.ActivityAvailable {
+		t.Fatalf("postgres config must not surface stale SQLite evidence: %+v", snap.Evidence)
+	}
+	if snap.Evidence.AuditEntries != 0 || snap.Evidence.Decisions.Allowed != 0 || snap.Evidence.Decisions.Blocked != 0 {
+		t.Fatalf("postgres config must report zero counts, got %+v", snap.Evidence)
+	}
+	if snap.Config.DBAvailable {
+		t.Fatalf("db_available must be false for postgres in Order 1")
+	}
+}
+
+func TestSnapshot_NeverMutatesConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	beforeBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	_ = buildAt(t, Options{ConfigPath: cfgPath})
+	afterBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(beforeBytes) != string(afterBytes) {
+		t.Fatalf("snapshot mutated oktsec.yaml")
+	}
+}
+
+func TestSnapshot_OutputContainsNoSensitiveKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	cfg := minimalCfg()
+	cfg.Server.APIKey = "super-secret-api-key"
+	cfg.LLM.APIKey = "sk-live-shouldnotleak"
+	cfg.Identity.Principals = []config.PrincipalConfig{
+		{ID: "p1", Tokens: []config.PrincipalTokenConfig{{ID: "t1", Hash: "sha256:abc:def"}}},
+	}
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	snap := buildAt(t, Options{ConfigPath: cfgPath})
+	raw := requireJSON(t, snap)
+	for _, banned := range []string{"super-secret-api-key", "sk-live-shouldnotleak", "sha256:abc:def"} {
+		if strings.Contains(raw, banned) {
+			t.Errorf("snapshot leaked %q", banned)
+		}
+	}
+}
+
+// minimalCfg returns a config that passes validation. Tests that need
+// more keys mutate fields directly.
+func minimalCfg() *config.Config {
+	return &config.Config{
+		Version:  "1",
+		Identity: config.IdentityConfig{KeysDir: "/tmp/keys"},
+		Server:   config.ServerConfig{Port: 8080, LogLevel: "info"},
+	}
+}
+
+// seedAuditDB creates an audit_log table with the columns
+// QueryChainEntries reads, then inserts the requested number of
+// delivered + blocked rows with valid chain links. We don't use
+// audit.NewStore because that would test the production batcher; for
+// snapshot read-only inspection, a plain sql.DB is enough.
+func seedAuditDB(t *testing.T, path string, delivered, blocked int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		signature_verified INTEGER,
+		pubkey_fingerprint TEXT,
+		status TEXT NOT NULL,
+		rules_triggered TEXT,
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER,
+		intent TEXT DEFAULT '',
+		session_id TEXT DEFAULT '',
+		tool_name TEXT DEFAULT '',
+		prev_hash TEXT DEFAULT '',
+		entry_hash TEXT DEFAULT '',
+		proxy_signature TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create audit_log: %v", err)
+	}
+	insert := func(status, decision string, at time.Time, prev string) string {
+		id := status + "-" + at.Format("150405")
+		entryHash := "hash-" + id
+		_, err := db.Exec(`INSERT INTO audit_log
+			(id, timestamp, from_agent, to_agent, content_hash, status, rules_triggered, policy_decision, latency_ms, signature_verified, prev_hash, entry_hash)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			id, at.UTC().Format(time.RFC3339), "agent-a", "agent-b", "content", status, "[]", decision, 5, 1, prev, entryHash)
+		if err != nil {
+			t.Fatalf("insert %s: %v", status, err)
+		}
+		return entryHash
+	}
+	prev := ""
+	base := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < delivered; i++ {
+		prev = insert("delivered", "allow", base.Add(time.Duration(i)*time.Minute), prev)
+	}
+	for i := 0; i < blocked; i++ {
+		prev = insert("blocked", "block", base.Add(time.Duration(delivered+i)*time.Minute), prev)
+	}
+}
+
+func hasWarning(ws []Warning, code string) bool {
+	for _, w := range ws {
+		if w.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// seedSignedAuditChain creates an audit_log table with three rows
+// linked by valid prev_hash / entry_hash and signed with the
+// provided proxy private key. Returns the entry IDs in chain order
+// so a follow-up test can tamper with a specific row.
+func seedSignedAuditChain(t *testing.T, path string, proxyPriv ed25519.PrivateKey) []string {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		signature_verified INTEGER,
+		pubkey_fingerprint TEXT,
+		status TEXT NOT NULL,
+		rules_triggered TEXT,
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER,
+		intent TEXT DEFAULT '',
+		session_id TEXT DEFAULT '',
+		tool_name TEXT DEFAULT '',
+		prev_hash TEXT DEFAULT '',
+		entry_hash TEXT DEFAULT '',
+		proxy_signature TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create audit_log: %v", err)
+	}
+	base := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	prev := ""
+	ids := make([]string, 0, 3)
+	for i, row := range []struct{ status, decision string }{
+		{"delivered", "allow"},
+		{"delivered", "allow"},
+		{"blocked", "content_blocked"},
+	} {
+		id := "row-" + time.Duration(i).String()
+		ts := base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339)
+		hash := audit.ComputeEntryHash(prev, id, ts, "agent-a", "agent-b", "content-hash", row.status, row.decision, "[]", 1)
+		sig := audit.SignEntryHash(proxyPriv, hash)
+		if _, err := db.Exec(`INSERT INTO audit_log
+			(id, timestamp, from_agent, to_agent, content_hash, status, rules_triggered, policy_decision, latency_ms, signature_verified, prev_hash, entry_hash, proxy_signature)
+			VALUES (?, ?, 'agent-a', 'agent-b', 'content-hash', ?, '[]', ?, 5, 1, ?, ?, ?)`,
+			id, ts, row.status, row.decision, prev, hash, sig,
+		); err != nil {
+			t.Fatalf("insert chain row: %v", err)
+		}
+		prev = hash
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// seedPartiallySignedChain creates an audit_log with three linked
+// rows where only the first row carries a proxy_signature. Hashes
+// are valid end-to-end so VerifyChain passes on the hash chain.
+// Used to lock down the contract that audit_chain_signatures_checked
+// must require FULL signature coverage, not "at least one".
+func seedPartiallySignedChain(t *testing.T, path string, proxyPriv ed25519.PrivateKey) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		signature_verified INTEGER,
+		pubkey_fingerprint TEXT,
+		status TEXT NOT NULL,
+		rules_triggered TEXT,
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER,
+		intent TEXT DEFAULT '',
+		session_id TEXT DEFAULT '',
+		tool_name TEXT DEFAULT '',
+		prev_hash TEXT DEFAULT '',
+		entry_hash TEXT DEFAULT '',
+		proxy_signature TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create audit_log: %v", err)
+	}
+	base := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	prev := ""
+	for i, row := range []struct {
+		status, decision string
+		signed           bool
+	}{
+		{"delivered", "allow", true},
+		{"delivered", "allow", false},
+		{"blocked", "content_blocked", false},
+	} {
+		id := "row-partial-" + time.Duration(i).String()
+		ts := base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339)
+		hash := audit.ComputeEntryHash(prev, id, ts, "agent-a", "agent-b", "ch", row.status, row.decision, "[]", 1)
+		sig := ""
+		if row.signed {
+			sig = audit.SignEntryHash(proxyPriv, hash)
+		}
+		if _, err := db.Exec(`INSERT INTO audit_log
+			(id, timestamp, from_agent, to_agent, content_hash, status, rules_triggered, policy_decision, latency_ms, signature_verified, prev_hash, entry_hash, proxy_signature)
+			VALUES (?, ?, 'agent-a', 'agent-b', 'ch', ?, '[]', ?, 5, 1, ?, ?, ?)`,
+			id, ts, row.status, row.decision, prev, hash, sig,
+		); err != nil {
+			t.Fatalf("insert partial row: %v", err)
+		}
+		prev = hash
+	}
+}
+
+// writeProxyKeys persists an Ed25519 keypair under keysDir/proxy.{pub,key}
+// using the same PEM types internal/identity uses for proxy keys, so
+// loadProxyPubKeyForSnapshot picks them up the same way the real
+// product does.
+func writeProxyKeys(t *testing.T, keysDir string) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatalf("mkdir keys: %v", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate proxy: %v", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "OKTSEC ED25519 PUBLIC KEY", Bytes: pub})
+	if err := os.WriteFile(filepath.Join(keysDir, "proxy.pub"), pubPEM, 0o644); err != nil {
+		t.Fatalf("write proxy.pub: %v", err)
+	}
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "OKTSEC ED25519 PRIVATE KEY", Bytes: priv})
+	if err := os.WriteFile(filepath.Join(keysDir, "proxy.key"), privPEM, 0o600); err != nil {
+		t.Fatalf("write proxy.key: %v", err)
+	}
+	return pub, priv
+}
+
+func TestSnapshot_VerifiesSignaturesWithCustomKeysDir(t *testing.T) {
+	// Regression: if the operator configures identity.keys_dir,
+	// the snapshot must verify proxy signatures against THAT key,
+	// not whatever lives under the default ~/.oktsec/keys/. A
+	// passing signature check is recorded as
+	// audit_chain_signatures_checked=true + key fingerprint.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	customKeys := filepath.Join(dir, "custom-keys")
+	_, priv := writeProxyKeys(t, customKeys)
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save cfg: %v", err)
+	}
+	seedSignedAuditChain(t, cfg.DBPath, priv)
+
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !snap.Evidence.AuditChainVerified {
+		t.Fatalf("expected chain to verify, got %+v", snap.Evidence)
+	}
+	if !snap.Evidence.AuditChainSignaturesChecked {
+		t.Fatalf("expected signatures to be checked against custom keys_dir, got %+v", snap.Evidence)
+	}
+	if snap.Evidence.AuditChainKeyFingerprint == "" {
+		t.Fatalf("expected key fingerprint to be reported when signatures checked")
+	}
+	if hasWarning(snap.Warnings, WarnAuditChainSignaturesNotChecked) {
+		t.Fatalf("must not warn about missing signatures when custom keys_dir provided")
+	}
+}
+
+func TestSnapshot_TamperedSignatureWithCustomKeysDir(t *testing.T) {
+	// Regression: tampering with proxy_signature on any chain row
+	// must surface as audit_chain_verified=false when the
+	// configured keys_dir is used to verify. Order 1 evidence must
+	// not paper over a swapped/forged signature with hash-only
+	// "valid" success.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	customKeys := filepath.Join(dir, "custom-keys")
+	_, priv := writeProxyKeys(t, customKeys)
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save cfg: %v", err)
+	}
+	ids := seedSignedAuditChain(t, cfg.DBPath, priv)
+	if len(ids) == 0 {
+		t.Fatal("seed produced no rows")
+	}
+	// Replace the second row's signature with one produced by a
+	// different key — the hash stays valid, but the signature
+	// check must fail.
+	_, otherPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen other: %v", err)
+	}
+	db, err := sql.Open("sqlite", cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	var entryHash string
+	if err := db.QueryRow(`SELECT entry_hash FROM audit_log WHERE id = ?`, ids[1]).Scan(&entryHash); err != nil {
+		t.Fatalf("read entry_hash: %v", err)
+	}
+	bogusSig := audit.SignEntryHash(otherPriv, entryHash)
+	if _, err := db.Exec(`UPDATE audit_log SET proxy_signature = ? WHERE id = ?`, bogusSig, ids[1]); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	_ = db.Close()
+
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if snap.Evidence.AuditChainVerified {
+		t.Fatalf("tampered signature must cause audit_chain_verified=false")
+	}
+	// Under the strict contract, SignaturesChecked is a positive
+	// claim — "every signature in scope verified". A failed
+	// signature breaks that claim, so the field must be false.
+	// The key fingerprint stays populated because the verifier did
+	// load and use the configured key.
+	if snap.Evidence.AuditChainSignaturesChecked {
+		t.Fatalf("tampered signature must drop audit_chain_signatures_checked to false")
+	}
+	if snap.Evidence.AuditChainKeyFingerprint == "" {
+		t.Fatalf("key fingerprint should still be reported even when verification failed")
+	}
+}
+
+func TestSnapshot_HashOnlyWhenNoProxyKey(t *testing.T) {
+	// Regression: no proxy.pub in identity.keys_dir => hash chain
+	// alone is verified, AuditChainSignaturesChecked=false, and the
+	// snapshot emits audit_chain_signatures_not_checked so consumers
+	// do not mistake the result for full evidence.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	// Make the keys dir but DO NOT write proxy.pub there.
+	customKeys := filepath.Join(dir, "custom-keys")
+	if err := os.MkdirAll(customKeys, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save cfg: %v", err)
+	}
+	// Need a proxy key to seed valid signed rows for the hash chain
+	// to be intact; the seeded signatures will not be checked
+	// because the loader can't find the key.
+	_, sigPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	seedSignedAuditChain(t, cfg.DBPath, sigPriv)
+
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !snap.Evidence.AuditChainVerified {
+		t.Fatalf("hash chain alone should verify, got %+v", snap.Evidence)
+	}
+	if snap.Evidence.AuditChainSignaturesChecked {
+		t.Fatalf("signatures must be reported NOT checked without a reachable proxy.pub")
+	}
+	if !hasWarning(snap.Warnings, WarnAuditChainSignaturesNotChecked) {
+		t.Fatalf("expected audit_chain_signatures_not_checked warning, got %#v", snap.Warnings)
+	}
+}
+
+func TestSnapshot_PartiallySignedChainDoesNotClaimSignaturesChecked(t *testing.T) {
+	// Regression: a 3-row chain with one signed row and two
+	// unsigned rows must NOT report audit_chain_signatures_checked.
+	// audit.VerifyChain skips empty signatures, so without this
+	// guard the field would report "signed" for a mostly-unsigned
+	// range and overclaim evidence to a fleet report.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	customKeys := filepath.Join(dir, "custom-keys")
+	_, priv := writeProxyKeys(t, customKeys)
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	seedPartiallySignedChain(t, cfg.DBPath, priv)
+
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !snap.Evidence.AuditChainVerified {
+		t.Fatalf("partial chain hash links must verify, got %+v", snap.Evidence)
+	}
+	if snap.Evidence.AuditChainSignaturesChecked {
+		t.Fatalf("partial signature coverage must NOT set signatures_checked=true")
+	}
+	if !hasWarning(snap.Warnings, WarnAuditChainSignaturesPartial) {
+		t.Fatalf("expected audit_chain_signatures_partial warning, got %#v", snap.Warnings)
+	}
+	if hasWarning(snap.Warnings, WarnAuditChainSignaturesNotChecked) {
+		t.Fatalf("partial coverage must use the partial warning, not the no-key one")
+	}
+}
+
+func TestSnapshot_AllUnsignedChainEmitsNotCheckedWarning(t *testing.T) {
+	// Regression: a chain where every row is unsigned (e.g. legacy
+	// data before proxy signing was enabled) must use the
+	// "not_checked" warning code, not "partial". This keeps the
+	// two failure modes cleanly separated for consumers.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	customKeys := filepath.Join(dir, "custom-keys")
+	writeProxyKeys(t, customKeys) // key exists but rows are unsigned
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	cfg.DBPath = filepath.Join(dir, "oktsec.db")
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	seedAuditDB(t, cfg.DBPath, 2, 1) // uses bogus hashes, no proxy_signature
+
+	snap := buildAt(t, Options{
+		ConfigPath: cfgPath,
+		DBPath:     cfg.DBPath,
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if snap.Evidence.AuditChainSignaturesChecked {
+		t.Fatalf("all-unsigned chain must NOT set signatures_checked=true")
+	}
+	if hasWarning(snap.Warnings, WarnAuditChainSignaturesPartial) {
+		t.Fatalf("all-unsigned must not emit the partial-coverage warning")
+	}
+	if !hasWarning(snap.Warnings, WarnAuditChainSignaturesNotChecked) {
+		t.Fatalf("expected audit_chain_signatures_not_checked for unsigned chain, got %#v", snap.Warnings)
+	}
+}
+
+func TestSnapshot_CustomKeysDirMissingProxyDoesNotFallBackToDefault(t *testing.T) {
+	// Regression: even if the default ~/.oktsec/keys/proxy.pub
+	// exists on the developer's machine, a config with a custom
+	// identity.keys_dir that lacks proxy.pub must NOT silently
+	// substitute the default key — that would make the snapshot
+	// claim integrity using an unrelated key.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	customKeys := filepath.Join(dir, "custom-keys")
+	if err := os.MkdirAll(customKeys, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := minimalCfg()
+	cfg.Identity.KeysDir = customKeys
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	pub, _ := loadProxyPubKeyForSnapshot(customKeys)
+	if pub != nil {
+		t.Fatalf("custom keys_dir without proxy.pub must return nil, got %x", pub)
+	}
+}

--- a/internal/node/testhelpers_test.go
+++ b/internal/node/testhelpers_test.go
@@ -1,0 +1,25 @@
+package node
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// toJSON returns the JSON marshalling of v as a string. Test helper.
+func toJSON(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// requireJSON marshals or fails the test.
+func requireJSON(t *testing.T, v any) string {
+	t.Helper()
+	s, err := toJSON(v)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return s
+}


### PR DESCRIPTION
## Summary

- New `oktsec node` command group (`init`, `status`, `snapshot`) plus an `internal/node` package that owns the local node identity and a strictly read-only snapshot of what the local install can see, control, and prove.
- JSON shapes are versioned (`node_identity.v1`, `node_snapshot.v1`) so downstream tooling can rely on a stable contract.
- Strictly additive: enforcement, gateway, proxy, hooks, dashboard, and the audit/runtime/activity stores are untouched. No config migration. No new top-level oktsec.yaml fields.

## What it adds

- `oktsec node init` writes `~/.oktsec/node/{identity.json,node.key,node.pub}` with PEM types distinct from agent keys. Idempotent. Refuses symlinked targets. Identity is reported `invalid` (not `present`) if keys are missing or the public-key fingerprint does not match `identity.json`.
- `oktsec node status --json` reports identity presence with structured warnings.
- `oktsec node snapshot --json` emits sections for node, config, surfaces, inventory, posture, evidence, and warnings. Supports `--since` (Go duration or RFC3339), `--until` (RFC3339), and `--output` for atomic file writes. Inventory is redacted: paths to tail + hash, URLs to host hash, commands to basename, env values to count only.

## Safety properties

- Read-only by construction: no DB is created, no migrations run, no external clients are queried, no config is modified. SQLite is opened through a `net/url`-built `file:` URI so paths containing `?` or `#` cannot collapse into the query string.
- Postgres-backed installs skip SQLite inspection entirely and emit `postgres_snapshot_limited`, so a stale local DB cannot contaminate evidence.
- Posture uses the dashboard coverage vocabulary. `protected` requires fresh real runtime evidence in the snapshot window; heartbeats are diagnostic only and never produce `protected`.
- Decision counts group by `(status, policy_decision)` so `content_flagged` no longer hides inside `allowed`.
- Audit chain verification uses the operator-configured `identity.keys_dir` with no silent fallback to the default. `audit_chain_signatures_checked=true` only when every entry in scope was signed and every signature verified. Partial coverage emits `audit_chain_signatures_partial`; missing key or unsigned-only chain emits `audit_chain_signatures_not_checked`. Consumers must read `audit_chain_verified` (overall) and `audit_chain_signatures_checked` (full signed coverage) together.

## Test plan

- [x] `make build`
- [x] `go vet ./...`
- [x] `make lint` (0 issues)
- [x] `go test -race -count=1 ./...`
- [x] `make integration-test`
- [x] CLI smoke against a config-less install: `oktsec node --help`, `oktsec node status --json`, `oktsec node snapshot --json`.