### PR TITLE
Add local policy signature verification to node snapshot

### DIFF
--- a/cmd/oktsec/commands/node.go
+++ b/cmd/oktsec/commands/node.go
@@ -123,6 +123,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 		jsonOutput       bool
 		includeDiscovery bool
 		policyBundle     string
+		policyTrustFP    string
 	)
 	cmd := &cobra.Command{
 		Use:   "snapshot",
@@ -132,6 +133,7 @@ func newNodeSnapshotCmd() *cobra.Command {
 		Example: "  oktsec node snapshot --json\n" +
 			"  oktsec node snapshot --since 24h --output /tmp/node.json\n" +
 			"  oktsec node snapshot --policy-bundle /etc/oktsec/policy.signed.json --json\n" +
+			"  oktsec node snapshot --policy-bundle /etc/oktsec/policy.signed.json --policy-trust-fingerprint sha256:... --json\n" +
 			"  oktsec node snapshot --since 2026-05-20T00:00:00Z --json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sinceT, err := parseSnapshotSince(since)
@@ -143,15 +145,16 @@ func newNodeSnapshotCmd() *cobra.Command {
 				return err
 			}
 			opts := node.Options{
-				ConfigPath:       cfgFile,
-				DBPath:           nodeSnapshotDBPathOverride,
-				IdentityStore:    nodeStoreForTest(),
-				Since:            sinceT,
-				Until:            untilT,
-				IncludeDiscovery: includeDiscovery,
-				PolicyBundlePath: policyBundle,
-				OktsecVersion:    version,
-				OktsecCommit:     commit,
+				ConfigPath:             cfgFile,
+				DBPath:                 nodeSnapshotDBPathOverride,
+				IdentityStore:          nodeStoreForTest(),
+				Since:                  sinceT,
+				Until:                  untilT,
+				IncludeDiscovery:       includeDiscovery,
+				PolicyBundlePath:       policyBundle,
+				PolicyTrustFingerprint: policyTrustFP,
+				OktsecVersion:          version,
+				OktsecCommit:           commit,
 			}
 			snap, err := node.Build(context.Background(), opts)
 			if err != nil {
@@ -182,7 +185,8 @@ func newNodeSnapshotCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputPath, "output", "", "write snapshot to this path instead of stdout")
 	cmd.Flags().BoolVar(&jsonOutput, "json", true, "emit JSON (always true in Order 1)")
 	cmd.Flags().BoolVar(&includeDiscovery, "include-discovery", false, "request MCP client discovery (Order 1: not supported, warns)")
-	cmd.Flags().StringVar(&policyBundle, "policy-bundle", "", "path to a local signed policy bundle to report as this node's active policy (declarative only; not verified or applied)")
+	cmd.Flags().StringVar(&policyBundle, "policy-bundle", "", "path to a local signed policy bundle to report as this node's active policy")
+	cmd.Flags().StringVar(&policyTrustFP, "policy-trust-fingerprint", "", "policy signing key fingerprint (sha256:<hex>) to verify the bundle signature against; omit to report the bundle unverified")
 	return cmd
 }
 

--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -1,8 +1,14 @@
 package node
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/safefile"
@@ -13,36 +19,58 @@ import (
 // cap keeps a planted multi-gigabyte file from stalling a snapshot.
 const maxPolicyBundleBytes = 1 << 20 // 1 MiB
 
-// rawPolicyBundle is the minimal, tolerant projection of an Enterprise
-// signed policy bundle that Order 4B needs. Community is parse-only
-// here: it does NOT own the policy bundle contract, so the decode is
-// deliberately tolerant (no DisallowUnknownFields) and ignores the
-// signature block entirely.
-//
-// NOTE (4B.2 follow-up): the authoritative bundle field names live in
-// the Enterprise policy_bundle schema. These tags are taken from the
-// Order 4B decisions; the cross-repo fixture that proves this reader and
-// the Enterprise bundle agree lands when Enterprise pins the 4B.1 anchor.
+// Frozen constants of the policy_bundle.v1 signing contract this node
+// verifies. Order 4C.1 verifies a bundle's signature locally, which
+// means reproducing the exact signing payload the bundle signer
+// covered. These values are part of that contract: a drift here
+// surfaces as a broken signature on every bundle, which is the right
+// failure mode. A vendored signed fixture (testdata) guards the format
+// against silent divergence.
+const (
+	policyBundleSchemaVersion    = "policy_bundle.v1"
+	policyBundleVersion          = 1
+	policyBundleCanonicalization = "oktsec-policy-v1-typed-utc-json"
+	policyBundleSignatureAlg     = "Ed25519"
+)
+
+// rawPolicyBundle is the tolerant projection of a signed policy_bundle.v1
+// the snapshot needs. This node does not own the bundle contract, so the
+// decode stays tolerant (no DisallowUnknownFields). Order 4C.1 added the
+// signature block + canonicalization tag so the node can verify the
+// signature locally; the field names follow the policy_bundle.v1 shape.
 type rawPolicyBundle struct {
-	SchemaVersion string `json:"schema_version"`
-	BundleVersion int    `json:"bundle_version"`
-	PolicyHash    string `json:"policy_hash"`
-	Policy        struct {
+	SchemaVersion    string `json:"schema_version"`
+	BundleVersion    int    `json:"bundle_version"`
+	PolicyHash       string `json:"policy_hash"`
+	Canonicalization string `json:"canonicalization"`
+	Policy           struct {
 		PolicyID      string `json:"policy_id"`
 		PolicyVersion string `json:"policy_version"`
 	} `json:"policy"`
+	Signature struct {
+		Alg                  string `json:"alg"`
+		KeyID                string `json:"key_id"`
+		PublicKey            string `json:"public_key"`
+		PublicKeyFingerprint string `json:"public_key_fingerprint"`
+		SignedAt             string `json:"signed_at"`
+		Value                string `json:"value"`
+	} `json:"signature"`
 }
 
 // buildPolicySection produces the additive Order 4B policy block from
-// the supplied --policy-bundle path. It is declarative and read-only:
-// it reads and parses the bundle, echoes the declared policy_hash, and
-// never verifies the signature, recomputes the hash, or applies policy.
+// the supplied --policy-bundle path, with Order 4C.1 verification.
+//
+// Verification (4C.1) is signature-only: the node verifies the Ed25519
+// signature over the declared policy hash against the bundle's embedded
+// public key, and that the embedded key's fingerprint matches the
+// operator-configured trust fingerprint. It does NOT recompute the
+// policy body hash and does NOT apply the policy — "verified" means
+// exactly "signature over the declared policy hash verified", nothing
+// more. ActivePolicyVerificationStatus reports which check decided it.
 //
 // Returned block is never nil for a 4B+ node — the none case is an
-// explicit PolicyStatusNone block, not an absent one. Any unreadable
-// path is reported as PolicyStatusUnreadable plus a warning so a
-// consumer can tell "could not read" from "no policy here".
-func buildPolicySection(bundlePath string) (*SnapshotPolicy, []Warning) {
+// explicit PolicyStatusNone block, not an absent one.
+func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, []Warning) {
 	if bundlePath == "" {
 		return &SnapshotPolicy{
 			ActivePolicySource:   PolicySourceNone,
@@ -53,9 +81,10 @@ func buildPolicySection(bundlePath string) (*SnapshotPolicy, []Warning) {
 
 	unreadable := func(msg string) (*SnapshotPolicy, []Warning) {
 		return &SnapshotPolicy{
-				ActivePolicySource:   PolicySourceLocalFile,
-				ActivePolicyVerified: false,
-				PolicyStatus:         PolicyStatusUnreadable,
+				ActivePolicySource:             PolicySourceLocalFile,
+				ActivePolicyVerified:           false,
+				ActivePolicyVerificationStatus: PolicyVerificationBundleUnreadable,
+				PolicyStatus:                   PolicyStatusUnreadable,
 			}, []Warning{{
 				Code:    WarnPolicyBundleUnreadable,
 				Message: "Policy bundle could not be read as a declared active policy: " + msg,
@@ -85,15 +114,94 @@ func buildPolicySection(bundlePath string) (*SnapshotPolicy, []Warning) {
 		return unreadable("bundle declares no policy.policy_id")
 	}
 
+	verified, status := verifyPolicyBundle(bundle, trustFingerprint)
 	return &SnapshotPolicy{
-		ActivePolicyHash:     bundle.PolicyHash,
-		ActivePolicyID:       bundle.Policy.PolicyID,
-		ActivePolicyVersion:  bundle.Policy.PolicyVersion,
-		ActivePolicySource:   PolicySourceLocalFile,
-		ActivePolicyLoadedAt: policyBundleLoadedAt(bundlePath),
-		ActivePolicyVerified: false,
-		PolicyStatus:         PolicyStatusActive,
+		ActivePolicyHash:               bundle.PolicyHash,
+		ActivePolicyID:                 bundle.Policy.PolicyID,
+		ActivePolicyVersion:            bundle.Policy.PolicyVersion,
+		ActivePolicySource:             PolicySourceLocalFile,
+		ActivePolicyLoadedAt:           policyBundleLoadedAt(bundlePath),
+		ActivePolicyVerified:           verified,
+		ActivePolicyVerificationStatus: status,
+		PolicyStatus:                   PolicyStatusActive,
 	}, nil
+}
+
+// verifyPolicyBundle runs the Order 4C.1 verification state machine
+// against a readable bundle. Check order is the contract:
+//
+//	unsupported signature shape         -> unsupported_bundle
+//	no trust fingerprint configured     -> no_trust_anchor
+//	embedded key fp != trust fingerprint-> signing_key_mismatch
+//	signature does not verify           -> signature_invalid
+//	all pass                            -> verified
+//
+// The signature covers policy_hash via the domain-separated payload,
+// so a verified signature authenticates the reported hash. The body is
+// NOT re-hashed here (that is 4C.2 apply territory).
+func verifyPolicyBundle(b rawPolicyBundle, trustFingerprint string) (bool, string) {
+	sig := b.Signature
+	pub, err := base64.StdEncoding.DecodeString(sig.PublicKey)
+	switch {
+	case b.SchemaVersion != policyBundleSchemaVersion,
+		b.BundleVersion != policyBundleVersion,
+		b.Canonicalization != policyBundleCanonicalization,
+		sig.Alg != policyBundleSignatureAlg,
+		sig.Value == "",
+		err != nil,
+		len(pub) != ed25519.PublicKeySize:
+		return false, PolicyVerificationUnsupportedBundle
+	}
+	// Self-consistency: the embedded key must hash to the fingerprint
+	// the bundle claims for it. A mismatch means a malformed/hand-edited
+	// signature block, not a trust decision — treat it as unsupported.
+	derivedFP := policyKeyFingerprint(pub)
+	if sig.PublicKeyFingerprint != "" && sig.PublicKeyFingerprint != derivedFP {
+		return false, PolicyVerificationUnsupportedBundle
+	}
+	if trustFingerprint == "" {
+		return false, PolicyVerificationNoTrustAnchor
+	}
+	if derivedFP != trustFingerprint {
+		return false, PolicyVerificationSigningKeyMismatch
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(sig.Value)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return false, PolicyVerificationSignatureInvalid
+	}
+	payload := policyBundleSigningPayload(
+		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
+		sig.SignedAt, sig.KeyID, sig.PublicKeyFingerprint)
+	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigBytes) {
+		return false, PolicyVerificationSignatureInvalid
+	}
+	return true, PolicyVerificationVerified
+}
+
+// policyBundleSigningPayload reproduces the exact bytes the
+// policy_bundle.v1 signer covers. Domain-separated labeled lines,
+// newline-joined, no trailing newline. MUST stay byte-identical to the
+// signing contract or every bundle signature fails to verify.
+func policyBundleSigningPayload(policyID, policyVersion, policyHash, signedAt, keyID, publicKeyFingerprint string) []byte {
+	lines := []string{
+		"oktsec." + policyBundleSchemaVersion,
+		fmt.Sprintf("bundle_version:%d", policyBundleVersion),
+		"policy_id:" + policyID,
+		"policy_version:" + policyVersion,
+		"policy_hash:" + policyHash,
+		"canonicalization:" + policyBundleCanonicalization,
+		"signed_at:" + signedAt,
+		"signature_key_id:" + keyID,
+		"signature_public_key_fingerprint:" + publicKeyFingerprint,
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// policyKeyFingerprint is the policy_bundle.v1 key fingerprint format:
+// the wire-format fingerprint of an Ed25519 public key, sha256:<64-hex>.
+func policyKeyFingerprint(pub []byte) string {
+	sum := sha256.Sum256(pub)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // policyBundleLoadedAt returns the bundle file's modification time as

--- a/internal/node/policy_bundle_test.go
+++ b/internal/node/policy_bundle_test.go
@@ -35,7 +35,7 @@ const validBundleJSON = `{
 }`
 
 func TestBuildPolicySection_NoPath(t *testing.T) {
-	sec, warns := buildPolicySection("")
+	sec, warns := buildPolicySection("", "")
 	if sec == nil {
 		t.Fatal("policy block must never be nil for a 4B+ node")
 	}
@@ -58,7 +58,7 @@ func TestBuildPolicySection_NoPath(t *testing.T) {
 
 func TestBuildPolicySection_ValidBundle(t *testing.T) {
 	path := writePolicyBundle(t, validBundleJSON)
-	sec, warns := buildPolicySection(path)
+	sec, warns := buildPolicySection(path, "")
 	if len(warns) != 0 {
 		t.Errorf("valid bundle must not warn, got %v", warns)
 	}
@@ -96,7 +96,7 @@ func TestBuildPolicySection_Unreadable(t *testing.T) {
 	for name, contents := range cases {
 		t.Run(name, func(t *testing.T) {
 			path := writePolicyBundle(t, contents)
-			sec, warns := buildPolicySection(path)
+			sec, warns := buildPolicySection(path, "")
 			if sec.PolicyStatus != PolicyStatusUnreadable {
 				t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusUnreadable)
 			}
@@ -115,7 +115,7 @@ func TestBuildPolicySection_Unreadable(t *testing.T) {
 
 func TestBuildPolicySection_MissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "does-not-exist.json")
-	sec, warns := buildPolicySection(path)
+	sec, warns := buildPolicySection(path, "")
 	if sec.PolicyStatus != PolicyStatusUnreadable {
 		t.Errorf("status = %q, want %q", sec.PolicyStatus, PolicyStatusUnreadable)
 	}
@@ -137,7 +137,7 @@ func TestBuildPolicySection_Symlink(t *testing.T) {
 	if err := os.Symlink(target, link); err != nil {
 		t.Skipf("symlink not supported here: %v", err)
 	}
-	sec, warns := buildPolicySection(link)
+	sec, warns := buildPolicySection(link, "")
 	if sec.PolicyStatus != PolicyStatusUnreadable {
 		t.Errorf("symlinked bundle must be unreadable, got %q", sec.PolicyStatus)
 	}

--- a/internal/node/policy_bundle_v1_fixture.json
+++ b/internal/node/policy_bundle_v1_fixture.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "policy_bundle.v1",
+  "bundle_version": 1,
+  "policy_hash": "sha256:264cc6da2c81c68bdee9f9e69e73c27e32201b466beb05eaa2b42326d148b267",
+  "canonicalization": "oktsec-policy-v1-typed-utc-json",
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "mode": "enforce",
+    "rules": {
+      "enabled": [
+        "IAP-001",
+        "IAP-003",
+        "IAP-007"
+      ],
+      "disabled": [
+        "IAP-004"
+      ],
+      "overrides": {
+        "IAP-007": {
+          "action": "block"
+        }
+      }
+    },
+    "gateway": {
+      "tools_allowed": [
+        "calendar.read",
+        "voice.dial"
+      ],
+      "tools_denied": [
+        "shell.exec"
+      ]
+    },
+    "egress": {
+      "domains_allowed": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "domains_denied": [
+        "*.suspicious.example"
+      ]
+    },
+    "redaction": {
+      "level": "analyst"
+    },
+    "metadata": {
+      "created_at": "2026-05-23T12:00:00Z",
+      "created_by": "fixture-generator",
+      "reason": "Vendored test fixture for policy_bundle.v1 schema drift guard."
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "key_id": "enterprise-policy-fixture-v1",
+    "public_key": "6wccwmxHEVCpqZIobQWgBSqk872OmPUjQcUegTXuQj0=",
+    "public_key_fingerprint": "sha256:a6e0388bec0afcaa6a83463bcad7b0d37078263e163c58d56e03eb6b08d15dcc",
+    "signed_at": "2026-05-23T12:00:01Z",
+    "value": "7CjuiG4myt7uipoAYLOEUbBGUUyS/C4w3FMiVucZGkPSoqjJNE+s1PUDkbZ1FdwseWuJrya4f5r7571Vb9MtBg=="
+  }
+}

--- a/internal/node/policy_verify_test.go
+++ b/internal/node/policy_verify_test.go
@@ -1,0 +1,171 @@
+package node
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// vendoredPolicyBundleV1 is a real policy_bundle.v1 produced by the
+// upstream signer, embedded (not under the gitignored testdata/) so the
+// cross-contract guard ships with the repo and runs in CI.
+//
+//go:embed policy_bundle_v1_fixture.json
+var vendoredPolicyBundleV1 []byte
+
+// signedBundleJSON builds a policy_bundle.v1 JSON signed by priv over
+// the mirrored Enterprise signing payload. mutate lets a test corrupt
+// a field after signing to exercise a failure path.
+func signedBundleJSON(t *testing.T, priv ed25519.PrivateKey, mutate func(m map[string]any)) []byte {
+	t.Helper()
+	pub := priv.Public().(ed25519.PublicKey)
+	fp := policyKeyFingerprint(pub)
+	const (
+		id       = "voice-ai-prod"
+		ver      = "1"
+		hash     = "sha256:9f588db2911071e2f6a62042a2b66b184f6103a358d31481eb215bccdc993368"
+		signedAt = "2026-05-22T00:00:00Z"
+		keyID    = "enterprise-policy"
+	)
+	sig := ed25519.Sign(priv, policyBundleSigningPayload(id, ver, hash, signedAt, keyID, fp))
+	m := map[string]any{
+		"schema_version":   policyBundleSchemaVersion,
+		"bundle_version":   policyBundleVersion,
+		"policy_hash":      hash,
+		"canonicalization": policyBundleCanonicalization,
+		"policy":           map[string]any{"policy_id": id, "policy_version": ver},
+		"signature": map[string]any{
+			"alg":                    policyBundleSignatureAlg,
+			"key_id":                 keyID,
+			"public_key":             base64.StdEncoding.EncodeToString(pub),
+			"public_key_fingerprint": fp,
+			"signed_at":              signedAt,
+			"value":                  base64.StdEncoding.EncodeToString(sig),
+		},
+	}
+	if mutate != nil {
+		mutate(m)
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	return raw
+}
+
+func newKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	return priv
+}
+
+// TestBuildPolicySection_VerificationStates walks the Order 4C.1
+// verification state machine. Each case writes a bundle, runs
+// buildPolicySection with a trust fingerprint, and asserts the verdict.
+func TestBuildPolicySection_VerificationStates(t *testing.T) {
+	priv := newKey(t)
+	pub := priv.Public().(ed25519.PublicKey)
+	trustFP := policyKeyFingerprint(pub)
+	otherFP := policyKeyFingerprint(newKey(t).Public().(ed25519.PublicKey))
+
+	write := func(raw []byte) string {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "policy.signed.json")
+		if err := os.WriteFile(p, raw, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return p
+	}
+
+	t.Run("verified", func(t *testing.T) {
+		sec, _ := buildPolicySection(write(signedBundleJSON(t, priv, nil)), trustFP)
+		if !sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationVerified {
+			t.Fatalf("got verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("no_trust_anchor", func(t *testing.T) {
+		sec, _ := buildPolicySection(write(signedBundleJSON(t, priv, nil)), "")
+		if sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationNoTrustAnchor {
+			t.Fatalf("got verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("signing_key_mismatch", func(t *testing.T) {
+		sec, _ := buildPolicySection(write(signedBundleJSON(t, priv, nil)), otherFP)
+		if sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationSigningKeyMismatch {
+			t.Fatalf("got verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("signature_invalid", func(t *testing.T) {
+		// Sign for the real fields, then change policy_hash so the
+		// committed bytes no longer match the signature.
+		raw := signedBundleJSON(t, priv, func(m map[string]any) {
+			m["policy_hash"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		})
+		sec, _ := buildPolicySection(write(raw), trustFP)
+		if sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationSignatureInvalid {
+			t.Fatalf("got verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("unsupported_bundle_no_signature", func(t *testing.T) {
+		raw := signedBundleJSON(t, priv, func(m map[string]any) { delete(m, "signature") })
+		sec, _ := buildPolicySection(write(raw), trustFP)
+		if sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("got verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("unsupported_bundle_wrong_schema", func(t *testing.T) {
+		raw := signedBundleJSON(t, priv, func(m map[string]any) { m["schema_version"] = "policy_bundle_envelope.v1" })
+		sec, _ := buildPolicySection(write(raw), trustFP)
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status=%q, want unsupported_bundle", sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("unsupported_bundle_self_inconsistent_fp", func(t *testing.T) {
+		raw := signedBundleJSON(t, priv, func(m map[string]any) {
+			m["signature"].(map[string]any)["public_key_fingerprint"] = otherFP
+		})
+		sec, _ := buildPolicySection(write(raw), trustFP)
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status=%q, want unsupported_bundle (embedded key fp mismatch)", sec.ActivePolicyVerificationStatus)
+		}
+	})
+
+	t.Run("bundle_unreadable", func(t *testing.T) {
+		sec, _ := buildPolicySection(filepath.Join(t.TempDir(), "missing.json"), trustFP)
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationBundleUnreadable {
+			t.Fatalf("status=%q, want bundle_unreadable", sec.ActivePolicyVerificationStatus)
+		}
+	})
+}
+
+// TestVerifyPolicyBundle_AcceptsVendoredFixture is the contract guard:
+// a real policy_bundle.v1 produced by the upstream signer (vendored
+// verbatim into testdata) must verify under this node's independently
+// implemented signing-payload reconstruction. If the two ever drift,
+// this fails — the right failure mode.
+func TestVerifyPolicyBundle_AcceptsVendoredFixture(t *testing.T) {
+	var bundle rawPolicyBundle
+	if err := json.Unmarshal(vendoredPolicyBundleV1, &bundle); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	// Trust exactly the key the fixture was signed with.
+	verified, status := verifyPolicyBundle(bundle, bundle.Signature.PublicKeyFingerprint)
+	if !verified || status != PolicyVerificationVerified {
+		t.Fatalf("vendored policy_bundle.v1 fixture did not verify: verified=%v status=%q "+
+			"(signing-payload contract drift?)", verified, status)
+	}
+}

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -79,6 +79,34 @@ const (
 	PolicySourceNone = "none"
 )
 
+// Policy verification status values (Order 4C.1) reported in
+// SnapshotPolicy.ActivePolicyVerificationStatus. "verified" means
+// exactly that the Ed25519 signature over the declared policy hash
+// verified against a trusted key — NOT that the policy body was
+// re-validated or applied.
+const (
+	// PolicyVerificationVerified: signature verified against the
+	// configured trust fingerprint.
+	PolicyVerificationVerified = "verified"
+	// PolicyVerificationNoTrustAnchor: a bundle is present but no
+	// --policy-trust-fingerprint was configured, so the node cannot
+	// claim the signing key is trusted.
+	PolicyVerificationNoTrustAnchor = "no_trust_anchor"
+	// PolicyVerificationSigningKeyMismatch: the bundle's signing key
+	// fingerprint does not match the configured trust fingerprint.
+	PolicyVerificationSigningKeyMismatch = "signing_key_mismatch"
+	// PolicyVerificationSignatureInvalid: the Ed25519 signature did
+	// not verify over the reconstructed signing payload.
+	PolicyVerificationSignatureInvalid = "signature_invalid"
+	// PolicyVerificationBundleUnreadable: the bundle could not be read
+	// or parsed (mirrors PolicyStatusUnreadable).
+	PolicyVerificationBundleUnreadable = "bundle_unreadable"
+	// PolicyVerificationUnsupportedBundle: the bundle parsed but
+	// carries no usable signature block / unknown bundle shape, so it
+	// cannot be verified.
+	PolicyVerificationUnsupportedBundle = "unsupported_bundle"
+)
+
 // SnapshotPolicy is the additive Order 4B block reporting which policy
 // the node has locally. It is DECLARATIVE evidence only: the node
 // echoes the policy_hash the bundle declares and does not verify the
@@ -105,10 +133,16 @@ type SnapshotPolicy struct {
 	// time (UTC RFC3339) — when the bundle landed on the node, a
 	// staleness signal. Omitted when not active.
 	ActivePolicyLoadedAt string `json:"active_policy_loaded_at,omitempty"`
-	// ActivePolicyVerified is always false in Order 4B: the field
-	// means "self-reported by the node, not yet cryptographically
-	// verified locally". 4C performs real signature verification.
+	// ActivePolicyVerified is the Order 4C.1 verification result: true
+	// only when the bundle's signature over the declared policy hash
+	// verified against the operator-configured trust fingerprint. It
+	// does NOT assert the policy body was re-validated or applied.
 	ActivePolicyVerified bool `json:"active_policy_verified"`
+	// ActivePolicyVerificationStatus (Order 4C.1) reports which check
+	// decided ActivePolicyVerified: verified / no_trust_anchor /
+	// signing_key_mismatch / signature_invalid / bundle_unreadable /
+	// unsupported_bundle. Omitted when no bundle path was supplied.
+	ActivePolicyVerificationStatus string `json:"active_policy_verification_status,omitempty"`
 	// PolicyStatus is one of active / none / unreadable.
 	PolicyStatus string `json:"policy_status"`
 }

--- a/internal/node/snapshot.go
+++ b/internal/node/snapshot.go
@@ -53,8 +53,13 @@ type Options struct {
 	// operator copied onto the node. When set, Order 4B reports its
 	// declared policy_hash in the snapshot's policy block. Empty
 	// means "no locally-declared active policy" (policy_status none).
-	// Declarative only: the bundle is never verified or applied here.
 	PolicyBundlePath string
+
+	// PolicyTrustFingerprint is the operator-configured policy signing
+	// key fingerprint (sha256:<hex>) the node verifies a bundle's
+	// signature against (Order 4C.1). Empty means the node reports the
+	// bundle but cannot claim it is verified (no_trust_anchor).
+	PolicyTrustFingerprint string
 
 	// OktsecVersion / OktsecCommit override the version stamped
 	// into the snapshot. CLI fills these from version.go; tests
@@ -149,7 +154,7 @@ func Build(ctx context.Context, opts Options) (Snapshot, error) {
 	// Policy reporting (Order 4B) is independent of the audit DB, so
 	// populate it before any DB-dependent early return below — the
 	// block must appear on every snapshot a 4B+ node emits.
-	policySec, policyWarnings := buildPolicySection(opts.PolicyBundlePath)
+	policySec, policyWarnings := buildPolicySection(opts.PolicyBundlePath, opts.PolicyTrustFingerprint)
 	snap.Policy = policySec
 	snap.Warnings = append(snap.Warnings, policyWarnings...)
 


### PR DESCRIPTION
## What

The node can now verify the signature on a local policy bundle and report whether it came from a **trusted** policy key. `active_policy_verified` becomes a real `true`/`false` instead of always-`false`, and a new `active_policy_verification_status` reports which check decided it.

```
oktsec node snapshot --policy-bundle <path> --policy-trust-fingerprint sha256:<hex> --json
```

## How

- **Trust anchor is a fingerprint, not a key file.** The bundle carries its own public key; the node derives the fingerprint from it, checks it against the configured `--policy-trust-fingerprint`, and verifies the Ed25519 signature over the declared policy hash. No keystore, no key-file management.
- **Verification is signature-only and reporting-only.** "verified" means exactly: the signature over the declared policy hash verified against a trusted key. It does **not** recompute the policy body hash and does **not** apply the policy.

## Verification states

`active_policy_verification_status` is one of:

| Status | Meaning |
|---|---|
| `verified` | signature verified against the configured trust fingerprint |
| `no_trust_anchor` | bundle present, no `--policy-trust-fingerprint` given |
| `signing_key_mismatch` | bundle's signing-key fingerprint != configured |
| `signature_invalid` | signature did not verify |
| `bundle_unreadable` | bundle could not be read/parsed |
| `unsupported_bundle` | parsed but no usable signature block / unknown shape |

The status is reported **alongside** the existing hash comparison, never folded into it (a node can be `matches_desired` + `verified:false` + `no_trust_anchor`, which is honest).

## Contract guard

The field is additive on `node_snapshot.v1` (`active_policy_verification_status`, omitempty). A real signed `policy_bundle.v1` fixture is embedded and verified in the tests, so the node's signing-payload reconstruction cannot drift from the signer without CI failing.

## Tests

State-machine coverage for all six statuses + the embedded-fixture contract guard. Verified end-to-end against the built binary (`verified` / `no_trust_anchor` / `signing_key_mismatch`). `make build && test && lint && vet` green.

## Out of scope

No policy apply, no enforcement, no body-hash recompute, no automated trust-anchor distribution (the operator configures the fingerprint). The consumer-side surfacing of these fields ships next.