### PR TITLE
Add active policy block to node snapshot

### DIFF
--- a/cmd/oktsec/commands/node.go
+++ b/cmd/oktsec/commands/node.go
@@ -122,6 +122,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 		outputPath       string
 		jsonOutput       bool
 		includeDiscovery bool
+		policyBundle     string
 	)
 	cmd := &cobra.Command{
 		Use:   "snapshot",
@@ -130,6 +131,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 			"Read-only: no databases are created, no migrations run, no external clients are touched.",
 		Example: "  oktsec node snapshot --json\n" +
 			"  oktsec node snapshot --since 24h --output /tmp/node.json\n" +
+			"  oktsec node snapshot --policy-bundle /etc/oktsec/policy.signed.json --json\n" +
 			"  oktsec node snapshot --since 2026-05-20T00:00:00Z --json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sinceT, err := parseSnapshotSince(since)
@@ -147,6 +149,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 				Since:            sinceT,
 				Until:            untilT,
 				IncludeDiscovery: includeDiscovery,
+				PolicyBundlePath: policyBundle,
 				OktsecVersion:    version,
 				OktsecCommit:     commit,
 			}
@@ -179,6 +182,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputPath, "output", "", "write snapshot to this path instead of stdout")
 	cmd.Flags().BoolVar(&jsonOutput, "json", true, "emit JSON (always true in Order 1)")
 	cmd.Flags().BoolVar(&includeDiscovery, "include-discovery", false, "request MCP client discovery (Order 1: not supported, warns)")
+	cmd.Flags().StringVar(&policyBundle, "policy-bundle", "", "path to a local signed policy bundle to report as this node's active policy (declarative only; not verified or applied)")
 	return cmd
 }
 

--- a/internal/node/errors.go
+++ b/internal/node/errors.go
@@ -37,4 +37,5 @@ const (
 	WarnAuditChainSignaturesPartial    = "audit_chain_signatures_partial"
 	WarnClientDiscoveryNotIncluded     = "client_discovery_not_included"
 	WarnPostgresSnapshotLimited        = "postgres_snapshot_limited"
+	WarnPolicyBundleUnreadable         = "policy_bundle_unreadable"
 )

--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -1,0 +1,110 @@
+package node
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/safefile"
+)
+
+// maxPolicyBundleBytes caps how much of a --policy-bundle file the
+// snapshot reads. Policy bundles are small signed JSON documents; the
+// cap keeps a planted multi-gigabyte file from stalling a snapshot.
+const maxPolicyBundleBytes = 1 << 20 // 1 MiB
+
+// rawPolicyBundle is the minimal, tolerant projection of an Enterprise
+// signed policy bundle that Order 4B needs. Community is parse-only
+// here: it does NOT own the policy bundle contract, so the decode is
+// deliberately tolerant (no DisallowUnknownFields) and ignores the
+// signature block entirely.
+//
+// NOTE (4B.2 follow-up): the authoritative bundle field names live in
+// the Enterprise policy_bundle schema. These tags are taken from the
+// Order 4B decisions; the cross-repo fixture that proves this reader and
+// the Enterprise bundle agree lands when Enterprise pins the 4B.1 anchor.
+type rawPolicyBundle struct {
+	SchemaVersion string `json:"schema_version"`
+	BundleVersion int    `json:"bundle_version"`
+	PolicyHash    string `json:"policy_hash"`
+	Policy        struct {
+		PolicyID      string `json:"policy_id"`
+		PolicyVersion string `json:"policy_version"`
+	} `json:"policy"`
+}
+
+// buildPolicySection produces the additive Order 4B policy block from
+// the supplied --policy-bundle path. It is declarative and read-only:
+// it reads and parses the bundle, echoes the declared policy_hash, and
+// never verifies the signature, recomputes the hash, or applies policy.
+//
+// Returned block is never nil for a 4B+ node — the none case is an
+// explicit PolicyStatusNone block, not an absent one. Any unreadable
+// path is reported as PolicyStatusUnreadable plus a warning so a
+// consumer can tell "could not read" from "no policy here".
+func buildPolicySection(bundlePath string) (*SnapshotPolicy, []Warning) {
+	if bundlePath == "" {
+		return &SnapshotPolicy{
+			ActivePolicySource:   PolicySourceNone,
+			ActivePolicyVerified: false,
+			PolicyStatus:         PolicyStatusNone,
+		}, nil
+	}
+
+	unreadable := func(msg string) (*SnapshotPolicy, []Warning) {
+		return &SnapshotPolicy{
+				ActivePolicySource:   PolicySourceLocalFile,
+				ActivePolicyVerified: false,
+				PolicyStatus:         PolicyStatusUnreadable,
+			}, []Warning{{
+				Code:    WarnPolicyBundleUnreadable,
+				Message: "Policy bundle could not be read as a declared active policy: " + msg,
+			}}
+	}
+
+	// RejectSymlink uses Lstat, so this also catches a missing path
+	// or a path the node cannot stat — the err text disambiguates the
+	// symlink case from the not-found case.
+	if err := safefile.RejectSymlink(bundlePath); err != nil {
+		return unreadable("path not usable: " + err.Error())
+	}
+	data, err := safefile.ReadFileMax(bundlePath, maxPolicyBundleBytes)
+	if err != nil {
+		return unreadable("read failed: " + err.Error())
+	}
+	var bundle rawPolicyBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return unreadable("invalid JSON: " + err.Error())
+	}
+	// A bundle that does not declare the minimal identity Enterprise
+	// compares against (hash + id) is not a usable active policy.
+	if bundle.PolicyHash == "" {
+		return unreadable("bundle declares no policy_hash")
+	}
+	if bundle.Policy.PolicyID == "" {
+		return unreadable("bundle declares no policy.policy_id")
+	}
+
+	return &SnapshotPolicy{
+		ActivePolicyHash:     bundle.PolicyHash,
+		ActivePolicyID:       bundle.Policy.PolicyID,
+		ActivePolicyVersion:  bundle.Policy.PolicyVersion,
+		ActivePolicySource:   PolicySourceLocalFile,
+		ActivePolicyLoadedAt: policyBundleLoadedAt(bundlePath),
+		ActivePolicyVerified: false,
+		PolicyStatus:         PolicyStatusActive,
+	}, nil
+}
+
+// policyBundleLoadedAt returns the bundle file's modification time as
+// UTC RFC3339 — when the bundle landed on the node, a staleness signal.
+// Returns "" if the time cannot be read; the field is omitempty so an
+// unknown mtime simply drops out of the JSON rather than emitting a
+// misleading zero time.
+func policyBundleLoadedAt(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	return info.ModTime().UTC().Format(time.RFC3339)
+}

