### PR TITLE
Add safe in-place policy apply (backup + atomic replace)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # (oktsec.yaml.example is the tracked sample and is intentionally not ignored.)
 /oktsec.yaml.bak
 /oktsec.yaml.demo-backup
+# Timestamped backups written by `oktsec policy apply` (config.bak.<ts>[.N]).
+/oktsec.yaml.bak.*
 *.exe
 dist/
 

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -62,6 +62,9 @@ func newPolicyApplyCmd() *cobra.Command {
 			if trustFP == "" {
 				return fmt.Errorf("--trust-fingerprint sha256:<fp> is required")
 			}
+			if allowPartial && !dryRun {
+				return fmt.Errorf("--allow-partial is only valid with --dry-run; a real apply never applies partially")
+			}
 
 			if err := safefile.RejectSymlink(bundlePath); err != nil {
 				return fmt.Errorf("bundle path not usable: %w", err)

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -82,10 +82,15 @@ func newPolicyApplyCmd() *cobra.Command {
 			if cfgFile == "" {
 				return fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
 			}
-			// Real apply writes the config, so validate the path is a writable
-			// regular file BEFORE reading it; a missing config is a hard error
-			// (apply never creates a config — spec 7A.3 §5.2).
+			// Real apply mutates the config, so it requires an explicit
+			// --config target — never a cascaded default (cwd/home) the
+			// operator did not name. It must also be a writable regular file
+			// BEFORE reading it; a missing config is a hard error (apply never
+			// creates a config — spec 7A.3 §5.2).
 			if !dryRun {
+				if !cmd.Flags().Changed("config") {
+					return fmt.Errorf("real apply requires an explicit --config <path> (refusing to mutate a cascaded default config)")
+				}
 				if err := ensureWritableConfigPath(cfgFile); err != nil {
 					return emitApplyFailure(cmd, jsonOut, false, err)
 				}

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -88,8 +88,8 @@ func newPolicyApplyCmd() *cobra.Command {
 			// BEFORE reading it; a missing config is a hard error (apply never
 			// creates a config — spec 7A.3 §5.2).
 			if !dryRun {
-				if !cmd.Flags().Changed("config") {
-					return fmt.Errorf("real apply requires an explicit --config <path> (refusing to mutate a cascaded default config)")
+				if !cfgFileExplicit {
+					return fmt.Errorf("real apply requires an explicit, non-empty --config <path> (refusing to mutate a cascaded default config)")
 				}
 				if err := ensureWritableConfigPath(cfgFile); err != nil {
 					return emitApplyFailure(cmd, jsonOut, false, err)

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/oktsec/oktsec/internal/apply"
 	"github.com/oktsec/oktsec/internal/config"
@@ -15,10 +16,10 @@ import (
 // maxPolicyBundleApplyBytes caps the signed bundle file the apply path reads.
 const maxPolicyBundleApplyBytes = 1 << 20 // 1 MiB
 
-// newPolicyCmd builds `oktsec policy`. Order 7A.2 ships `apply --dry-run`:
-// it verifies a signed policy_bundle.v1 and projects its supported subset
-// onto the local config in memory, reporting the exact changes WITHOUT
-// writing anything. The safe in-place write lands in a later slice.
+// newPolicyCmd builds `oktsec policy`. `apply` verifies a signed
+// policy_bundle.v1 and projects its supported subset onto the local config:
+// `--dry-run` reports the exact changes without writing; without `--dry-run`
+// it safely writes the config in place (backup + atomic replace).
 func newPolicyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "policy",
@@ -39,19 +40,19 @@ func newPolicyApplyCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "apply",
-		Short: "Project a signed policy bundle onto the local config (dry-run)",
+		Short: "Project a signed policy bundle onto the local config (dry-run or in place)",
 		Long: "Verify a signed policy_bundle.v1 against a trust fingerprint and project its " +
 			"supported subset (rules globally; gateway tools and egress for one --agent) onto " +
-			"the local config. Order 7A.2 supports --dry-run only: it computes and validates the " +
-			"target config in memory and prints the exact changes, writing nothing.",
+			"the local config. With --dry-run it computes and validates the target config in " +
+			"memory and prints the exact changes, writing nothing. Without --dry-run it writes " +
+			"the config in place after verification and validation, creating a timestamped " +
+			"backup first and replacing the file atomically. A no-op writes nothing; a missing " +
+			"config is an error (apply never creates a config).",
 		Example: "  oktsec policy apply --bundle voice-ai-prod.signed.json \\\n" +
 			"    --trust-fingerprint sha256:<policy-key-fp> --config oktsec.yaml \\\n" +
 			"    --agent voice-ai --dry-run --json",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !dryRun {
-				return fmt.Errorf("policy apply currently supports --dry-run only (in-place apply lands in a later release)")
-			}
 			if agent == "" {
 				return fmt.Errorf("--agent <name> is required (apply targets exactly one agent for gateway/egress scope)")
 			}
@@ -72,7 +73,7 @@ func newPolicyApplyCmd() *cobra.Command {
 
 			v, verr := policybundle.VerifyBundle(raw, trustFP)
 			if verr != nil {
-				return emitApplyFailure(cmd, jsonOut, verr)
+				return emitApplyFailure(cmd, jsonOut, dryRun, verr)
 			}
 
 			// cfgFile is the root's cascading-resolved config path (honors
@@ -80,6 +81,14 @@ func newPolicyApplyCmd() *cobra.Command {
 			// PersistentPreRunE — do not shadow it with a command-local flag.
 			if cfgFile == "" {
 				return fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
+			}
+			// Real apply writes the config, so validate the path is a writable
+			// regular file BEFORE reading it; a missing config is a hard error
+			// (apply never creates a config — spec 7A.3 §5.2).
+			if !dryRun {
+				if err := ensureWritableConfigPath(cfgFile); err != nil {
+					return emitApplyFailure(cmd, jsonOut, false, err)
+				}
 			}
 			cfg, err := config.Load(cfgFile)
 			if err != nil {
@@ -92,14 +101,35 @@ func newPolicyApplyCmd() *cobra.Command {
 			plan, perr := apply.DryRun(v, cfg, agent, cfgFile)
 			if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
 				// Missing agent or an invalid projected config: no plan to show.
-				return emitApplyFailure(cmd, jsonOut, perr)
+				return emitApplyFailure(cmd, jsonOut, dryRun, perr)
 			}
-			// On ErrUnsupported the plan is non-nil and lists the offending
-			// semantics; print it, then fail unless --allow-partial.
-			emitPlan(cmd, jsonOut, plan)
-			if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
+
+			if dryRun {
+				// Print the plan; fail on unsupported unless --allow-partial.
+				emitPlan(cmd, jsonOut, plan)
+				if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
+					return perr
+				}
+				return nil
+			}
+
+			// --- Real in-place apply (spec 7A.3). ---
+			// Unsupported semantics always fail with no write; --allow-partial
+			// is a dry-run-only affordance and never enables a partial apply.
+			if errors.Is(perr, apply.ErrUnsupported) {
+				emitApplyResult(cmd, jsonOut, plan, "", false)
 				return perr
 			}
+			// No changes: write nothing, no backup, report changed:false.
+			if len(plan.Changes) == 0 {
+				emitApplyResult(cmd, jsonOut, plan, "", false)
+				return nil
+			}
+			backupPath, cerr := apply.Commit(plan, cfgFile)
+			if cerr != nil {
+				return emitApplyFailure(cmd, jsonOut, false, cerr)
+			}
+			emitApplyResult(cmd, jsonOut, plan, backupPath, true)
 			return nil
 		},
 	}
@@ -107,10 +137,33 @@ func newPolicyApplyCmd() *cobra.Command {
 	f.StringVar(&bundlePath, "bundle", "", "path to the signed policy_bundle.v1 JSON")
 	f.StringVar(&trustFP, "trust-fingerprint", "", "sha256:<fp> the bundle's signing key must match")
 	f.StringVar(&agent, "agent", "", "the single agent gateway/egress changes apply to")
-	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing (required)")
-	f.BoolVar(&jsonOut, "json", false, "emit the plan as JSON")
-	f.BoolVar(&allowPartial, "allow-partial", false, "proceed (exit 0) even when the bundle has unsupported semantics")
+	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing; omit to apply in place")
+	f.BoolVar(&jsonOut, "json", false, "emit the plan/result as JSON")
+	f.BoolVar(&allowPartial, "allow-partial", false, "dry-run only: exit 0 even when the bundle has unsupported semantics")
 	return cmd
+}
+
+// ensureWritableConfigPath checks the config path is a writable regular file
+// before a real apply: a missing config is a hard error (apply never creates a
+// config), and symlinks/directories are rejected so no write follows a link.
+func ensureWritableConfigPath(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("config %q does not exist; policy apply does not create configs (run setup first)", path)
+		}
+		return fmt.Errorf("stat config %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("config %q is a symlink (rejected for security)", path)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("config %q is a directory, not a file", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("config %q is not a regular file", path)
+	}
+	return nil
 }
 
 // emitPlan prints the dry-run plan as JSON (when --json) or a short summary.
@@ -139,12 +192,70 @@ func emitPlan(cmd *cobra.Command, jsonOut bool, p *apply.Plan) {
 	}
 }
 
+// applyOutcome is the JSON contract for a real `policy apply` (write or no-op).
+type applyOutcome struct {
+	Applied       bool                `json:"applied"`
+	DryRun        bool                `json:"dry_run"`
+	Changed       bool                `json:"changed"`
+	PolicyHash    string              `json:"policy_hash"`
+	PolicyID      string              `json:"policy_id"`
+	PolicyVersion string              `json:"policy_version"`
+	Mode          string              `json:"mode"`
+	TargetConfig  string              `json:"target_config"`
+	Agent         string              `json:"agent"`
+	BackupPath    string              `json:"backup_path"`
+	Changes       []apply.Change      `json:"changes"`
+	Unsupported   []apply.Unsupported `json:"unsupported"`
+}
+
+// emitApplyResult prints the real-apply outcome as JSON (when --json) or a
+// concise human summary. applied==true means the config was written; a backup
+// path is present only then.
+func emitApplyResult(cmd *cobra.Command, jsonOut bool, p *apply.Plan, backupPath string, applied bool) {
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(applyOutcome{
+			Applied:       applied,
+			DryRun:        false,
+			Changed:       applied,
+			PolicyHash:    p.PolicyHash,
+			PolicyID:      p.PolicyID,
+			PolicyVersion: p.PolicyVersion,
+			Mode:          p.Mode,
+			TargetConfig:  p.TargetConfig,
+			Agent:         p.Agent,
+			BackupPath:    backupPath,
+			Changes:       p.Changes,
+			Unsupported:   p.Unsupported,
+		})
+		return
+	}
+	if !applied {
+		if len(p.Unsupported) > 0 {
+			fmt.Fprintf(out, "not applied: %d unsupported semantic(s), config unchanged\n", len(p.Unsupported))
+			for _, u := range p.Unsupported {
+				fmt.Fprintf(out, "  ! %s — %s\n", u.Kind, u.Detail)
+			}
+			return
+		}
+		fmt.Fprintf(out, "no changes: config already on policy %s v%s, nothing written\n", p.PolicyID, p.PolicyVersion)
+		return
+	}
+	fmt.Fprintf(out, "policy applied\n")
+	fmt.Fprintf(out, "  policy_hash: %s\n", p.PolicyHash)
+	fmt.Fprintf(out, "  agent: %s\n", p.Agent)
+	fmt.Fprintf(out, "  backup_path: %s\n", backupPath)
+	fmt.Fprintf(out, "  changes: %d\n", len(p.Changes))
+}
+
 // emitApplyFailure prints a structured JSON failure (with a stable reject_code
 // for bundle-verification errors) and returns the error so the exit is
-// non-zero.
-func emitApplyFailure(cmd *cobra.Command, jsonOut bool, err error) error {
+// non-zero. dryRun records which mode the failure occurred in.
+func emitApplyFailure(cmd *cobra.Command, jsonOut, dryRun bool, err error) error {
 	if jsonOut {
-		failure := map[string]any{"applied": false, "dry_run": true, "error": err.Error()}
+		failure := map[string]any{"applied": false, "dry_run": dryRun, "error": err.Error()}
 		var re *policybundle.RejectError
 		if errors.As(err, &re) {
 			failure["reject_code"] = string(re.Code)

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -202,12 +202,21 @@ func TestPolicyApply_RealApplyWritesBacksUpAndIsIdempotent(t *testing.T) {
 
 func TestPolicyApply_RealApplyRequiresExplicitConfig(t *testing.T) {
 	bundlePath, _ := writePolicyApplyInputs(t)
+	t.Setenv("OKTSEC_CONFIG", "") // ensure no env fallback masks the guard
 	// No --config: real apply must refuse rather than mutate a cascaded default.
 	if _, err := runPolicyApply(t,
 		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
 		"--agent", "voice-ai", "--json",
 	); err == nil {
 		t.Fatal("real apply without an explicit --config must fail")
+	}
+	// An explicitly EMPTY --config still resolves to a cascaded default, so it
+	// must be refused too.
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", "", "--agent", "voice-ai", "--json",
+	); err == nil {
+		t.Fatal("real apply with an empty --config must fail")
 	}
 }
 

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
 )
 
 // policyBundleFixture is a deterministically signed policy_bundle.v1
@@ -114,16 +116,153 @@ func TestPolicyApply_RejectsUntrustedBundle(t *testing.T) {
 	}
 }
 
-func TestPolicyApply_RequiresDryRunAndAgent(t *testing.T) {
+func TestPolicyApply_RequiresAgent(t *testing.T) {
 	bundlePath, configPath := writePolicyApplyInputs(t)
-	// Missing --dry-run.
-	if _, err := runPolicyApply(t, "--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
-		"--config", configPath, "--agent", "voice-ai"); err == nil {
-		t.Fatal("apply without --dry-run must fail in this release")
-	}
-	// Missing --agent.
+	// Missing --agent fails in both dry-run and real apply.
 	if _, err := runPolicyApply(t, "--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
 		"--config", configPath, "--dry-run"); err == nil {
 		t.Fatal("apply without --agent must fail")
+	}
+	if _, err := runPolicyApply(t, "--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath); err == nil {
+		t.Fatal("real apply without --agent must fail")
+	}
+}
+
+func TestPolicyApply_RealApplyWritesBacksUpAndIsIdempotent(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	original, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	// First real apply (no --dry-run) writes the projection.
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--json",
+	)
+	if err != nil {
+		t.Fatalf("real apply must succeed: %v", err)
+	}
+	if got["applied"] != true || got["changed"] != true || got["dry_run"] != false {
+		t.Fatalf("applied/changed/dry_run = %v/%v/%v, want true/true/false", got["applied"], got["changed"], got["dry_run"])
+	}
+	backupPath, _ := got["backup_path"].(string)
+	if backupPath == "" {
+		t.Fatal("real apply must report a backup_path")
+	}
+
+	// The backup holds the EXACT original bytes.
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if !bytes.Equal(backup, original) {
+		t.Fatal("backup is not the exact original config")
+	}
+
+	// The config changed and still loads + validates.
+	afterFirst, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if bytes.Equal(afterFirst, original) {
+		t.Fatal("real apply did not modify the config")
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("applied config must load: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("applied config must validate: %v", err)
+	}
+
+	// Second apply is a no-op: changed:false, no backup, bytes unchanged.
+	got2, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--json",
+	)
+	if err != nil {
+		t.Fatalf("second apply must succeed: %v", err)
+	}
+	if got2["applied"] != false || got2["changed"] != false {
+		t.Fatalf("idempotent apply: applied/changed = %v/%v, want false/false", got2["applied"], got2["changed"])
+	}
+	if bp, _ := got2["backup_path"].(string); bp != "" {
+		t.Fatalf("no-op apply must not create a backup, got %q", bp)
+	}
+	afterSecond, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(afterFirst, afterSecond) {
+		t.Fatal("no-op apply rewrote the config")
+	}
+}
+
+func TestPolicyApply_RealApplyMatchesDryRun(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	dry, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--dry-run", "--json",
+	)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	real, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--json",
+	)
+	if err != nil {
+		t.Fatalf("real apply: %v", err)
+	}
+	// Same inputs must yield the same change set.
+	dc, _ := json.Marshal(dry["changes"])
+	rc, _ := json.Marshal(real["changes"])
+	if string(dc) != string(rc) {
+		t.Fatalf("apply changes %s != dry-run changes %s", rc, dc)
+	}
+}
+
+func TestPolicyApply_MissingConfigRejectedNoWrite(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	missing := configPath + ".does-not-exist"
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", missing, "--agent", "voice-ai", "--json",
+	); err == nil {
+		t.Fatal("real apply against a missing config must fail")
+	}
+	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
+		t.Fatal("apply must not create the missing config")
+	}
+}
+
+func TestPolicyApply_DirectoryConfigRejected(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", filepath.Dir(configPath), "--agent", "voice-ai", "--json",
+	); err == nil {
+		t.Fatal("real apply against a directory must fail")
+	}
+}
+
+func TestPolicyApply_SymlinkConfigRejectedNoWrite(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	link := configPath + ".link"
+	if err := os.Symlink(configPath, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	original, _ := os.ReadFile(configPath)
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", link, "--agent", "voice-ai", "--json",
+	); err == nil {
+		t.Fatal("real apply through a symlink must fail")
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(original, after) {
+		t.Fatal("symlinked apply must not write through to the target")
 	}
 }

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -220,6 +220,20 @@ func TestPolicyApply_RealApplyRequiresExplicitConfig(t *testing.T) {
 	}
 }
 
+func TestPolicyApply_AllowPartialRejectedOnRealApply(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+	original, _ := os.ReadFile(configPath)
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--allow-partial", "--json",
+	); err == nil {
+		t.Fatal("--allow-partial on a real apply must fail")
+	}
+	if after, _ := os.ReadFile(configPath); !bytes.Equal(original, after) {
+		t.Fatal("rejected --allow-partial apply must not modify the config")
+	}
+}
+
 func TestPolicyApply_RealApplyMatchesDryRun(t *testing.T) {
 	bundlePath, configPath := writePolicyApplyInputs(t)
 	dry, err := runPolicyApply(t,

--- a/cmd/oktsec/commands/policy_test.go
+++ b/cmd/oktsec/commands/policy_test.go
@@ -200,6 +200,17 @@ func TestPolicyApply_RealApplyWritesBacksUpAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestPolicyApply_RealApplyRequiresExplicitConfig(t *testing.T) {
+	bundlePath, _ := writePolicyApplyInputs(t)
+	// No --config: real apply must refuse rather than mutate a cascaded default.
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--agent", "voice-ai", "--json",
+	); err == nil {
+		t.Fatal("real apply without an explicit --config must fail")
+	}
+}
+
 func TestPolicyApply_RealApplyMatchesDryRun(t *testing.T) {
 	bundlePath, configPath := writePolicyApplyInputs(t)
 	dry, err := runPolicyApply(t,

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -1,11 +1,18 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var cfgFile string
+
+// cfgFileExplicit is true when the operator passed a non-empty --config. It is
+// captured before resolution overwrites cfgFile, so a mutating command can
+// require an explicitly-named target and refuse a cascaded default.
+var cfgFileExplicit bool
 
 func NewRoot() *cobra.Command {
 	root := &cobra.Command{
@@ -35,6 +42,10 @@ func NewRoot() *cobra.Command {
 	// Resolve config path before any command runs
 	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		flagExplicit := cmd.Flags().Changed("config")
+		// Capture explicitness from the raw flag value before resolution
+		// overwrites cfgFile: an empty --config still resolves to a cascaded
+		// default but is NOT an explicit target.
+		cfgFileExplicit = flagExplicit && strings.TrimSpace(cfgFile) != ""
 		resolved, _ := config.ResolveConfigPath(cfgFile, flagExplicit)
 		cfgFile = resolved
 		return nil

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -171,19 +171,29 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 	}
 
 	if patchTools || patchEgress {
-		agents := mapGet(root, "agents")
-		if agents == nil || agents.Kind != yaml.MappingNode {
-			return nil, errors.New("agents section missing or not a mapping")
-		}
 		proj, ok := plan.projected.Agents[plan.Agent]
 		if !ok {
 			return nil, fmt.Errorf("agent %q not in projected config", plan.Agent)
 		}
-		node := mapGet(agents, plan.Agent)
-		if node != nil && node.Kind == yaml.MappingNode {
+		agents := mapGet(root, "agents")
+		switch {
+		case agents == nil || agents.Kind != yaml.MappingNode:
+			// The whole agents section is reachable only via a YAML alias
+			// ("agents: *all") or a root-level `<<` merge — config.Load resolved
+			// it, so dry-run saw the agent. Materialize the resolved agents map
+			// (target's governed changes + the others) as an explicit mapping so
+			// real apply matches dry-run instead of treating it as missing.
+			var n yaml.Node
+			if err := n.Encode(plan.projected.Agents); err != nil {
+				return nil, fmt.Errorf("encode agents: %w", err)
+			}
+			mapSet(root, "agents", &n)
+
+		case isExplicitMapping(mapGet(agents, plan.Agent)):
 			// Explicit agent mapping (including one with a `<<` merge key):
 			// patch only the governed keys in place, preserving the agent's
 			// other fields and its merge.
+			node := mapGet(agents, plan.Agent)
 			if patchTools {
 				if err := guardAnchored(&doc, mapGet(node, "allowed_tools"), "the agent's allowed_tools"); err != nil {
 					return nil, err
@@ -204,7 +214,8 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 				}
 				mapSet(node, "egress", &n)
 			}
-		} else {
+
+		default:
 			// The agent is reachable only via a YAML alias value
 			// ("voice-ai: *defaults") or an agents-level `<<` merge — config.Load
 			// resolved it, so dry-run saw it. Materialize the fully-resolved
@@ -294,6 +305,12 @@ func collectAliasNames(n *yaml.Node, out map[string]bool) {
 	for _, c := range n.Content {
 		collectAliasNames(c, out)
 	}
+}
+
+// isExplicitMapping reports whether n is a concrete mapping node (not nil, an
+// alias, or a scalar).
+func isExplicitMapping(n *yaml.Node) bool {
+	return n != nil && n.Kind == yaml.MappingNode
 }
 
 // mapGet returns the value node for key in a mapping node, or nil.

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -160,6 +160,9 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 	}
 
 	if patchRules {
+		if err := guardAnchored(&doc, mapGet(root, "rules"), "rules"); err != nil {
+			return nil, err
+		}
 		var n yaml.Node
 		if err := n.Encode(plan.projected.Rules); err != nil {
 			return nil, fmt.Errorf("encode rules: %w", err)
@@ -182,6 +185,9 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 			// patch only the governed keys in place, preserving the agent's
 			// other fields and its merge.
 			if patchTools {
+				if err := guardAnchored(&doc, mapGet(node, "allowed_tools"), "the agent's allowed_tools"); err != nil {
+					return nil, err
+				}
 				var n yaml.Node
 				if err := n.Encode(proj.AllowedTools); err != nil {
 					return nil, fmt.Errorf("encode allowed_tools: %w", err)
@@ -189,6 +195,9 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 				mapSet(node, "allowed_tools", &n)
 			}
 			if patchEgress {
+				if err := guardAnchored(&doc, mapGet(node, "egress"), "the agent's egress"); err != nil {
+					return nil, err
+				}
 				var n yaml.Node
 				if err := n.Encode(proj.Egress); err != nil {
 					return nil, fmt.Errorf("encode egress: %w", err)
@@ -235,6 +244,56 @@ func backupOriginal(targetConfig string, data []byte, mode os.FileMode) (string,
 		candidate = fmt.Sprintf("%s.%d", base, i)
 	}
 	return "", fmt.Errorf("could not create a unique backup for %q", targetConfig)
+}
+
+// guardAnchored refuses to replace oldNode when it (or a descendant) defines a
+// YAML anchor that an alias elsewhere in the document references: replacing it
+// would orphan that alias and emit invalid YAML. Rather than silently break the
+// document or expand the operator's anchors, apply refuses and asks the operator
+// to inline. A config with no anchors (the common case) is unaffected.
+func guardAnchored(doc, oldNode *yaml.Node, field string) error {
+	if oldNode == nil {
+		return nil
+	}
+	anchors := map[string]bool{}
+	collectAnchors(oldNode, anchors)
+	if len(anchors) == 0 {
+		return nil
+	}
+	aliases := map[string]bool{}
+	collectAliasNames(doc, aliases)
+	for name := range anchors {
+		if aliases[name] {
+			return fmt.Errorf("%s defines a YAML anchor %q referenced elsewhere; inline it before applying policy", field, name)
+		}
+	}
+	return nil
+}
+
+// collectAnchors records every anchor name defined in the subtree rooted at n.
+func collectAnchors(n *yaml.Node, out map[string]bool) {
+	if n == nil {
+		return
+	}
+	if n.Anchor != "" {
+		out[n.Anchor] = true
+	}
+	for _, c := range n.Content {
+		collectAnchors(c, out)
+	}
+}
+
+// collectAliasNames records every anchor name referenced by an alias in the doc.
+func collectAliasNames(n *yaml.Node, out map[string]bool) {
+	if n == nil {
+		return
+	}
+	if n.Kind == yaml.AliasNode && n.Value != "" {
+		out[n.Value] = true
+	}
+	for _, c := range n.Content {
+		collectAliasNames(c, out)
+	}
 }
 
 // mapGet returns the value node for key in a mapping node, or nil.

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -194,6 +194,13 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 			// patch only the governed keys in place, preserving the agent's
 			// other fields and its merge.
 			node := mapGet(agents, plan.Agent)
+			// If the agent node itself is an anchor referenced by another agent,
+			// patching its children would leak the change to that aliasing agent
+			// (and dry-run only scoped the change to this agent). Refuse rather
+			// than silently change a non-targeted agent.
+			if node.Anchor != "" && anchorReferenced(&doc, node.Anchor) {
+				return nil, fmt.Errorf("agent %q has a YAML anchor %q referenced elsewhere; inline it before applying policy", plan.Agent, node.Anchor)
+			}
 			if patchTools {
 				if err := guardAnchored(&doc, mapGet(node, "allowed_tools"), "the agent's allowed_tools"); err != nil {
 					return nil, err
@@ -305,6 +312,17 @@ func collectAliasNames(n *yaml.Node, out map[string]bool) {
 	for _, c := range n.Content {
 		collectAliasNames(c, out)
 	}
+}
+
+// anchorReferenced reports whether an alias anywhere in doc references the
+// given anchor name.
+func anchorReferenced(doc *yaml.Node, name string) bool {
+	if name == "" {
+		return false
+	}
+	aliases := map[string]bool{}
+	collectAliasNames(doc, aliases)
+	return aliases[name]
 }
 
 // isExplicitMapping reports whether n is a concrete mapping node (not nil, an

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -168,24 +168,44 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 	}
 
 	if patchTools || patchEgress {
-		agentNode, err := agentMapping(root, plan.Agent)
-		if err != nil {
-			return nil, err
+		agents := mapGet(root, "agents")
+		if agents == nil || agents.Kind != yaml.MappingNode {
+			return nil, errors.New("agents section missing or not a mapping")
 		}
-		proj := plan.projected.Agents[plan.Agent]
-		if patchTools {
-			var n yaml.Node
-			if err := n.Encode(proj.AllowedTools); err != nil {
-				return nil, fmt.Errorf("encode allowed_tools: %w", err)
-			}
-			mapSet(agentNode, "allowed_tools", &n)
+		proj, ok := plan.projected.Agents[plan.Agent]
+		if !ok {
+			return nil, fmt.Errorf("agent %q not in projected config", plan.Agent)
 		}
-		if patchEgress {
-			var n yaml.Node
-			if err := n.Encode(proj.Egress); err != nil {
-				return nil, fmt.Errorf("encode egress: %w", err)
+		node := mapGet(agents, plan.Agent)
+		if node != nil && node.Kind == yaml.MappingNode {
+			// Explicit agent mapping (including one with a `<<` merge key):
+			// patch only the governed keys in place, preserving the agent's
+			// other fields and its merge.
+			if patchTools {
+				var n yaml.Node
+				if err := n.Encode(proj.AllowedTools); err != nil {
+					return nil, fmt.Errorf("encode allowed_tools: %w", err)
+				}
+				mapSet(node, "allowed_tools", &n)
 			}
-			mapSet(agentNode, "egress", &n)
+			if patchEgress {
+				var n yaml.Node
+				if err := n.Encode(proj.Egress); err != nil {
+					return nil, fmt.Errorf("encode egress: %w", err)
+				}
+				mapSet(node, "egress", &n)
+			}
+		} else {
+			// The agent is reachable only via a YAML alias value
+			// ("voice-ai: *defaults") or an agents-level `<<` merge — config.Load
+			// resolved it, so dry-run saw it. Materialize the fully-resolved
+			// agent (inherited fields + governed changes) as an explicit key so
+			// real apply matches dry-run and no inherited field is lost.
+			var n yaml.Node
+			if err := n.Encode(proj); err != nil {
+				return nil, fmt.Errorf("encode agent %q: %w", plan.Agent, err)
+			}
+			mapSet(agents, plan.Agent, &n)
 		}
 	}
 
@@ -238,34 +258,6 @@ func mapSet(m *yaml.Node, key string, val *yaml.Node) {
 	}
 	m.Content = append(m.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
-}
-
-// agentMapping returns the mapping node for agents.<name> so governed keys can
-// be set on it. A normal mapping (including one with a `<<` merge key) is used
-// in place. A bare "agent:" (null) has no fields to lose, so it is materialized
-// into an empty mapping. A YAML alias ("agent: *defaults") is REFUSED: rewriting
-// it would drop the inherited fields config.Load resolved, so the operator must
-// inline it first. The agent is guaranteed to exist (DryRun rejects a missing one).
-func agentMapping(root *yaml.Node, name string) (*yaml.Node, error) {
-	agents := mapGet(root, "agents")
-	if agents == nil || agents.Kind != yaml.MappingNode {
-		return nil, errors.New("agents section missing or not a mapping")
-	}
-	node := mapGet(agents, name)
-	if node == nil {
-		return nil, fmt.Errorf("agent %q not found in config", name)
-	}
-	switch {
-	case node.Kind == yaml.MappingNode:
-		return node, nil
-	case node.Kind == yaml.ScalarNode && (node.Tag == "!!null" || node.Value == ""):
-		*node = yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-		return node, nil
-	case node.Kind == yaml.AliasNode:
-		return nil, fmt.Errorf("agent %q is a YAML alias; inline it before applying policy (refusing to drop inherited fields)", name)
-	default:
-		return nil, fmt.Errorf("agent %q is not a mapping and cannot be patched", name)
-	}
 }
 
 // writeExclusive creates path with O_EXCL — it never overwrites an existing

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -53,6 +53,16 @@ func Commit(plan *Plan, targetConfig string) (string, error) {
 	}
 	mode := info.Mode().Perm()
 
+	// Refuse a read-only config: os.Rename would replace it via directory
+	// permissions, so a plain mode/regular-file check is not enough. Probing
+	// O_WRONLY respects the real permissions (owner/group/ACL) portably; it
+	// neither truncates nor writes.
+	if probe, err := os.OpenFile(targetConfig, os.O_WRONLY, 0); err != nil {
+		return "", fmt.Errorf("apply: config %q is not writable: %w", targetConfig, err)
+	} else {
+		_ = probe.Close()
+	}
+
 	orig, err := safefile.ReadFileMax(targetConfig, maxConfigBytes)
 	if err != nil {
 		return "", fmt.Errorf("apply: read original config: %w", err)
@@ -104,10 +114,10 @@ func Commit(plan *Plan, targetConfig string) (string, error) {
 
 	// 15: exclusive timestamped backup of the exact original bytes, created
 	// only after validation passed. If this fails, the config is untouched.
-	backupPath := targetConfig + ".bak." + time.Now().UTC().Format("20060102T150405Z")
-	if err := writeExclusive(backupPath, orig, mode); err != nil {
+	backupPath, err := backupOriginal(targetConfig, orig, mode)
+	if err != nil {
 		cleanup()
-		return "", fmt.Errorf("apply: create backup %q: %w", backupPath, err)
+		return "", fmt.Errorf("apply: create backup: %w", err)
 	}
 
 	// 18-19: atomic replace. On failure the original config and the backup
@@ -186,6 +196,27 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 	return out, nil
 }
 
+// backupOriginal creates an exclusive backup of data beside targetConfig,
+// preferring the spec name "<config>.bak.YYYYMMDDTHHMMSSZ". Seconds-resolution
+// names collide for two applies in the same second (or a pre-existing backup),
+// so on collision it appends ".N" until a unique name succeeds — a valid apply
+// is never aborted by a backup-name clash.
+func backupOriginal(targetConfig string, data []byte, mode os.FileMode) (string, error) {
+	base := targetConfig + ".bak." + time.Now().UTC().Format("20060102T150405Z")
+	candidate := base
+	for i := 1; i <= 100; i++ {
+		err := writeExclusive(candidate, data, mode)
+		if err == nil {
+			return candidate, nil
+		}
+		if !os.IsExist(err) {
+			return "", err
+		}
+		candidate = fmt.Sprintf("%s.%d", base, i)
+	}
+	return "", fmt.Errorf("could not create a unique backup for %q", targetConfig)
+}
+
 // mapGet returns the value node for key in a mapping node, or nil.
 func mapGet(m *yaml.Node, key string) *yaml.Node {
 	for i := 0; i+1 < len(m.Content); i += 2 {
@@ -209,9 +240,12 @@ func mapSet(m *yaml.Node, key string, val *yaml.Node) {
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
 }
 
-// agentMapping returns the mapping node for agents.<name>, materializing an
-// empty mapping in place if the agent was written with no fields (e.g.
-// "voice-ai:"). The agent is guaranteed to exist (DryRun rejects a missing one).
+// agentMapping returns the mapping node for agents.<name> so governed keys can
+// be set on it. A normal mapping (including one with a `<<` merge key) is used
+// in place. A bare "agent:" (null) has no fields to lose, so it is materialized
+// into an empty mapping. A YAML alias ("agent: *defaults") is REFUSED: rewriting
+// it would drop the inherited fields config.Load resolved, so the operator must
+// inline it first. The agent is guaranteed to exist (DryRun rejects a missing one).
 func agentMapping(root *yaml.Node, name string) (*yaml.Node, error) {
 	agents := mapGet(root, "agents")
 	if agents == nil || agents.Kind != yaml.MappingNode {
@@ -221,10 +255,17 @@ func agentMapping(root *yaml.Node, name string) (*yaml.Node, error) {
 	if node == nil {
 		return nil, fmt.Errorf("agent %q not found in config", name)
 	}
-	if node.Kind != yaml.MappingNode {
+	switch {
+	case node.Kind == yaml.MappingNode:
+		return node, nil
+	case node.Kind == yaml.ScalarNode && (node.Tag == "!!null" || node.Value == ""):
 		*node = yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		return node, nil
+	case node.Kind == yaml.AliasNode:
+		return nil, fmt.Errorf("agent %q is a YAML alias; inline it before applying policy (refusing to drop inherited fields)", name)
+	default:
+		return nil, fmt.Errorf("agent %q is not a mapping and cannot be patched", name)
 	}
-	return node, nil
 }
 
 // writeExclusive creates path with O_EXCL — it never overwrites an existing

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -12,45 +12,35 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// maxConfigBytes caps the original config the backup reads (mirrors config.Load).
+// maxConfigBytes caps the original config the backup/patch reads (mirrors config.Load).
 const maxConfigBytes = 1 << 20 // 1 MiB
 
 // ErrNoProjection is returned when Commit is given a plan with no computed
 // target config (DryRun must run first and succeed).
 var ErrNoProjection = errors.New("apply: plan has no projected config to commit")
 
-// Commit writes the plan's projected config to targetConfig using a backup +
+// Commit writes the plan's projected changes to targetConfig using a backup +
 // atomic-replace protocol. Call it only for a plan that has changes and no
 // unsupported items; it returns the created backup path.
 //
-// Sequence (spec 7A.3 §4 steps 13-19 / §5): marshal the projection ->
-// revalidate it by re-parsing (independent of the in-memory Validate) ->
-// exclusive backup of the EXACT original bytes in the same directory ->
-// exclusive temp write -> fsync -> atomic same-dir rename -> parent dir fsync.
-// Nothing mutates the config path until the projected config has validated AND
-// the backup exists; if the rename fails the original config and the backup
-// both remain.
+// Only the governed sections (rules; the target agent's allowed_tools and
+// egress) are rewritten — they are patched onto the operator's original YAML
+// document, so unrelated fields and any load-time defaults (e.g. db_path) are
+// preserved verbatim rather than re-marshaled from the defaulted struct.
+//
+// Sequence (spec 7A.3 §4 / §5): patch the original -> write the patched bytes
+// to an exclusive temp in the same dir -> validate THOSE bytes via the real
+// load path (defaults + migrations) -> exclusive backup of the exact original
+// bytes -> atomic rename of the validated temp over the config -> parent dir
+// fsync. The config path is not mutated until the patched config has validated
+// AND the backup exists; a failed rename leaves the original and backup intact.
 func Commit(plan *Plan, targetConfig string) (string, error) {
 	if plan == nil || plan.projected == nil {
 		return "", ErrNoProjection
 	}
 
-	// 13-14: marshal deterministically, then revalidate by re-parsing the
-	// bytes that will actually be written — not the in-memory struct.
-	data, err := yaml.Marshal(plan.projected)
-	if err != nil {
-		return "", fmt.Errorf("apply: marshal projected config: %w", err)
-	}
-	var reparsed config.Config
-	if err := yaml.Unmarshal(data, &reparsed); err != nil {
-		return "", fmt.Errorf("apply: projected config does not re-parse: %w", err)
-	}
-	if err := reparsed.Validate(); err != nil {
-		return "", fmt.Errorf("apply: projected config invalid after marshal: %w", err)
-	}
-
-	// Re-check the config path right before writing: never follow a symlink,
-	// never write through a directory or irregular file.
+	// Re-check the path right before writing: never follow a symlink, never
+	// write through a directory or irregular file.
 	info, err := os.Lstat(targetConfig)
 	if err != nil {
 		return "", fmt.Errorf("apply: stat config %q: %w", targetConfig, err)
@@ -63,26 +53,178 @@ func Commit(plan *Plan, targetConfig string) (string, error) {
 	}
 	mode := info.Mode().Perm()
 
-	// Backup uses the exact original bytes (pre-migration, pre-defaults), so
-	// it round-trips the operator's file verbatim — not the re-marshaled form.
 	orig, err := safefile.ReadFileMax(targetConfig, maxConfigBytes)
 	if err != nil {
 		return "", fmt.Errorf("apply: read original config: %w", err)
 	}
 
-	// 15: exclusive timestamped backup in the same directory. If this fails,
-	// the config is untouched.
+	patched, err := patchConfigYAML(orig, plan)
+	if err != nil {
+		return "", fmt.Errorf("apply: %w", err)
+	}
+
+	dir := filepath.Dir(targetConfig)
+
+	// Write the patched bytes to an exclusive temp in the same directory and
+	// validate THOSE bytes through the real load path before any backup or
+	// config mutation. The validated temp is the file we rename — no rewrite.
+	tmp, err := os.CreateTemp(dir, filepath.Base(targetConfig)+".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("apply: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(patched); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", fmt.Errorf("apply: write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", fmt.Errorf("apply: fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: close temp: %w", err)
+	}
+	loaded, err := config.Load(tmpPath)
+	if err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: patched config does not load: %w", err)
+	}
+	if err := loaded.Validate(); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: patched config is invalid: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: chmod temp: %w", err)
+	}
+
+	// 15: exclusive timestamped backup of the exact original bytes, created
+	// only after validation passed. If this fails, the config is untouched.
 	backupPath := targetConfig + ".bak." + time.Now().UTC().Format("20060102T150405Z")
 	if err := writeExclusive(backupPath, orig, mode); err != nil {
+		cleanup()
 		return "", fmt.Errorf("apply: create backup %q: %w", backupPath, err)
 	}
 
-	// 16-19: atomic replace. On failure the original config and the backup
-	// both remain; the temp file is removed.
-	if err := atomicReplace(targetConfig, data, mode); err != nil {
+	// 18-19: atomic replace. On failure the original config and the backup
+	// both remain; the temp is removed.
+	if err := os.Rename(tmpPath, targetConfig); err != nil {
+		cleanup()
 		return backupPath, fmt.Errorf("apply: atomic replace %q (backup kept at %q): %w", targetConfig, backupPath, err)
 	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
 	return backupPath, nil
+}
+
+// patchConfigYAML applies only the plan's governed changes onto the original
+// YAML document, preserving every untouched field (and any load-time default
+// the operator never wrote — e.g. db_path) verbatim. Governed sections that
+// actually changed are re-serialized from the validated projection.
+func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(original, &doc); err != nil {
+		return nil, fmt.Errorf("parse original config: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("original config is not a YAML mapping")
+	}
+	root := doc.Content[0]
+
+	var patchRules, patchTools, patchEgress bool
+	for _, c := range plan.Changes {
+		switch c.Kind {
+		case "rule_override", "rule_reset_default":
+			patchRules = true
+		case "agent_allowed_tools":
+			patchTools = true
+		case "agent_egress_allowed_domains", "agent_egress_denied_domains":
+			patchEgress = true
+		}
+	}
+
+	if patchRules {
+		var n yaml.Node
+		if err := n.Encode(plan.projected.Rules); err != nil {
+			return nil, fmt.Errorf("encode rules: %w", err)
+		}
+		mapSet(root, "rules", &n)
+	}
+
+	if patchTools || patchEgress {
+		agentNode, err := agentMapping(root, plan.Agent)
+		if err != nil {
+			return nil, err
+		}
+		proj := plan.projected.Agents[plan.Agent]
+		if patchTools {
+			var n yaml.Node
+			if err := n.Encode(proj.AllowedTools); err != nil {
+				return nil, fmt.Errorf("encode allowed_tools: %w", err)
+			}
+			mapSet(agentNode, "allowed_tools", &n)
+		}
+		if patchEgress {
+			var n yaml.Node
+			if err := n.Encode(proj.Egress); err != nil {
+				return nil, fmt.Errorf("encode egress: %w", err)
+			}
+			mapSet(agentNode, "egress", &n)
+		}
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal patched config: %w", err)
+	}
+	return out, nil
+}
+
+// mapGet returns the value node for key in a mapping node, or nil.
+func mapGet(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mapSet sets key to val in a mapping node, replacing an existing value or
+// appending a new key/value pair.
+func mapSet(m *yaml.Node, key string, val *yaml.Node) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1] = val
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
+}
+
+// agentMapping returns the mapping node for agents.<name>, materializing an
+// empty mapping in place if the agent was written with no fields (e.g.
+// "voice-ai:"). The agent is guaranteed to exist (DryRun rejects a missing one).
+func agentMapping(root *yaml.Node, name string) (*yaml.Node, error) {
+	agents := mapGet(root, "agents")
+	if agents == nil || agents.Kind != yaml.MappingNode {
+		return nil, errors.New("agents section missing or not a mapping")
+	}
+	node := mapGet(agents, name)
+	if node == nil {
+		return nil, fmt.Errorf("agent %q not found in config", name)
+	}
+	if node.Kind != yaml.MappingNode {
+		*node = yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	}
+	return node, nil
 }
 
 // writeExclusive creates path with O_EXCL — it never overwrites an existing
@@ -106,49 +248,6 @@ func writeExclusive(path string, data []byte, mode os.FileMode) error {
 	if err := f.Close(); err != nil {
 		_ = os.Remove(path)
 		return err
-	}
-	return nil
-}
-
-// atomicReplace writes data to an exclusively-created temp file in path's
-// directory, fsyncs it, chmods to mode, atomically renames it over path, then
-// fsyncs the parent directory. On any failure before the rename the temp file
-// is removed and path is left untouched.
-func atomicReplace(path string, data []byte, mode os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpPath) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Chmod(tmpPath, mode); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		cleanup()
-		return err
-	}
-	// Parent fsync makes the rename durable across a crash.
-	if d, err := os.Open(dir); err == nil {
-		_ = d.Sync()
-		_ = d.Close()
 	}
 	return nil
 }

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -1,0 +1,154 @@
+package apply
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/safefile"
+	"gopkg.in/yaml.v3"
+)
+
+// maxConfigBytes caps the original config the backup reads (mirrors config.Load).
+const maxConfigBytes = 1 << 20 // 1 MiB
+
+// ErrNoProjection is returned when Commit is given a plan with no computed
+// target config (DryRun must run first and succeed).
+var ErrNoProjection = errors.New("apply: plan has no projected config to commit")
+
+// Commit writes the plan's projected config to targetConfig using a backup +
+// atomic-replace protocol. Call it only for a plan that has changes and no
+// unsupported items; it returns the created backup path.
+//
+// Sequence (spec 7A.3 §4 steps 13-19 / §5): marshal the projection ->
+// revalidate it by re-parsing (independent of the in-memory Validate) ->
+// exclusive backup of the EXACT original bytes in the same directory ->
+// exclusive temp write -> fsync -> atomic same-dir rename -> parent dir fsync.
+// Nothing mutates the config path until the projected config has validated AND
+// the backup exists; if the rename fails the original config and the backup
+// both remain.
+func Commit(plan *Plan, targetConfig string) (string, error) {
+	if plan == nil || plan.projected == nil {
+		return "", ErrNoProjection
+	}
+
+	// 13-14: marshal deterministically, then revalidate by re-parsing the
+	// bytes that will actually be written — not the in-memory struct.
+	data, err := yaml.Marshal(plan.projected)
+	if err != nil {
+		return "", fmt.Errorf("apply: marshal projected config: %w", err)
+	}
+	var reparsed config.Config
+	if err := yaml.Unmarshal(data, &reparsed); err != nil {
+		return "", fmt.Errorf("apply: projected config does not re-parse: %w", err)
+	}
+	if err := reparsed.Validate(); err != nil {
+		return "", fmt.Errorf("apply: projected config invalid after marshal: %w", err)
+	}
+
+	// Re-check the config path right before writing: never follow a symlink,
+	// never write through a directory or irregular file.
+	info, err := os.Lstat(targetConfig)
+	if err != nil {
+		return "", fmt.Errorf("apply: stat config %q: %w", targetConfig, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("apply: config %q is a symlink (rejected for security)", targetConfig)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("apply: config %q is not a regular file", targetConfig)
+	}
+	mode := info.Mode().Perm()
+
+	// Backup uses the exact original bytes (pre-migration, pre-defaults), so
+	// it round-trips the operator's file verbatim — not the re-marshaled form.
+	orig, err := safefile.ReadFileMax(targetConfig, maxConfigBytes)
+	if err != nil {
+		return "", fmt.Errorf("apply: read original config: %w", err)
+	}
+
+	// 15: exclusive timestamped backup in the same directory. If this fails,
+	// the config is untouched.
+	backupPath := targetConfig + ".bak." + time.Now().UTC().Format("20060102T150405Z")
+	if err := writeExclusive(backupPath, orig, mode); err != nil {
+		return "", fmt.Errorf("apply: create backup %q: %w", backupPath, err)
+	}
+
+	// 16-19: atomic replace. On failure the original config and the backup
+	// both remain; the temp file is removed.
+	if err := atomicReplace(targetConfig, data, mode); err != nil {
+		return backupPath, fmt.Errorf("apply: atomic replace %q (backup kept at %q): %w", targetConfig, backupPath, err)
+	}
+	return backupPath, nil
+}
+
+// writeExclusive creates path with O_EXCL — it never overwrites an existing
+// file and never follows a symlink at path — writes data, fsyncs, and closes.
+// On any write/sync failure the partial file is removed.
+func writeExclusive(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	return nil
+}
+
+// atomicReplace writes data to an exclusively-created temp file in path's
+// directory, fsyncs it, chmods to mode, atomically renames it over path, then
+// fsyncs the parent directory. On any failure before the rename the temp file
+// is removed and path is left untouched.
+func atomicReplace(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return err
+	}
+	// Parent fsync makes the rename durable across a crash.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -188,9 +188,10 @@ func TestCommit_ReadOnlyConfigRejectedNoMutation(t *testing.T) {
 	}
 }
 
-func TestCommit_AliasAgentRejectedNoMutation(t *testing.T) {
-	// An agent written as a YAML alias resolves at load time, but rewriting it
-	// would drop the inherited fields — Commit must refuse, not nuke them.
+func TestCommit_AliasAgentMaterializedPreservingInheritedFields(t *testing.T) {
+	// An agent written as a YAML alias resolves at load time; a real apply
+	// materializes the resolved agent (governed changes + inherited fields) so
+	// it matches dry-run and never drops inherited fields like suspended.
 	const aliasYAML = `version: "1"
 server:
   port: 8080
@@ -198,6 +199,7 @@ identity:
   require_signature: false
 defaults: &defaults
   allowed_tools: [old.tool]
+  suspended: true
 agents:
   voice-ai: *defaults
 rules: []
@@ -207,14 +209,59 @@ rules: []
 	if err := os.WriteFile(path, []byte(aliasYAML), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	orig, _ := os.ReadFile(path)
 	plan := planWithChanges(t, path) // changes the agent's allowed_tools
 
-	if _, err := Commit(plan, path); err == nil {
-		t.Fatal("Commit must refuse to patch a YAML-alias agent")
+	if _, err := Commit(plan, path); err != nil {
+		t.Fatalf("Commit must materialize an alias agent: %v", err)
 	}
-	if after, _ := os.ReadFile(path); string(after) != string(orig) {
-		t.Fatal("alias-agent config was mutated")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("written config must validate: %v", err)
+	}
+	va := cfg.Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("governed change not applied: %v", va.AllowedTools)
+	}
+	if !va.Suspended {
+		t.Fatal("inherited field (suspended) was dropped materializing the alias agent")
+	}
+}
+
+func TestCommit_AgentsLevelMergeMaterialized(t *testing.T) {
+	// Agents defined via an agents-level `<<` merge resolve at load time, so a
+	// real apply must materialize the target agent rather than fail to find it.
+	const mergeYAML = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+agentdefs: &agentdefs
+  voice-ai:
+    allowed_tools: [old.tool]
+agents:
+  <<: *agentdefs
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(mergeYAML), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	plan := planWithChanges(t, path)
+
+	if _, err := Commit(plan, path); err != nil {
+		t.Fatalf("Commit must materialize an agents-level merged agent: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	va := cfg.Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("governed change not applied to merged agent: %v", va.AllowedTools)
 	}
 }
 

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -334,6 +334,41 @@ rules: []
 	}
 }
 
+func TestCommit_AnchoredAgentNodeReferencedElsewhereRejected(t *testing.T) {
+	// The target agent mapping is itself an anchor another agent aliases.
+	// Patching its children in place would also change the aliasing agent, so
+	// Commit refuses rather than silently widen the change beyond --agent.
+	const anchorYAML = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+agents:
+  voice-ai: &shared
+    allowed_tools: [old.tool]
+  other: *shared
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(anchorYAML), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	orig, _ := os.ReadFile(path)
+	plan := planWithChanges(t, path)
+
+	_, err := Commit(plan, path)
+	if err == nil {
+		t.Fatal("Commit must refuse an anchored agent node referenced elsewhere")
+	}
+	if !strings.Contains(err.Error(), "anchor") {
+		t.Fatalf("error should mention the anchor, got: %v", err)
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("config mutated despite anchored-agent refusal")
+	}
+}
+
 func TestCommit_UnreferencedAnchorOnGovernedFieldApplies(t *testing.T) {
 	// An anchor that nothing aliases is harmless to drop, so apply proceeds —
 	// the refusal is precise, not blanket.

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -172,6 +172,78 @@ func TestCommit_SymlinkConfigRejectedNoWrite(t *testing.T) {
 	}
 }
 
+func TestCommit_ReadOnlyConfigRejectedNoMutation(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permission bits")
+	}
+	path := writeOrigConfig(t, 0o400) // read-only
+	orig, _ := os.ReadFile(path)
+	plan := planWithChanges(t, path)
+
+	if _, err := Commit(plan, path); err == nil {
+		t.Fatal("Commit must refuse a read-only config")
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("read-only config was mutated")
+	}
+}
+
+func TestCommit_AliasAgentRejectedNoMutation(t *testing.T) {
+	// An agent written as a YAML alias resolves at load time, but rewriting it
+	// would drop the inherited fields — Commit must refuse, not nuke them.
+	const aliasYAML = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+defaults: &defaults
+  allowed_tools: [old.tool]
+agents:
+  voice-ai: *defaults
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(aliasYAML), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	orig, _ := os.ReadFile(path)
+	plan := planWithChanges(t, path) // changes the agent's allowed_tools
+
+	if _, err := Commit(plan, path); err == nil {
+		t.Fatal("Commit must refuse to patch a YAML-alias agent")
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("alias-agent config was mutated")
+	}
+}
+
+func TestBackupOriginal_CollisionStaysUnique(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Two backups (likely the same second) must both succeed with distinct
+	// names — a backup-name clash never aborts a valid apply.
+	b1, err := backupOriginal(path, []byte("one"), 0o600)
+	if err != nil {
+		t.Fatalf("backup 1: %v", err)
+	}
+	b2, err := backupOriginal(path, []byte("two"), 0o600)
+	if err != nil {
+		t.Fatalf("backup 2: %v", err)
+	}
+	if b1 == b2 {
+		t.Fatalf("backups collided: both %q", b1)
+	}
+	for _, b := range []string{b1, b2} {
+		if _, err := os.Stat(b); err != nil {
+			t.Fatalf("backup %q missing: %v", b, err)
+		}
+	}
+}
+
 func TestWriteExclusive_RefusesExistingTarget(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "backup")

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -265,6 +265,74 @@ rules: []
 	}
 }
 
+func TestCommit_AnchorOnGovernedFieldReferencedElsewhereRejected(t *testing.T) {
+	// A governed field carrying an anchor that another agent aliases cannot be
+	// replaced without orphaning the alias; Commit refuses with a clear error
+	// rather than emit invalid YAML.
+	const anchorYAML = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+agents:
+  voice-ai:
+    allowed_tools: &shared [old.tool]
+  other:
+    allowed_tools: *shared
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(anchorYAML), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	orig, _ := os.ReadFile(path)
+	plan := planWithChanges(t, path)
+
+	_, err := Commit(plan, path)
+	if err == nil {
+		t.Fatal("Commit must refuse an anchored governed field referenced elsewhere")
+	}
+	if !strings.Contains(err.Error(), "anchor") {
+		t.Fatalf("error should mention the anchor, got: %v", err)
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("config mutated despite anchor refusal")
+	}
+}
+
+func TestCommit_UnreferencedAnchorOnGovernedFieldApplies(t *testing.T) {
+	// An anchor that nothing aliases is harmless to drop, so apply proceeds —
+	// the refusal is precise, not blanket.
+	const yamlSrc = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+agents:
+  voice-ai:
+    allowed_tools: &shared [old.tool]
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(yamlSrc), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	plan := planWithChanges(t, path)
+
+	if _, err := Commit(plan, path); err != nil {
+		t.Fatalf("apply must proceed past an unreferenced anchor: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	if va := cfg.Agents["voice-ai"]; len(va.AllowedTools) != 2 {
+		t.Fatalf("governed change not applied: %v", va.AllowedTools)
+	}
+}
+
 func TestBackupOriginal_CollisionStaysUnique(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "oktsec.yaml")

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -1,0 +1,187 @@
+package apply
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// origConfigYAML is a minimal valid config with a voice-ai agent, written
+// verbatim so the backup assertion can compare exact bytes (comment included).
+const origConfigYAML = `# operator config
+version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+agents:
+  voice-ai:
+    allowed_tools: [old.tool]
+rules: []
+`
+
+// writeOrigConfig drops origConfigYAML into a temp dir and returns its path.
+func writeOrigConfig(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(origConfigYAML), mode); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+	return path
+}
+
+// planWithChanges builds a real projection plan (tools change) for the config
+// at path, so Commit has something to write.
+func planWithChanges(t *testing.T, path string) *Plan {
+	t.Helper()
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	b := body()
+	b.Gateway.ToolsAllowed = []string{"calendar.read", "voice.dial"}
+	p, err := DryRun(verified(b), cfg, "voice-ai", path)
+	if err != nil {
+		t.Fatalf("DryRun: %v", err)
+	}
+	if len(p.Changes) == 0 {
+		t.Fatal("test setup: plan must have changes")
+	}
+	return p
+}
+
+func TestCommit_WritesBacksUpAndPreservesMode(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	orig, _ := os.ReadFile(path)
+	plan := planWithChanges(t, path)
+
+	backupPath, err := Commit(plan, path)
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Backup is the exact original bytes, in the same directory.
+	if filepath.Dir(backupPath) != filepath.Dir(path) {
+		t.Fatalf("backup not in config dir: %q", backupPath)
+	}
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backup) != origConfigYAML {
+		t.Fatal("backup is not the exact original bytes")
+	}
+
+	// Config was rewritten, loads, validates, and reflects the projection.
+	after, _ := os.ReadFile(path)
+	if string(after) == origConfigYAML {
+		t.Fatal("Commit did not rewrite the config")
+	}
+	written, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	if err := written.Validate(); err != nil {
+		t.Fatalf("written config must validate: %v", err)
+	}
+	va := written.Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("written allowed tools = %v", va.AllowedTools)
+	}
+
+	// Mode preserved.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %v, want 0600", info.Mode().Perm())
+	}
+	_ = orig
+}
+
+func TestCommit_NilProjectionIsError(t *testing.T) {
+	if _, err := Commit(&Plan{}, "ignored"); !errors.Is(err, ErrNoProjection) {
+		t.Fatalf("err = %v, want ErrNoProjection", err)
+	}
+}
+
+func TestCommit_InvalidProjectedRejectedBeforeAnyWrite(t *testing.T) {
+	// A plan whose projected config fails validation must be refused before
+	// any filesystem mutation. Port 0 is invalid.
+	plan := &Plan{projected: &config.Config{}}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if _, err := Commit(plan, path); err == nil {
+		t.Fatal("Commit must reject an invalid projected config")
+	}
+	// No config and no backup should have been created.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("Commit wrote files for an invalid projection: %v", entries)
+	}
+}
+
+func TestCommit_SymlinkConfigRejectedNoWrite(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	plan := planWithChanges(t, path)
+
+	link := path + ".link"
+	if err := os.Symlink(path, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	orig, _ := os.ReadFile(path)
+
+	if _, err := Commit(plan, link); err == nil {
+		t.Fatal("Commit must reject a symlink config path")
+	}
+	// The real target must be untouched, and no backup created beside it.
+	after, _ := os.ReadFile(path)
+	if string(after) != string(orig) {
+		t.Fatal("Commit wrote through a symlink to the target")
+	}
+}
+
+func TestWriteExclusive_RefusesExistingTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "backup")
+	if err := os.WriteFile(path, []byte("pre-existing"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// O_EXCL must refuse to clobber an existing file (the backup-collision and
+	// existing-symlink guarantees both rely on this).
+	if err := writeExclusive(path, []byte("new"), 0o600); err == nil {
+		t.Fatal("writeExclusive must refuse an existing target")
+	}
+	if got, _ := os.ReadFile(path); string(got) != "pre-existing" {
+		t.Fatal("writeExclusive clobbered an existing file")
+	}
+}
+
+func TestAtomicReplace_WritesAndPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := atomicReplace(path, []byte("new content"), 0o640); err != nil {
+		t.Fatalf("atomicReplace: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "new content" {
+		t.Fatalf("content = %q, want %q", got, "new content")
+	}
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %v, want 0640", info.Mode().Perm())
+	}
+	// No temp files left behind.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("stray files after atomicReplace: %v", entries)
+	}
+}

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/config"
@@ -101,6 +102,16 @@ func TestCommit_WritesBacksUpAndPreservesMode(t *testing.T) {
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("config mode = %v, want 0600", info.Mode().Perm())
 	}
+
+	// Only governed sections change: load-time defaults the operator never
+	// wrote (e.g. db_path) must NOT be persisted, and untouched content (the
+	// header comment) survives.
+	if strings.Contains(string(after), "db_path") {
+		t.Fatal("apply persisted a load-time default (db_path) the original lacked")
+	}
+	if !strings.Contains(string(after), "operator config") {
+		t.Fatal("apply dropped an unrelated header comment")
+	}
 	_ = orig
 }
 
@@ -110,19 +121,34 @@ func TestCommit_NilProjectionIsError(t *testing.T) {
 	}
 }
 
-func TestCommit_InvalidProjectedRejectedBeforeAnyWrite(t *testing.T) {
-	// A plan whose projected config fails validation must be refused before
-	// any filesystem mutation. Port 0 is invalid.
-	plan := &Plan{projected: &config.Config{}}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "oktsec.yaml")
-	if _, err := Commit(plan, path); err == nil {
-		t.Fatal("Commit must reject an invalid projected config")
+func TestCommit_InvalidPatchedConfigRejectedNoMutation(t *testing.T) {
+	// If the patched result would not validate, Commit must refuse before
+	// touching the config or leaving a backup. A hand-built plan injects an
+	// invalid rule action into the projection that the patch would write.
+	path := writeOrigConfig(t, 0o600)
+	orig, _ := os.ReadFile(path)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	// No config and no backup should have been created.
-	entries, _ := os.ReadDir(dir)
-	if len(entries) != 0 {
-		t.Fatalf("Commit wrote files for an invalid projection: %v", entries)
+	cfg.Rules = []config.RuleAction{{ID: "X", Action: "not-a-valid-action"}}
+	plan := &Plan{
+		Agent:     "voice-ai",
+		Changes:   []Change{{Kind: "rule_override", ID: "X", Action: "not-a-valid-action"}},
+		projected: cfg,
+	}
+
+	if _, err := Commit(plan, path); err == nil {
+		t.Fatal("Commit must reject an invalid patched config")
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("config mutated despite an invalid patched result")
+	}
+	// Validation fails before the backup, so no stray files beside the config.
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	if len(entries) != 1 || entries[0].Name() != "oktsec.yaml" {
+		t.Fatalf("stray files after rejected apply: %v", entries)
 	}
 }
 
@@ -162,26 +188,20 @@ func TestWriteExclusive_RefusesExistingTarget(t *testing.T) {
 	}
 }
 
-func TestAtomicReplace_WritesAndPreservesMode(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "oktsec.yaml")
-	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
-		t.Fatalf("seed: %v", err)
+func TestCommit_NoStrayTempAfterApply(t *testing.T) {
+	// A successful apply leaves exactly the config + one backup, no temp files.
+	path := writeOrigConfig(t, 0o600)
+	plan := planWithChanges(t, path)
+	if _, err := Commit(plan, path); err != nil {
+		t.Fatalf("Commit: %v", err)
 	}
-	if err := atomicReplace(path, []byte("new content"), 0o640); err != nil {
-		t.Fatalf("atomicReplace: %v", err)
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	if len(entries) != 2 {
+		t.Fatalf("want config + backup only, got %v", entries)
 	}
-	got, _ := os.ReadFile(path)
-	if string(got) != "new content" {
-		t.Fatalf("content = %q, want %q", got, "new content")
-	}
-	info, _ := os.Stat(path)
-	if info.Mode().Perm() != 0o640 {
-		t.Fatalf("mode = %v, want 0640", info.Mode().Perm())
-	}
-	// No temp files left behind.
-	entries, _ := os.ReadDir(dir)
-	if len(entries) != 1 {
-		t.Fatalf("stray files after atomicReplace: %v", entries)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Fatalf("stray temp file left behind: %s", e.Name())
+		}
 	}
 }

--- a/internal/apply/write_test.go
+++ b/internal/apply/write_test.go
@@ -230,6 +230,39 @@ rules: []
 	}
 }
 
+func TestCommit_WholeAgentsSectionAliasMaterialized(t *testing.T) {
+	// The entire agents section defined via a YAML alias resolves at load
+	// time; real apply must materialize it rather than treat it as missing.
+	const aliasYAML = `version: "1"
+server:
+  port: 8080
+identity:
+  require_signature: false
+allagents: &allagents
+  voice-ai:
+    allowed_tools: [old.tool]
+agents: *allagents
+rules: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(path, []byte(aliasYAML), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	plan := planWithChanges(t, path)
+
+	if _, err := Commit(plan, path); err != nil {
+		t.Fatalf("Commit must materialize an aliased agents section: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	if va := cfg.Agents["voice-ai"]; len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("governed change not applied: %v", va.AllowedTools)
+	}
+}
+
 func TestCommit_AgentsLevelMergeMaterialized(t *testing.T) {
 	// Agents defined via an agents-level `<<` merge resolve at load time, so a
 	// real apply must materialize the target agent rather than fail to find it.


### PR DESCRIPTION
Order 7A.3. `oktsec policy apply` without `--dry-run` now writes the config in place, reusing the 7A.2 projection exactly (no duplicated mapping).

## Flow
verify bundle → compute the same 7A.2 plan → validate the projected config → back up the original → atomically replace → structured result.

`internal/apply.Commit`: marshal projection → revalidate by re-parsing the bytes to be written → exclusive timestamped backup of the exact original bytes (same dir) → exclusive temp write → fsync → atomic rename over config → parent-dir fsync. Nothing mutates the config path until the projection has validated AND the backup exists; a failed rename leaves the original and the backup intact.

## Safety
- Missing config = hard error (apply never creates a config).
- Symlink and directory config paths rejected; never write through a link.
- Original file mode preserved; parent dirs never chmodded.
- No-op writes nothing and creates no backup.
- Unsupported semantics fail with no write.
- Real apply produces the same change set as `--dry-run` for the same inputs.

## Non-goals (held)
No rollback command, no `--all-agents`, no `--allow-partial` for real apply, no `--no-backup`, no `--init-config`, no remote/browser apply, no Enterprise/release changes.

## Tests
`internal/apply`: Commit writes + exact-byte backup + mode preserved; nil projection; invalid projected rejected before any write; symlink rejected no-write; writeExclusive refuses existing target; atomicReplace writes + preserves mode + no stray temp. `cmd`: real apply writes + backs up + idempotent no-op; apply matches dry-run; missing/dir/symlink config rejected with no write; `--agent` required.