### PR TITLE
Add oktsec policy apply --dry-run (local policy projection)

### DIFF
--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -1,0 +1,150 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/oktsec/oktsec/internal/apply"
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+	"github.com/oktsec/oktsec/internal/safefile"
+	"github.com/spf13/cobra"
+)
+
+// maxPolicyBundleApplyBytes caps the signed bundle file the apply path reads.
+const maxPolicyBundleApplyBytes = 1 << 20 // 1 MiB
+
+// newPolicyCmd builds `oktsec policy`. Order 7A.2 ships `apply --dry-run`:
+// it verifies a signed policy_bundle.v1 and projects its supported subset
+// onto the local config in memory, reporting the exact changes WITHOUT
+// writing anything. The safe in-place write lands in a later slice.
+func newPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Apply signed policy bundles to the local Oktsec runtime config",
+	}
+	cmd.AddCommand(newPolicyApplyCmd())
+	return cmd
+}
+
+func newPolicyApplyCmd() *cobra.Command {
+	var (
+		bundlePath   string
+		trustFP      string
+		configPath   string
+		agent        string
+		dryRun       bool
+		jsonOut      bool
+		allowPartial bool
+	)
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Project a signed policy bundle onto the local config (dry-run)",
+		Long: "Verify a signed policy_bundle.v1 against a trust fingerprint and project its " +
+			"supported subset (rules globally; gateway tools and egress for one --agent) onto " +
+			"the local config. Order 7A.2 supports --dry-run only: it computes and validates the " +
+			"target config in memory and prints the exact changes, writing nothing.",
+		Example: "  oktsec policy apply --bundle voice-ai-prod.signed.json \\\n" +
+			"    --trust-fingerprint sha256:<policy-key-fp> --config oktsec.yaml \\\n" +
+			"    --agent voice-ai --dry-run --json",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !dryRun {
+				return fmt.Errorf("policy apply currently supports --dry-run only (in-place apply lands in a later release)")
+			}
+			if agent == "" {
+				return fmt.Errorf("--agent <name> is required (apply targets exactly one agent for gateway/egress scope)")
+			}
+			if bundlePath == "" {
+				return fmt.Errorf("--bundle <path> is required")
+			}
+			if trustFP == "" {
+				return fmt.Errorf("--trust-fingerprint sha256:<fp> is required")
+			}
+
+			if err := safefile.RejectSymlink(bundlePath); err != nil {
+				return fmt.Errorf("bundle path not usable: %w", err)
+			}
+			raw, err := safefile.ReadFileMax(bundlePath, maxPolicyBundleApplyBytes)
+			if err != nil {
+				return fmt.Errorf("read bundle: %w", err)
+			}
+
+			v, verr := policybundle.VerifyBundle(raw, trustFP)
+			if verr != nil {
+				return emitApplyFailure(cmd, jsonOut, verr)
+			}
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config %q: %w", configPath, err)
+			}
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("current config %q is invalid: %w", configPath, err)
+			}
+
+			plan, perr := apply.DryRun(v, cfg, agent, configPath)
+			if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
+				// Missing agent or an invalid projected config: no plan to show.
+				return emitApplyFailure(cmd, jsonOut, perr)
+			}
+			// On ErrUnsupported the plan is non-nil and lists the offending
+			// semantics; print it, then fail unless --allow-partial.
+			emitPlan(cmd, jsonOut, plan)
+			if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
+				return perr
+			}
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&bundlePath, "bundle", "", "path to the signed policy_bundle.v1 JSON")
+	f.StringVar(&trustFP, "trust-fingerprint", "", "sha256:<fp> the bundle's signing key must match")
+	f.StringVar(&configPath, "config", "oktsec.yaml", "path to the Oktsec config to project onto")
+	f.StringVar(&agent, "agent", "", "the single agent gateway/egress changes apply to")
+	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing (required)")
+	f.BoolVar(&jsonOut, "json", false, "emit the plan as JSON")
+	f.BoolVar(&allowPartial, "allow-partial", false, "proceed (exit 0) even when the bundle has unsupported semantics")
+	return cmd
+}
+
+// emitPlan prints the dry-run plan as JSON (when --json) or a short summary.
+func emitPlan(cmd *cobra.Command, jsonOut bool, p *apply.Plan) {
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(p)
+		return
+	}
+	fmt.Fprintf(out, "dry-run: %s v%s (%s) → %s, agent %s\n", p.PolicyID, p.PolicyVersion, p.Mode, p.TargetConfig, p.Agent)
+	fmt.Fprintf(out, "  %d change(s), %d unsupported\n", len(p.Changes), len(p.Unsupported))
+	for _, c := range p.Changes {
+		if c.Kind == "rule_override" {
+			fmt.Fprintf(out, "  - rule %s → %s\n", c.ID, c.Action)
+		} else {
+			fmt.Fprintf(out, "  - %s (agent %s): %d\n", c.Kind, c.Agent, c.Count)
+		}
+	}
+	for _, u := range p.Unsupported {
+		fmt.Fprintf(out, "  ! unsupported: %s — %s\n", u.Kind, u.Detail)
+	}
+}
+
+// emitApplyFailure prints a structured JSON failure (with a stable reject_code
+// for bundle-verification errors) and returns the error so the exit is
+// non-zero.
+func emitApplyFailure(cmd *cobra.Command, jsonOut bool, err error) error {
+	if jsonOut {
+		failure := map[string]any{"applied": false, "dry_run": true, "error": err.Error()}
+		var re *policybundle.RejectError
+		if errors.As(err, &re) {
+			failure["reject_code"] = string(re.Code)
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(failure)
+	}
+	return err
+}

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -32,7 +32,6 @@ func newPolicyApplyCmd() *cobra.Command {
 	var (
 		bundlePath   string
 		trustFP      string
-		configPath   string
 		agent        string
 		dryRun       bool
 		jsonOut      bool
@@ -76,15 +75,21 @@ func newPolicyApplyCmd() *cobra.Command {
 				return emitApplyFailure(cmd, jsonOut, verr)
 			}
 
-			cfg, err := config.Load(configPath)
+			// cfgFile is the root's cascading-resolved config path (honors
+			// --config, $OKTSEC_CONFIG, and the home default) set by
+			// PersistentPreRunE — do not shadow it with a command-local flag.
+			if cfgFile == "" {
+				return fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
+			}
+			cfg, err := config.Load(cfgFile)
 			if err != nil {
-				return fmt.Errorf("load config %q: %w", configPath, err)
+				return fmt.Errorf("load config %q: %w", cfgFile, err)
 			}
 			if err := cfg.Validate(); err != nil {
-				return fmt.Errorf("current config %q is invalid: %w", configPath, err)
+				return fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
 			}
 
-			plan, perr := apply.DryRun(v, cfg, agent, configPath)
+			plan, perr := apply.DryRun(v, cfg, agent, cfgFile)
 			if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
 				// Missing agent or an invalid projected config: no plan to show.
 				return emitApplyFailure(cmd, jsonOut, perr)
@@ -101,7 +106,6 @@ func newPolicyApplyCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&bundlePath, "bundle", "", "path to the signed policy_bundle.v1 JSON")
 	f.StringVar(&trustFP, "trust-fingerprint", "", "sha256:<fp> the bundle's signing key must match")
-	f.StringVar(&configPath, "config", "oktsec.yaml", "path to the Oktsec config to project onto")
 	f.StringVar(&agent, "agent", "", "the single agent gateway/egress changes apply to")
 	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing (required)")
 	f.BoolVar(&jsonOut, "json", false, "emit the plan as JSON")

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -125,9 +125,12 @@ func emitPlan(cmd *cobra.Command, jsonOut bool, p *apply.Plan) {
 	fmt.Fprintf(out, "dry-run: %s v%s (%s) → %s, agent %s\n", p.PolicyID, p.PolicyVersion, p.Mode, p.TargetConfig, p.Agent)
 	fmt.Fprintf(out, "  %d change(s), %d unsupported\n", len(p.Changes), len(p.Unsupported))
 	for _, c := range p.Changes {
-		if c.Kind == "rule_override" {
+		switch c.Kind {
+		case "rule_override":
 			fmt.Fprintf(out, "  - rule %s → %s\n", c.ID, c.Action)
-		} else {
+		case "rule_reset_default":
+			fmt.Fprintf(out, "  - rule %s → severity default (local override removed)\n", c.ID)
+		default:
 			fmt.Fprintf(out, "  - %s (agent %s): %d\n", c.Kind, c.Agent, c.Count)
 		}
 	}

--- a/cmd/oktsec/commands/policy_bundle_v1_fixture.json
+++ b/cmd/oktsec/commands/policy_bundle_v1_fixture.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "policy_bundle.v1",
+  "bundle_version": 1,
+  "policy_hash": "sha256:264cc6da2c81c68bdee9f9e69e73c27e32201b466beb05eaa2b42326d148b267",
+  "canonicalization": "oktsec-policy-v1-typed-utc-json",
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "mode": "enforce",
+    "rules": {
+      "enabled": [
+        "IAP-001",
+        "IAP-003",
+        "IAP-007"
+      ],
+      "disabled": [
+        "IAP-004"
+      ],
+      "overrides": {
+        "IAP-007": {
+          "action": "block"
+        }
+      }
+    },
+    "gateway": {
+      "tools_allowed": [
+        "calendar.read",
+        "voice.dial"
+      ],
+      "tools_denied": [
+        "shell.exec"
+      ]
+    },
+    "egress": {
+      "domains_allowed": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "domains_denied": [
+        "*.suspicious.example"
+      ]
+    },
+    "redaction": {
+      "level": "analyst"
+    },
+    "metadata": {
+      "created_at": "2026-05-23T12:00:00Z",
+      "created_by": "fixture-generator",
+      "reason": "Vendored test fixture for policy_bundle.v1 schema drift guard."
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "key_id": "enterprise-policy-fixture-v1",
+    "public_key": "6wccwmxHEVCpqZIobQWgBSqk872OmPUjQcUegTXuQj0=",
+    "public_key_fingerprint": "sha256:a6e0388bec0afcaa6a83463bcad7b0d37078263e163c58d56e03eb6b08d15dcc",
+    "signed_at": "2026-05-23T12:00:01Z",
+    "value": "7CjuiG4myt7uipoAYLOEUbBGUUyS/C4w3FMiVucZGkPSoqjJNE+s1PUDkbZ1FdwseWuJrya4f5r7571Vb9MtBg=="
+  }
+}

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// policyBundleFixture is a deterministically signed policy_bundle.v1
+// (vendored from the upstream signer) the apply dry-run tests project.
+//
+//go:embed policy_bundle_v1_fixture.json
+var policyBundleFixture []byte
+
+// fixtureTrustFP returns the fixture's self-declared signing fingerprint,
+// which the verifier requires --trust-fingerprint to match.
+func fixtureTrustFP(t *testing.T) string {
+	t.Helper()
+	var b struct {
+		Signature struct {
+			PublicKeyFingerprint string `json:"public_key_fingerprint"`
+		} `json:"signature"`
+	}
+	if err := json.Unmarshal(policyBundleFixture, &b); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	return b.Signature.PublicKeyFingerprint
+}
+
+// writePolicyApplyInputs drops the bundle + a minimal config with a
+// voice-ai agent into a temp dir and returns their paths.
+func writePolicyApplyInputs(t *testing.T) (bundlePath, configPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	bundlePath = filepath.Join(dir, "voice-ai-prod.signed.json")
+	if err := os.WriteFile(bundlePath, policyBundleFixture, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	configPath = filepath.Join(dir, "oktsec.yaml")
+	cfg := []byte("version: \"1\"\nserver:\n  port: 8080\nidentity:\n  require_signature: false\nagents:\n  voice-ai:\n    allowed_tools: [old.tool]\nrules: []\n")
+	if err := os.WriteFile(configPath, cfg, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return bundlePath, configPath
+}
+
+func runPolicyApply(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	cmd := newPolicyCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(append([]string{"apply"}, args...))
+	err := cmd.Execute()
+	var got map[string]any
+	if out.Len() > 0 {
+		_ = json.Unmarshal(out.Bytes(), &got)
+	}
+	return got, err
+}
+
+func TestPolicyApply_DryRunProjectsAndWritesNothing(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--dry-run", "--json",
+	)
+	if err != nil {
+		t.Fatalf("dry-run apply must succeed: %v", err)
+	}
+	if got["applied"] != false || got["dry_run"] != true {
+		t.Fatalf("applied/dry_run = %v/%v, want false/true", got["applied"], got["dry_run"])
+	}
+	if got["policy_id"] == "" || got["policy_hash"] == "" {
+		t.Fatalf("plan missing policy identity: %v", got)
+	}
+	if changes, ok := got["changes"].([]any); !ok || len(changes) == 0 {
+		t.Fatalf("plan must report changes: %v", got["changes"])
+	}
+
+	// The config file must be byte-identical — dry-run writes nothing.
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("dry-run apply modified the config file")
+	}
+}
+
+func TestPolicyApply_RejectsUntrustedBundle(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath,
+		"--trust-fingerprint", "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"--config", configPath, "--agent", "voice-ai", "--dry-run", "--json",
+	)
+	if err == nil {
+		t.Fatal("apply with a wrong trust fingerprint must fail")
+	}
+	if got["reject_code"] != "policy_signing_key_mismatch" {
+		t.Fatalf("reject_code = %v, want policy_signing_key_mismatch", got["reject_code"])
+	}
+}
+
+func TestPolicyApply_RequiresDryRunAndAgent(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	// Missing --dry-run.
+	if _, err := runPolicyApply(t, "--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai"); err == nil {
+		t.Fatal("apply without --dry-run must fail in this release")
+	}
+	// Missing --agent.
+	if _, err := runPolicyApply(t, "--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--dry-run"); err == nil {
+		t.Fatal("apply without --agent must fail")
+	}
+}

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -47,14 +47,17 @@ func writePolicyApplyInputs(t *testing.T) (bundlePath, configPath string) {
 	return bundlePath, configPath
 }
 
+// runPolicyApply runs `oktsec policy apply ...` through the real root command
+// so the persistent --config flag and its cascading resolution
+// (PersistentPreRunE) apply, exactly as in production.
 func runPolicyApply(t *testing.T, args ...string) (map[string]any, error) {
 	t.Helper()
-	cmd := newPolicyCmd()
+	root := NewRoot()
 	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs(append([]string{"apply"}, args...))
-	err := cmd.Execute()
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(append([]string{"policy", "apply"}, args...))
+	err := root.Execute()
 	var got map[string]any
 	if out.Len() > 0 {
 		_ = json.Unmarshal(out.Bytes(), &got)

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -116,5 +116,7 @@ func NewRoot() *cobra.Command {
 	verifyCmd.Hidden = true
 	root.AddCommand(verifyCmd)
 
+	root.AddCommand(newPolicyCmd())
+
 	return root
 }

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -157,27 +157,52 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		plan.Changes = append(plan.Changes, Change{Kind: "rule_override", ID: id, Action: action})
 	}
 
+	// resetToDefault restores a rule to its severity-based default by removing
+	// any local override. Community rules are active by default, so "enabled"
+	// without an override means "enforce at the rule's severity default" — and
+	// the runtime treats a config.rules entry as an override, so leaving (or
+	// adding) an allow-and-flag entry would WEAKEN a high/critical rule instead
+	// of enabling it. Removing a local override is a change; no local override
+	// is already at default and a no-op.
+	resetToDefault := func(id string) {
+		i, ok := idx[id]
+		if !ok {
+			return
+		}
+		target.Rules = append(target.Rules[:i], target.Rules[i+1:]...)
+		delete(idx, id)
+		for j := i; j < len(target.Rules); j++ {
+			idx[target.Rules[j].ID] = j
+		}
+		plan.Changes = append(plan.Changes, Change{Kind: "rule_reset_default", ID: id})
+	}
+
 	enabled := append([]string(nil), body.Rules.Enabled...)
 	sort.Strings(enabled)
 	for _, id := range enabled {
-		// An enabled rule is active and flagged by default; an explicit
-		// override escalates it. Observe mode forces every enabled/overridden
-		// rule down to allow-and-flag (signal without block/quarantine).
-		action := "allow-and-flag"
-		if !observe {
-			if ov, ok := body.Rules.Overrides[id]; ok {
-				m, mok := mapAction(ov.Action)
-				if !mok {
-					plan.Unsupported = append(plan.Unsupported, Unsupported{
-						Kind:   "rule_override_action",
-						Detail: fmt.Sprintf("rule %q has unmappable action %q", id, ov.Action),
-					})
-					continue
-				}
-				action = m
-			}
+		// Observe mode forces every enabled/overridden rule down to
+		// allow-and-flag (signal without block/quarantine) — the explicit,
+		// intended downgrade of observe.
+		if observe {
+			upsert(id, "allow-and-flag")
+			continue
 		}
-		upsert(id, action)
+		// Enforce mode: an explicit override sets the action; without one the
+		// rule runs at its severity default (reset any weakening local override).
+		ov, ok := body.Rules.Overrides[id]
+		if !ok {
+			resetToDefault(id)
+			continue
+		}
+		m, mok := mapAction(ov.Action)
+		if !mok {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "rule_override_action",
+				Detail: fmt.Sprintf("rule %q has unmappable action %q", id, ov.Action),
+			})
+			continue
+		}
+		upsert(id, m)
 	}
 
 	disabled := append([]string(nil), body.Rules.Disabled...)
@@ -218,6 +243,25 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	if agent.Egress != nil {
 		curAllowed, curDenied = agent.Egress.AllowedDomains, agent.Egress.BlockedDomains
 	}
+
+	// The egress resolver UNIONS an agent's allowed_domains with the global
+	// forward_proxy allowlist and any integration presets, so a per-agent
+	// allowlist can only RESTRICT when no wider allow-source exists. With one
+	// present, the bundle's intended restriction can't be expressed here —
+	// refuse rather than emit a config that still permits excluded domains.
+	// (Denied domains are monotonic: a deny is additive and always faithful.)
+	if len(body.Egress.DomainsAllowed) > 0 {
+		widened := len(target.ForwardProxy.AllowedDomains) > 0 ||
+			(agent.Egress != nil && len(agent.Egress.Integrations) > 0)
+		if widened {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_allowed_not_restrictable",
+				Detail: "egress.domains_allowed cannot restrict the agent: a global forward_proxy allowlist or integration preset widens the effective allowlist additively",
+			})
+			body.Egress.DomainsAllowed = nil // do not emit a misleading change
+		}
+	}
+
 	allowedChange := len(body.Egress.DomainsAllowed) > 0 && !slices.Equal(curAllowed, body.Egress.DomainsAllowed)
 	deniedChange := len(body.Egress.DomainsDenied) > 0 && !slices.Equal(curDenied, body.Egress.DomainsDenied)
 	if allowedChange || deniedChange {

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -197,9 +197,30 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		plan.Changes = append(plan.Changes, Change{Kind: "rule_reset_default", ID: id})
 	}
 
