### PR TITLE
policy_bundle.v1 strict apply-acceptance (containers, created_at, duplicate keys, enums)

### DIFF
--- a/internal/policybundle/canonical.go
+++ b/internal/policybundle/canonical.go
@@ -92,6 +92,42 @@ func policyBundleSigningPayload(policyID, policyVersion, policyHash, signedAt, k
 	return []byte(strings.Join(lines, "\n"))
 }
 
+// validateCanonicalPolicyContainers requires every list/map container in the
+// body to be present in its canonical empty form ([] / {}), never null or
+// omitted. The official signer always emits []/{} for empty sections, so the
+// apply verifier refuses a null or absent container as a non-canonical
+// artifact (policy_schema_invalid) rather than silently projecting it — the
+// apply path stays conservative about what it will trust.
+func validateCanonicalPolicyContainers(body PolicyBody) error {
+	var nilFields []string
+	if body.Rules.Enabled == nil {
+		nilFields = append(nilFields, "rules.enabled")
+	}
+	if body.Rules.Disabled == nil {
+		nilFields = append(nilFields, "rules.disabled")
+	}
+	if body.Rules.Overrides == nil {
+		nilFields = append(nilFields, "rules.overrides")
+	}
+	if body.Gateway.ToolsAllowed == nil {
+		nilFields = append(nilFields, "gateway.tools_allowed")
+	}
+	if body.Gateway.ToolsDenied == nil {
+		nilFields = append(nilFields, "gateway.tools_denied")
+	}
+	if body.Egress.DomainsAllowed == nil {
+		nilFields = append(nilFields, "egress.domains_allowed")
+	}
+	if body.Egress.DomainsDenied == nil {
+		nilFields = append(nilFields, "egress.domains_denied")
+	}
+	if len(nilFields) > 0 {
+		return fmt.Errorf("container(s) must be present as [] or {}, not null or omitted: %s",
+			strings.Join(nilFields, ", "))
+	}
+	return nil
+}
+
 // publicKeyFingerprint is the policy_bundle.v1 key fingerprint format:
 // sha256:<64-hex> over the raw Ed25519 public key bytes.
 func publicKeyFingerprint(pub ed25519.PublicKey) string {

--- a/internal/policybundle/schema.go
+++ b/internal/policybundle/schema.go
@@ -1,0 +1,108 @@
+package policybundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// rejectDuplicateKeys walks the JSON token stream and fails if any object
+// anywhere in the bundle declares the same key twice. Go's encoding/json
+// keeps the last duplicate silently, which is unacceptable for a signed
+// artifact that gates apply: a bundle could present one value to a human
+// reviewer (first occurrence) and another to the verifier (last). This runs
+// before the typed decode trusts any field.
+func rejectDuplicateKeys(raw []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	return checkNoDuplicateKeys(dec)
+}
+
+// checkNoDuplicateKeys consumes exactly one JSON value, recursing into
+// objects and arrays. Trailing content after the value is the typed
+// decoder's concern (EOF check), not this scan's.
+func checkNoDuplicateKeys(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil // scalar
+	}
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyTok.(string)
+			if !ok {
+				return fmt.Errorf("object key is not a string")
+			}
+			if _, dup := seen[key]; dup {
+				return fmt.Errorf("duplicate object key %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := checkNoDuplicateKeys(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token() // consume '}'
+		return err
+	case '[':
+		for dec.More() {
+			if err := checkNoDuplicateKeys(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token() // consume ']'
+		return err
+	}
+	return nil
+}
+
+// policy_bundle.v1 enum value sets for fields that are part of the signed
+// policy model. An out-of-set value is policy_schema_invalid: the verifier
+// must not label a bundle "verified" with a mode/action/level the v1 schema
+// does not define, since apply (or a reader) could otherwise fail open.
+var (
+	validModes           = map[string]bool{"enforce": true, "observe": true}
+	validOverrideActions = map[string]bool{"flag": true, "quarantine": true, "block": true}
+	validRedactionLevels = map[string]bool{"full": true, "analyst": true, "external": true}
+)
+
+// validatePolicySchema enforces required-non-empty scalar fields and the
+// signed-model enum value sets. Returns an error (mapped to
+// policy_schema_invalid by the caller) on the first violation. Container
+// presence and timestamp canonical form are validated separately. Fields
+// already covered by other checks are not re-validated here: schema/
+// canonicalization/alg tags (constant checks), policy_hash (hash recompute),
+// signed_at/created_at (timestamp checks), public_key/fingerprint/value
+// (signature checks).
+func validatePolicySchema(b *PolicyBundle) error {
+	for _, f := range []struct{ name, val string }{
+		{"policy.policy_id", b.Policy.PolicyID},
+		{"policy.policy_version", b.Policy.PolicyVersion},
+		{"policy.metadata.created_by", b.Policy.Metadata.CreatedBy},
+		{"policy.metadata.reason", b.Policy.Metadata.Reason},
+		{"signature.key_id", b.Signature.KeyID},
+	} {
+		if f.val == "" {
+			return fmt.Errorf("%s must not be empty", f.name)
+		}
+	}
+	if !validModes[b.Policy.Mode] {
+		return fmt.Errorf("policy.mode %q not in {enforce, observe}", b.Policy.Mode)
+	}
+	if !validRedactionLevels[b.Policy.Redaction.Level] {
+		return fmt.Errorf("policy.redaction.level %q not in {full, analyst, external}", b.Policy.Redaction.Level)
+	}
+	for id, ov := range b.Policy.Rules.Overrides {
+		if !validOverrideActions[ov.Action] {
+			return fmt.Errorf("policy.rules.overrides[%q].action %q not in {flag, quarantine, block}", id, ov.Action)
+		}
+	}
+	return nil
+}

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -112,20 +112,25 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectSchemaInvalid, "signature.alg=%q, want %q", b.Signature.Alg, SignatureAlg)
 	}
 
-	// (3) timestamp canonical-form checks. policy_bundle.v1 has exactly one
-	// timestamp wire form; there is no "same instant" equivalence class at
-	// verification time. A byte-different but parseable timestamp (fractional
-	// seconds, an offset, lowercase t/z) is rejected here as a schema/
-	// canonicalization failure, before the hash is recomputed — so even a
-	// self-consistent bundle signed with a non-canonical timestamp is
-	// refused. created_at is optional; signed_at is required.
-	if ca := b.Policy.Metadata.CreatedAt; ca != "" {
-		if err := validateCanonicalPolicyTimestamp(ca); err != nil {
-			return nil, reject(RejectSchemaInvalid, "policy.metadata.created_at %s", err)
-		}
+	// (3) canonical-form checks: timestamps and containers. policy_bundle.v1
+	// has exactly one timestamp wire form, and one canonical empty container
+	// form ([] / {}) — there is no "same instant" or "null == []" equivalence
+	// class at verification time. A byte-different but parseable timestamp
+	// (fractional seconds, offset, lowercase t/z) or a null/omitted container
+	// is rejected here as a schema/canonicalization failure, before the hash
+	// is recomputed, so even a self-consistent bundle signed in a
+	// non-canonical form is refused. created_at and signed_at are both
+	// required and must be canonical (a struct decode cannot distinguish a
+	// missing created_at from an empty one, so empty is rejected — which
+	// covers both).
+	if err := validateCanonicalPolicyTimestamp(b.Policy.Metadata.CreatedAt); err != nil {
+		return nil, reject(RejectSchemaInvalid, "policy.metadata.created_at %s", err)
 	}
 	if err := validateCanonicalPolicyTimestamp(b.Signature.SignedAt); err != nil {
 		return nil, reject(RejectSchemaInvalid, "signature.signed_at %s", err)
+	}
+	if err := validateCanonicalPolicyContainers(b.Policy); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
 	}
 
 	// (4) re-canonicalize the body and recompute the hash from the EXACT

--- a/internal/policybundle/verify.go
+++ b/internal/policybundle/verify.go
@@ -63,9 +63,12 @@ type VerifiedBundle struct {
 // most-informative one:
 //
 //  1. strict JSON decode + EOF (rejects unknown fields and trailing tokens)
+//     and duplicate-object-key rejection
 //  2. schema_version / bundle_version / canonicalization / signature.alg
-//  3. timestamp canonical-form checks (created_at, signed_at) — one
-//     canonical wire form, no equivalence class
+//  3. canonical-form + schema checks (all policy_schema_invalid): timestamps
+//     (created_at, signed_at) in the single canonical wire form; containers
+//     present as []/{} not null; required scalar fields non-empty; signed-
+//     model enums (mode, redaction.level, override actions) in range
 //  4. body re-canonicalization + policy hash recompute over exact wire
 //     strings (catches any tampering of the signed body — the check
 //     reporting verification omits)
@@ -76,8 +79,9 @@ type VerifiedBundle struct {
 //     wire signed_at and the bound key_id + fingerprint
 //
 // Steps 4 (hash recompute) and 7 (trust match) are what make this stricter
-// than snapshot-time reporting verification; step 3 enforces that timestamps
-// have exactly one canonical wire form (no parse/reformat normalization).
+// than snapshot-time reporting verification; step 3 enforces that the
+// artifact is in exactly the canonical form the official signer emits (no
+// equivalence classes, no fail-open enum values).
 func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) {
 	if trustFingerprint == "" {
 		return nil, ErrTrustFingerprintRequired
@@ -98,6 +102,13 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectDecode, "trailing JSON content after the bundle")
 	default:
 		return nil, reject(RejectDecode, "trailing content after the bundle: %s", err)
+	}
+
+	// Duplicate object keys: encoding/json keeps the last value silently, so
+	// a signed bundle could show one value to a reader and another to the
+	// verifier. Reject before trusting any field.
+	if err := rejectDuplicateKeys(raw); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
 	}
 
 	// (2) schema constant tags.
@@ -130,6 +141,9 @@ func VerifyBundle(raw []byte, trustFingerprint string) (*VerifiedBundle, error) 
 		return nil, reject(RejectSchemaInvalid, "signature.signed_at %s", err)
 	}
 	if err := validateCanonicalPolicyContainers(b.Policy); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
