### PR TITLE
Add signed snapshot envelope support

### DIFF
--- a/cmd/oktsec/commands/node.go
+++ b/cmd/oktsec/commands/node.go
@@ -15,20 +15,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newNodeCmd builds the `oktsec node` command group. Order 1 ships
-// three subcommands: init / status / snapshot. All are additive and
-// read-only with respect to existing oktsec runtime state.
+// newNodeCmd builds the `oktsec node` command group. Order 1 shipped
+// init / status / snapshot; Phase 5 Order 3A adds sign-snapshot for
+// producing signed envelopes that downstream consumers (e.g.
+// `oktsec-enterprise ingest`) can verify against the local node key.
+// All subcommands are local-only and read-only with respect to the
+// Oktsec runtime — none of them open a network socket or modify
+// running enforcement.
 func newNodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
-		Short: "Manage the local Oktsec node identity and snapshot",
+		Short: "Manage the local Oktsec node identity, snapshot, and signed envelopes",
 		Long: "Node commands manage this Oktsec install as a single protected runtime node. " +
 			"Identity is local-only; snapshot is read-only and reports what this node sees, " +
-			"controls, and can prove.",
+			"controls, and can prove. sign-snapshot wraps a snapshot in a signed envelope so " +
+			"downstream consumers can verify it came from this node's identity without " +
+			"exposing the private key.",
 	}
 	cmd.AddCommand(newNodeInitCmd())
 	cmd.AddCommand(newNodeStatusCmd())
 	cmd.AddCommand(newNodeSnapshotCmd())
+	cmd.AddCommand(newNodeSignSnapshotCmd())
 	return cmd
 }
 

--- a/cmd/oktsec/commands/node_sign_snapshot.go
+++ b/cmd/oktsec/commands/node_sign_snapshot.go
@@ -103,20 +103,43 @@ func readSnapshotInput(path string) ([]byte, error) {
 }
 
 // decodeSnapshotStrict parses raw into a node.Snapshot using a