-	enabled := append([]string(nil), body.Rules.Enabled...)
-	sort.Strings(enabled)
-	for _, id := range enabled {
+	// The policy governs every rule it enables OR overrides: an override for a
+	// rule not also in enabled is still meaningful (Community rules are active
+	// by default), so it must be projected too — the verifier accepts such a
+	// bundle. Disabled rules win and are handled separately below.
+	disabledSet := make(map[string]struct{}, len(body.Rules.Disabled))
+	for _, id := range body.Rules.Disabled {
+		disabledSet[id] = struct{}{}
+	}
+	governed := make(map[string]struct{}, len(body.Rules.Enabled)+len(body.Rules.Overrides))
+	for _, id := range body.Rules.Enabled {
+		governed[id] = struct{}{}
+	}
+	for id := range body.Rules.Overrides {
+		governed[id] = struct{}{}
+	}
+	active := make([]string, 0, len(governed))
+	for id := range governed {
+		if _, off := disabledSet[id]; off {
+			continue // disabled wins
+		}
+		active = append(active, id)
+	}
+	sort.Strings(active)
+	for _, id := range active {
 		// Observe mode forces every enabled/overridden rule down to
 		// allow-and-flag (signal without block/quarantine) — the explicit,
 		// intended downgrade of observe.
@@ -294,11 +315,30 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		if agent.Egress != nil && len(agent.Egress.Integrations) > 0 {
 			additive = append(additive, config.ResolveIntegrationDomains(agent.Egress.Integrations)...)
 		}
+		// DomainAllowed checks blocked domains BEFORE allowed, so an additively
+		// permitted domain that the policy also denies is still blocked — not a
+		// widening. Effective deny set = bundle domains_denied (replacing the
+		// agent's when present, else the agent's current) ∪ global blocked.
+		denySet := make(map[string]struct{})
+		for _, d := range target.ForwardProxy.BlockedDomains {
+			denySet[d] = struct{}{}
+		}
+		effDenied := body.Egress.DomainsDenied
+		if len(effDenied) == 0 && agent.Egress != nil {
+			effDenied = agent.Egress.BlockedDomains
+		}
+		for _, d := range effDenied {
+			denySet[d] = struct{}{}
+		}
 		var outside []string
 		for _, d := range additive {
-			if _, ok := policySet[d]; !ok {
-				outside = append(outside, d)
+			if _, ok := policySet[d]; ok {
+				continue // within the policy allowlist
 			}
+			if _, denied := denySet[d]; denied {
+				continue // blocked wins — denied regardless of the allowlist
+			}
+			outside = append(outside, d)
 		}
 		if len(outside) > 0 {
 			plan.Unsupported = append(plan.Unsupported, Unsupported{

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -1,0 +1,239 @@
+// Package apply projects a verified policy_bundle.v1 onto the local Oktsec
+// runtime config. Order 7A.2 ships the dry-run projection only: it computes
+// the target config in memory, validates it, and reports the exact changes
+// without writing anything. The safe in-place write (backup + atomic
+// rename) lands in a later slice.
+//
+// Scope of the supported subset (post-6E spec §7-§9): rules are global
+// (enabled / disabled / overrides); gateway tools and egress domains are
+// scoped to a single explicitly-selected --agent. Semantics outside this
+// subset that would change runtime meaning are reported as unsupported and
+// refused by default — never silently applied or ignored.
+//
+// The signed bundle carries the Enterprise policy vocabulary
+// (flag/quarantine/block); the Enterprise→Community action mapping happens
+// here, at projection time, NOT in the bundle.
+package apply
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+	"gopkg.in/yaml.v3"
+)
+
+// Mode values carried by the signed policy body.
+const (
+	ModeEnforce = "enforce"
+	ModeObserve = "observe"
+)
+
+// Sentinels callers branch on.
+var (
+	// ErrMissingAgent: the --agent named is not declared in the config.
+	ErrMissingAgent = errors.New("apply: target agent not found in config")
+	// ErrUnsupported: the bundle declares supported-model semantics the
+	// narrow apply projection cannot express. The returned Plan still lists
+	// them under Unsupported; the caller refuses by default.
+	ErrUnsupported = errors.New("apply: bundle contains semantics not supported by the narrow apply projection")
+)
+
+// mapAction maps an Enterprise override action to a Community rule action.
+// Returns ok=false for an action outside the Enterprise vocabulary (a
+// verified bundle never carries one, but the projection refuses rather than
+// silently mis-mapping).
+func mapAction(enterprise string) (string, bool) {
+	switch enterprise {
+	case "flag":
+		return "allow-and-flag", true
+	case "quarantine":
+		return "quarantine", true
+	case "block":
+		return "block", true
+	default:
+		return "", false
+	}
+}
+
+// Change is one concrete edit the projection would make to the config.
+type Change struct {
+	Kind   string `json:"kind"`
+	ID     string `json:"id,omitempty"`
+	Action string `json:"action,omitempty"`
+	Agent  string `json:"agent,omitempty"`
+	Count  int    `json:"count,omitempty"`
+}
+
+// Unsupported is one supported-model value the narrow projection refuses.
+type Unsupported struct {
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
+}
+
+// Plan is the dry-run result. Its JSON shape is the stable contract.
+type Plan struct {
+	Applied       bool          `json:"applied"`
+	DryRun        bool          `json:"dry_run"`
+	PolicyHash    string        `json:"policy_hash"`
+	PolicyID      string        `json:"policy_id"`
+	PolicyVersion string        `json:"policy_version"`
+	Mode          string        `json:"mode"`
+	TargetConfig  string        `json:"target_config"`
+	Agent         string        `json:"agent"`
+	Changes       []Change      `json:"changes"`
+	Unsupported   []Unsupported `json:"unsupported"`
+
+	projected *config.Config // computed target config; used by a later write slice, not serialized
+}
+
+// Projected returns the in-memory target config the projection computed.
+func (p *Plan) Projected() *config.Config { return p.projected }
+
+// DryRun projects a verified bundle's supported subset onto a copy of cfg,
+// scoped to agentName, writing nothing. Rules are global; gateway tools and
+// egress are scoped to the selected agent. The returned Plan always reflects
+// what would change; DryRun returns ErrUnsupported when the bundle declares
+// semantics the narrow projection cannot express (refuse-by-default), and
+// ErrMissingAgent when the agent is not in the config.
+func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName, targetConfig string) (*Plan, error) {
+	body := verified.Bundle.Policy
+	plan := &Plan{
+		DryRun:        true,
+		PolicyHash:    verified.PolicyHash,
+		PolicyID:      body.PolicyID,
+		PolicyVersion: body.PolicyVersion,
+		Mode:          body.Mode,
+		TargetConfig:  targetConfig,
+		Agent:         agentName,
+		Changes:       []Change{},
+		Unsupported:   []Unsupported{},
+	}
+
+	// Deep-copy so the projection never mutates the loaded config; unrelated
+	// fields are carried over verbatim and preserved in the target.
+	target, err := cloneConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	agent, ok := target.Agents[agentName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrMissingAgent, agentName)
+	}
+
+	observe := body.Mode == ModeObserve
+
+	// --- Rules (global). Upsert by ID so existing rules not named by the
+	// policy are preserved, and an updated rule keeps its other fields
+	// (severity, notify, ...) while only its action changes. ---
+	idx := make(map[string]int, len(target.Rules))
+	for i, ra := range target.Rules {
+		idx[ra.ID] = i
+	}
+	upsert := func(id, action string) {
+		if i, ok := idx[id]; ok {
+			target.Rules[i].Action = action
+		} else {
+			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
+			idx[id] = len(target.Rules) - 1
+		}
+		plan.Changes = append(plan.Changes, Change{Kind: "rule_override", ID: id, Action: action})
+	}
+
+	enabled := append([]string(nil), body.Rules.Enabled...)
+	sort.Strings(enabled)
+	for _, id := range enabled {
+		// An enabled rule is active and flagged by default; an explicit
+		// override escalates it. Observe mode forces every enabled/overridden
+		// rule down to allow-and-flag (signal without block/quarantine).
+		action := "allow-and-flag"
+		if !observe {
+			if ov, ok := body.Rules.Overrides[id]; ok {
+				m, mok := mapAction(ov.Action)
+				if !mok {
+					plan.Unsupported = append(plan.Unsupported, Unsupported{
+						Kind:   "rule_override_action",
+						Detail: fmt.Sprintf("rule %q has unmappable action %q", id, ov.Action),
+					})
+					continue
+				}
+				action = m
+			}
+		}
+		upsert(id, action)
+	}
+
+	disabled := append([]string(nil), body.Rules.Disabled...)
+	sort.Strings(disabled)
+	for _, id := range disabled {
+		upsert(id, "ignore")
+	}
+
+	// --- Gateway tools (agent-scoped). ---
+	switch {
+	case len(body.Gateway.ToolsAllowed) > 0:
+		agent.AllowedTools = append([]string(nil), body.Gateway.ToolsAllowed...)
+		plan.Changes = append(plan.Changes, Change{
+			Kind: "agent_allowed_tools", Agent: agentName, Count: len(agent.AllowedTools)})
+	case len(body.Gateway.ToolsDenied) > 0:
+		// Community gateway control is an allowlist, not a per-agent denylist
+		// over an unknown tool universe; tools_denied without tools_allowed
+		// cannot be expressed.
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "gateway_tools_denied_without_allowlist",
+			Detail: "gateway.tools_denied has no gateway.tools_allowed to project onto a Community agent allowlist",
+		})
+	}
+
+	// --- Egress (agent-scoped). ---
+	if len(body.Egress.DomainsAllowed) > 0 || len(body.Egress.DomainsDenied) > 0 {
+		if agent.Egress == nil {
+			agent.Egress = &config.EgressPolicy{}
+		}
+		if len(body.Egress.DomainsAllowed) > 0 {
+			agent.Egress.AllowedDomains = append([]string(nil), body.Egress.DomainsAllowed...)
+			plan.Changes = append(plan.Changes, Change{
+				Kind: "agent_egress_allowed_domains", Agent: agentName, Count: len(agent.Egress.AllowedDomains)})
+		}
+		if len(body.Egress.DomainsDenied) > 0 {
+			agent.Egress.BlockedDomains = append([]string(nil), body.Egress.DomainsDenied...)
+			plan.Changes = append(plan.Changes, Change{
+				Kind: "agent_egress_denied_domains", Agent: agentName, Count: len(agent.Egress.BlockedDomains)})
+		}
+	}
+
+	target.Agents[agentName] = agent
+
+	// redaction.level and metadata are Enterprise report/display + audit
+	// concerns, not Community runtime settings — intentionally not projected,
+	// and NOT "unsupported": they do not change runtime meaning here.
+
+	// Validate the computed target (the spec's "validate target config").
+	if err := target.Validate(); err != nil {
+		return nil, fmt.Errorf("apply: projected config is invalid: %w", err)
+	}
+	plan.projected = target
+
+	if len(plan.Unsupported) > 0 {
+		return plan, ErrUnsupported
+	}
+	return plan, nil
+}
+
+// cloneConfig deep-copies via a YAML round-trip. Config is entirely
+// yaml-tagged exported fields, so the clone is faithful and lets the
+// projection mutate freely without touching the caller's config.
+func cloneConfig(cfg *config.Config) (*config.Config, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("clone config: %w", err)
+	}
+	var out config.Config
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("clone config: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -134,15 +134,22 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	for i, ra := range target.Rules {
 		idx[ra.ID] = i
 	}
-	// upsert sets a rule's action, recording a change ONLY when it differs
-	// from the current config — a dry-run reports exact changes, so a config
-	// already on this policy shows none.
+	// upsert sets a policy-owned rule's action. Policy rules are GLOBAL: the
+	// signed bundle carries no per-tool rule scoping, so an existing
+	// tool-scoped override (apply_to_tools / exempt_tools) must be widened to
+	// global — otherwise a policy that blocks a rule would silently stay
+	// limited to the previously-scoped tools. Widening is itself a change even
+	// when the action already matches. A dry-run reports exact diffs, so a
+	// rule already global on this action shows none.
 	upsert := func(id, action string) {
 		if i, ok := idx[id]; ok {
-			if target.Rules[i].Action == action {
-				return // already on policy — no change
+			scoped := len(target.Rules[i].ApplyToTools) > 0 || len(target.Rules[i].ExemptTools) > 0
+			if target.Rules[i].Action == action && !scoped {
+				return // already global on policy — no change
 			}
 			target.Rules[i].Action = action
+			target.Rules[i].ApplyToTools = nil
+			target.Rules[i].ExemptTools = nil
 		} else {
 			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
 			idx[id] = len(target.Rules) - 1
@@ -179,7 +186,14 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		upsert(id, "ignore")
 	}
 
-	// --- Gateway tools (agent-scoped). Only a real diff is a change. ---
+	// --- Gateway tools (agent-scoped). The narrow projection is additive
+	// scoping: a non-empty allowlist replaces the agent's tools (a change only
+	// when it actually differs). An empty list means "this policy does not
+	// govern tools" — NOT "clear the allowlist". Canonical bundles always
+	// carry [] for ungoverned dimensions, so treating empty as a clear would
+	// make a rules-only policy silently wipe every agent's tools. Removal is a
+	// distinct semantic the bundle cannot signal and the projection does not
+	// express. ---
 	switch {
 	case len(body.Gateway.ToolsAllowed) > 0:
 		if !slices.Equal(agent.AllowedTools, body.Gateway.ToolsAllowed) {
@@ -197,7 +211,9 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		})
 	}
 
-	// --- Egress (agent-scoped). Only a real diff is a change. ---
+	// --- Egress (agent-scoped). Same additive-scoping rule as gateway tools:
+	// a non-empty domain list replaces the agent's (change only on a real
+	// diff); an empty list is "not governed", never a clear. ---
 	var curAllowed, curDenied []string
 	if agent.Egress != nil {
 		curAllowed, curDenied = agent.Egress.AllowedDomains, agent.Egress.BlockedDomains

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -59,6 +59,26 @@ func mapAction(enterprise string) (string, bool) {
 	}
 }
 
+// subtractTools returns the allowed tools with any denied tool removed,
+// preserving allow order. Deny wins over allow, which the Community allowlist
+// expresses by simply omitting the denied entries.
+func subtractTools(allowed, denied []string) []string {
+	if len(denied) == 0 {
+		return append([]string(nil), allowed...)
+	}
+	deny := make(map[string]struct{}, len(denied))
+	for _, d := range denied {
+		deny[d] = struct{}{}
+	}
+	out := make([]string, 0, len(allowed))
+	for _, a := range allowed {
+		if _, blocked := deny[a]; !blocked {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
 // Change is one concrete edit the projection would make to the config.
 type Change struct {
 	Kind   string `json:"kind"`
@@ -221,10 +241,22 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	// express. ---
 	switch {
 	case len(body.Gateway.ToolsAllowed) > 0:
-		if !slices.Equal(agent.AllowedTools, body.Gateway.ToolsAllowed) {
-			agent.AllowedTools = append([]string(nil), body.Gateway.ToolsAllowed...)
+		// Deny wins over allow: the gateway enforces only AllowedTools, so a
+		// denied tool must be subtracted here or it would stay callable. An
+		// empty result cannot be expressed (a Community empty allowlist means
+		// "all tools allowed"), so refuse rather than silently widen to all.
+		effective := subtractTools(body.Gateway.ToolsAllowed, body.Gateway.ToolsDenied)
+		if len(effective) == 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "gateway_tools_all_denied",
+				Detail: "gateway.tools_denied removes every gateway.tools_allowed entry; a Community empty allowlist means 'all tools', so an empty allowlist cannot be expressed",
+			})
+			break
+		}
+		if !slices.Equal(agent.AllowedTools, effective) {
+			agent.AllowedTools = effective
 			plan.Changes = append(plan.Changes, Change{
-				Kind: "agent_allowed_tools", Agent: agentName, Count: len(agent.AllowedTools)})
+				Kind: "agent_allowed_tools", Agent: agentName, Count: len(effective)})
 		}
 	case len(body.Gateway.ToolsDenied) > 0:
 		// Community gateway control is an allowlist, not a per-agent denylist
@@ -245,18 +277,33 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	}
 
 	// The egress resolver UNIONS an agent's allowed_domains with the global
-	// forward_proxy allowlist and any integration presets, so a per-agent
-	// allowlist can only RESTRICT when no wider allow-source exists. With one
-	// present, the bundle's intended restriction can't be expressed here —
-	// refuse rather than emit a config that still permits excluded domains.
+	// forward_proxy allowlist and any integration presets. Setting the agent's
+	// list to the bundle's yields an effective allowlist of (bundle ∪ global ∪
+	// presets), which equals the bundle's intended restriction ONLY when those
+	// other sources add nothing outside it. If they add a domain the policy
+	// excludes, the restriction can't be expressed here — refuse rather than
+	// emit a config that still permits that domain. Membership is exact: a
+	// non-listed additive domain is treated as outside (conservative).
 	// (Denied domains are monotonic: a deny is additive and always faithful.)
 	if len(body.Egress.DomainsAllowed) > 0 {
-		widened := len(target.ForwardProxy.AllowedDomains) > 0 ||
-			(agent.Egress != nil && len(agent.Egress.Integrations) > 0)
-		if widened {
+		policySet := make(map[string]struct{}, len(body.Egress.DomainsAllowed))
+		for _, d := range body.Egress.DomainsAllowed {
+			policySet[d] = struct{}{}
+		}
+		additive := append([]string(nil), target.ForwardProxy.AllowedDomains...)
+		if agent.Egress != nil && len(agent.Egress.Integrations) > 0 {
+			additive = append(additive, config.ResolveIntegrationDomains(agent.Egress.Integrations)...)
+		}
+		var outside []string
+		for _, d := range additive {
+			if _, ok := policySet[d]; !ok {
+				outside = append(outside, d)
+			}
+		}
+		if len(outside) > 0 {
 			plan.Unsupported = append(plan.Unsupported, Unsupported{
 				Kind:   "agent_egress_allowed_not_restrictable",
-				Detail: "egress.domains_allowed cannot restrict the agent: a global forward_proxy allowlist or integration preset widens the effective allowlist additively",
+				Detail: fmt.Sprintf("egress.domains_allowed cannot restrict the agent: a global forward_proxy allowlist or integration preset additively permits domain(s) outside the policy: %v", outside),
 			})
 			body.Egress.DomainsAllowed = nil // do not emit a misleading change
 		}

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -18,6 +18,7 @@ package apply
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/oktsec/oktsec/internal/config"
@@ -133,8 +134,14 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	for i, ra := range target.Rules {
 		idx[ra.ID] = i
 	}
+	// upsert sets a rule's action, recording a change ONLY when it differs
+	// from the current config — a dry-run reports exact changes, so a config
+	// already on this policy shows none.
 	upsert := func(id, action string) {
 		if i, ok := idx[id]; ok {
+			if target.Rules[i].Action == action {
+				return // already on policy — no change
+			}
 			target.Rules[i].Action = action
 		} else {
 			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
@@ -172,12 +179,14 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		upsert(id, "ignore")
 	}
 
-	// --- Gateway tools (agent-scoped). ---
+	// --- Gateway tools (agent-scoped). Only a real diff is a change. ---
 	switch {
 	case len(body.Gateway.ToolsAllowed) > 0:
-		agent.AllowedTools = append([]string(nil), body.Gateway.ToolsAllowed...)
-		plan.Changes = append(plan.Changes, Change{
-			Kind: "agent_allowed_tools", Agent: agentName, Count: len(agent.AllowedTools)})
+		if !slices.Equal(agent.AllowedTools, body.Gateway.ToolsAllowed) {
+			agent.AllowedTools = append([]string(nil), body.Gateway.ToolsAllowed...)
+			plan.Changes = append(plan.Changes, Change{
+				Kind: "agent_allowed_tools", Agent: agentName, Count: len(agent.AllowedTools)})
+		}
 	case len(body.Gateway.ToolsDenied) > 0:
 		// Community gateway control is an allowlist, not a per-agent denylist
 		// over an unknown tool universe; tools_denied without tools_allowed
@@ -188,17 +197,23 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 		})
 	}
 
-	// --- Egress (agent-scoped). ---
-	if len(body.Egress.DomainsAllowed) > 0 || len(body.Egress.DomainsDenied) > 0 {
+	// --- Egress (agent-scoped). Only a real diff is a change. ---
+	var curAllowed, curDenied []string
+	if agent.Egress != nil {
+		curAllowed, curDenied = agent.Egress.AllowedDomains, agent.Egress.BlockedDomains
+	}
+	allowedChange := len(body.Egress.DomainsAllowed) > 0 && !slices.Equal(curAllowed, body.Egress.DomainsAllowed)
+	deniedChange := len(body.Egress.DomainsDenied) > 0 && !slices.Equal(curDenied, body.Egress.DomainsDenied)
+	if allowedChange || deniedChange {
 		if agent.Egress == nil {
 			agent.Egress = &config.EgressPolicy{}
 		}
-		if len(body.Egress.DomainsAllowed) > 0 {
+		if allowedChange {
 			agent.Egress.AllowedDomains = append([]string(nil), body.Egress.DomainsAllowed...)
 			plan.Changes = append(plan.Changes, Change{
 				Kind: "agent_egress_allowed_domains", Agent: agentName, Count: len(agent.Egress.AllowedDomains)})
 		}
-		if len(body.Egress.DomainsDenied) > 0 {
+		if deniedChange {
 			agent.Egress.BlockedDomains = append([]string(nil), body.Egress.DomainsDenied...)
 			plan.Changes = append(plan.Changes, Change{
 				Kind: "agent_egress_denied_domains", Agent: agentName, Count: len(agent.Egress.BlockedDomains)})

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -84,14 +84,18 @@ func TestDryRun_MissingAgent(t *testing.T) {
 
 func TestDryRun_EnabledAndDisabledRules(t *testing.T) {
 	b := body()
-	b.Rules.Enabled = []string{"IAP-001"}
-	b.Rules.Disabled = []string{"IAP-002"}
+	b.Rules.Enabled = []string{"IAP-001"}  // no local override → severity default → no change
+	b.Rules.Disabled = []string{"IAP-002"} // → ignore
 	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
 	if err != nil {
 		t.Fatalf("DryRun: %v", err)
 	}
-	if got := ruleAction(t, p, "IAP-001"); got != "allow-and-flag" {
-		t.Fatalf("enabled rule action = %q, want allow-and-flag", got)
+	// Enabling a rule with no local override must NOT add an override entry —
+	// that would weaken a high/critical rule from its severity default.
+	for _, c := range p.Changes {
+		if c.Kind == "rule_override" && c.ID == "IAP-001" {
+			t.Fatalf("enabled rule with no override produced an override change: %+v", c)
+		}
 	}
 	if got := ruleAction(t, p, "IAP-002"); got != "ignore" {
 		t.Fatalf("disabled rule action = %q, want ignore", got)
@@ -157,17 +161,22 @@ func TestDryRun_NoChangesWhenConfigAlreadyOnPolicy(t *testing.T) {
 	// dry-run reports exact diffs, so automation never treats a clean node
 	// as drifted.
 	b := body()
-	b.Rules.Enabled = []string{"IAP-001"}    // → allow-and-flag
+	b.Rules.Enabled = []string{"IAP-001"}    // no local override → severity default → no-op
 	b.Rules.Disabled = []string{"IAP-002"}   // → ignore
+	b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{"IAP-003": {Action: "block"}}
+	b.Rules.Enabled = []string{"IAP-001", "IAP-003"}
 	b.Gateway.ToolsAllowed = []string{"calendar.read", "mail.read"}
 	b.Egress.DomainsAllowed = []string{"api.openai.com"}
 	b.Egress.DomainsDenied = []string{"evil.test"}
 
 	cfg := baseConfig()
-	// Pre-apply the policy by hand so the current config already matches it.
+	// Pre-apply the policy by hand so the current config already matches it:
+	// the disabled rule is locally ignored and the override is locally set,
+	// but IAP-001 (enabled, no override) has no local entry — it is already at
+	// its severity default.
 	cfg.Rules = append(cfg.Rules,
-		config.RuleAction{ID: "IAP-001", Action: "allow-and-flag"},
 		config.RuleAction{ID: "IAP-002", Action: "ignore"},
+		config.RuleAction{ID: "IAP-003", Action: "block"},
 	)
 	va := cfg.Agents["voice-ai"]
 	va.AllowedTools = []string{"calendar.read", "mail.read"}
@@ -249,6 +258,68 @@ func TestDryRun_EmptyBundleListsDoNotClearAgentScopes(t *testing.T) {
 	for _, c := range p.Changes {
 		if c.Kind != "rule_override" {
 			t.Fatalf("unexpected agent-scope change from rules-only policy: %+v", c)
+		}
+	}
+}
+
+func TestDryRun_EnabledRuleResetsLocalOverride(t *testing.T) {
+	// Enabling a rule (no override) in enforce mode restores severity-default
+	// enforcement: a weakening local override must be removed, not left in
+	// place — and the removal is reported as a change.
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"}
+
+	cfg := baseConfig()
+	cfg.Rules = append(cfg.Rules, config.RuleAction{ID: "IAP-001", Action: "allow-and-flag"})
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	for _, ra := range p.Projected().Rules {
+		if ra.ID == "IAP-001" {
+			t.Fatalf("enabled rule must reset to default, local override remains: %+v", ra)
+		}
+	}
+	var reset bool
+	for _, c := range p.Changes {
+		if c.Kind == "rule_reset_default" && c.ID == "IAP-001" {
+			reset = true
+		}
+	}
+	if !reset {
+		t.Fatalf("expected rule_reset_default change, got %+v", p.Changes)
+	}
+}
+
+func TestDryRun_UnsupportedEgressAllowlistWithGlobalWidener(t *testing.T) {
+	// The egress resolver unions the global forward_proxy allowlist with the
+	// agent's, so a per-agent allowlist can't restrict when a global allowlist
+	// already widens it. The projection must refuse rather than emit a config
+	// that still permits the excluded domains.
+	b := body()
+	b.Egress.DomainsAllowed = []string{"api.openai.com"}
+
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	var found bool
+	for _, u := range p.Unsupported {
+		if u.Kind == "agent_egress_allowed_not_restrictable" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected egress-allowlist unsupported, got %+v", p.Unsupported)
+	}
+	// And it must not have written the misleading allowlist change.
+	for _, c := range p.Changes {
+		if c.Kind == "agent_egress_allowed_domains" {
+			t.Fatalf("must not report an egress allow change it cannot enforce: %+v", c)
 		}
 	}
 }

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -324,6 +324,42 @@ func TestDryRun_UnsupportedEgressAllowlistWithGlobalWidener(t *testing.T) {
 	}
 }
 
+func TestDryRun_StandaloneOverrideIsProjected(t *testing.T) {
+	// An override for a rule NOT listed in enabled is still meaningful and
+	// must be projected — the verifier accepts such a bundle.
+	b := body()
+	b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{"IAP-007": {Action: "quarantine"}}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if got := ruleAction(t, p, "IAP-007"); got != "quarantine" {
+		t.Fatalf("standalone override action = %q, want quarantine", got)
+	}
+}
+
+func TestDryRun_EgressGlobalDomainDeniedIsSupported(t *testing.T) {
+	// Allowing only api.openai.com while denying the globally-allowed
+	// github.com is enforceable: blocked is checked before allowed.
+	b := body()
+	b.Egress.DomainsAllowed = []string{"api.openai.com"}
+	b.Egress.DomainsDenied = []string{"github.com"}
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun (denied global domain must be supported): %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	if va.Egress == nil || len(va.Egress.AllowedDomains) != 1 || va.Egress.AllowedDomains[0] != "api.openai.com" {
+		t.Fatalf("egress allowlist not projected: %+v", va.Egress)
+	}
+	if len(va.Egress.BlockedDomains) != 1 || va.Egress.BlockedDomains[0] != "github.com" {
+		t.Fatalf("egress denylist not projected: %+v", va.Egress)
+	}
+}
+
 func TestDryRun_ToolDenialSubtractedFromAllowlist(t *testing.T) {
 	// A bundle that both allows and denies a tool must project an allowlist
 	// with the denied tool removed — the gateway enforces only AllowedTools.

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -1,0 +1,195 @@
+package apply
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+)
+
+const targetPath = "oktsec.yaml"
+
+// baseConfig is a minimal valid config with two agents and one unrelated
+// existing rule, used to prove scoping and preservation.
+func baseConfig() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{Port: 8080},
+		Agents: map[string]config.Agent{
+			"voice-ai": {AllowedTools: []string{"old.tool"}},
+			"other":    {AllowedTools: []string{"keep.tool"}},
+		},
+		Rules: []config.RuleAction{{ID: "KEEP-1", Action: "block", Severity: "high"}},
+	}
+}
+
+// verified wraps a PolicyBody as a (pre-)verified bundle; the projection
+// operates on the verified body, so no signing is needed in these tests.
+func verified(body policybundle.PolicyBody) *policybundle.VerifiedBundle {
+	return &policybundle.VerifiedBundle{
+		Bundle:     &policybundle.PolicyBundle{PolicyHash: "sha256:deadbeef", Policy: body},
+		PolicyHash: "sha256:deadbeef",
+	}
+}
+
+// body is a canonical-shape PolicyBody with empty containers, mutated per test.
+func body() policybundle.PolicyBody {
+	return policybundle.PolicyBody{
+		PolicyID: "voice-ai-prod", PolicyVersion: "1", Mode: ModeEnforce,
+		Rules:     policybundle.PolicyRules{Enabled: []string{}, Disabled: []string{}, Overrides: map[string]policybundle.PolicyRuleOverride{}},
+		Gateway:   policybundle.PolicyGateway{ToolsAllowed: []string{}, ToolsDenied: []string{}},
+		Egress:    policybundle.PolicyEgress{DomainsAllowed: []string{}, DomainsDenied: []string{}},
+		Redaction: policybundle.PolicyRedaction{Level: "analyst"},
+		Metadata:  policybundle.PolicyMetadata{CreatedAt: "2026-05-23T12:00:00Z", CreatedBy: "alice", Reason: "test"},
+	}
+}
+
+func ruleAction(t *testing.T, p *Plan, id string) string {
+	t.Helper()
+	for _, c := range p.Changes {
+		if c.Kind == "rule_override" && c.ID == id {
+			return c.Action
+		}
+	}
+	t.Fatalf("no rule_override change for %q in %+v", id, p.Changes)
+	return ""
+}
+
+func TestDryRun_PlanShapeAndNoMutation(t *testing.T) {
+	cfg := baseConfig()
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"}
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if p.Applied || !p.DryRun {
+		t.Fatalf("applied=%v dry_run=%v, want false/true", p.Applied, p.DryRun)
+	}
+	if p.PolicyHash != "sha256:deadbeef" || p.PolicyID != "voice-ai-prod" || p.PolicyVersion != "1" || p.Mode != "enforce" || p.Agent != "voice-ai" || p.TargetConfig != targetPath {
+		t.Fatalf("plan header fields wrong: %+v", p)
+	}
+	// Input config must be untouched (projection works on a clone).
+	if len(cfg.Rules) != 1 || cfg.Agents["voice-ai"].AllowedTools[0] != "old.tool" {
+		t.Fatal("DryRun mutated the input config")
+	}
+}
+
+func TestDryRun_MissingAgent(t *testing.T) {
+	_, err := DryRun(verified(body()), baseConfig(), "ghost", targetPath)
+	if !errors.Is(err, ErrMissingAgent) {
+		t.Fatalf("err = %v, want ErrMissingAgent", err)
+	}
+}
+
+func TestDryRun_EnabledAndDisabledRules(t *testing.T) {
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"}
+	b.Rules.Disabled = []string{"IAP-002"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if got := ruleAction(t, p, "IAP-001"); got != "allow-and-flag" {
+		t.Fatalf("enabled rule action = %q, want allow-and-flag", got)
+	}
+	if got := ruleAction(t, p, "IAP-002"); got != "ignore" {
+		t.Fatalf("disabled rule action = %q, want ignore", got)
+	}
+}
+
+func TestDryRun_OverrideActionMapping(t *testing.T) {
+	cases := map[string]string{"flag": "allow-and-flag", "quarantine": "quarantine", "block": "block"}
+	for ent, comm := range cases {
+		b := body()
+		b.Rules.Enabled = []string{"IAP-003"}
+		b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{"IAP-003": {Action: ent}}
+		p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+		if err != nil {
+			t.Fatalf("[%s] DryRun: %v", ent, err)
+		}
+		if got := ruleAction(t, p, "IAP-003"); got != comm {
+			t.Fatalf("override %q mapped to %q, want %q", ent, got, comm)
+		}
+	}
+}
+
+func TestDryRun_ObserveDowngradesToAllowAndFlag(t *testing.T) {
+	b := body()
+	b.Mode = ModeObserve
+	b.Rules.Enabled = []string{"IAP-003"}
+	b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{"IAP-003": {Action: "block"}}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if got := ruleAction(t, p, "IAP-003"); got != "allow-and-flag" {
+		t.Fatalf("observe mode: block override projected as %q, want allow-and-flag", got)
+	}
+}
+
+func TestDryRun_ToolsAndEgressScopedToSelectedAgent(t *testing.T) {
+	b := body()
+	b.Gateway.ToolsAllowed = []string{"calendar.read", "mail.read"}
+	b.Egress.DomainsAllowed = []string{"api.openai.com"}
+	b.Egress.DomainsDenied = []string{"evil.test"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	tgt := p.Projected()
+	va := tgt.Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("voice-ai allowed tools = %v", va.AllowedTools)
+	}
+	if va.Egress == nil || va.Egress.AllowedDomains[0] != "api.openai.com" || va.Egress.BlockedDomains[0] != "evil.test" {
+		t.Fatalf("voice-ai egress not projected: %+v", va.Egress)
+	}
+	// The other agent must be untouched.
+	other := tgt.Agents["other"]
+	if len(other.AllowedTools) != 1 || other.AllowedTools[0] != "keep.tool" || other.Egress != nil {
+		t.Fatalf("non-selected agent was modified: %+v", other)
+	}
+}
+
+func TestDryRun_UnsupportedToolsDeniedWithoutAllowlist(t *testing.T) {
+	b := body()
+	b.Gateway.ToolsDenied = []string{"shell.exec"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if len(p.Unsupported) != 1 || p.Unsupported[0].Kind != "gateway_tools_denied_without_allowlist" {
+		t.Fatalf("unsupported = %+v", p.Unsupported)
+	}
+}
+
+func TestDryRun_PreservesUnrelatedConfigAndValidates(t *testing.T) {
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"}
+	b.Gateway.ToolsAllowed = []string{"calendar.read"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	tgt := p.Projected()
+	if tgt == nil {
+		t.Fatal("projected config must be returned")
+	}
+	if err := tgt.Validate(); err != nil {
+		t.Fatalf("projected config must validate: %v", err)
+	}
+	// Unrelated existing rule preserved verbatim.
+	var found bool
+	for _, ra := range tgt.Rules {
+		if ra.ID == "KEEP-1" {
+			found = true
+			if ra.Action != "block" || ra.Severity != "high" {
+				t.Fatalf("unrelated rule KEEP-1 was modified: %+v", ra)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("unrelated rule KEEP-1 was dropped")
+	}
+}

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -152,6 +152,40 @@ func TestDryRun_ToolsAndEgressScopedToSelectedAgent(t *testing.T) {
 	}
 }
 
+func TestDryRun_NoChangesWhenConfigAlreadyOnPolicy(t *testing.T) {
+	// A config already projecting this policy must show zero changes: a
+	// dry-run reports exact diffs, so automation never treats a clean node
+	// as drifted.
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"}    // → allow-and-flag
+	b.Rules.Disabled = []string{"IAP-002"}   // → ignore
+	b.Gateway.ToolsAllowed = []string{"calendar.read", "mail.read"}
+	b.Egress.DomainsAllowed = []string{"api.openai.com"}
+	b.Egress.DomainsDenied = []string{"evil.test"}
+
+	cfg := baseConfig()
+	// Pre-apply the policy by hand so the current config already matches it.
+	cfg.Rules = append(cfg.Rules,
+		config.RuleAction{ID: "IAP-001", Action: "allow-and-flag"},
+		config.RuleAction{ID: "IAP-002", Action: "ignore"},
+	)
+	va := cfg.Agents["voice-ai"]
+	va.AllowedTools = []string{"calendar.read", "mail.read"}
+	va.Egress = &config.EgressPolicy{
+		AllowedDomains: []string{"api.openai.com"},
+		BlockedDomains: []string{"evil.test"},
+	}
+	cfg.Agents["voice-ai"] = va
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if len(p.Changes) != 0 {
+		t.Fatalf("already-on-policy config must report no changes, got %+v", p.Changes)
+	}
+}
+
 func TestDryRun_UnsupportedToolsDeniedWithoutAllowlist(t *testing.T) {
 	b := body()
 	b.Gateway.ToolsDenied = []string{"shell.exec"}

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -186,6 +186,73 @@ func TestDryRun_NoChangesWhenConfigAlreadyOnPolicy(t *testing.T) {
 	}
 }
 
+func TestDryRun_GlobalizesToolScopedRule(t *testing.T) {
+	// Policy rules are global. An existing tool-scoped override must be
+	// widened (apply_to_tools/exempt_tools cleared), and that is a change
+	// even when the action already matches — otherwise a global block would
+	// silently stay limited to the prior tools.
+	b := body()
+	b.Rules.Enabled = []string{"IAP-009"}
+	b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{"IAP-009": {Action: "block"}}
+
+	cfg := baseConfig()
+	cfg.Rules = append(cfg.Rules, config.RuleAction{
+		ID: "IAP-009", Action: "block", ApplyToTools: []string{"shell.exec"},
+	})
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	// Action already matched, but widening to global is still a change.
+	if got := ruleAction(t, p, "IAP-009"); got != "block" {
+		t.Fatalf("rule action = %q, want block", got)
+	}
+	var found bool
+	for _, ra := range p.Projected().Rules {
+		if ra.ID == "IAP-009" {
+			found = true
+			if len(ra.ApplyToTools) != 0 || len(ra.ExemptTools) != 0 {
+				t.Fatalf("tool scope must be cleared for a global policy rule: %+v", ra)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("IAP-009 missing from projected config")
+	}
+}
+
+func TestDryRun_EmptyBundleListsDoNotClearAgentScopes(t *testing.T) {
+	// Canonical bundles carry [] for dimensions a policy does not govern, so
+	// empty lists are "not governed", never "clear". A rules-only policy must
+	// not wipe an agent's existing tools or egress.
+	b := body()
+	b.Rules.Enabled = []string{"IAP-001"} // governs rules; tools/egress empty
+
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.AllowedTools = []string{"keep.one", "keep.two"}
+	va.Egress = &config.EgressPolicy{AllowedDomains: []string{"api.keep.com"}}
+	cfg.Agents["voice-ai"] = va
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	tgt := p.Projected().Agents["voice-ai"]
+	if len(tgt.AllowedTools) != 2 || tgt.AllowedTools[0] != "keep.one" {
+		t.Fatalf("rules-only policy must not touch agent tools: %v", tgt.AllowedTools)
+	}
+	if tgt.Egress == nil || len(tgt.Egress.AllowedDomains) != 1 {
+		t.Fatalf("rules-only policy must not touch agent egress: %+v", tgt.Egress)
+	}
+	for _, c := range p.Changes {
+		if c.Kind != "rule_override" {
+			t.Fatalf("unexpected agent-scope change from rules-only policy: %+v", c)
+		}
+	}
+}
+
 func TestDryRun_UnsupportedToolsDeniedWithoutAllowlist(t *testing.T) {
 	b := body()
 	b.Gateway.ToolsDenied = []string{"shell.exec"}

--- a/internal/apply/projection_test.go
+++ b/internal/apply/projection_test.go
@@ -324,6 +324,67 @@ func TestDryRun_UnsupportedEgressAllowlistWithGlobalWidener(t *testing.T) {
 	}
 }
 
+func TestDryRun_ToolDenialSubtractedFromAllowlist(t *testing.T) {
+	// A bundle that both allows and denies a tool must project an allowlist
+	// with the denied tool removed — the gateway enforces only AllowedTools.
+	b := body()
+	b.Gateway.ToolsAllowed = []string{"calendar.read", "mail.read", "shell.exec"}
+	b.Gateway.ToolsDenied = []string{"shell.exec"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	for _, tl := range va.AllowedTools {
+		if tl == "shell.exec" {
+			t.Fatalf("denied tool must be subtracted: %v", va.AllowedTools)
+		}
+	}
+	if len(va.AllowedTools) != 2 {
+		t.Fatalf("allowlist = %v, want 2 tools", va.AllowedTools)
+	}
+}
+
+func TestDryRun_UnsupportedWhenAllToolsDenied(t *testing.T) {
+	// Denying every allowed tool would leave an empty allowlist, which
+	// Community reads as "all tools allowed" — refuse rather than widen.
+	b := body()
+	b.Gateway.ToolsAllowed = []string{"a.read", "b.read"}
+	b.Gateway.ToolsDenied = []string{"a.read", "b.read"}
+	p, err := DryRun(verified(b), baseConfig(), "voice-ai", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	var found bool
+	for _, u := range p.Unsupported {
+		if u.Kind == "gateway_tools_all_denied" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected gateway_tools_all_denied, got %+v", p.Unsupported)
+	}
+}
+
+func TestDryRun_EgressAllowlistSupportedWhenGlobalIsSubset(t *testing.T) {
+	// When the global allowlist is a subset of the bundle's, the effective
+	// union still equals the policy, so the projection is supported.
+	b := body()
+	b.Egress.DomainsAllowed = []string{"api.openai.com", "github.com"}
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+
+	p, err := DryRun(verified(b), cfg, "voice-ai", targetPath)
+	if err != nil {
+		t.Fatalf("DryRun (global subset of policy must be supported): %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	if va.Egress == nil || len(va.Egress.AllowedDomains) != 2 ||
+		va.Egress.AllowedDomains[0] != "api.openai.com" || va.Egress.AllowedDomains[1] != "github.com" {
+		t.Fatalf("egress allowlist not projected: %+v", va.Egress)
+	}
+}
+
 func TestDryRun_UnsupportedToolsDeniedWithoutAllowlist(t *testing.T) {
 	b := body()
 	b.Gateway.ToolsDenied = []string{"shell.exec"}


### PR DESCRIPTION
Order 7A.2 — Community dry-run apply projection. Projects a verified
`policy_bundle.v1` onto the local Oktsec config and reports the exact
changes, **writing nothing**. The safe in-place write (backup + atomic
rename) is a later slice.

## internal/apply (pure)
`DryRun(verified, cfg, agent, target)` deep-copies the config, projects the
supported subset, validates the target config, and returns a typed `Plan`
(`applied:false, dry_run:true, policy_hash/id/version, mode, target_config,
agent, changes[], unsupported[]`).

Supported subset (post-6E spec §7-§9):
- **Rules are global**: enabled/disabled/overrides upserted by ID (existing
  rules and their other fields preserved). enabled defaults to
  `allow-and-flag`; overrides map `flag→allow-and-flag`,
  `quarantine→quarantine`, `block→block`; disabled→`ignore`; **observe** mode
  forces every enabled/overridden rule to `allow-and-flag`.
- **Gateway tools + egress domains scoped to one explicit `--agent`**.
- `redaction.level` and `metadata` are display/audit, not runtime → not
  projected (and not "unsupported").
- Semantics the narrow projection can't express (`gateway.tools_denied`
  without `tools_allowed` — Community uses allowlists) → reported under
  `unsupported[]` and **refused by default** (`ErrUnsupported`); missing agent
  → `ErrMissingAgent`.
- The Enterprise→Community action mapping happens here at projection time,
  **not in the signed bundle**.

## CLI
`oktsec policy apply --bundle --trust-fingerprint --config --agent --dry-run
[--json]`. Verifies via `internal/policybundle` (verification failure → a
structured JSON failure with the stable `reject_code`, non-zero exit), loads
and validates the current config, prints the plan. `--dry-run` and `--agent`
are required.

## Non-goals (this slice)
No write, no backup, no rollback, no `--all-agents`, no silent partial apply.

## Tests / gates
apply: dry-run writes nothing + JSON shape; missing agent; enabled→action;
disabled→ignore; override flag→allow-and-flag; observe downgrades
block/quarantine; tools/egress scoped to the selected agent only;
unsupported `tools_denied` refused; projected config validates; unrelated
config preserved. cmd: dry-run writes nothing + JSON; untrusted bundle →
`reject_code`; `--dry-run`/`--agent` required. `make build/test/lint/vet`
green (32 packages, race).

## Risky areas for Codex
- no accidental writes (dry-run only)
- no runtime-vocabulary leak into the signed bundle (mapping is projection-side)
- preserve unrelated config (deep-copy + upsert by ID)
- mode observe mapping
- agent scoping (gateway/egress touch only the selected agent)
- unsupported semantics refused, not silently ignored