### PR TITLE
chore: gitignore local operator config backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Binary (only at root, not cmd/oktsec/)
 /oktsec
 /oktsec.yaml
+# Local operator config backups — may contain real secrets, never commit.
+# (oktsec.yaml.example is the tracked sample and is intentionally not ignored.)
+/oktsec.yaml.bak
+/oktsec.yaml.demo-backup
 *.exe
 dist/
 


### PR DESCRIPTION
Small hygiene chore. Ignore local operator config backups
(`oktsec.yaml.bak`, `oktsec.yaml.demo-backup`) that can contain real
secrets, root-anchored like the existing `/oktsec.yaml`. The tracked sample
`oktsec.yaml.example` is intentionally left visible (the broad
`oktsec.yaml.*` pattern was avoided for that reason).

## Why
While opening the 7A.1 PR, `git add -A` swept untracked local backups into a
commit; GitHub push protection blocked the push because those files held
real secrets. The commit was reset and no allow-secret bypass was used. This
prevents recurrence.

Owner action tracked out of band (assume compromised): rotate the Slack
Incoming Webhook, Anthropic API key, and OpenRouter API key. Process: use
path-specific `git add`, never `git add -A` in this repo.

## Scope
`.gitignore` only. No product code, no `internal/policybundle`, no secret
files touched. Not mixed with 7A.2 or the Enterprise alignment.