--- a/internal/node/policy_bundle_test.go
+++ b/internal/node/policy_bundle_test.go
@@ -1,0 +1,226 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writePolicyBundle drops a bundle JSON file into a temp dir and
+// returns its path. mtime is pinned so loaded_at assertions are
+// deterministic.
+func writePolicyBundle(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.signed.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	mtime := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return path
+}
+
+const validBundleJSON = `{
+  "schema_version": "policy_bundle_envelope.v1",
+  "bundle_version": 1,
+  "policy_hash": "sha256:deadbeef",
+  "signature": {"alg": "Ed25519", "value": "ignored-in-4b"},
+  "policy": {"policy_id": "voice-ai-prod", "policy_version": "1", "rules": ["ignored"]}
+}`
+
+func TestBuildPolicySection_NoPath(t *testing.T) {
+	sec, warns := buildPolicySection("")
+	if sec == nil {
+		t.Fatal("policy block must never be nil for a 4B+ node")
+	}
+	if sec.PolicyStatus != PolicyStatusNone {
+		t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusNone)
+	}
+	if sec.ActivePolicySource != PolicySourceNone {
+		t.Errorf("source = %q, want %q", sec.ActivePolicySource, PolicySourceNone)
+	}
+	if sec.ActivePolicyHash != "" {
+		t.Errorf("hash = %q, want empty", sec.ActivePolicyHash)
+	}
+	if sec.ActivePolicyVerified {
+		t.Error("verified must be false in 4B")
+	}
+	if len(warns) != 0 {
+		t.Errorf("no-path case must not warn, got %v", warns)
+	}
+}
+
+func TestBuildPolicySection_ValidBundle(t *testing.T) {
+	path := writePolicyBundle(t, validBundleJSON)
+	sec, warns := buildPolicySection(path)
+	if len(warns) != 0 {
+		t.Errorf("valid bundle must not warn, got %v", warns)
+	}
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusActive)
+	}
+	if sec.ActivePolicySource != PolicySourceLocalFile {
+		t.Errorf("source = %q, want %q", sec.ActivePolicySource, PolicySourceLocalFile)
+	}
+	if sec.ActivePolicyHash != "sha256:deadbeef" {
+		t.Errorf("hash = %q, want echoed bundle hash", sec.ActivePolicyHash)
+	}
+	if sec.ActivePolicyID != "voice-ai-prod" {
+		t.Errorf("id = %q", sec.ActivePolicyID)
+	}
+	if sec.ActivePolicyVersion != "1" {
+		t.Errorf("version = %q", sec.ActivePolicyVersion)
+	}
+	if sec.ActivePolicyLoadedAt != "2026-05-24T12:00:00Z" {
+		t.Errorf("loaded_at = %q, want file mtime", sec.ActivePolicyLoadedAt)
+	}
+	if sec.ActivePolicyVerified {
+		t.Error("verified must be false in 4B even for a parseable bundle")
+	}
+}
+
+func TestBuildPolicySection_Unreadable(t *testing.T) {
+	cases := map[string]string{
+		"bad json":         `{not json`,
+		"missing hash":     `{"policy": {"policy_id": "x"}}`,
+		"empty hash":       `{"policy_hash": "", "policy": {"policy_id": "x"}}`,
+		"missing id":       `{"policy_hash": "sha256:abc", "policy": {}}`,
+		"empty everything": `{}`,
+	}
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writePolicyBundle(t, contents)
+			sec, warns := buildPolicySection(path)
+			if sec.PolicyStatus != PolicyStatusUnreadable {
+				t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusUnreadable)
+			}
+			if sec.ActivePolicySource != PolicySourceLocalFile {
+				t.Errorf("source = %q, want %q (a path was supplied)", sec.ActivePolicySource, PolicySourceLocalFile)
+			}
+			if sec.ActivePolicyHash != "" {
+				t.Errorf("unreadable must not echo a hash, got %q", sec.ActivePolicyHash)
+			}
+			if len(warns) != 1 || warns[0].Code != WarnPolicyBundleUnreadable {
+				t.Errorf("expected one %q warning, got %v", WarnPolicyBundleUnreadable, warns)
+			}
+		})
+	}
+}
+
+func TestBuildPolicySection_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	sec, warns := buildPolicySection(path)
+	if sec.PolicyStatus != PolicyStatusUnreadable {
+		t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusUnreadable)
+	}
+	if len(warns) != 1 || warns[0].Code != WarnPolicyBundleUnreadable {
+		t.Errorf("expected one %q warning, got %v", WarnPolicyBundleUnreadable, warns)
+	}
+}
+
+func TestBuildPolicySection_Symlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(target, []byte(validBundleJSON), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported here: %v", err)
+	}
+	sec, warns := buildPolicySection(link)
+	if sec.PolicyStatus != PolicyStatusUnreadable {
+		t.Errorf("symlinked bundle must be unreadable, got %q", sec.PolicyStatus)
+	}
+	if len(warns) != 1 || warns[0].Code != WarnPolicyBundleUnreadable {
+		t.Errorf("expected one %q warning, got %v", WarnPolicyBundleUnreadable, warns)
+	}
+}
+
+// TestCanonicalSnapshotBytes_NilPolicyOmitted is the backward-compat
+// guard: a snapshot with no policy block (pre-4B shape) must canonicalize
+// without a "policy" key so existing signed envelopes keep verifying.
+func TestCanonicalSnapshotBytes_NilPolicyOmitted(t *testing.T) {
+	_, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Policy = nil
+	canon, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	if strings.Contains(string(canon), `"policy":`) {
+		t.Fatalf("nil policy must be omitted from canonical bytes; got:\n%s", canon)
+	}
+}
+
+// TestBuild_PolicyBlock_NoneByDefault verifies node.Build always emits
+// the policy block (never nil) and reports none when no bundle path is
+// supplied — the block must be present on every 4B+ snapshot.
+func TestBuild_PolicyBlock_NoneByDefault(t *testing.T) {
+	snap := buildAt(t, Options{ConfigPath: filepath.Join(t.TempDir(), "missing.yaml")})
+	if snap.Policy == nil {
+		t.Fatal("Build must always populate the policy block for a 4B+ node")
+	}
+	if snap.Policy.PolicyStatus != PolicyStatusNone {
+		t.Fatalf("default policy_status = %q, want %q", snap.Policy.PolicyStatus, PolicyStatusNone)
+	}
+}
+
+// TestBuild_PolicyBlock_ActiveFromBundle verifies Options.PolicyBundlePath
+// is wired through Build into the reported active policy.
+func TestBuild_PolicyBlock_ActiveFromBundle(t *testing.T) {
+	path := writePolicyBundle(t, validBundleJSON)
+	snap := buildAt(t, Options{
+		ConfigPath:       filepath.Join(t.TempDir(), "missing.yaml"),
+		PolicyBundlePath: path,
+	})
+	if snap.Policy == nil || snap.Policy.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("expected active policy block, got %+v", snap.Policy)
+	}
+	if snap.Policy.ActivePolicyHash != "sha256:deadbeef" {
+		t.Errorf("hash = %q, want echoed bundle hash", snap.Policy.ActivePolicyHash)
+	}
+	if snap.Policy.ActivePolicyVerified {
+		t.Error("verified must be false in 4B")
+	}
+}
+
+// TestSealSnapshotEnvelope_WithPolicyBlock proves the envelope still
+// signs and self-verifies when the additive policy block is present,
+// and that the block survives into the embedded snapshot.
+func TestSealSnapshotEnvelope_WithPolicyBlock(t *testing.T) {
+	store, id := seedIdentity(t)
+	snap := baseSnapshot(id)
+	snap.Policy = &SnapshotPolicy{
+		ActivePolicyHash:     "sha256:deadbeef",
+		ActivePolicyID:       "voice-ai-prod",
+		ActivePolicyVersion:  "1",
+		ActivePolicySource:   PolicySourceLocalFile,
+		ActivePolicyLoadedAt: "2026-05-24T12:00:00Z",
+		ActivePolicyVerified: false,
+		PolicyStatus:         PolicyStatusActive,
+	}
+	env, err := SealSnapshotEnvelope(store, snap, time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("seal with policy block: %v", err)
+	}
+	if env.Snapshot.Policy == nil || env.Snapshot.Policy.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("policy block did not survive into the envelope snapshot")
+	}
+	canon, err := CanonicalSnapshotBytes(snap)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	if !strings.Contains(string(canon), `"policy":`) {
+		t.Fatalf("populated policy block must appear in canonical bytes")
+	}
+}

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -51,7 +51,66 @@ type Snapshot struct {
 	Inventory     SnapshotInventory `json:"inventory"`
 	Posture       SnapshotPosture  `json:"posture"`
 	Evidence      SnapshotEvidence `json:"evidence"`
+	Policy        *SnapshotPolicy  `json:"policy,omitempty"`
 	Warnings      []Warning        `json:"warnings"`
+}
+
+// Policy status values reported in SnapshotPolicy.PolicyStatus.
+const (
+	// PolicyStatusActive: a local policy bundle was found and its
+	// declared policy_hash was read. NOT a verification claim.
+	PolicyStatusActive = "active"
+	// PolicyStatusNone: no --policy-bundle path was supplied; the node
+	// has no locally-declared active policy.
+	PolicyStatusNone = "none"
+	// PolicyStatusUnreadable: a path was supplied but the bundle could
+	// not be read or parsed, or it lacked the minimal fields. Distinct
+	// from PolicyStatusNone so Enterprise does not mistake "I could not
+	// read it" for "there is no policy here".
+	PolicyStatusUnreadable = "unreadable"
+)
+
+// Policy source values reported in SnapshotPolicy.ActivePolicySource.
+const (
+	// PolicySourceLocalFile: a local bundle path was supplied (active
+	// or unreadable — source records where the node looked).
+	PolicySourceLocalFile = "local_file"
+	// PolicySourceNone: no bundle path was supplied.
+	PolicySourceNone = "none"
+)
+
+// SnapshotPolicy is the additive Order 4B block reporting which policy
+// the node has locally. It is DECLARATIVE evidence only: the node
+// echoes the policy_hash the bundle declares and does not verify the
+// signature, recompute the hash, or apply the policy. Signature
+// verification and application are deferred to Order 4C.
+//
+// The block is carried as a pointer on Snapshot with omitempty so a
+// pre-4B snapshot (no policy key) reproduces byte-identical canonical
+// bytes and existing signed envelopes keep verifying. A 4B+ node always
+// populates it, including the PolicyStatusNone case.
+type SnapshotPolicy struct {
+	// ActivePolicyHash is the policy_hash echoed from the local
+	// bundle. Empty when PolicyStatus is none or unreadable. NOT
+	// recomputed by the node and NOT a verification result.
+	ActivePolicyHash string `json:"active_policy_hash"`
+	// ActivePolicyID / ActivePolicyVersion mirror the bundle's
+	// declared identity. Omitted when not active.
+	ActivePolicyID      string `json:"active_policy_id,omitempty"`
+	ActivePolicyVersion string `json:"active_policy_version,omitempty"`
+	// ActivePolicySource is local_file when a path was supplied,
+	// none otherwise.
+	ActivePolicySource string `json:"active_policy_source"`
+	// ActivePolicyLoadedAt is the local bundle file's modification
+	// time (UTC RFC3339) — when the bundle landed on the node, a
+	// staleness signal. Omitted when not active.
+	ActivePolicyLoadedAt string `json:"active_policy_loaded_at,omitempty"`
+	// ActivePolicyVerified is always false in Order 4B: the field
+	// means "self-reported by the node, not yet cryptographically
+	// verified locally". 4C performs real signature verification.
+	ActivePolicyVerified bool `json:"active_policy_verified"`
+	// PolicyStatus is one of active / none / unreadable.
+	PolicyStatus string `json:"policy_status"`
 }
 
 // SnapshotRange describes the time window the snapshot was computed