-// decoder that refuses unknown fields. Strictness here closes the
-// signed-subset-is-implicit gap: if a snapshot file carries a field
-// the typed struct does not represent, we cannot canonicalize it
-// without silently dropping content — so we refuse the sign-snapshot
-// call instead of producing an envelope that signs a partial view of
-// the artifact. The schema_version is also explicitly enforced
-// rather than left to the JSON Schema validator, because this
-// command does not depend on the JSON Schema files at runtime.
+// decoder that refuses unknown fields AND refuses trailing JSON
+// content. Strictness here closes two distinct flavors of the
+// "signed subset" gap:
+//
+//   - unknown fields would be silently dropped by the typed-struct
+//     decoder, so the envelope would sign a smaller artifact than
+//     the operator handed us;
+//   - trailing JSON tokens after the first object would be lost
+//     completely. A file like
+//         { "schema_version": "node_snapshot.v1", ... }
+//         { "extra": "not signed" }
+//     decodes the first object cleanly under DisallowUnknownFields,
+//     and without the EOF check we would happily sign that first
+//     object and discard the second. Same threat model, different
+//     vector — so both gates live here.
+//
+// schema_version is also enforced explicitly rather than left to
+// the JSON Schema validator, because this command does not depend
+// on the JSON Schema files at runtime.
 func decodeSnapshotStrict(raw []byte) (node.Snapshot, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	var s node.Snapshot
 	if err := dec.Decode(&s); err != nil {
 		return node.Snapshot{}, fmt.Errorf("strict decode: %w", err)
+	}
+	// Refuse trailing tokens. Decoding into a throwaway value with
+	// the same decoder reads the next JSON value; anything other
+	// than io.EOF means the input contained more than a single
+	// snapshot object and the rest would be silently dropped if
+	// signing went ahead.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return node.Snapshot{}, fmt.Errorf("strict decode: trailing JSON content after snapshot object")
+		}
+		return node.Snapshot{}, fmt.Errorf("strict decode: trailing content not parseable: %w", err)
 	}
 	if s.SchemaVersion != node.SchemaSnapshot {
 		return node.Snapshot{}, fmt.Errorf("schema_version %q is not %q", s.SchemaVersion, node.SchemaSnapshot)

--- a/cmd/oktsec/commands/node_sign_snapshot.go
+++ b/cmd/oktsec/commands/node_sign_snapshot.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/node"
+	"github.com/oktsec/oktsec/internal/safefile"
+	"github.com/spf13/cobra"
+)
+
+// maxSnapshotFileBytes mirrors the 4 MiB cap node.snapshot.go uses
+// for its own --output path. Anything larger almost certainly is
+// not a snapshot, so we refuse it pre-parse to keep the signing
+// path's memory footprint bounded.
+const maxSnapshotFileBytes = 4 * 1024 * 1024
+
+// newNodeSignSnapshotCmd wraps a redacted node_snapshot.v1 JSON file
+// in a signed envelope (node_snapshot_envelope.v1). The private key
+// never leaves ~/.oktsec/node/node.key; the envelope embeds the
+// public key in raw base64 so downstream verifiers can check the
+// signature without consulting the node again.
+func newNodeSignSnapshotCmd() *cobra.Command {
+	var (
+		snapshotPath string
+		outputPath   string
+	)
+	cmd := &cobra.Command{
+		Use:   "sign-snapshot",
+		Short: "Wrap a redacted node_snapshot.v1 file in a signed envelope",
+		Long: "Reads a snapshot file produced by `oktsec node snapshot --json`, " +
+			"validates that it belongs to this node's identity, canonicalizes it, " +
+			"signs the domain-separated payload with the local node Ed25519 key, " +
+			"and emits a node_snapshot_envelope.v1 JSON object. The original " +
+			"snapshot is embedded verbatim. No data leaves this machine.",
+		Example: "  oktsec node snapshot --json --output /tmp/snap.json\n" +
+			"  oktsec node sign-snapshot --snapshot /tmp/snap.json --output /tmp/snap.envelope.json\n" +
+			"  oktsec node sign-snapshot --snapshot /tmp/snap.json\n" +
+			"  cat /tmp/snap.json | oktsec node sign-snapshot --snapshot -",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			raw, err := readSnapshotInput(snapshotPath)
+			if err != nil {
+				return err
+			}
+			snap, err := decodeSnapshotStrict(raw)
+			if err != nil {
+				return fmt.Errorf("snapshot: %w", err)
+			}
+			env, err := node.SealSnapshotEnvelope(nodeStoreForTest(), snap, time.Now())
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(env, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode envelope: %w", err)
+			}
+			out = append(out, '\n')
+			if outputPath != "" {
+				return writeSnapshotFile(outputPath, out)
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&snapshotPath, "snapshot", "",
+		"path to a node_snapshot.v1 JSON file, or '-' for stdin (required)")
+	cmd.Flags().StringVar(&outputPath, "output", "",
+		"write the signed envelope here (default: stdout)")
+	_ = cmd.MarkFlagRequired("snapshot")
+	return cmd
+}
+
+// readSnapshotInput pulls bytes from a file path or stdin under the
+// 4 MiB cap. The file path goes through safefile.ReadFileMax so a
+// symlinked input is refused atomically (no TOCTOU window between
+// stat and read). Stdin has no symlink concern but still respects
+// the size cap.
+func readSnapshotInput(path string) ([]byte, error) {
+	switch path {
+	case "":
+		return nil, errors.New("--snapshot is required (use '-' for stdin)")
+	case "-":
+		body, err := io.ReadAll(io.LimitReader(os.Stdin, maxSnapshotFileBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		if int64(len(body)) > maxSnapshotFileBytes {
+			return nil, fmt.Errorf("stdin snapshot exceeds %d bytes", maxSnapshotFileBytes)
+		}
+		return body, nil
+	default:
+		body, err := safefile.ReadFileMax(path, maxSnapshotFileBytes)
+		if err != nil {
+			return nil, fmt.Errorf("read snapshot: %w", err)
+		}
+		return body, nil
+	}
+}
+
+// decodeSnapshotStrict parses raw into a node.Snapshot using a
+// decoder that refuses unknown fields. Strictness here closes the
+// signed-subset-is-implicit gap: if a snapshot file carries a field
+// the typed struct does not represent, we cannot canonicalize it
+// without silently dropping content — so we refuse the sign-snapshot
+// call instead of producing an envelope that signs a partial view of
+// the artifact. The schema_version is also explicitly enforced
+// rather than left to the JSON Schema validator, because this
+// command does not depend on the JSON Schema files at runtime.
+func decodeSnapshotStrict(raw []byte) (node.Snapshot, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var s node.Snapshot
+	if err := dec.Decode(&s); err != nil {
+		return node.Snapshot{}, fmt.Errorf("strict decode: %w", err)
+	}
+	if s.SchemaVersion != node.SchemaSnapshot {
+		return node.Snapshot{}, fmt.Errorf("schema_version %q is not %q", s.SchemaVersion, node.SchemaSnapshot)
+	}
+	return s, nil
+}

--- a/cmd/oktsec/commands/node_sign_snapshot_test.go
+++ b/cmd/oktsec/commands/node_sign_snapshot_test.go
@@ -214,6 +214,46 @@ func TestSignSnapshotCLI_RejectsUnknownFields(t *testing.T) {
 	}
 }
 
+func TestSignSnapshotCLI_RejectsTrailingJSON(t *testing.T) {
+	// Two distinct closing braces of the "signed subset" gap:
+	// the DisallowUnknownFields test catches dropped fields, this
+	// one catches dropped objects after the first. A file like
+	//   { ... valid snapshot ... }
+	//   { "extra": "not signed" }
+	// must refuse signing — without the EOF check we would sign
+	// the first object and discard the rest silently.
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, _ := stagedSnapshot(t, dir, store)
+	original, err := os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	trailers := map[string]string{
+		"second-object": "\n{\"extra\":\"not signed\"}\n",
+		"bare-token":    "\nnull\n",
+		"junk":          "\nnot-json-at-all\n",
+	}
+	for name, trailer := range trailers {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(snapPath, append([]byte(nil), append(original, []byte(trailer)...)...), 0o644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			out, err := runSignSnapshot(t, []string{"--snapshot", snapPath})
+			if err == nil {
+				t.Fatalf("trailing %s must refuse signing; output:\n%s", name, out)
+			}
+			if !strings.Contains(err.Error(), "trailing") &&
+				!strings.Contains(err.Error(), "strict decode") {
+				t.Fatalf("error must surface the trailing-content failure, got %v", err)
+			}
+		})
+	}
+}
+
 func TestSignSnapshotCLI_RejectsBadSchemaVersion(t *testing.T) {
 	store := withTestNodeStore(t)
 	if _, err := store.Init(node.ProfileLocal); err != nil {

--- a/cmd/oktsec/commands/node_sign_snapshot_test.go
+++ b/cmd/oktsec/commands/node_sign_snapshot_test.go
@@ -1,0 +1,261 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/node"
+)
+
+// stagedSnapshot writes a minimal-but-real node_snapshot.v1 JSON
+// file matching the IdentityStore the test injected. The returned
+// path is the path the sign-snapshot CLI receives via --snapshot.
+// Centralizing the fixture here means every CLI test runs against
+// the same baseline shape; specific tests mutate the file post-write
+// when they need to exercise an error path.
+func stagedSnapshot(t *testing.T, dir string, store node.IdentityStore) (path string, id *node.Identity) {
+	t.Helper()
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("load identity: %v", err)
+	}
+	snap := node.Snapshot{
+		SchemaVersion: node.SchemaSnapshot,
+		GeneratedAt:   "2026-05-22T00:00:00Z",
+		Range:         node.SnapshotRange{Since: "2026-05-21T00:00:00Z"},
+		Node: node.SnapshotNode{
+			NodeID:               loaded.NodeID,
+			IdentityStatus:       "present",
+			HostFingerprint:      loaded.HostFingerprint,
+			PublicKeyFingerprint: loaded.PublicKeyFingerprint,
+			GOOS:                 "linux",
+			GOARCH:               "amd64",
+			Profile:              node.ProfileLocal,
+		},
+		Config:    node.SnapshotConfig{Status: "missing"},
+		Inventory: node.SnapshotInventory{},
+	}
+	body, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	path = filepath.Join(dir, "snap.json")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	return path, loaded
+}
+
+// runSignSnapshot executes `node sign-snapshot` with the given args
+// and returns combined stdout/stderr. The test caller pre-injects
+// nodeStoreForTest so the command finds the seeded identity.
+func runSignSnapshot(t *testing.T, args []string) (string, error) {
+	t.Helper()
+	cmd := newNodeSignSnapshotCmd()
+	cmd.SetArgs(args)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestSignSnapshotCLI_OutputFileHasOwnerOnlyPerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits do not apply on Windows")
+	}
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, id := stagedSnapshot(t, dir, store)
+	outPath := filepath.Join(dir, "out.envelope.json")
+	out, err := runSignSnapshot(t, []string{"--snapshot", snapPath, "--output", outPath})
+	if err != nil {
+		t.Fatalf("execute: %v\n%s", err, out)
+	}
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("output perm = %o, want 0o600", perm)
+	}
+	// Re-read and confirm we wrote a recognizable envelope for
+	// the seeded identity.
+	body, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var env node.SnapshotEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("envelope parse: %v\n%s", err, body)
+	}
+	if env.SchemaVersion != node.SchemaSnapshotEnvelope ||
+		env.NodeID != id.NodeID {
+		t.Fatalf("envelope shape wrong: %+v", env)
+	}
+}
+
+func TestSignSnapshotCLI_StdoutWhenNoOutputFlag(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, id := stagedSnapshot(t, dir, store)
+	out, err := runSignSnapshot(t, []string{"--snapshot", snapPath})
+	if err != nil {
+		t.Fatalf("execute: %v\n%s", err, out)
+	}
+	// Output must be parseable JSON — nothing else can be
+	// interleaved (no human-prose log lines).
+	var env node.SnapshotEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("stdout must be pure JSON: %v\n%s", err, out)
+	}
+	if env.NodeID != id.NodeID {
+		t.Fatalf("envelope node_id wrong: %q vs %q", env.NodeID, id.NodeID)
+	}
+	if env.Signature.PublicKey == "" {
+		t.Fatalf("envelope signature is missing public_key")
+	}
+	if _, err := base64.StdEncoding.DecodeString(env.Signature.PublicKey); err != nil {
+		t.Fatalf("envelope public_key not std-base64: %v", err)
+	}
+}
+
+func TestSignSnapshotCLI_RefusesSymlinkSnapshotInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	realPath, _ := stagedSnapshot(t, dir, store)
+	linkPath := filepath.Join(dir, "link.json")
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	out, err := runSignSnapshot(t, []string{"--snapshot", linkPath})
+	if err == nil {
+		t.Fatalf("expected refusal for symlinked input; output:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "symbolic link") &&
+		!strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error should mention symlink: %v", err)
+	}
+}
+
+func TestSignSnapshotCLI_RefusesSymlinkOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, _ := stagedSnapshot(t, dir, store)
+	realOut := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(realOut, []byte("placeholder"), 0o600); err != nil {
+		t.Fatalf("placeholder: %v", err)
+	}
+	linkOut := filepath.Join(dir, "out.envelope.json")
+	if err := os.Symlink(realOut, linkOut); err != nil {
+		t.Fatalf("symlink output: %v", err)
+	}
+	out, err := runSignSnapshot(t, []string{"--snapshot", snapPath, "--output", linkOut})
+	if err == nil {
+		t.Fatalf("expected refusal for symlinked output; output:\n%s", out)
+	}
+}
+
+func TestSignSnapshotCLI_RejectsUnknownFields(t *testing.T) {
+	// The reviewer caveat: the signed path must NEVER tolerate
+	// unknown fields silently. Hand-edit a real snapshot to add
+	// an `extra` field at top level — DisallowUnknownFields
+	// must refuse it BEFORE we canonicalize and sign, otherwise
+	// the envelope would cover a subset of the artifact.
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, _ := stagedSnapshot(t, dir, store)
+	raw, err := os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	generic["extra"] = "would-be-silently-dropped"
+	modified, err := json.MarshalIndent(generic, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(snapPath, modified, 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	out, err := runSignSnapshot(t, []string{"--snapshot", snapPath})
+	if err == nil {
+		t.Fatalf("unknown-field snapshot must refuse signing; output:\n%s", out)
+	}
+}
+
+func TestSignSnapshotCLI_RejectsBadSchemaVersion(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init(node.ProfileLocal); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	dir := t.TempDir()
+	snapPath, _ := stagedSnapshot(t, dir, store)
+	raw, err := os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	generic["schema_version"] = "node_snapshot.v0"
+	modified, err := json.MarshalIndent(generic, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(snapPath, modified, 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	out, err := runSignSnapshot(t, []string{"--snapshot", snapPath})
+	if err == nil {
+		t.Fatalf("wrong schema_version must refuse signing; output:\n%s", out)
+	}
+}
+
+func TestSignSnapshotCLI_RegisteredOnNodeGroup(t *testing.T) {
+	// Make sure `oktsec node sign-snapshot` is actually wired
+	// up under the node command tree.
+	root := NewRoot()
+	for _, c := range root.Commands() {
+		if c.Name() != "node" {
+			continue
+		}
+		for _, sub := range c.Commands() {
+			if sub.Name() == "sign-snapshot" {
+				return
+			}
+		}
+	}
+	t.Fatalf("sign-snapshot subcommand not registered under `oktsec node`")
+}

--- a/internal/node/envelope.go
+++ b/internal/node/envelope.go
@@ -1,0 +1,255 @@
+package node
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Stable envelope schema version. Bumping is a contract break and
+// must come with a coordinated Enterprise-side release; this constant
+// is the single source of truth on the Community side and the value
+// Enterprise vendors into its JSON Schema fixtures.
+const SchemaSnapshotEnvelope = "node_snapshot_envelope.v1"
+
+// EnvelopeVersion is the integer envelope-shape version. Distinct
+// from SchemaSnapshotEnvelope so a future field-only addition can
+// bump the integer without rotating the schema name; current
+// Enterprise verifiers should still accept it under the same
+// schema string, refusing fields they do not understand.
+const EnvelopeVersion = 1
+
+// CanonicalizationTag identifies the exact canonicalization
+// algorithm used to compute the snapshot hash that goes into the
+// envelope. Enterprise must verify against this exact tag so an
+// untagged or differently-tagged envelope is rejected outright.
+const CanonicalizationTag = "node_snapshot.v1.canonical_json.utc_minified"
+
+// SnapshotSignature is the cryptographic-evidence half of the
+// envelope. The public key is carried in raw base64 form because
+// node_identity.v1 only exposes the fingerprint; without the raw
+// bytes Enterprise cannot verify the Ed25519 signature.
+type SnapshotSignature struct {
+	Alg                  string `json:"alg"`
+	KeyID                string `json:"key_id"`
+	PublicKey            string `json:"public_key"`
+	PublicKeyFingerprint string `json:"public_key_fingerprint"`
+	SignedAt             string `json:"signed_at"`
+	Value                string `json:"value"`
+}
+
+// SnapshotEnvelope is the signed wrapper around a redacted
+// node_snapshot.v1 artifact. Field order in the struct controls JSON
+// marshal order, which the canonical-bytes contract relies on; do not
+// reorder without bumping EnvelopeVersion.
+//
+// Embedded Snapshot is the SAME shape `oktsec node snapshot --json`
+// emits; the envelope adds no new snapshot data and never carries
+// raw prompts, tool I/O, host names or filesystem paths beyond what
+// node_snapshot.v1 already redacts.
+type SnapshotEnvelope struct {
+	SchemaVersion         string            `json:"schema_version"`
+	EnvelopeVersion       int               `json:"envelope_version"`
+	NodeID                string            `json:"node_id"`
+	SnapshotSchemaVersion string            `json:"snapshot_schema_version"`
+	SnapshotSHA256        string            `json:"snapshot_sha256"`
+	Canonicalization      string            `json:"canonicalization"`
+	Signature             SnapshotSignature `json:"signature"`
+	Snapshot              Snapshot          `json:"snapshot"`
+}
+
+// CanonicalSnapshotBytes returns the bytes Enterprise must reproduce
+// to verify the signature. The contract:
+//
+//  1. RFC3339 timestamps that the snapshot uses for time bounds
+//     (generated_at, range.since, range.until) are parsed and
+//     re-emitted in UTC. A zone-shifted but identical-instant
+//     value normalizes to the same string.
+//  2. The typed Snapshot struct is marshalled with encoding/json's
+//     SetEscapeHTML(false) so '<', '>', '&' are not rewritten into
+//     Unicode escapes by either side.
+//  3. The trailing newline json.Encoder adds is stripped — the
+//     canonical bytes are exactly the JSON object body.
+//
+// The function does NOT mutate the caller's Snapshot; a shallow
+// copy is enough because the only field types touched are strings.
+//
+// Returning the canonical bytes (not just the hash) lets callers
+// avoid the second walk through CanonicalSnapshotBytes when they
+// later embed the snapshot back into an envelope — SnapshotSHA256
+// is the helper for the common path.
+func CanonicalSnapshotBytes(s Snapshot) ([]byte, error) {
+	s.GeneratedAt = normalizeRFC3339OrKeep(s.GeneratedAt)
+	s.Range.Since = normalizeRFC3339OrKeep(s.Range.Since)
+	if s.Range.Until != "" {
+		s.Range.Until = normalizeRFC3339OrKeep(s.Range.Until)
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return nil, fmt.Errorf("canonical snapshot encode: %w", err)
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// SnapshotSHA256 returns the lowercase-hex SHA-256 of the canonical
+// snapshot bytes, paired with those bytes. The hash has NO sha256:
+// prefix because Enterprise's snapshots.id already uses raw hex; the
+// fingerprint prefix is reserved for identity-shaped values.
+func SnapshotSHA256(s Snapshot) (string, []byte, error) {
+	canon, err := CanonicalSnapshotBytes(s)
+	if err != nil {
+		return "", nil, err
+	}
+	sum := sha256.Sum256(canon)
+	return hex.EncodeToString(sum[:]), canon, nil
+}
+
+// SnapshotEnvelopeSigningPayload returns the exact byte sequence
+// that gets signed. The format is domain-separated lines joined by
+// "\n" with no trailing newline. The helper owns the byte layout so
+// signer and verifier cannot drift: callers MUST NOT hand-assemble
+// the payload from these arguments.
+//
+// Lines (in order):
+//
+//	oktsec.node_snapshot_envelope.v1
+//	node_id:<node_id>
+//	snapshot_sha256:<snapshot_sha256>
+//	snapshot_schema_version:node_snapshot.v1
+//	canonicalization:<CanonicalizationTag>
+//	signed_at:<signed_at>
+//
+// Any change here is a contract break and requires a v2 envelope.
+func SnapshotEnvelopeSigningPayload(nodeID, snapshotSHA256, signedAt string) []byte {
+	lines := []string{
+		"oktsec." + SchemaSnapshotEnvelope,
+		"node_id:" + nodeID,
+		"snapshot_sha256:" + snapshotSHA256,
+		"snapshot_schema_version:" + SchemaSnapshot,
+		"canonicalization:" + CanonicalizationTag,
+		"signed_at:" + signedAt,
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// SealSnapshotEnvelope binds a redacted Snapshot to a node identity
+// by signing it with the supplied IdentityStore. It does NOT load
+// the snapshot from disk or validate the snapshot beyond identity-
+// agreement checks — the caller (oktsec node sign-snapshot) is
+// responsible for schema validation, symlink refusal, and size
+// limits before calling here.
+//
+// Identity agreement checks run BEFORE signing so a hand-edited
+// snapshot whose node_id or fingerprint do not match the local
+// identity is rejected without producing a misleading signature.
+// Order 2 of the trust model relies on this: an envelope is only
+// trustworthy because the signing node also vouched for the
+// metadata it covers.
+//
+// signedAt is normalized to UTC RFC3339 before signing AND before
+// being written into the envelope, so a future verifier sees the
+// same string the signer hashed.
+func SealSnapshotEnvelope(store IdentityStore, snap Snapshot, signedAt time.Time) (*SnapshotEnvelope, error) {
+	id, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("sign-snapshot: load identity: %w", err)
+	}
+	if snap.Node.IdentityStatus != "present" {
+		return nil, fmt.Errorf("sign-snapshot: snapshot identity_status is %q; need 'present'", snap.Node.IdentityStatus)
+	}
+	if snap.Node.NodeID != id.NodeID {
+		return nil, fmt.Errorf("sign-snapshot: snapshot node_id %q does not match local identity %q",
+			snap.Node.NodeID, id.NodeID)
+	}
+	if snap.Node.PublicKeyFingerprint != id.PublicKeyFingerprint {
+		return nil, fmt.Errorf("sign-snapshot: snapshot public_key_fingerprint does not match local identity")
+	}
+	if snap.Node.HostFingerprint != "" && id.HostFingerprint != "" &&
+		snap.Node.HostFingerprint != id.HostFingerprint {
+		return nil, fmt.Errorf("sign-snapshot: snapshot host_fingerprint does not match local identity (snapshot was taken on a different host)")
+	}
+	pub, err := store.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("sign-snapshot: read public key: %w", err)
+	}
+	hash, _, err := SnapshotSHA256(snap)
+	if err != nil {
+		return nil, err
+	}
+	ts := signedAt.UTC().Format(time.RFC3339)
+	payload := SnapshotEnvelopeSigningPayload(id.NodeID, hash, ts)
+	sig, err := store.Sign(payload)
+	if err != nil {
+		return nil, fmt.Errorf("sign-snapshot: sign payload: %w", err)
+	}
+	env := &SnapshotEnvelope{
+		SchemaVersion:         SchemaSnapshotEnvelope,
+		EnvelopeVersion:       EnvelopeVersion,
+		NodeID:                id.NodeID,
+		SnapshotSchemaVersion: SchemaSnapshot,
+		SnapshotSHA256:        hash,
+		Canonicalization:      CanonicalizationTag,
+		Signature: SnapshotSignature{
+			Alg:                  "Ed25519",
+			KeyID:                id.NodeID,
+			PublicKey:            base64.StdEncoding.EncodeToString(pub),
+			PublicKeyFingerprint: id.PublicKeyFingerprint,
+			SignedAt:             ts,
+			Value:                sig.Base64,
+		},
+		Snapshot: snap,
+	}
+	// Sanity check the produced signature with the public key
+	// we just emitted; a mismatch here would mean the
+	// IdentityStore's key files are out of sync with each other
+	// (private key signs something the public key cannot
+	// verify) — refuse to emit such an envelope.
+	if err := verifyEnvelopeSelf(env, pub); err != nil {
+		return nil, fmt.Errorf("sign-snapshot: post-sign self-check failed: %w", err)
+	}
+	return env, nil
+}
+
+// verifyEnvelopeSelf runs the same Ed25519 verification a future
+// Enterprise verifier would run, against the IdentityStore's
+// current public key. It catches an entire class of subtle
+// breakage (mismatched key files, accidental key rotation
+// mid-process) without depending on Enterprise being installed.
+func verifyEnvelopeSelf(env *SnapshotEnvelope, pub ed25519.PublicKey) error {
+	sigBytes, err := base64.StdEncoding.DecodeString(env.Signature.Value)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if len(sigBytes) != ed25519.SignatureSize {
+		return fmt.Errorf("signature length %d, want %d", len(sigBytes), ed25519.SignatureSize)
+	}
+	payload := SnapshotEnvelopeSigningPayload(env.NodeID, env.SnapshotSHA256, env.Signature.SignedAt)
+	if !ed25519.Verify(pub, payload, sigBytes) {
+		return fmt.Errorf("ed25519.Verify returned false")
+	}
+	return nil
+}
+
+// normalizeRFC3339OrKeep returns the UTC RFC3339 form of s when s
+// parses, and the original string otherwise. The canonicalizer
+// uses this so a missing or non-RFC3339 timestamp does not crash
+// the signing path — schema validation upstream is the gate that
+// catches malformed timestamps before we reach here.
+func normalizeRFC3339OrKeep(s string) string {
+	if s == "" {
+		return s
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return s
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/node/envelope_test.go
+++ b/internal/node/envelope_test.go
@@ -1,0 +1,311 @@
+package node
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// baseSnapshot returns a Snapshot whose identity fields match the
+// IdentityStore the test seeds. Tests mutate just the fields they
+// need so the diff between cases stays narrow.
+func baseSnapshot(id *Identity) Snapshot {
+	return Snapshot{
+		SchemaVersion: SchemaSnapshot,
+		GeneratedAt:   "2026-05-22T00:00:00Z",
+		Range: SnapshotRange{
+			Since: "2026-05-21T00:00:00Z",
+		},
+		Node: SnapshotNode{
+			NodeID:               id.NodeID,
+			IdentityStatus:       "present",
+			HostFingerprint:      id.HostFingerprint,
+			PublicKeyFingerprint: id.PublicKeyFingerprint,
+			GOOS:                 "linux",
+			GOARCH:               "amd64",
+			Profile:              ProfileLocal,
+		},
+		Config:    SnapshotConfig{Status: "missing"},
+		Inventory: SnapshotInventory{},
+	}
+}
+
+// seedIdentity returns a fresh IdentityStore + the matching
+// Identity record so envelope tests have a working signer.
+func seedIdentity(t *testing.T) (IdentityStore, *Identity) {
+	t.Helper()
+	store := IdentityStore{Dir: filepath.Join(t.TempDir(), "node")}
+	id, err := store.Init(ProfileLocal)
+	if err != nil {
+		t.Fatalf("seed identity: %v", err)
+	}
+	return store, id
+}
+
+func TestCanonicalSnapshotBytes_StableAcrossWhitespace(t *testing.T) {
+	// Two semantically-identical snapshots must canonicalize to
+	// the same bytes regardless of how the test built them. The
+	// guarantee is critical because it is the signer/verifier
+	// contract: any whitespace divergence here would silently
+	// break Enterprise's signature check.
+	_, id := seedIdentity(t)
+	a := baseSnapshot(id)
+	b := baseSnapshot(id)
+	canonA, err := CanonicalSnapshotBytes(a)
+	if err != nil {
+		t.Fatalf("canon a: %v", err)
+	}
+	canonB, err := CanonicalSnapshotBytes(b)
+	if err != nil {
+		t.Fatalf("canon b: %v", err)
+	}
+	if string(canonA) != string(canonB) {
+		t.Fatalf("canonical bytes diverge for equivalent snapshots:\n  a=%q\n  b=%q",
+			canonA, canonB)
+	}
+	// And no trailing newline survived encoder.Encode.
+	if strings.HasSuffix(string(canonA), "\n") {
+		t.Fatalf("canonical bytes must not end with newline: %q", canonA)
+	}
+}
+
+func TestCanonicalSnapshotBytes_NormalizesZoneOffset(t *testing.T) {
+	// generated_at expressed in two equivalent zone forms must
+	// produce identical canonical bytes. The fixture in
+	// Enterprise's vendored corpus relies on this so a
+	// snapshot signed under -03:00 verifies after the operator
+	// moves the file across zones.
+	_, id := seedIdentity(t)
+	utc := baseSnapshot(id)
+	offset := baseSnapshot(id)
+	offset.GeneratedAt = "2026-05-21T21:00:00-03:00"     // same instant as utc.GeneratedAt
+	offset.Range.Since = "2026-05-20T21:00:00-03:00"     // same instant as utc.Range.Since
+	hashUTC, _, err := SnapshotSHA256(utc)
+	if err != nil {
+		t.Fatalf("hash utc: %v", err)
+	}
+	hashOffset, _, err := SnapshotSHA256(offset)
+	if err != nil {
+		t.Fatalf("hash offset: %v", err)
+	}
+	if hashUTC != hashOffset {
+		t.Fatalf("zone-shifted equivalent timestamps must produce identical hash: utc=%s offset=%s",
+			hashUTC, hashOffset)
+	}
+}
+
+func TestCanonicalSnapshotBytes_DoesNotMutateCaller(t *testing.T) {
+	_, id := seedIdentity(t)
+	s := baseSnapshot(id)
+	s.GeneratedAt = "2026-05-21T21:00:00-03:00"
+	before := s.GeneratedAt
+	if _, err := CanonicalSnapshotBytes(s); err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	if s.GeneratedAt != before {
+		t.Fatalf("CanonicalSnapshotBytes must not mutate caller's Snapshot; got %q want %q",
+			s.GeneratedAt, before)
+	}
+}
+
+func TestSnapshotEnvelopeSigningPayload_ExactBytes(t *testing.T) {
+	got := SnapshotEnvelopeSigningPayload(
+		"node_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"deadbeef",
+		"2026-05-22T00:00:00Z",
+	)
+	want := strings.Join([]string{
+		"oktsec.node_snapshot_envelope.v1",
+		"node_id:node_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"snapshot_sha256:deadbeef",
+		"snapshot_schema_version:node_snapshot.v1",
+		"canonicalization:node_snapshot.v1.canonical_json.utc_minified",
+		"signed_at:2026-05-22T00:00:00Z",
+	}, "\n")
+	if string(got) != want {
+		t.Fatalf("payload bytes diverge:\n  got:  %q\n  want: %q", got, want)
+	}
+	if strings.HasSuffix(string(got), "\n") {
+		t.Fatalf("payload must not end with newline")
+	}
+}
+
+func TestSealSnapshotEnvelope_HappyPath(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	env, err := SealSnapshotEnvelope(store, snap, time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if env.SchemaVersion != SchemaSnapshotEnvelope ||
+		env.EnvelopeVersion != EnvelopeVersion {
+		t.Fatalf("envelope versions wrong: %+v", env)
+	}
+	if env.NodeID != id.NodeID || env.Signature.KeyID != id.NodeID {
+		t.Fatalf("envelope/sig node mismatch: %+v", env)
+	}
+	if env.Canonicalization != CanonicalizationTag {
+		t.Fatalf("canonicalization tag wrong: %q", env.Canonicalization)
+	}
+	hash, _, err := SnapshotSHA256(snap)
+	if err != nil {
+		t.Fatalf("recompute hash: %v", err)
+	}
+	if env.SnapshotSHA256 != hash {
+		t.Fatalf("envelope hash diverges from local SnapshotSHA256: %s vs %s",
+			env.SnapshotSHA256, hash)
+	}
+	// Verify the signature with the public key the envelope
+	// carries — this mirrors what Enterprise will do.
+	pubBytes, err := base64.StdEncoding.DecodeString(env.Signature.PublicKey)
+	if err != nil {
+		t.Fatalf("decode public_key: %v", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		t.Fatalf("public_key length %d, want %d", len(pubBytes), ed25519.PublicKeySize)
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(env.Signature.Value)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	payload := SnapshotEnvelopeSigningPayload(env.NodeID, env.SnapshotSHA256, env.Signature.SignedAt)
+	if !ed25519.Verify(ed25519.PublicKey(pubBytes), payload, sigBytes) {
+		t.Fatalf("ed25519.Verify failed against envelope's own public key")
+	}
+}
+
+func TestSealSnapshotEnvelope_RefusesNodeIDMismatch(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Node.NodeID = "node_" + strings.Repeat("1", 36)
+	_, err := SealSnapshotEnvelope(store, snap, time.Now())
+	if err == nil {
+		t.Fatalf("snapshot with foreign node_id must refuse signing")
+	}
+	if !strings.Contains(err.Error(), "node_id") {
+		t.Fatalf("error must mention node_id, got %v", err)
+	}
+}
+
+func TestSealSnapshotEnvelope_RefusesPubKeyFingerprintMismatch(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Node.PublicKeyFingerprint = "sha256:" + strings.Repeat("e", 64)
+	_, err := SealSnapshotEnvelope(store, snap, time.Now())
+	if err == nil {
+		t.Fatalf("snapshot with foreign pubkey fingerprint must refuse signing")
+	}
+}
+
+func TestSealSnapshotEnvelope_RefusesHostMismatchWhenBothPresent(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Node.HostFingerprint = "sha256:" + strings.Repeat("c", 64)
+	_, err := SealSnapshotEnvelope(store, snap, time.Now())
+	if err == nil {
+		t.Fatalf("snapshot host_fp mismatch must refuse signing")
+	}
+}
+
+func TestSealSnapshotEnvelope_AcceptsHostMissingOnEitherSide(t *testing.T) {
+	// When the snapshot omits host_fingerprint (older Community
+	// build, or an explicit operator scrub) the check is
+	// skipped. The pubkey/node_id checks still gate the call.
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Node.HostFingerprint = ""
+	if _, err := SealSnapshotEnvelope(store, snap, time.Now()); err != nil {
+		t.Fatalf("missing snapshot host_fp must not refuse signing: %v", err)
+	}
+}
+
+func TestSealSnapshotEnvelope_RefusesUnpresentIdentityStatus(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Node.IdentityStatus = "missing"
+	_, err := SealSnapshotEnvelope(store, snap, time.Now())
+	if err == nil {
+		t.Fatalf("snapshot with identity_status != present must refuse signing")
+	}
+}
+
+func TestSealSnapshotEnvelope_NormalizesSignedAtToUTC(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	// Use a non-UTC location to force a normalization step.
+	loc, err := time.LoadLocation("America/Argentina/Buenos_Aires")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	ts := time.Date(2026, 5, 21, 21, 0, 0, 0, loc) // same instant as 2026-05-22T00:00:00Z
+	env, err := SealSnapshotEnvelope(store, snap, ts)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if env.Signature.SignedAt != "2026-05-22T00:00:00Z" {
+		t.Fatalf("signed_at not UTC-normalized: %q", env.Signature.SignedAt)
+	}
+}
+
+func TestSealSnapshotEnvelope_JSONShape(t *testing.T) {
+	// The envelope must marshal to a JSON object whose top-level
+	// keys match the spec; Enterprise's vendored JSON Schema will
+	// be derived from this shape. Spot-check the keys here so a
+	// future struct reorder shows up as a real test failure
+	// rather than a downstream verifier mystery.
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	env, err := SealSnapshotEnvelope(store, snap, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	buf, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	for _, key := range []string{
+		"schema_version", "envelope_version", "node_id",
+		"snapshot_schema_version", "snapshot_sha256",
+		"canonicalization", "signature", "snapshot",
+	} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("envelope JSON missing key %q", key)
+		}
+	}
+	var sig map[string]json.RawMessage
+	if err := json.Unmarshal(raw["signature"], &sig); err != nil {
+		t.Fatalf("re-parse signature: %v", err)
+	}
+	for _, key := range []string{
+		"alg", "key_id", "public_key", "public_key_fingerprint",
+		"signed_at", "value",
+	} {
+		if _, ok := sig[key]; !ok {
+			t.Errorf("signature JSON missing key %q", key)
+		}
+	}
+}
+
+func TestSealSnapshotEnvelope_RefusesWhenIdentityMissing(t *testing.T) {
+	// Pointing the store at an empty directory simulates an
+	// uninitialized node — the signing path must refuse rather
+	// than emit an envelope signed with whatever key it could
+	// scrape together.
+	store := IdentityStore{Dir: filepath.Join(t.TempDir(), "empty-node")}
+	snap := Snapshot{SchemaVersion: SchemaSnapshot, Node: SnapshotNode{
+		NodeID: "node_" + strings.Repeat("a", 36),
+		IdentityStatus: "present",
+	}}
+	_, err := SealSnapshotEnvelope(store, snap, time.Now())
+	if err == nil {
+		t.Fatalf("missing identity must refuse signing")
+	}
+}


### PR DESCRIPTION
## Summary

First slice of Phase 5 Order 3A. Adds the Community half of the signed-evidence trust upgrade: a canonical JSON form for `node_snapshot.v1`, a domain-separated signing payload, and an `oktsec node sign-snapshot` CLI that wraps a redacted snapshot in a `node_snapshot_envelope.v1` shape downstream consumers can verify without ever seeing the private key.

The runtime hot path is untouched. `~/.oktsec/node/node.key` never leaves the machine. `node_identity.v1` stays as-is — the envelope carries the public key in raw base64 so verifiers can check Ed25519 signatures without consulting the node again.

## What lands

### `internal/node/envelope.go`

- `SchemaSnapshotEnvelope`, `EnvelopeVersion`, `CanonicalizationTag` constants so signer and future verifier hash the same artifact.
- `SnapshotEnvelope` + `SnapshotSignature` structs with stable JSON field order.
- `CanonicalSnapshotBytes(Snapshot)` — typed struct, UTC-normalized timestamps, `SetEscapeHTML(false)`, trailing newline stripped, caller's Snapshot not mutated.
- `SnapshotSHA256(Snapshot)` — lowercase-hex (no `sha256:` prefix; that's reserved for identity-shaped values).
- `SnapshotEnvelopeSigningPayload(nodeID, snapshotSHA256, signedAt)` — owns the exact domain-separated byte sequence so signer and verifier can't drift.
- `SealSnapshotEnvelope(IdentityStore, Snapshot, signedAt)` — refuses to sign before identity agreement (`identity_status=present`, node_id, public_key_fingerprint, host_fp when both present). Runs a post-sign Ed25519 self-verify against the emitted public key to catch mismatched key files.

### `oktsec node sign-snapshot`

```
oktsec node sign-snapshot --snapshot snap.json --output snap.envelope.json
oktsec node sign-snapshot --snapshot snap.json                      # stdout
cat snap.json | oktsec node sign-snapshot --snapshot -
```

- Reads with `safefile.ReadFileMax` (symlink-refusing, 4 MiB cap); stdin supported via `--snapshot -`.
- **Strict decoder**: `DisallowUnknownFields` + `schema_version` equality **before** canonicalization. The signing path must NOT silently drop fields the typed struct does not represent — Enterprise's future verifier will rely on this guarantee.
- Atomic write at `0600` via the existing `writeSnapshotFile` helper. No human prose on stdout when JSON is emitted.

## What is NOT in this PR

- No Enterprise changes — `oktsec-enterprise` stays at its pinned Community commit (`cf45617`) until PR 3A.2 bumps the pin and adds the verifier.
- No change to `node_snapshot.v1` or `node_identity.v1`.
- No combined `oktsec node snapshot --signed` shortcut — explicit two-step keeps the trust step auditable.
- No remote command, no new HTTP listener, no network egress.

## Tests

`internal/node/envelope_test.go`:

- Canonical bytes stable across whitespace + zone-offset shuffles, no trailing newline, caller `Snapshot` unchanged.
- Signing payload exact byte sequence.
- Happy seal round-trips through `ed25519.Verify` against the envelope's own public key.
- Seal refuses `node_id` / pubkey fingerprint / host_fp mismatch, `identity_status != present`, missing identity store.
- `signed_at` always normalized to UTC even when constructed in another zone.
- Envelope JSON contains every documented top-level key.

`cmd/oktsec/commands/node_sign_snapshot_test.go`:

- File and stdout paths.
- Output is `0600`.
- Symlinked input refused.
- Symlinked output refused.
- Unknown-field snapshot refused.
- Bad `schema_version` refused.
- Subcommand registered under `oktsec node`.

## Test plan

- [x] `make build`
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] `go test -race -count=1 ./...`
- [x] `make integration-test`
- [x] README contract guards (`TestREADMEContract_*`)
- [x] End-to-end smoke: `oktsec node init` → `oktsec node snapshot --json --output …` → `oktsec node sign-snapshot --snapshot … --output …` produces an envelope whose `signature.value` verifies with `signature.public_key` against `SnapshotEnvelopeSigningPayload(node_id, snapshot_sha256, signed_at)`.