+	}
+	if err := validatePolicySchema(&b); err != nil {
 		return nil, reject(RejectSchemaInvalid, "%s", err)
 	}
 

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -175,6 +175,35 @@ func TestVerify_NonCanonicalSignedAtRejected(t *testing.T) {
 	}
 }
 
+func TestVerify_NullContainersRejected(t *testing.T) {
+	_, fp := loadFixture(t)
+	// The signer always emits []/{} for empty sections; a null or omitted
+	// container is non-canonical and must be refused, not silently projected.
+	cases := map[string]func(*PolicyBundle){
+		"rules.enabled":          func(b *PolicyBundle) { b.Policy.Rules.Enabled = nil },
+		"rules.disabled":         func(b *PolicyBundle) { b.Policy.Rules.Disabled = nil },
+		"rules.overrides":        func(b *PolicyBundle) { b.Policy.Rules.Overrides = nil },
+		"gateway.tools_allowed":  func(b *PolicyBundle) { b.Policy.Gateway.ToolsAllowed = nil },
+		"gateway.tools_denied":   func(b *PolicyBundle) { b.Policy.Gateway.ToolsDenied = nil },
+		"egress.domains_allowed": func(b *PolicyBundle) { b.Policy.Egress.DomainsAllowed = nil },
+		"egress.domains_denied":  func(b *PolicyBundle) { b.Policy.Egress.DomainsDenied = nil },
+	}
+	for name, mut := range cases {
+		raw := remarshal(t, mut)
+		_, err := VerifyBundle(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "null "+name)
+	}
+}
+
+func TestVerify_EmptyCreatedAtRejected(t *testing.T) {
+	_, fp := loadFixture(t)
+	// created_at is required and must be canonical; empty (and, indistinguishably,
+	// omitted) is a schema failure.
+	raw := remarshal(t, func(b *PolicyBundle) { b.Policy.Metadata.CreatedAt = "" })
+	_, err := VerifyBundle(raw, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+}
+
 // A canonical-but-different created_at second passes the form check, so the
 // body hash recompute must catch it (the hash covers exact wire bytes, with
 // no normalization that could fold two values together).

--- a/internal/policybundle/verify_test.go
+++ b/internal/policybundle/verify_test.go
@@ -6,8 +6,21 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
+
+// bytesReplaceOnce replaces the first occurrence of old in raw, failing if
+// it is absent — keeps the tamper tests honest about what they edit.
+func bytesReplaceOnce(t *testing.T, raw []byte, old, replacement string) []byte {
+	t.Helper()
+	s := string(raw)
+	i := strings.Index(s, old)
+	if i < 0 {
+		t.Fatalf("fixture missing %q", old)
+	}
+	return []byte(s[:i] + replacement + s[i+len(old):])
+}
 
 // fixtureBytes is a deterministically signed policy_bundle.v1 produced by
 // the upstream signer, vendored verbatim. It is embedded (not placed under
@@ -192,6 +205,53 @@ func TestVerify_NullContainersRejected(t *testing.T) {
 		raw := remarshal(t, mut)
 		_, err := VerifyBundle(raw, fp)
 		wantRejectMsg(t, err, RejectSchemaInvalid, "null "+name)
+	}
+}
+
+func TestVerify_DuplicateKeysRejected(t *testing.T) {
+	raw, fp := loadFixture(t)
+	// Prepend a conflicting duplicate of a signed field. encoding/json would
+	// keep the last value silently; the verifier must reject the duplicate.
+	dup := append([]byte(`{"policy_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",`), raw[1:]...)
+	_, err := VerifyBundle(dup, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+
+	// Duplicate nested inside policy.metadata is also rejected.
+	nested := bytesReplaceOnce(t, raw, `"created_by"`, `"created_by":"x","created_by"`)
+	_, err = VerifyBundle(nested, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+}
+
+func TestVerify_InvalidEnumsRejected(t *testing.T) {
+	_, fp := loadFixture(t)
+	cases := map[string]func(*PolicyBundle){
+		"mode":            func(b *PolicyBundle) { b.Policy.Mode = "enforced" },
+		"mode empty":      func(b *PolicyBundle) { b.Policy.Mode = "" },
+		"redaction.level": func(b *PolicyBundle) { b.Policy.Redaction.Level = "externl" },
+		"override.action": func(b *PolicyBundle) {
+			b.Policy.Rules.Overrides = map[string]PolicyRuleOverride{"IAP-001": {Action: "warn"}}
+		},
+	}
+	for name, mut := range cases {
+		raw := remarshal(t, mut)
+		_, err := VerifyBundle(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "enum "+name)
+	}
+}
+
+func TestVerify_RequiredScalarsRejected(t *testing.T) {
+	_, fp := loadFixture(t)
+	cases := map[string]func(*PolicyBundle){
+		"policy_id":           func(b *PolicyBundle) { b.Policy.PolicyID = "" },
+		"policy_version":      func(b *PolicyBundle) { b.Policy.PolicyVersion = "" },
+		"metadata.created_by": func(b *PolicyBundle) { b.Policy.Metadata.CreatedBy = "" },
+		"metadata.reason":     func(b *PolicyBundle) { b.Policy.Metadata.Reason = "" },
+		"signature.key_id":    func(b *PolicyBundle) { b.Signature.KeyID = "" },
+	}
+	for name, mut := range cases {
+		raw := remarshal(t, mut)
+		_, err := VerifyBundle(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "empty "+name)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #192 (merged at the round-5 state). Closes the canonicalization/
schema gaps Codex flagged in rounds 5 and 6, implemented in one pass against
the **Policy Bundle v1 Canonicalization and Strict Apply Acceptance
Amendment**.

#192 went in carrying these gaps; this PR brings `internal/policybundle` to
the full strict apply-acceptance contract so the verifier accepts only the
canonical artifact the official signer emits — no equivalence classes, no
fail-open shapes.

## What this adds on top of #192
- **Canonical containers**: list/map sections must be present as `[]`/`{}`;
  `null` or omitted (rules.enabled/disabled/overrides, gateway.tools_*,
  egress.domains_*) is `policy_schema_invalid`. No silent coercion.
- **Required fields**: `metadata.created_at` required + canonical; plus
  non-empty `policy_id`, `policy_version`, `metadata.created_by`,
  `metadata.reason`, `signature.key_id`.
- **Duplicate JSON keys**: a token-stream scan rejects any object that
  declares a key twice, anywhere in the bundle (encoding/json silently keeps
  the last value — a bundle could show one value to a reader, another to the
  verifier).
- **Signed-model enums**: `mode` (enforce|observe), `redaction.level`
  (full|analyst|external), `rules.overrides[*].action`
  (flag|quarantine|block) must be in range.

All of these are `policy_schema_invalid`, in the canonical-form/schema step
before hash recompute. Timestamp strictness (no verifier-side normalization,
exact wire bytes) was already in #192. 7A.2 dry-run remains responsible only
for values valid in v1 but unsupported by the narrow apply projection.

## Context: stop-and-respec history
7A.1 was stopped after repeated timestamp-canonicalization P2s and resumed
only after the canonicalization amendment. It stopped again at round 6 when
duplicate-key and enum P2s surfaced outside the then-current contract; the
owner extended the amendment to the full strict apply-acceptance contract,
and this PR implements rounds 5 + 6 together rather than patching
review-by-review. The verifier now treats timestamps as strict wire-format
fields (YYYY-MM-DDTHH:MM:SSZ only, no normalization) and hashes/signs exact
bundle strings.

## Non-goals
No apply, no config writes, no commands. Enterprise signer/verifier must
align separately (amendment §9) or the repos drift.

## Tests / gates
20 package tests: fixture verifies; tamper/hash/signature/trust/self-
consistency; non-canonical created_at + signed_at tables; null containers
(7 fields); duplicate keys (top-level + nested); invalid enums; empty
required scalars; canonical-but-different second → hash_mismatch /
signature_invalid; signing-payload byte layout locked. make build/test/lint/
vet green.

## Risky areas for Codex
- duplicate-key scan correctness (nested objects/arrays, key types)
- enum/required-field coverage vs amendment §6.3–§6.4
- no verifier-side timestamp normalization remains
- hash + signing payload use exact bundle strings
- reject codes: schema vs signature classification