--- a/internal/node/snapshot.go
+++ b/internal/node/snapshot.go
@@ -49,6 +49,13 @@ type Options struct {
 	// client_discovery_not_included warning instead.
 	IncludeDiscovery bool
 
+	// PolicyBundlePath points at a local signed policy bundle the
+	// operator copied onto the node. When set, Order 4B reports its
+	// declared policy_hash in the snapshot's policy block. Empty
+	// means "no locally-declared active policy" (policy_status none).
+	// Declarative only: the bundle is never verified or applied here.
+	PolicyBundlePath string
+
 	// OktsecVersion / OktsecCommit override the version stamped
 	// into the snapshot. CLI fills these from version.go; tests
 	// pin them so golden output stays deterministic.
@@ -138,6 +145,13 @@ func Build(ctx context.Context, opts Options) (Snapshot, error) {
 	populateConfigSection(&snap, cfg, cfgPath)
 	populateSurfacesSection(&snap, cfg)
 	populateInventorySection(&snap, cfg, opts.IncludeDiscovery)
+
+	// Policy reporting (Order 4B) is independent of the audit DB, so
+	// populate it before any DB-dependent early return below — the
+	// block must appear on every snapshot a 4B+ node emits.
+	policySec, policyWarnings := buildPolicySection(opts.PolicyBundlePath)
+	snap.Policy = policySec
+	snap.Warnings = append(snap.Warnings, policyWarnings...)
 
 	// Postgres-backed installs must not be inspected as if they
 	// were SQLite — that would silently report stale ~/.oktsec/oktsec.db


### PR DESCRIPTION
## What

Adds an additive optional `policy` block to `node_snapshot.v1`. The node reports which policy it has locally so a downstream consumer can compare an expected policy hash against what the node actually declares.

`oktsec node snapshot --policy-bundle <path>` reads a local signed policy bundle and reports the `policy_hash`, `policy_id`, and `policy_version` it declares, plus the file mtime as `active_policy_loaded_at`.

## Design

- **Additive on `node_snapshot.v1`, no schema bump.** The signed snapshot envelope pins `node_snapshot.v1` in the signing payload and canonicalization tag; an additive optional block leaves the envelope contract untouched.
- **Pointer + `omitempty`.** Go does not omit zero structs, only nil pointers. Carrying the block as `*SnapshotPolicy` means snapshots without it reproduce byte-identical canonical bytes, so existing signed envelopes keep verifying. A current-version node always populates the block (including the `none` case); only older snapshots omit it.
- **Declarative only.** The node echoes the hash the bundle declares. It does not verify the signature, recompute the hash, or apply the policy. `active_policy_verified` is always `false` and documented as "self-reported, not yet cryptographically verified locally".
- **Parse-only and tolerant.** The bundle reader takes only the minimal fields and ignores unknown fields, since this package does not own the bundle contract. Reads go through `safefile` (symlink rejection + size cap).

## States

| `policy_status` | When |
|---|---|
| `active` | bundle read and parsed with the minimal fields |
| `none` | no `--policy-bundle` path supplied |
| `unreadable` | path supplied but unreadable / invalid JSON / missing the minimal fields (reported with a `policy_bundle_unreadable` warning) |

`active_policy_source` is `local_file` when a path was supplied (active or unreadable), `none` otherwise.

## Tests

- Section builder: none / active / unreadable (bad JSON, empty/missing hash, missing id, missing file, symlink).
- `Build` wiring: block always present; `--policy-bundle` flows through to an active block.
- Envelope: seals and self-verifies with the block present; nil block is omitted from canonical bytes (backward-compat guard for existing envelopes).

`make build && make test && make lint && make vet` all green.