### PR TITLE
Add strict policy_bundle.v1 verifier for apply

### DIFF
--- a/internal/policybundle/canonical.go
+++ b/internal/policybundle/canonical.go
@@ -1,0 +1,89 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// canonicalPolicyBodyBytes returns the exact byte layout that policy_hash
+// and the Ed25519 signature cover: a typed-struct JSON projection of the
+// body, HTML escaping off, no trailing newline. Encoding the typed struct
+// (never a map[string]any) fixes field order; map keys serialize
+// alphabetically under encoding/json, so Rules.Overrides is deterministic.
+//
+// Metadata.created_at is UTC-normalized: a value that parses as RFC3339 is
+// rewritten to its UTC form, so two bundles that wrote the same instant in
+// different timezones canonicalize identically. A value that does not parse
+// is left as-is.
+func canonicalPolicyBodyBytes(body PolicyBody) ([]byte, error) {
+	body.Metadata.CreatedAt = normalizeRFC3339OrKeep(body.Metadata.CreatedAt)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body); err != nil {
+		return nil, fmt.Errorf("encode canonical body: %w", err)
+	}
+	// Encode appends a trailing newline; strip it so the hashed bytes are
+	// exactly the marshaled JSON.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// policyHashHex returns the sha256 hex of the canonical body bytes with
+// the "sha256:" wire prefix, plus the canonical bytes themselves.
+func policyHashHex(body PolicyBody) (string, []byte, error) {
+	canon, err := canonicalPolicyBodyBytes(body)
+	if err != nil {
+		return "", nil, err
+	}
+	sum := sha256.Sum256(canon)
+	return "sha256:" + hex.EncodeToString(sum[:]), canon, nil
+}
+
+// policyBundleSigningPayload returns the exact bytes the Ed25519 signature
+// covers: domain-separated labeled lines, newline-joined, no trailing
+// newline. The header and the bundle_version / canonicalization tags make
+// the payload schema-specific so two artifacts sharing free-form values
+// cannot collide across schemas. key_id and the public key fingerprint are
+// part of the payload — bound by the signature — so they cannot be
+// rewritten after signing. The signer and this verifier MUST produce
+// identical bytes or every signature fails to verify.
+func policyBundleSigningPayload(policyID, policyVersion, policyHash, signedAt, keyID, publicKeyFingerprint string) []byte {
+	lines := []string{
+		"oktsec." + SchemaVersion,
+		fmt.Sprintf("bundle_version:%d", BundleVersion),
+		"policy_id:" + policyID,
+		"policy_version:" + policyVersion,
+		"policy_hash:" + policyHash,
+		"canonicalization:" + Canonicalization,
+		"signed_at:" + signedAt,
+		"signature_key_id:" + keyID,
+		"signature_public_key_fingerprint:" + publicKeyFingerprint,
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// publicKeyFingerprint is the policy_bundle.v1 key fingerprint format:
+// sha256:<64-hex> over the raw Ed25519 public key bytes.
+func publicKeyFingerprint(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// normalizeRFC3339OrKeep rewrites a timestamp to UTC if it parses as
+// RFC3339, otherwise returns it verbatim.
+func normalizeRFC3339OrKeep(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return s
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/policybundle/canonical.go
+++ b/internal/policybundle/canonical.go
@@ -77,13 +77,21 @@ func publicKeyFingerprint(pub ed25519.PublicKey) string {
 
 // normalizeRFC3339OrKeep rewrites a timestamp to UTC if it parses as
 // RFC3339, otherwise returns it verbatim.
+//
+// Precision is preserved with RFC3339Nano: a fractional-second timestamp
+// keeps its fraction in the canonical bytes. Formatting through plain
+// RFC3339 would drop the fraction, so a signed body could be edited from
+// "…00Z" to "…00.999Z" without changing the recomputed hash — a body
+// mutation the apply verifier must catch. Whole-second timestamps carry no
+// fraction, so RFC3339Nano emits them exactly as RFC3339 would and the hash
+// of an unmodified bundle is unchanged.
 func normalizeRFC3339OrKeep(s string) string {
 	if s == "" {
 		return ""
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return s
 	}
-	return t.UTC().Format(time.RFC3339)
+	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/internal/policybundle/canonical.go
+++ b/internal/policybundle/canonical.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -17,12 +18,13 @@ import (
 // (never a map[string]any) fixes field order; map keys serialize
 // alphabetically under encoding/json, so Rules.Overrides is deterministic.
 //
-// Metadata.created_at is UTC-normalized: a value that parses as RFC3339 is
-// rewritten to its UTC form, so two bundles that wrote the same instant in
-// different timezones canonicalize identically. A value that does not parse
-// is left as-is.
+// Timestamps are NOT normalized here. The verifier hashes the exact wire
+// strings (per the policy_bundle.v1 canonicalization amendment): a verifier
+// must not make tampered bytes disappear by parsing and reformatting them.
+// The signer is responsible for embedding canonical timestamp strings;
+// validateCanonicalPolicyTimestamp enforces the single accepted form before
+// the hash is recomputed.
 func canonicalPolicyBodyBytes(body PolicyBody) ([]byte, error) {
-	body.Metadata.CreatedAt = normalizeRFC3339OrKeep(body.Metadata.CreatedAt)
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
@@ -32,6 +34,28 @@ func canonicalPolicyBodyBytes(body PolicyBody) ([]byte, error) {
 	// Encode appends a trailing newline; strip it so the hashed bytes are
 	// exactly the marshaled JSON.
 	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// canonicalTimestamp is the single accepted policy_bundle.v1 timestamp wire
+// form: UTC, seconds precision, uppercase T and Z, exactly 20 bytes. No
+// fractional seconds, no offsets, no lowercase variants.
+var canonicalTimestamp = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`)
+
+// validateCanonicalPolicyTimestamp rejects any timestamp string that is not
+// the single canonical wire form. It first checks the exact byte shape
+// (which alone rejects fractional seconds, offsets, lowercase t/z, and wrong
+// length), then parses to reject impossible calendar values and leap-second
+// ":60". It returns no replacement string: the caller hashes and signs the
+// original wire bytes, so there is no "same instant" equivalence class —
+// a byte-different timestamp is a different artifact.
+func validateCanonicalPolicyTimestamp(s string) error {
+	if !canonicalTimestamp.MatchString(s) {
+		return fmt.Errorf("not canonical YYYY-MM-DDTHH:MM:SSZ form: %q", s)
+	}
+	if _, err := time.Parse("2006-01-02T15:04:05Z", s); err != nil {
+		return fmt.Errorf("not a valid UTC timestamp: %q", s)
+	}
+	return nil
 }
 
 // policyHashHex returns the sha256 hex of the canonical body bytes with
@@ -73,25 +97,4 @@ func policyBundleSigningPayload(policyID, policyVersion, policyHash, signedAt, k
 func publicKeyFingerprint(pub ed25519.PublicKey) string {
 	sum := sha256.Sum256(pub)
 	return "sha256:" + hex.EncodeToString(sum[:])
-}
-
-// normalizeRFC3339OrKeep rewrites a timestamp to UTC if it parses as
-// RFC3339, otherwise returns it verbatim.
-//
-// Precision is preserved with RFC3339Nano: a fractional-second timestamp
-// keeps its fraction in the canonical bytes. Formatting through plain
-// RFC3339 would drop the fraction, so a signed body could be edited from
-// "…00Z" to "…00.999Z" without changing the recomputed hash — a body
-// mutation the apply verifier must catch. Whole-second timestamps carry no
-// fraction, so RFC3339Nano emits them exactly as RFC3339 would and the hash
-// of an unmodified bundle is unchanged.
-func normalizeRFC3339OrKeep(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339Nano, s)
-	if err != nil {
-		return s
-	}
-	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/internal/policybundle/policy_bundle_v1_fixture.json
+++ b/internal/policybundle/policy_bundle_v1_fixture.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "policy_bundle.v1",
+  "bundle_version": 1,
+  "policy_hash": "sha256:264cc6da2c81c68bdee9f9e69e73c27e32201b466beb05eaa2b42326d148b267",
+  "canonicalization": "oktsec-policy-v1-typed-utc-json",
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "mode": "enforce",
+    "rules": {
+      "enabled": [
+        "IAP-001",
+        "IAP-003",
+        "IAP-007"
+      ],
+      "disabled": [
+        "IAP-004"
+      ],
+      "overrides": {
+        "IAP-007": {
+          "action": "block"
+        }
+      }
+    },
+    "gateway": {
+      "tools_allowed": [
+        "calendar.read",
+        "voice.dial"
+      ],
+      "tools_denied": [
+        "shell.exec"
+      ]
+    },
+    "egress": {
+      "domains_allowed": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "domains_denied": [
+        "*.suspicious.example"
+      ]
+    },
+    "redaction": {
+      "level": "analyst"
+    },
+    "metadata": {
+      "created_at": "2026-05-23T12:00:00Z",
+      "created_by": "fixture-generator",
+      "reason": "Vendored test fixture for policy_bundle.v1 schema drift guard."
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "key_id": "enterprise-policy-fixture-v1",
+    "public_key": "6wccwmxHEVCpqZIobQWgBSqk872OmPUjQcUegTXuQj0=",
+    "public_key_fingerprint": "sha256:a6e0388bec0afcaa6a83463bcad7b0d37078263e163c58d56e03eb6b08d15dcc",
+    "signed_at": "2026-05-23T12:00:01Z",
+    "value": "7CjuiG4myt7uipoAYLOEUbBGUUyS/C4w3FMiVucZGkPSoqjJNE+s1PUDkbZ1FdwseWuJrya4f5r7571Vb9MtBg=="
+  }
+}

--- a/internal/policybundle/types.go
+++ b/internal/policybundle/types.go
@@ -1,0 +1,102 @@
+// Package policybundle verifies a signed policy_bundle.v1 artifact
+// strongly enough to apply it to the local Oktsec runtime config.
+//
+// This is stricter than the snapshot-time verification a node does when
+// it reports an active policy. Reporting verification authenticates the
+// signature over the bundle's declared policy hash. Apply verification
+// additionally recomputes the policy hash from the bundle body and
+// requires the signing key's fingerprint to match an operator-supplied
+// trust fingerprint, so a bundle is never trusted for apply merely
+// because it is present on disk.
+//
+// The package owns the policy_bundle.v1 wire contract on the Community
+// side: the typed body layout, the canonicalization, and the
+// domain-separated signing payload. A vendored signed fixture guards
+// these bytes against drift — if any of them diverge from the contract
+// the fixture's signature stops verifying, which is the right failure
+// mode. It imports nothing outside the standard library.
+package policybundle
+
+// Frozen constants of the policy_bundle.v1 signing contract. A change to
+// any of these is a contract change: it must be matched on the signing
+// side, and the vendored fixture must be regenerated. Drift here surfaces
+// as a broken signature on every bundle.
+const (
+	SchemaVersion    = "policy_bundle.v1"
+	BundleVersion    = 1
+	Canonicalization = "oktsec-policy-v1-typed-utc-json"
+	SignatureAlg     = "Ed25519"
+)
+
+// PolicyBundle is the signed JSON artifact: the outer envelope carries
+// the declared hash and the signature; the inner PolicyBody is the
+// signed content.
+type PolicyBundle struct {
+	SchemaVersion    string          `json:"schema_version"`
+	BundleVersion    int             `json:"bundle_version"`
+	PolicyHash       string          `json:"policy_hash"`
+	Canonicalization string          `json:"canonicalization"`
+	Policy           PolicyBody      `json:"policy"`
+	Signature        PolicySignature `json:"signature"`
+}
+
+// PolicyBody is the content covered by policy_hash and the Ed25519
+// signature. The field order IS the canonical projection order: the
+// signed bytes are produced by encoding this struct exactly as declared.
+// Never reorder these fields or change a json tag without changing
+// Canonicalization and regenerating the fixture.
+type PolicyBody struct {
+	PolicyID      string          `json:"policy_id"`
+	PolicyVersion string          `json:"policy_version"`
+	Mode          string          `json:"mode"`
+	Rules         PolicyRules     `json:"rules"`
+	Gateway       PolicyGateway   `json:"gateway"`
+	Egress        PolicyEgress    `json:"egress"`
+	Redaction     PolicyRedaction `json:"redaction"`
+	Metadata      PolicyMetadata  `json:"metadata"`
+}
+
+// PolicyRules is the rule-ID layer. Overrides keys map a rule id to its
+// action; map keys serialize alphabetically under encoding/json, so the
+// canonical bytes are deterministic without explicit sorting.
+type PolicyRules struct {
+	Enabled   []string                      `json:"enabled"`
+	Disabled  []string                      `json:"disabled"`
+	Overrides map[string]PolicyRuleOverride `json:"overrides"`
+}
+
+type PolicyRuleOverride struct {
+	Action string `json:"action"`
+}
+
+type PolicyGateway struct {
+	ToolsAllowed []string `json:"tools_allowed"`
+	ToolsDenied  []string `json:"tools_denied"`
+}
+
+type PolicyEgress struct {
+	DomainsAllowed []string `json:"domains_allowed"`
+	DomainsDenied  []string `json:"domains_denied"`
+}
+
+type PolicyRedaction struct {
+	Level string `json:"level"`
+}
+
+type PolicyMetadata struct {
+	CreatedAt string `json:"created_at"`
+	CreatedBy string `json:"created_by"`
+	Reason    string `json:"reason"`
+}
+
+// PolicySignature carries the Ed25519 signature and the key material the
+// signing payload binds. key_id and public_key_fingerprint are covered by
+// the signature, so they cannot be rewritten post-sign without breaking it.
+type PolicySignature struct {
+	Alg                  string `json:"alg"`
+	KeyID                string `json:"key_id"`
+	PublicKey            string `json:"public_key"`
+	PublicKeyFingerprint string `json:"public_key_fingerprint"`
+	SignedAt             string `json:"signed_at"`
+	Value                string `json:"value"`
+}

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -1,0 +1,176 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// RejectCode is the stable machine reason a bundle failed apply
+// verification. Callers branch on it via errors.As to a *RejectError.
+type RejectCode string
+
+const (
+	RejectDecode             RejectCode = "policy_decode"
+	RejectSchemaInvalid      RejectCode = "policy_schema_invalid"
+	RejectHashMismatch       RejectCode = "policy_hash_mismatch"
+	RejectSigningKeyMismatch RejectCode = "policy_signing_key_mismatch"
+	RejectSignatureInvalid   RejectCode = "policy_signature_invalid"
+	RejectUnsupportedBundle  RejectCode = "policy_unsupported_bundle"
+)
+
+// RejectError is a structured bundle-verification failure carrying the
+// stable RejectCode plus an operator-facing message.
+type RejectError struct {
+	Code RejectCode
+	Msg  string
+}
+
+func (e *RejectError) Error() string { return string(e.Code) + ": " + e.Msg }
+
+func reject(code RejectCode, format string, args ...any) error {
+	return &RejectError{Code: code, Msg: fmt.Sprintf(format, args...)}
+}
+
+// ErrTrustFingerprintRequired is a usage error, not a bundle reject:
+// apply verification is meaningless without a trust anchor to compare the
+// signing key against. A bundle is never trusted for apply just because it
+// is present on disk.
+var ErrTrustFingerprintRequired = errors.New("policybundle: a trust fingerprint is required to verify a bundle for apply")
+
+// VerifiedBundle is the typed result of a successful VerifyBundle. The
+// caller gets the decoded bundle, the recomputed canonical body bytes, the
+// recomputed policy hash, the matched key fingerprint, and the
+// UTC-normalized signed_at.
+type VerifiedBundle struct {
+	Bundle           *PolicyBundle
+	CanonicalBody    []byte
+	PolicyHash       string
+	TrustFingerprint string
+	SignedAtUTC      string
+}
+
+// VerifyBundle decodes and verifies a signed policy_bundle.v1 strongly
+// enough to apply it. It is the contract authority on the Community side:
+// it re-runs every cryptographic check rather than trusting any field the
+// artifact declares about itself.
+//
+// Checks fire in a fixed order so the first failure is the cheapest,
+// most-informative one:
+//
+//  1. strict JSON decode + EOF (rejects unknown fields and trailing tokens)
+//  2. schema_version / bundle_version / canonicalization / signature.alg
+//  3. body re-canonicalization + policy hash recompute (catches any
+//     tampering of the signed body — the check reporting verification omits)
+//  4. signature public key shape (base64 + Ed25519 length)
+//  5. signature self-consistency (sha256(public_key) == claimed fingerprint)
+//  6. trust fingerprint match (the operator's apply trust decision)
+//  7. signed_at RFC3339 parse + UTC normalize
+//  8. Ed25519 verify over the canonical signing payload, using the
+//     normalized signed_at and the bound key_id + fingerprint
+//
+// Steps 3 (hash recompute) and 6 (trust match) are what make this stricter
+// than snapshot-time reporting verification.
+func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) {
+	if trustFingerprint == "" {
+		return nil, ErrTrustFingerprintRequired
+	}
+
+	// (1) strict decode + EOF.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var b PolicyBundle
+	if err := dec.Decode(&b); err != nil {
+		return nil, reject(RejectDecode, "decode: %s", err)
+	}
+	var trailing json.RawMessage
+	switch err := dec.Decode(&trailing); {
+	case errors.Is(err, io.EOF):
+		// clean termination — the only acceptable path
+	case err == nil:
+		return nil, reject(RejectDecode, "trailing JSON content after the bundle")
+	default:
+		return nil, reject(RejectDecode, "trailing content after the bundle: %s", err)
+	}
+
+	// (2) schema constant tags.
+	switch {
+	case b.SchemaVersion != SchemaVersion:
+		return nil, reject(RejectSchemaInvalid, "schema_version=%q, want %q", b.SchemaVersion, SchemaVersion)
+	case b.BundleVersion != BundleVersion:
+		return nil, reject(RejectSchemaInvalid, "bundle_version=%d, want %d", b.BundleVersion, BundleVersion)
+	case b.Canonicalization != Canonicalization:
+		return nil, reject(RejectSchemaInvalid, "canonicalization=%q, want %q", b.Canonicalization, Canonicalization)
+	case b.Signature.Alg != SignatureAlg:
+		return nil, reject(RejectSchemaInvalid, "signature.alg=%q, want %q", b.Signature.Alg, SignatureAlg)
+	}
+
+	// (3) re-canonicalize the body and recompute the hash. A tampered
+	// body keeps a well-formed signature block but no longer matches the
+	// bytes that signature commits to.
+	computed, canonical, err := policyHashHex(b.Policy)
+	if err != nil {
+		return nil, reject(RejectSchemaInvalid, "canonicalize body: %s", err)
+	}
+	if computed != b.PolicyHash {
+		return nil, reject(RejectHashMismatch, "claimed=%s computed=%s", b.PolicyHash, computed)
+	}
+
+	// (4) public key shape.
+	pub, err := base64.StdEncoding.DecodeString(b.Signature.PublicKey)
+	if err != nil {
+		return nil, reject(RejectUnsupportedBundle, "signature.public_key base64 decode: %s", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, reject(RejectUnsupportedBundle, "signature.public_key length=%d, want %d", len(pub), ed25519.PublicKeySize)
+	}
+
+	// (5) self-consistency: the embedded key must hash to the fingerprint
+	// the bundle claims for it. A mismatch is an internally inconsistent
+	// artifact, a distinct failure class from a wrong trust anchor.
+	derivedFP := publicKeyFingerprint(ed25519.PublicKey(pub))
+	if derivedFP != b.Signature.PublicKeyFingerprint {
+		return nil, reject(RejectUnsupportedBundle,
+			"signature.public_key_fingerprint claimed=%s computed=%s", b.Signature.PublicKeyFingerprint, derivedFP)
+	}
+
+	// (6) trust fingerprint match — the operator's apply trust decision.
+	if derivedFP != trustFingerprint {
+		return nil, reject(RejectSigningKeyMismatch,
+			"bundle signing key %s does not match trust fingerprint %s", derivedFP, trustFingerprint)
+	}
+
+	// (7) signed_at parse + UTC normalize. The payload is reconstructed
+	// with the UTC form, so a bundle signed in a non-UTC offset still
+	// verifies; an unparseable signed_at cannot form a payload at all.
+	signedAt, err := time.Parse(time.RFC3339, b.Signature.SignedAt)
+	if err != nil {
+		return nil, reject(RejectSignatureInvalid, "signature.signed_at not RFC3339: %s", err)
+	}
+	signedAtUTC := signedAt.UTC().Format(time.RFC3339)
+
+	// (8) signature value + Ed25519 verify over the canonical payload.
+	sigBytes, err := base64.StdEncoding.DecodeString(b.Signature.Value)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, reject(RejectSignatureInvalid, "signature.value is not a valid Ed25519 signature")
+	}
+	payload := policyBundleSigningPayload(
+		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
+		signedAtUTC, b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
+	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigBytes) {
+		return nil, reject(RejectSignatureInvalid, "signature does not verify over the policy_bundle.v1 signing payload")
+	}
+
+	return &VerifiedBundle{
+		Bundle:           &b,
+		CanonicalBody:    canonical,
+		PolicyHash:       computed,
+		TrustFingerprint: derivedFP,
+		SignedAtUTC:      signedAtUTC,
+	}, nil
+}

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 )
 
 // RejectCode is the stable machine reason a bundle failed apply
@@ -65,17 +64,20 @@ type VerifiedBundle struct {
 //
 //  1. strict JSON decode + EOF (rejects unknown fields and trailing tokens)
 //  2. schema_version / bundle_version / canonicalization / signature.alg
-//  3. body re-canonicalization + policy hash recompute (catches any
-//     tampering of the signed body — the check reporting verification omits)
-//  4. signature public key shape (base64 + Ed25519 length)
-//  5. signature self-consistency (sha256(public_key) == claimed fingerprint)
-//  6. trust fingerprint match (the operator's apply trust decision)
-//  7. signed_at RFC3339 parse + UTC normalize
-//  8. Ed25519 verify over the canonical signing payload, using the
-//     normalized signed_at and the bound key_id + fingerprint
+//  3. timestamp canonical-form checks (created_at, signed_at) — one
+//     canonical wire form, no equivalence class
+//  4. body re-canonicalization + policy hash recompute over exact wire
+//     strings (catches any tampering of the signed body — the check
+//     reporting verification omits)
+//  5. signature public key shape (base64 + Ed25519 length)
+//  6. signature self-consistency (sha256(public_key) == claimed fingerprint)
+//  7. trust fingerprint match (the operator's apply trust decision)
+//  8. Ed25519 verify over the canonical signing payload, binding the exact
+//     wire signed_at and the bound key_id + fingerprint
 //
-// Steps 3 (hash recompute) and 6 (trust match) are what make this stricter
-// than snapshot-time reporting verification.
+// Steps 4 (hash recompute) and 7 (trust match) are what make this stricter
+// than snapshot-time reporting verification; step 3 enforces that timestamps
+// have exactly one canonical wire form (no parse/reformat normalization).
 func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) {
 	if trustFingerprint == "" {
 		return nil, ErrTrustFingerprintRequired
@@ -110,9 +112,26 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectSchemaInvalid, "signature.alg=%q, want %q", b.Signature.Alg, SignatureAlg)
 	}
 
-	// (3) re-canonicalize the body and recompute the hash. A tampered
-	// body keeps a well-formed signature block but no longer matches the
-	// bytes that signature commits to.
+	// (3) timestamp canonical-form checks. policy_bundle.v1 has exactly one
+	// timestamp wire form; there is no "same instant" equivalence class at
+	// verification time. A byte-different but parseable timestamp (fractional
+	// seconds, an offset, lowercase t/z) is rejected here as a schema/
+	// canonicalization failure, before the hash is recomputed — so even a
+	// self-consistent bundle signed with a non-canonical timestamp is
+	// refused. created_at is optional; signed_at is required.
+	if ca := b.Policy.Metadata.CreatedAt; ca != "" {
+		if err := validateCanonicalPolicyTimestamp(ca); err != nil {
+			return nil, reject(RejectSchemaInvalid, "policy.metadata.created_at %s", err)
+		}
+	}
+	if err := validateCanonicalPolicyTimestamp(b.Signature.SignedAt); err != nil {
+		return nil, reject(RejectSchemaInvalid, "signature.signed_at %s", err)
+	}
+
+	// (4) re-canonicalize the body and recompute the hash from the EXACT
+	// wire strings (no timestamp normalization). A tampered body keeps a
+	// well-formed signature block but no longer matches the bytes that
+	// signature commits to.
 	computed, canonical, err := policyHashHex(b.Policy)
 	if err != nil {
 		return nil, reject(RejectSchemaInvalid, "canonicalize body: %s", err)
@@ -121,7 +140,7 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectHashMismatch, "claimed=%s computed=%s", b.PolicyHash, computed)
 	}
 
-	// (4) public key shape.
+	// (5) public key shape.
 	pub, err := base64.StdEncoding.DecodeString(b.Signature.PublicKey)
 	if err != nil {
 		return nil, reject(RejectUnsupportedBundle, "signature.public_key base64 decode: %s", err)
@@ -130,7 +149,7 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectUnsupportedBundle, "signature.public_key length=%d, want %d", len(pub), ed25519.PublicKeySize)
 	}
 
-	// (5) self-consistency: the embedded key must hash to the fingerprint
+	// (6) self-consistency: the embedded key must hash to the fingerprint
 	// the bundle claims for it. A mismatch is an internally inconsistent
 	// artifact, a distinct failure class from a wrong trust anchor.
 	derivedFP := publicKeyFingerprint(ed25519.PublicKey(pub))
@@ -139,27 +158,16 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 			"signature.public_key_fingerprint claimed=%s computed=%s", b.Signature.PublicKeyFingerprint, derivedFP)
 	}
 
-	// (6) trust fingerprint match — the operator's apply trust decision.
+	// (7) trust fingerprint match — the operator's apply trust decision.
 	if derivedFP != trustFingerprint {
 		return nil, reject(RejectSigningKeyMismatch,
 			"bundle signing key %s does not match trust fingerprint %s", derivedFP, trustFingerprint)
 	}
 
-	// (7) signed_at must be a well-formed RFC3339 timestamp.
-	signedAt, err := time.Parse(time.RFC3339, b.Signature.SignedAt)
-	if err != nil {
-		return nil, reject(RejectSignatureInvalid, "signature.signed_at not RFC3339: %s", err)
-	}
-
-	// (8) signature value + Ed25519 verify over the canonical payload.
-	// The payload binds signature.signed_at as the EXACT wire bytes, not a
-	// reparsed/reformatted form: reformatting through RFC3339 would silently
-	// drop fractional seconds (and any other precision the signer covered),
-	// letting an edited signed_at still verify. Using the wire bytes means
-	// any post-sign edit of signed_at breaks the signature. The signer
-	// normalizes signed_at before writing it, so the field already equals
-	// the value it signed. SignedAtUTC below is a convenience for callers
-	// and is never part of the verified payload.
+	// (8) signature value + Ed25519 verify over the canonical payload. The
+	// payload binds signature.signed_at as the EXACT wire bytes (already
+	// validated canonical in step 3): it is never parsed and reformatted, so
+	// any edit to signed_at breaks the signature.
 	sigBytes, err := base64.StdEncoding.DecodeString(b.Signature.Value)
 	if err != nil || len(sigBytes) != ed25519.SignatureSize {
 		return nil, reject(RejectSignatureInvalid, "signature.value is not a valid Ed25519 signature")
@@ -171,11 +179,12 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectSignatureInvalid, "signature does not verify over the policy_bundle.v1 signing payload")
 	}
 
+	// signed_at is already canonical UTC seconds (step 3); expose it verbatim.
 	return &VerifiedBundle{
 		Bundle:           &b,
 		CanonicalBody:    canonical,
 		PolicyHash:       computed,
 		TrustFingerprint: derivedFP,
-		SignedAtUTC:      signedAt.UTC().Format(time.RFC3339Nano),
+		SignedAtUTC:      b.Signature.SignedAt,
 	}, nil
 }

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -176,6 +176,6 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		CanonicalBody:    canonical,
 		PolicyHash:       computed,
 		TrustFingerprint: derivedFP,
-		SignedAtUTC:      signedAt.UTC().Format(time.RFC3339),
+		SignedAtUTC:      signedAt.UTC().Format(time.RFC3339Nano),
 	}, nil
 }

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -145,23 +145,28 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 			"bundle signing key %s does not match trust fingerprint %s", derivedFP, trustFingerprint)
 	}
 
-	// (7) signed_at parse + UTC normalize. The payload is reconstructed
-	// with the UTC form, so a bundle signed in a non-UTC offset still
-	// verifies; an unparseable signed_at cannot form a payload at all.
+	// (7) signed_at must be a well-formed RFC3339 timestamp.
 	signedAt, err := time.Parse(time.RFC3339, b.Signature.SignedAt)
 	if err != nil {
 		return nil, reject(RejectSignatureInvalid, "signature.signed_at not RFC3339: %s", err)
 	}
-	signedAtUTC := signedAt.UTC().Format(time.RFC3339)
 
 	// (8) signature value + Ed25519 verify over the canonical payload.
+	// The payload binds signature.signed_at as the EXACT wire bytes, not a
+	// reparsed/reformatted form: reformatting through RFC3339 would silently
+	// drop fractional seconds (and any other precision the signer covered),
+	// letting an edited signed_at still verify. Using the wire bytes means
+	// any post-sign edit of signed_at breaks the signature. The signer
+	// normalizes signed_at before writing it, so the field already equals
+	// the value it signed. SignedAtUTC below is a convenience for callers
+	// and is never part of the verified payload.
 	sigBytes, err := base64.StdEncoding.DecodeString(b.Signature.Value)
 	if err != nil || len(sigBytes) != ed25519.SignatureSize {
 		return nil, reject(RejectSignatureInvalid, "signature.value is not a valid Ed25519 signature")
 	}
 	payload := policyBundleSigningPayload(
 		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
-		signedAtUTC, b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
+		b.Signature.SignedAt, b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
 	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigBytes) {
 		return nil, reject(RejectSignatureInvalid, "signature does not verify over the policy_bundle.v1 signing payload")
 	}
@@ -171,6 +176,6 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		CanonicalBody:    canonical,
 		PolicyHash:       computed,
 		TrustFingerprint: derivedFP,
-		SignedAtUTC:      signedAtUTC,
+		SignedAtUTC:      signedAt.UTC().Format(time.RFC3339),
 	}, nil
 }

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 )
 
 // fixtureBytes is a deterministically signed policy_bundle.v1 produced by
@@ -128,6 +129,23 @@ func TestVerify_SelfInconsistentKey(t *testing.T) {
 	})
 	_, err := VerifyBundle(raw, fp)
 	wantReject(t, err, RejectUnsupportedBundle)
+}
+
+func TestVerify_CreatedAtFractionIsCovered(t *testing.T) {
+	_, fp := loadFixture(t)
+	// Adding a fractional second to metadata.created_at within the same
+	// second must change the canonical body (and thus the recomputed hash).
+	// A RFC3339-truncating canonicalizer would drop the fraction and still
+	// verify — this guards that the fraction is part of the hashed bytes.
+	raw := remarshal(t, func(b *PolicyBundle) {
+		ts, err := time.Parse(time.RFC3339, b.Policy.Metadata.CreatedAt)
+		if err != nil {
+			t.Fatalf("fixture created_at not RFC3339: %v", err)
+		}
+		b.Policy.Metadata.CreatedAt = ts.Add(500 * time.Millisecond).Format(time.RFC3339Nano)
+	})
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
 }
 
 func TestVerify_SignedAtIsBound(t *testing.T) {

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -1,0 +1,184 @@
+package policybundle
+
+import (
+	"crypto/ed25519"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// fixtureBytes is a deterministically signed policy_bundle.v1 produced by
+// the upstream signer, vendored verbatim. It is embedded (not placed under
+// the gitignored testdata/) so it ships with the package and guards the
+// canonicalization + signing payload against drift on every CI run.
+//
+//go:embed policy_bundle_v1_fixture.json
+var fixtureBytes []byte
+
+// loadFixture returns the vendored fixture and its self-declared trust
+// fingerprint.
+func loadFixture(t *testing.T) (raw []byte, trustFP string) {
+	t.Helper()
+	var b PolicyBundle
+	if err := json.Unmarshal(fixtureBytes, &b); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	return fixtureBytes, b.Signature.PublicKeyFingerprint
+}
+
+// remarshal mutates the fixture's typed form and returns valid JSON the
+// strict verifier accepts structurally (so a check past decode can fire).
+func remarshal(t *testing.T, mutate func(b *PolicyBundle)) []byte {
+	t.Helper()
+	raw, _ := loadFixture(t)
+	var b PolicyBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	mutate(&b)
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}
+
+func wantReject(t *testing.T, err error, code RejectCode) {
+	t.Helper()
+	var re *RejectError
+	if !errors.As(err, &re) {
+		t.Fatalf("error %v is not a *RejectError", err)
+	}
+	if re.Code != code {
+		t.Fatalf("reject code = %q, want %q (%s)", re.Code, code, re.Msg)
+	}
+}
+
+func TestVerify_FixtureVerifies(t *testing.T) {
+	raw, fp := loadFixture(t)
+	v, err := VerifyBundle(raw, fp)
+	if err != nil {
+		t.Fatalf("fixture must verify: %v", err)
+	}
+	if v.Bundle.PolicyHash != v.PolicyHash {
+		t.Fatalf("declared %s != recomputed %s", v.Bundle.PolicyHash, v.PolicyHash)
+	}
+	if len(v.CanonicalBody) == 0 {
+		t.Fatal("canonical body must be returned")
+	}
+	if v.TrustFingerprint != fp {
+		t.Fatalf("trust fingerprint = %q, want %q", v.TrustFingerprint, fp)
+	}
+}
+
+// TestVerify_HashMatchesContract is the anti-drift guard: the Community
+// canonicalizer must reproduce, byte-for-byte, the policy hash the signer
+// declared. If the canonicalization diverges this fails.
+func TestVerify_HashMatchesContract(t *testing.T) {
+	raw, _ := loadFixture(t)
+	var b PolicyBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	computed, _, err := policyHashHex(b.Policy)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	if computed != b.PolicyHash {
+		t.Fatalf("canonicalizer drift: declared=%s computed=%s", b.PolicyHash, computed)
+	}
+}
+
+func TestVerify_TamperedBody(t *testing.T) {
+	_, fp := loadFixture(t)
+	// Change a signed body field; the declared hash + signature stay, so
+	// the recomputed hash no longer matches.
+	raw := remarshal(t, func(b *PolicyBundle) { b.Policy.Mode = "observe" })
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+func TestVerify_SignatureMismatch(t *testing.T) {
+	_, fp := loadFixture(t)
+	raw := remarshal(t, func(b *PolicyBundle) {
+		sig, _ := base64.StdEncoding.DecodeString(b.Signature.Value)
+		sig[0] ^= 0xff // flip a byte: valid shape, wrong signature
+		b.Signature.Value = base64.StdEncoding.EncodeToString(sig)
+	})
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectSignatureInvalid)
+}
+
+func TestVerify_WrongTrustFingerprint(t *testing.T) {
+	raw, _ := loadFixture(t)
+	// A real, self-consistent bundle but the operator's trust anchor is a
+	// different key.
+	other := publicKeyFingerprint(make(ed25519.PublicKey, ed25519.PublicKeySize))
+	_, err := VerifyBundle(raw, other)
+	wantReject(t, err, RejectSigningKeyMismatch)
+}
+
+func TestVerify_SelfInconsistentKey(t *testing.T) {
+	_, fp := loadFixture(t)
+	// Claimed fingerprint no longer matches the embedded public key.
+	raw := remarshal(t, func(b *PolicyBundle) {
+		b.Signature.PublicKeyFingerprint = publicKeyFingerprint(make(ed25519.PublicKey, ed25519.PublicKeySize))
+	})
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectUnsupportedBundle)
+}
+
+func TestVerify_SchemaInvalid(t *testing.T) {
+	_, fp := loadFixture(t)
+	raw := remarshal(t, func(b *PolicyBundle) { b.SchemaVersion = "policy_bundle.v2" })
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+}
+
+func TestVerify_UnknownField(t *testing.T) {
+	raw, fp := loadFixture(t)
+	// Inject an unknown top-level field; strict decode must refuse it.
+	injected := append([]byte(`{"x_unknown_field": 1,`), raw[1:]...)
+	_, err := VerifyBundle(injected, fp)
+	wantReject(t, err, RejectDecode)
+}
+
+func TestVerify_TrailingJSON(t *testing.T) {
+	raw, fp := loadFixture(t)
+	withTrailing := append(append([]byte{}, raw...), []byte("\n{}\n")...)
+	_, err := VerifyBundle(withTrailing, fp)
+	wantReject(t, err, RejectDecode)
+}
+
+func TestVerify_EmptyTrustIsUsageError(t *testing.T) {
+	raw, _ := loadFixture(t)
+	_, err := VerifyBundle(raw, "")
+	if !errors.Is(err, ErrTrustFingerprintRequired) {
+		t.Fatalf("empty trust fingerprint must be a usage error, got %v", err)
+	}
+	var re *RejectError
+	if errors.As(err, &re) {
+		t.Fatal("empty trust fingerprint must not be a bundle reject code")
+	}
+}
+
+// TestSigningPayload_Stable locks the cross-repo byte layout of the
+// signing payload. The signer and this verifier must agree exactly.
+func TestSigningPayload_Stable(t *testing.T) {
+	got := string(policyBundleSigningPayload(
+		"voice-ai-prod", "1", "sha256:abc", "2026-01-01T00:00:00Z", "kid", "sha256:fp"))
+	want := "oktsec.policy_bundle.v1\n" +
+		"bundle_version:1\n" +
+		"policy_id:voice-ai-prod\n" +
+		"policy_version:1\n" +
+		"policy_hash:sha256:abc\n" +
+		"canonicalization:oktsec-policy-v1-typed-utc-json\n" +
+		"signed_at:2026-01-01T00:00:00Z\n" +
+		"signature_key_id:kid\n" +
+		"signature_public_key_fingerprint:sha256:fp"
+	if got != want {
+		t.Fatalf("signing payload layout drift:\n got=%q\nwant=%q", got, want)
+	}
+}

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -130,6 +130,18 @@ func TestVerify_SelfInconsistentKey(t *testing.T) {
 	wantReject(t, err, RejectUnsupportedBundle)
 }
 
+func TestVerify_SignedAtIsBound(t *testing.T) {
+	_, fp := loadFixture(t)
+	// Editing signed_at after signing — even adding fractional seconds the
+	// RFC3339 reformatter would have dropped — must break verification,
+	// because the signature binds the exact signed_at bytes.
+	raw := remarshal(t, func(b *PolicyBundle) {
+		b.Signature.SignedAt = "2099-01-01T00:00:00.500Z"
+	})
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectSignatureInvalid)
+}
+
 func TestVerify_SchemaInvalid(t *testing.T) {
 	_, fp := loadFixture(t)
 	raw := remarshal(t, func(b *PolicyBundle) { b.SchemaVersion = "policy_bundle.v2" })

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 )
 
 // fixtureBytes is a deterministically signed policy_bundle.v1 produced by
@@ -54,6 +53,18 @@ func wantReject(t *testing.T, err error, code RejectCode) {
 	}
 	if re.Code != code {
 		t.Fatalf("reject code = %q, want %q (%s)", re.Code, code, re.Msg)
+	}
+}
+
+// wantRejectMsg is wantReject with a case label for table-driven tests.
+func wantRejectMsg(t *testing.T, err error, code RejectCode, label string) {
+	t.Helper()
+	var re *RejectError
+	if !errors.As(err, &re) {
+		t.Fatalf("[%s] error %v is not a *RejectError", label, err)
+	}
+	if re.Code != code {
+		t.Fatalf("[%s] reject code = %q, want %q (%s)", label, re.Code, code, re.Msg)
 	}
 }
 
@@ -131,31 +142,55 @@ func TestVerify_SelfInconsistentKey(t *testing.T) {
 	wantReject(t, err, RejectUnsupportedBundle)
 }
 
-func TestVerify_CreatedAtFractionIsCovered(t *testing.T) {
+// nonCanonicalTimestamps are byte-different-but-equivalent (or invalid)
+// timestamp strings that policy_bundle.v1 must reject. There is exactly one
+// canonical wire form (YYYY-MM-DDTHH:MM:SSZ); everything else is a
+// schema/canonicalization failure, not a signature failure.
+var nonCanonicalTimestamps = []string{
+	"2026-05-23T12:00:00.000Z",        // fractional seconds (zeroes)
+	"2026-05-23T12:00:00.999Z",        // fractional seconds
+	"2026-05-23T12:00:00.0000000001Z", // more than 9 fractional digits
+	"2026-05-23T09:00:00-03:00",       // offset form (equivalent instant)
+	"2026-05-23t12:00:00Z",            // lowercase separator
+	"2026-05-23T12:00:00z",            // lowercase zone
+	"2026-05-23T12:00:60Z",            // leap second / invalid time
+	"2026-02-30T12:00:00Z",            // invalid calendar date
+}
+
+func TestVerify_NonCanonicalCreatedAtRejected(t *testing.T) {
 	_, fp := loadFixture(t)
-	// Adding a fractional second to metadata.created_at within the same
-	// second must change the canonical body (and thus the recomputed hash).
-	// A RFC3339-truncating canonicalizer would drop the fraction and still
-	// verify — this guards that the fraction is part of the hashed bytes.
-	raw := remarshal(t, func(b *PolicyBundle) {
-		ts, err := time.Parse(time.RFC3339, b.Policy.Metadata.CreatedAt)
-		if err != nil {
-			t.Fatalf("fixture created_at not RFC3339: %v", err)
-		}
-		b.Policy.Metadata.CreatedAt = ts.Add(500 * time.Millisecond).Format(time.RFC3339Nano)
-	})
+	for _, ts := range nonCanonicalTimestamps {
+		raw := remarshal(t, func(b *PolicyBundle) { b.Policy.Metadata.CreatedAt = ts })
+		_, err := VerifyBundle(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "created_at "+ts)
+	}
+}
+
+func TestVerify_NonCanonicalSignedAtRejected(t *testing.T) {
+	_, fp := loadFixture(t)
+	for _, ts := range nonCanonicalTimestamps {
+		raw := remarshal(t, func(b *PolicyBundle) { b.Signature.SignedAt = ts })
+		_, err := VerifyBundle(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "signed_at "+ts)
+	}
+}
+
+// A canonical-but-different created_at second passes the form check, so the
+// body hash recompute must catch it (the hash covers exact wire bytes, with
+// no normalization that could fold two values together).
+func TestVerify_CanonicalCreatedAtChangeIsHashMismatch(t *testing.T) {
+	_, fp := loadFixture(t)
+	raw := remarshal(t, func(b *PolicyBundle) { b.Policy.Metadata.CreatedAt = "2030-01-01T00:00:00Z" })
 	_, err := VerifyBundle(raw, fp)
 	wantReject(t, err, RejectHashMismatch)
 }
 
-func TestVerify_SignedAtIsBound(t *testing.T) {
+// A canonical-but-different signed_at second passes the form check and does
+// not affect the body hash, so the signature (which binds the exact wire
+// signed_at) must fail.
+func TestVerify_CanonicalSignedAtChangeBreaksSignature(t *testing.T) {
 	_, fp := loadFixture(t)
-	// Editing signed_at after signing — even adding fractional seconds the
-	// RFC3339 reformatter would have dropped — must break verification,
-	// because the signature binds the exact signed_at bytes.
-	raw := remarshal(t, func(b *PolicyBundle) {
-		b.Signature.SignedAt = "2099-01-01T00:00:00.500Z"
-	})
+	raw := remarshal(t, func(b *PolicyBundle) { b.Signature.SignedAt = "2030-01-01T00:00:00Z" })
 	_, err := VerifyBundle(raw, fp)
 	wantReject(t, err, RejectSignatureInvalid)
 }


### PR DESCRIPTION
First slice of local policy apply (7A.1). Adds `internal/policybundle`: a
standard-library-only verifier that validates a signed `policy_bundle.v1`
strongly enough to apply it to the local runtime config. **Verification
only** — no apply, no config writes, no new commands.

## Why this is stricter than snapshot reporting
Snapshot-time verification authenticates the signature over the bundle's
**declared** policy hash. Applying a policy needs more, so `VerifyBundle`
additionally:

- strict-decodes the bundle (unknown fields **and** trailing JSON rejected)
- checks `schema_version` / `bundle_version` / `canonicalization` /
  `signature.alg`
- **recomputes** the policy hash from the canonical body and requires it to
  match the declared hash (catches body tampering)
- requires the signing key fingerprint to match an operator-supplied
  **trust fingerprint** — a bundle is never trusted for apply just because
  it is on disk

## API
`VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error)`
returns a typed result or a structured `*RejectError` with a stable
`RejectCode`: `policy_decode`, `policy_schema_invalid`,
`policy_hash_mismatch`, `policy_signing_key_mismatch`,
`policy_signature_invalid`, `policy_unsupported_bundle`. An empty trust
fingerprint is a usage error (`ErrTrustFingerprintRequired`), not a bundle
reject.

## Anti-drift guard
The package owns the `policy_bundle.v1` wire contract (typed body layout,
canonicalization, domain-separated signing payload). A deterministically
signed fixture is embedded in the package; the hash-recompute test fails if
the canonicalization ever drifts from the contract, and a signing-payload
test locks the exact byte layout.

## Non-goals
No apply, no config mutation, no CLI command, no remote execution. Those are
later slices.

## Tests / gates
fixture verifies; canonical hash matches the declared hash (drift guard);
tampered body → hash_mismatch; corrupted signature → signature_invalid;
wrong trust fingerprint → signing_key_mismatch; self-inconsistent key →
unsupported_bundle; bad schema → schema_invalid; unknown field / trailing
JSON → decode; empty trust → usage error; signing-payload byte layout
locked. `make build && make test && make lint && make vet` all green.

## Risky areas for Codex
- canonicalizer drift (body re-canonicalization vs declared hash)
- hash/signature verification order
- strict decode (unknown fields + trailing tokens)
- trust fingerprint comparison vs self-consistency separation
- no partial verification treated as "verified"