### PR TITLE
Add Startup/Team baseline evidence bundle example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 LDFLAGS := -ldflags "-s -w -X $(PKG)/cmd/oktsec/commands.version=$(VERSION) -X $(PKG)/cmd/oktsec/commands.commit=$(COMMIT)"
 
-.PHONY: build test integration-test lint run clean fmt vet bench
+.PHONY: build test integration-test lint run clean fmt vet bench baseline-bundle-smoke
 
 build:
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/oktsec
@@ -30,6 +30,9 @@ run:
 
 bench:
 	go run ./cmd/bench
+
+baseline-bundle-smoke:
+	go test -tags=examples -count=1 ./cmd/oktsec/commands/ -run TestStartupTeamBaselineBundle -v
 
 clean:
 	rm -f $(BINARY)

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -344,6 +344,29 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 		t.Errorf("status must record an unopenable DB as unavailable, not hide it:\n%s", out)
 	}
 
+	// Regression (failure reasons are scrubbed): a required step that fails
+	// writes its stderr reason into redactions.json. That reason must be path-
+	// scrubbed too, or the bundle leaks raw paths while claiming they are masked.
+	missCfg := filepath.Join(tmp, "missing-dir", "oktsec.yaml") // dir + file absent
+	failOut := filepath.Join(tmp, "bundle-failreason")
+	if _, err := runHarness("--config", missCfg, "--output", failOut); err == nil {
+		t.Error("expected non-zero exit when required collection steps fail on a missing config")
+	}
+	if data, err := os.ReadFile(filepath.Join(failOut, "redactions.json")); err != nil {
+		t.Errorf("read redactions.json: %v", err)
+	} else {
+		s := string(data)
+		if !json.Valid(data) {
+			t.Errorf("redactions.json is not valid JSON after failures:\n%s", s)
+		}
+		if strings.Contains(s, tmp) {
+			t.Errorf("redactions.json leaks raw path %q; failure reasons must be scrubbed:\n%s", tmp, s)
+		}
+		if !strings.Contains(s, "<CONFIG_DIR>") {
+			t.Errorf("redactions.json failure reason should mask the config dir as <CONFIG_DIR>:\n%s", s)
+		}
+	}
+
 	// Regression (secret scan coverage): exercise the harness's own SECRET_PAT
 	// against known token shapes and benign text, so it stays fail-closed for
 	// real tokens without flagging diagnostic env-var names.

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -17,12 +17,17 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
 )
 
 func repoRootForExample(t *testing.T) string {
@@ -212,16 +217,74 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 
 	// Regression (--force stale files): a pre-existing secret/unexpected file in
 	// the target dir must make the bundle fail closed rather than ship silently.
-	stale := filepath.Join(tmp, "bundle-stale")
-	if err := os.MkdirAll(stale, 0o700); err != nil {
+	// Includes a double-dot name (..secret.env) that an earlier glob missed.
+	for i, fname := range []string{"old-secret.env", "..secret.env"} {
+		stale := filepath.Join(tmp, fmt.Sprintf("bundle-stale-%d", i))
+		if err := os.MkdirAll(stale, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(stale, fname),
+			[]byte("ANTHROPIC_API_KEY=sk-ant-0123456789abcdefghij\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if logs, err := runHarness("--config", cfgPath, "--output", stale, "--force"); err == nil {
+			t.Errorf("expected failure with stale file %q in bundle dir\n%s", fname, logs)
+		}
+	}
+
+	// Regression (strict read-only DB): an existing empty/old DB must not be
+	// created, grown, or migrated by collecting status. Pre-create a 0-byte DB
+	// and assert its size is unchanged after a run.
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(stale, "old-secret.env"),
-		[]byte("ANTHROPIC_API_KEY=sk-ant-0123456789abcdefghij\n"), 0o600); err != nil {
-		t.Fatal(err)
+	roOut := filepath.Join(tmp, "bundle-ro")
+	if logs, err := runHarness("--config", cfgPath, "--output", roOut); err != nil {
+		t.Fatalf("harness failed against empty DB: %v\n%s", err, logs)
 	}
-	if logs, err := runHarness("--config", cfgPath, "--output", stale, "--force"); err == nil {
-		t.Errorf("expected failure when bundle dir contains a stale secret/unexpected file\n%s", logs)
+	if info, err := os.Stat(dbPath); err != nil {
+		t.Errorf("stat dbPath: %v", err)
+	} else if info.Size() != 0 {
+		t.Errorf("audit DB grew from 0 to %d bytes; collection must be strictly read-only", info.Size())
+	}
+
+	// Strict read-only must still READ a populated DB and report its stats
+	// without mutating the file (size stable across the run).
+	validDB := filepath.Join(tmp, "valid.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st, err := audit.NewStore(validDB, logger)
+	if err != nil {
+		t.Fatalf("seed audit DB: %v", err)
+	}
+	st.Log(audit.Entry{
+		ID: "e1", Timestamp: time.Now().UTC().Format(time.RFC3339),
+		FromAgent: "a", ToAgent: "b", ContentHash: "deadbeef",
+		Status: "delivered", PolicyDecision: "clean",
+	})
+	st.Flush()
+	if err := st.Close(); err != nil {
+		t.Fatalf("close seed DB: %v", err)
+	}
+	infoBefore, err := os.Stat(validDB)
+	if err != nil {
+		t.Fatalf("stat seeded DB: %v", err)
+	}
+	sizeBefore := infoBefore.Size()
+	validCfg := filepath.Join(tmp, "oktsec-valid.yaml")
+	writeBundleTestConfig(t, validCfg, keys, validDB)
+	validOut := filepath.Join(tmp, "bundle-valid")
+	if logs, err := runHarness("--config", validCfg, "--output", validOut); err != nil {
+		t.Fatalf("harness failed against populated DB: %v\n%s", err, logs)
+	}
+	if info, err := os.Stat(validDB); err != nil {
+		t.Errorf("stat populated DB: %v", err)
+	} else if info.Size() != sizeBefore {
+		t.Errorf("populated audit DB changed size %d -> %d under strict read-only", sizeBefore, info.Size())
+	}
+	if data, err := os.ReadFile(filepath.Join(validOut, "status.txt")); err != nil {
+		t.Errorf("read status.txt: %v", err)
+	} else if !strings.Contains(string(data), "Total msgs:") {
+		t.Errorf("status.txt missing message stats for a populated DB:\n%s", data)
 	}
 
 	// Regression (secret scan coverage): exercise the harness's own SECRET_PAT

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -15,6 +15,7 @@ package commands
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -287,6 +288,39 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 		t.Errorf("status.txt missing message stats for a populated DB:\n%s", data)
 	}
 
+	// Regression (legacy DB must not under-report): a DB with rows but missing
+	// the newer columns the query selects must report stats as unavailable, not
+	// silently print zero counts. Strict read-only skips migrations, so the
+	// query errors instead of materializing the columns.
+	legacyDB := filepath.Join(tmp, "legacy.db")
+	seedLegacyAuditDB(t, legacyDB)
+	legacyBefore, err := os.Stat(legacyDB)
+	if err != nil {
+		t.Fatalf("stat legacy DB: %v", err)
+	}
+	legacyCfg := filepath.Join(tmp, "oktsec-legacy.yaml")
+	writeBundleTestConfig(t, legacyCfg, keys, legacyDB)
+	legacyOut := filepath.Join(tmp, "bundle-legacy")
+	if logs, err := runHarness("--config", legacyCfg, "--output", legacyOut); err != nil {
+		t.Fatalf("harness failed against legacy DB: %v\n%s", err, logs)
+	}
+	if info, err := os.Stat(legacyDB); err != nil {
+		t.Errorf("stat legacy DB after run: %v", err)
+	} else if info.Size() != legacyBefore.Size() {
+		t.Errorf("legacy DB changed size %d -> %d; must not migrate under strict read-only", legacyBefore.Size(), info.Size())
+	}
+	if data, err := os.ReadFile(filepath.Join(legacyOut, "status.txt")); err != nil {
+		t.Errorf("read legacy status.txt: %v", err)
+	} else {
+		s := string(data)
+		if strings.Contains(s, "Total msgs:    0") {
+			t.Errorf("legacy DB with rows was under-reported as zero:\n%s", s)
+		}
+		if !strings.Contains(s, "unavailable") {
+			t.Errorf("legacy DB stats should be reported unavailable, not silently dropped:\n%s", s)
+		}
+	}
+
 	// Regression (secret scan coverage): exercise the harness's own SECRET_PAT
 	// against known token shapes and benign text, so it stays fail-closed for
 	// real tokens without flagging diagnostic env-var names.
@@ -333,6 +367,41 @@ func extractSecretPat(t *testing.T, script string) string {
 	}
 	t.Fatal("could not find SECRET_PAT in harness")
 	return ""
+}
+
+// seedLegacyAuditDB writes a minimal pre-migration audit_log: it has the
+// original columns and one delivered row but lacks the newer columns the
+// current query selects. Opened strictly read-only (no migration), the query
+// errors — exactly the legacy case the status command must not under-report.
+func seedLegacyAuditDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	const legacySchema = `CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		signature_verified INTEGER,
+		pubkey_fingerprint TEXT,
+		status TEXT NOT NULL,
+		rules_triggered TEXT,
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER
+	);`
+	if _, err := db.Exec(legacySchema); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO audit_log (id, timestamp, from_agent, to_agent, content_hash, status, policy_decision)`+
+			` VALUES ('e1', ?, 'a', 'b', 'deadbeef', 'delivered', 'clean')`,
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
 }
 
 // grepMatchesPattern reports whether grep -E pat matches s, using the same grep

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -96,6 +96,14 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 		return string(out), err
 	}
 
+	runStatus := func(cfg string) (string, error) {
+		cmd := exec.Command(bin, "--config", cfg, "status")
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(), "HOME="+home)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
 	// --- happy path ---
 	if logs, err := runHarness("--config", cfgPath, "--output", bundle); err != nil {
 		t.Fatalf("harness failed: %v\n%s", err, logs)
@@ -319,6 +327,21 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 		if !strings.Contains(s, "unavailable") {
 			t.Errorf("legacy DB stats should be reported unavailable, not silently dropped:\n%s", s)
 		}
+	}
+
+	// Regression (unopenable DB recorded, not hidden): a db_path whose parent is
+	// a regular file makes os.Stat fail with a non-IsNotExist error. status must
+	// report it as unavailable rather than silently omitting the audit section.
+	notDir := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(notDir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	badCfg := filepath.Join(tmp, "oktsec-baddb.yaml")
+	writeBundleTestConfig(t, badCfg, keys, filepath.Join(notDir, "oktsec.db"))
+	if out, err := runStatus(badCfg); err != nil {
+		t.Errorf("status should exit 0 even with an unopenable DB: %v\n%s", err, out)
+	} else if !strings.Contains(out, "Audit stats:   unavailable") {
+		t.Errorf("status must record an unopenable DB as unavailable, not hide it:\n%s", out)
 	}
 
 	// Regression (secret scan coverage): exercise the harness's own SECRET_PAT

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -95,6 +95,13 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 		t.Fatalf("harness failed: %v\n%s", err, logs)
 	}
 
+	// Regression (status read-only): the harness must not create or migrate the
+	// audit DB. `oktsec status` used to open it writable, which created an empty
+	// DB and desynced `node snapshot` (db_available) from `audit` (not created).
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Errorf("harness created/left an audit DB at %s; collection must stay read-only", dbPath)
+	}
+
 	// Required + generated files must exist. node-status / node-snapshot are
 	// best-effort and intentionally excluded from this hard list.
 	for _, f := range []string{"README.md", "manifest.json", "audit.json", "audit.sarif", "status.txt", "redactions.json"} {
@@ -202,4 +209,82 @@ func TestStartupTeamBaselineBundle(t *testing.T) {
 	if logs, err := runHarness("--config", cfgPath, "--output", bundle, "--force"); err != nil {
 		t.Errorf("--force overwrite should succeed: %v\n%s", err, logs)
 	}
+
+	// Regression (--force stale files): a pre-existing secret/unexpected file in
+	// the target dir must make the bundle fail closed rather than ship silently.
+	stale := filepath.Join(tmp, "bundle-stale")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "old-secret.env"),
+		[]byte("ANTHROPIC_API_KEY=sk-ant-0123456789abcdefghij\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if logs, err := runHarness("--config", cfgPath, "--output", stale, "--force"); err == nil {
+		t.Errorf("expected failure when bundle dir contains a stale secret/unexpected file\n%s", logs)
+	}
+
+	// Regression (secret scan coverage): exercise the harness's own SECRET_PAT
+	// against known token shapes and benign text, so it stays fail-closed for
+	// real tokens without flagging diagnostic env-var names.
+	pat := extractSecretPat(t, script)
+	for _, p := range []string{
+		"node server.js --token ghp_0123456789012345678901",
+		"AKIA0123456789ABCDEF",
+		"--key sk-ant-0123456789abcdefghij",
+		"glpat-0123456789abcdefghij",
+		"GITHUB_TOKEN=ghp_x",
+		"-----BEGIN OKTSEC ED25519 PRIVATE KEY-----",
+	} {
+		if !grepMatchesPattern(t, pat, p) {
+			t.Errorf("SECRET_PAT should match secret value %q", p)
+		}
+	}
+	for _, n := range []string{
+		"No agents registered",
+		`has env var "ANTHROPIC_API_KEY" which appears to contain a secret`,
+		"Health: 80/100 (B)",
+		"node_id: sha256:abcdef0123456789abcdef0123456789",
+	} {
+		if grepMatchesPattern(t, pat, n) {
+			t.Errorf("SECRET_PAT should NOT match benign text %q", n)
+		}
+	}
+}
+
+// extractSecretPat pulls the canonical SECRET_PAT one-liner out of run.sh so
+// the test exercises the exact pattern the harness uses (no parallel copy to
+// drift from).
+func extractSecretPat(t *testing.T, script string) string {
+	t.Helper()
+	data, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read harness: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		const prefix = "SECRET_PAT='"
+		if strings.HasPrefix(line, prefix) && strings.HasSuffix(line, "'") {
+			return line[len(prefix) : len(line)-1]
+		}
+	}
+	t.Fatal("could not find SECRET_PAT in harness")
+	return ""
+}
+
+// grepMatchesPattern reports whether grep -E pat matches s, using the same grep
+// the harness relies on.
+func grepMatchesPattern(t *testing.T, pat, s string) bool {
+	t.Helper()
+	cmd := exec.Command("grep", "-Eq", pat)
+	cmd.Stdin = strings.NewReader(s + "\n")
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+		return false // grep: no match
+	}
+	t.Fatalf("grep failed for pattern: %v", err)
+	return false
 }

--- a/cmd/oktsec/commands/baseline_bundle_example_test.go
+++ b/cmd/oktsec/commands/baseline_bundle_example_test.go
@@ -1,0 +1,205 @@
+//go:build examples
+
+// Smoke test for the Startup / Team baseline evidence bundle harness
+// (Order 8B.1). It builds the real oktsec binary, runs
+// examples/startup-team-baseline/run.sh against a hermetic HOME and config,
+// and asserts the bundle contract: required files present, manifest hashes
+// match, README boundary language present, no secrets, no identifying paths,
+// and no raw key/env/db artifacts copied in.
+//
+// Behind the `examples` build tag so it stays out of the default `make test`
+// (it shells out to bash and compiles the binary). Run via:
+//
+//	make baseline-bundle-smoke
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func repoRootForExample(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve caller path")
+	}
+	// cmd/oktsec/commands/<file> -> repo root is three directories up.
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+}
+
+func writeBundleTestConfig(t *testing.T, path, keysDir, dbPath string) {
+	t.Helper()
+	cfg := "version: \"1\"\n" +
+		"server:\n  port: 8080\n  log_level: info\n" +
+		"identity:\n  keys_dir: " + keysDir + "\n  require_signature: false\n" +
+		"db_path: " + dbPath + "\n" +
+		"agents: {}\n"
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestStartupTeamBaselineBundle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("harness is a bash script; skipping on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	root := repoRootForExample(t)
+	script := filepath.Join(root, "examples", "startup-team-baseline", "run.sh")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("harness not found: %v", err)
+	}
+
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "oktsec")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/oktsec")
+	build.Dir = root
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build oktsec: %v\n%s", err, out)
+	}
+
+	home := filepath.Join(tmp, "home")
+	keys := filepath.Join(tmp, "keys")
+	for _, d := range []string{home, keys} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgPath := filepath.Join(tmp, "oktsec.yaml")
+	dbPath := filepath.Join(tmp, "oktsec.db")
+	writeBundleTestConfig(t, cfgPath, keys, dbPath)
+
+	bundle := filepath.Join(tmp, "bundle")
+
+	runHarness := func(args ...string) (string, error) {
+		cmd := exec.Command("bash", append([]string{script}, args...)...)
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(), "HOME="+home, "OKTSEC_BIN="+bin)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	// --- happy path ---
+	if logs, err := runHarness("--config", cfgPath, "--output", bundle); err != nil {
+		t.Fatalf("harness failed: %v\n%s", err, logs)
+	}
+
+	// Required + generated files must exist. node-status / node-snapshot are
+	// best-effort and intentionally excluded from this hard list.
+	for _, f := range []string{"README.md", "manifest.json", "audit.json", "audit.sarif", "status.txt", "redactions.json"} {
+		if _, err := os.Stat(filepath.Join(bundle, f)); err != nil {
+			t.Errorf("missing required file %s: %v", f, err)
+		}
+	}
+
+	// Manifest parses, has the frozen schema, and every hash matches.
+	var man struct {
+		Schema string `json:"schema"`
+		Files  []struct {
+			Path   string `json:"path"`
+			SHA256 string `json:"sha256"`
+		} `json:"files"`
+	}
+	mb, err := os.ReadFile(filepath.Join(bundle, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if err := json.Unmarshal(mb, &man); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v\n%s", err, mb)
+	}
+	if man.Schema != "oktsec_startup_team_baseline.v1" {
+		t.Errorf("manifest schema = %q, want oktsec_startup_team_baseline.v1", man.Schema)
+	}
+	if len(man.Files) == 0 {
+		t.Fatal("manifest lists no files")
+	}
+	for _, fe := range man.Files {
+		data, err := os.ReadFile(filepath.Join(bundle, fe.Path))
+		if err != nil {
+			t.Errorf("manifest references missing file %s", fe.Path)
+			continue
+		}
+		sum := sha256.Sum256(data)
+		if got := hex.EncodeToString(sum[:]); got != fe.SHA256 {
+			t.Errorf("sha256 mismatch for %s: manifest %s, actual %s", fe.Path, fe.SHA256, got)
+		}
+	}
+
+	// redactions.json must be valid JSON too.
+	if rb, err := os.ReadFile(filepath.Join(bundle, "redactions.json")); err != nil {
+		t.Errorf("read redactions.json: %v", err)
+	} else if !json.Valid(rb) {
+		t.Errorf("redactions.json is not valid JSON:\n%s", rb)
+	}
+
+	// README boundary language (verbatim from the spec).
+	readme, err := os.ReadFile(filepath.Join(bundle, "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	for _, phrase := range []string{
+		"operational evidence, not a compliance certification",
+		"Only routed/configured surfaces are represented",
+		"Raw prompts, private keys, secrets and raw audit databases are omitted",
+	} {
+		if !strings.Contains(string(readme), phrase) {
+			t.Errorf("README missing boundary phrase: %q", phrase)
+		}
+	}
+
+	// Data files: no secrets and no identifying paths.
+	forbidden := []string{
+		"BEGIN OKTSEC ED25519 PRIVATE KEY",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+		"hooks.slack.com",
+	}
+	for _, f := range []string{"audit.json", "audit.sarif", "status.txt", "node-status.json", "node-snapshot.json"} {
+		data, err := os.ReadFile(filepath.Join(bundle, f))
+		if err != nil {
+			continue // best-effort files may be absent
+		}
+		s := string(data)
+		for _, bad := range forbidden {
+			if strings.Contains(s, bad) {
+				t.Errorf("%s contains forbidden token %q", f, bad)
+			}
+		}
+		if strings.Contains(s, home) {
+			t.Errorf("%s leaks home path %q", f, home)
+		}
+		if strings.Contains(s, tmp) {
+			t.Errorf("%s leaks unmasked path %q", f, tmp)
+		}
+	}
+
+	// No raw key/env/db artifacts copied into the bundle.
+	entries, err := os.ReadDir(bundle)
+	if err != nil {
+		t.Fatalf("read bundle dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == ".env" || strings.HasSuffix(name, ".key") || strings.HasSuffix(name, ".db") || strings.HasSuffix(name, ".pem") {
+			t.Errorf("bundle contains forbidden artifact: %s", name)
+		}
+	}
+
+	// --- overwrite refusal then --force ---
+	if logs, err := runHarness("--config", cfgPath, "--output", bundle); err == nil {
+		t.Errorf("expected non-zero exit overwriting non-empty dir without --force\n%s", logs)
+	}
+	if logs, err := runHarness("--config", cfgPath, "--output", bundle, "--force"); err != nil {
+		t.Errorf("--force overwrite should succeed: %v\n%s", err, logs)
+	}
+}

--- a/cmd/oktsec/commands/status.go
+++ b/cmd/oktsec/commands/status.go
@@ -77,10 +77,14 @@ func newStatusCmd() *cobra.Command {
 				fmt.Printf("  Detected:      %s\n", joinDetected(detected))
 			}
 
-			// Audit stats
+			// Audit stats. status is read-only: it must never create or
+			// migrate the audit DB. If the DB does not exist yet, report
+			// nothing rather than materializing an empty file (which would
+			// also desync read-only evidence tools like `node snapshot`).
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-			store, err := audit.NewStore(defaultDBPath(), logger)
-			if err == nil {
+			dbPath := defaultDBPath()
+			store, err := openReadOnlyAuditStoreIfPresent(dbPath, logger)
+			if err == nil && store != nil {
 				defer func() { _ = store.Close() }()
 
 				all, _ := store.Query(audit.QueryOpts{Limit: 100000})
@@ -120,6 +124,17 @@ func newStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// openReadOnlyAuditStoreIfPresent opens the audit DB read-only only when it
+// already exists. A missing DB returns (nil, nil) so callers can skip stats
+// without creating the file. Read-only avoids the migration-time auto-repair
+// that the writable constructor performs.
+func openReadOnlyAuditStoreIfPresent(dbPath string, logger *slog.Logger) (*audit.Store, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, nil //nolint:nilnil // "absent" is a valid, non-error state here
+	}
+	return audit.NewStoreReadOnly(dbPath, logger)
 }
 
 func joinDetected(detected []string) string {

--- a/cmd/oktsec/commands/status.go
+++ b/cmd/oktsec/commands/status.go
@@ -126,15 +126,16 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
-// openReadOnlyAuditStoreIfPresent opens the audit DB read-only only when it
-// already exists. A missing DB returns (nil, nil) so callers can skip stats
-// without creating the file. Read-only avoids the migration-time auto-repair
-// that the writable constructor performs.
+// openReadOnlyAuditStoreIfPresent opens the audit DB strictly read-only and
+// only when it already exists. A missing DB returns (nil, nil) so callers can
+// skip stats without creating the file. The strict constructor performs no
+// schema creation, ANALYZE, or migration, so reporting status never grows or
+// migrates an existing (possibly empty or old) DB.
 func openReadOnlyAuditStoreIfPresent(dbPath string, logger *slog.Logger) (*audit.Store, error) {
 	if _, err := os.Stat(dbPath); err != nil {
 		return nil, nil //nolint:nilnil // "absent" is a valid, non-error state here
 	}
-	return audit.NewStoreReadOnly(dbPath, logger)
+	return audit.NewStoreReadOnlyStrict(dbPath, logger)
 }
 
 func joinDetected(detected []string) string {

--- a/cmd/oktsec/commands/status.go
+++ b/cmd/oktsec/commands/status.go
@@ -84,7 +84,15 @@ func newStatusCmd() *cobra.Command {
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 			dbPath := defaultDBPath()
 			store, err := openReadOnlyAuditStoreIfPresent(dbPath, logger)
-			if err == nil && store != nil {
+			switch {
+			case err != nil:
+				// The DB path exists but could not be opened (permission,
+				// symlink rejection, not-a-directory, corrupt, ...). Record it
+				// rather than hiding the audit section. A missing DB returns
+				// (nil, nil) and stays quiet — that is the normal fresh install.
+				fmt.Println("  ────────────────────────────────────────")
+				fmt.Printf("  Audit stats:   unavailable (%v)\n", err)
+			case store != nil:
 				defer func() { _ = store.Close() }()
 
 				all, qErr := store.Query(audit.QueryOpts{Limit: 100000})
@@ -133,14 +141,19 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
-// openReadOnlyAuditStoreIfPresent opens the audit DB strictly read-only and
-// only when it already exists. A missing DB returns (nil, nil) so callers can
-// skip stats without creating the file. The strict constructor performs no
-// schema creation, ANALYZE, or migration, so reporting status never grows or
-// migrates an existing (possibly empty or old) DB.
+// openReadOnlyAuditStoreIfPresent opens the audit DB strictly read-only, only
+// when it already exists. A genuinely missing DB returns (nil, nil) so callers
+// stay quiet without creating the file — the normal fresh-install case. Any
+// other stat error (permission, not-a-directory, ...) and any open error are
+// returned so the caller can record the DB as unavailable rather than hiding
+// the audit section. The strict constructor performs no schema creation,
+// ANALYZE, or migration, so reporting status never grows or migrates the DB.
 func openReadOnlyAuditStoreIfPresent(dbPath string, logger *slog.Logger) (*audit.Store, error) {
 	if _, err := os.Stat(dbPath); err != nil {
-		return nil, nil //nolint:nilnil // "absent" is a valid, non-error state here
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // "absent" is a valid, non-error state here
+		}
+		return nil, err
 	}
 	return audit.NewStoreReadOnlyStrict(dbPath, logger)
 }

--- a/cmd/oktsec/commands/status.go
+++ b/cmd/oktsec/commands/status.go
@@ -87,31 +87,38 @@ func newStatusCmd() *cobra.Command {
 			if err == nil && store != nil {
 				defer func() { _ = store.Close() }()
 
-				all, _ := store.Query(audit.QueryOpts{Limit: 100000})
-				var delivered, blocked, rejected, quarantined int
-				for _, e := range all {
-					switch e.Status {
-					case audit.StatusDelivered:
-						delivered++
-					case audit.StatusBlocked:
-						blocked++
-					case audit.StatusRejected:
-						rejected++
-					case audit.StatusQuarantined:
-						quarantined++
-					}
-				}
-
+				all, qErr := store.Query(audit.QueryOpts{Limit: 100000})
 				fmt.Println("  ────────────────────────────────────────")
-				fmt.Printf("  Total msgs:    %d\n", len(all))
-				fmt.Printf("  Delivered:     %d\n", delivered)
-				fmt.Printf("  Blocked:       %d\n", blocked)
-				fmt.Printf("  Rejected:      %d\n", rejected)
-				fmt.Printf("  Quarantined:   %d\n", quarantined)
+				if qErr != nil {
+					// Strict read-only deliberately skips migrations, so an
+					// older DB can hold rows but lack columns the query selects.
+					// Never print zero counts in that case — that silently
+					// under-reports real data. Report it as unavailable instead.
+					fmt.Printf("  Audit stats:   unavailable (%v)\n", qErr)
+				} else {
+					var delivered, blocked, rejected, quarantined int
+					for _, e := range all {
+						switch e.Status {
+						case audit.StatusDelivered:
+							delivered++
+						case audit.StatusBlocked:
+							blocked++
+						case audit.StatusRejected:
+							rejected++
+						case audit.StatusQuarantined:
+							quarantined++
+						}
+					}
 
-				revoked, _ := store.ListRevokedKeys()
-				if len(revoked) > 0 {
-					fmt.Printf("  Revoked keys:  %d\n", len(revoked))
+					fmt.Printf("  Total msgs:    %d\n", len(all))
+					fmt.Printf("  Delivered:     %d\n", delivered)
+					fmt.Printf("  Blocked:       %d\n", blocked)
+					fmt.Printf("  Rejected:      %d\n", rejected)
+					fmt.Printf("  Quarantined:   %d\n", quarantined)
+
+					if revoked, rErr := store.ListRevokedKeys(); rErr == nil && len(revoked) > 0 {
+						fmt.Printf("  Revoked keys:  %d\n", len(revoked))
+					}
 				}
 			}
 

--- a/examples/startup-team-baseline/README.md
+++ b/examples/startup-team-baseline/README.md
@@ -1,0 +1,85 @@
+# Startup / Team Baseline Evidence Bundle
+
+A local-only harness that turns one Oktsec install into a single redacted
+evidence bundle a small team can review and share by hand. It is the technical
+artifact behind the Startup / Team package:
+
+```
+one local install -> shared baseline -> evidence report -> repeatable setup
+```
+
+It is **not** a SaaS workspace. It creates no accounts, aggregates nothing
+across machines, collects nothing remotely, and never mutates your local Oktsec
+config or services. The output is operational evidence, not a compliance
+certification.
+
+## Usage
+
+```bash
+# From a directory where `oktsec` is installed (or build ./oktsec first):
+./run.sh --output ./my-team-baseline
+
+# Point at a specific config:
+./run.sh --config /etc/oktsec/oktsec.yaml --output ./my-team-baseline
+
+# Overwrite an existing non-empty directory:
+./run.sh --output ./my-team-baseline --force
+```
+
+The binary is resolved from `$OKTSEC_BIN`, then `./oktsec`, then `oktsec` on
+your `PATH`.
+
+If `--output` is omitted, the bundle is written to
+`./oktsec-startup-team-baseline-<timestamp>/`.
+
+## What it produces
+
+A directory containing:
+
+| File | Source | Notes |
+|------|--------|-------|
+| `README.md` | generated | Boundary language + file guide |
+| `manifest.json` | generated | Schema, version, host os/arch, SHA-256 of each file |
+| `audit.json` | `oktsec audit --json` | Deployment security findings |
+| `audit.sarif` | `oktsec audit --sarif` | Same findings, SARIF v2.1.0 |
+| `status.txt` | `oktsec status` | Runtime status summary (text) |
+| `node-status.json` | `oktsec node status --json` | Local node identity status |
+| `node-snapshot.json` | `oktsec node snapshot --json` | Read-only coverage/evidence snapshot |
+| `redactions.json` | generated | What was omitted + any missing/partial files |
+
+`manifest.json` uses the stable schema `oktsec_startup_team_baseline.v1`.
+
+## Safety guarantees
+
+The harness:
+
+- writes only into the explicit output directory, created `0700`;
+- refuses to write through a symlink or into a non-empty directory without
+  `--force`;
+- runs without network access;
+- never copies the raw audit database, private keys, `.env`, API keys, raw
+  prompts/tool payloads, or the full `oktsec.yaml`;
+- masks identifying filesystem paths (config directory, working directory,
+  user home) as `<CONFIG_DIR>`, `<PWD>`, `<HOME>`;
+- self-scans the collected data files for known secret patterns and exits
+  non-zero (without presenting the bundle as safe) if any are found;
+- exits non-zero if a required collection step fails, and records missing or
+  partial files in `redactions.json` rather than failing silently.
+
+`oktsec node status` / `node snapshot` are best-effort: on a fresh install with
+no node identity they are recorded as missing rather than failing the bundle.
+
+Always inspect the bundle before sharing it.
+
+## Verification
+
+```bash
+make baseline-bundle-smoke
+```
+
+This builds the binary into a temp dir, runs the harness against a hermetic
+`HOME` and config, and asserts the bundle contract (files present, manifest
+hashes match, boundary language present, no secrets, no `.env`/`*.key`/`*.db`).
+The same checks live in
+`cmd/oktsec/commands/baseline_bundle_example_test.go` behind the `examples`
+build tag.

--- a/examples/startup-team-baseline/run.sh
+++ b/examples/startup-team-baseline/run.sh
@@ -173,15 +173,21 @@ run_oktsec() {
 SED_ARGS=()
 add_mask() {
 	local p="$1" label="$2" esc
-	[ -n "$p" ] || return 0
+	# Never mask empty or dangerously short roots ("." would replace every dot
+	# in the text, "/" every slash).
+	case "$p" in "" | "." | "./" | "/") return 0 ;; esac
 	esc="$(printf '%s' "$p" | sed 's/[][\.*^$/|]/\\&/g')"
 	SED_ARGS+=(-e "s|$esc|$label|g")
 }
-CONFIG_DIR=""
 if [ -n "$CONFIG" ]; then
-	CONFIG_DIR="$(cd "$(dirname "$CONFIG")" 2>/dev/null && pwd || true)"
+	# Mask both the canonical absolute config dir (when it exists) and the
+	# literal dirname as given. oktsec echoes an explicit --config path verbatim
+	# in errors, and that path may point at a directory that does not exist, in
+	# which case the canonical form is empty — so the literal form is what
+	# masks the path in a failure reason.
+	add_mask "$(cd "$(dirname "$CONFIG")" 2>/dev/null && pwd || true)" "<CONFIG_DIR>"
+	add_mask "$(dirname "$CONFIG")" "<CONFIG_DIR>"
 fi
-add_mask "$CONFIG_DIR" "<CONFIG_DIR>"
 add_mask "$(pwd)" "<PWD>"
 add_mask "${HOME:-}" "<HOME>"
 scrub() {
@@ -206,7 +212,10 @@ collect() {
 		return 0
 	fi
 	local reason
-	reason="$(tr '\n' ' ' <"$errf" 2>/dev/null | cut -c1-200)"
+	# Scrub identifying paths out of the failure reason (stderr is free text
+	# that often contains the config path) before recording it. Scrub before
+	# truncating so a full root still matches.
+	reason="$(tr '\n' ' ' <"$errf" 2>/dev/null | scrub | cut -c1-200)"
 	rm -f "$errf" "$OUTPUT/$out"
 	printf '%s\t%s\n' "$out" "$reason" >>"$MISSING_TSV"
 	if [ "$kind" = required ]; then

--- a/examples/startup-team-baseline/run.sh
+++ b/examples/startup-team-baseline/run.sh
@@ -358,7 +358,10 @@ is_listed() { case " $2 " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
 verify_bundle() {
 	local problem=0 entry base
-	for entry in "$OUTPUT"/* "$OUTPUT"/.[!.]*; do
+	# Globs cover: normal names, single-dot names (.foo), and double-dot names
+	# (..foo). "." and ".." themselves never match .[!.]* or ..?*, so they are
+	# not walked. Missing matches stay literal and are skipped by the -e guard.
+	for entry in "$OUTPUT"/* "$OUTPUT"/.[!.]* "$OUTPUT"/..?*; do
 		[ -e "$entry" ] || continue
 		base="$(basename "$entry")"
 		if [ ! -f "$entry" ]; then

--- a/examples/startup-team-baseline/run.sh
+++ b/examples/startup-team-baseline/run.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# Oktsec Startup / Team Baseline Evidence Bundle (Order 8B.1)
+#
+# Local-only harness. It orchestrates existing read-only oktsec commands into a
+# single redacted bundle a small team can review by hand and share manually
+# during a guided Startup / Team onboarding.
+#
+# It is NOT a SaaS workspace. It does not create accounts, aggregate across
+# machines, collect remotely, phone home, or mutate the local oktsec config or
+# services. The output is operational evidence, not a compliance certification.
+#
+# Usage:
+#   ./run.sh [--output <dir>] [--config <path>] [--force]
+#
+# Binary resolution: $OKTSEC_BIN, then ./oktsec, then `oktsec` on PATH.
+#
+set -euo pipefail
+
+SCHEMA="oktsec_startup_team_baseline.v1"
+PROG="$(basename "$0")"
+
+usage() {
+	cat <<EOF
+$PROG - produce a redacted Startup / Team baseline evidence bundle
+
+Usage:
+  $PROG [--output <dir>] [--config <path>] [--force]
+
+Options:
+  --output <dir>   Bundle directory to create.
+                   Default: ./oktsec-startup-team-baseline-<timestamp>
+  --config <path>  oktsec config file (passed through to oktsec commands).
+                   Default: oktsec's normal cascading resolution.
+  --force          Allow writing into an existing non-empty output directory.
+  -h, --help       Show this help.
+
+The bundle contains: README.md, manifest.json, audit.json, audit.sarif,
+status.txt, node-status.json, node-snapshot.json, redactions.json.
+
+Never included: raw prompts, tool payloads, private keys, API keys, .env,
+the full oktsec.yaml, or the raw audit database. Filesystem paths under the
+user home are masked as <HOME>.
+EOF
+}
+
+# --- arguments ---------------------------------------------------------------
+OUTPUT=""
+CONFIG=""
+FORCE=0
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--output)
+		OUTPUT="${2:?--output needs a value}"
+		shift 2
+		;;
+	--output=*)
+		OUTPUT="${1#*=}"
+		shift
+		;;
+	--config)
+		CONFIG="${2:?--config needs a value}"
+		shift 2
+		;;
+	--config=*)
+		CONFIG="${1#*=}"
+		shift
+		;;
+	--force)
+		FORCE=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "$PROG: unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+# --- binary ------------------------------------------------------------------
+BIN="${OKTSEC_BIN:-}"
+if [ -z "$BIN" ]; then
+	if [ -x "./oktsec" ]; then
+		BIN="./oktsec"
+	elif command -v oktsec >/dev/null 2>&1; then
+		BIN="oktsec"
+	else
+		echo "$PROG: oktsec binary not found. Set OKTSEC_BIN, add oktsec to PATH, or build ./oktsec." >&2
+		exit 2
+	fi
+fi
+
+# --- sha256 tool -------------------------------------------------------------
+if command -v sha256sum >/dev/null 2>&1; then
+	SHACMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+	SHACMD="shasum -a 256"
+else
+	echo "$PROG: no sha256 tool found (need sha256sum or shasum)." >&2
+	exit 2
+fi
+
+# --- output directory --------------------------------------------------------
+TS_COMPACT="$(date -u +%Y%m%dT%H%M%SZ)"
+TS_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [ -z "$OUTPUT" ]; then
+	OUTPUT="./oktsec-startup-team-baseline-${TS_COMPACT}"
+fi
+
+if [ -L "$OUTPUT" ]; then
+	echo "$PROG: refusing to write through a symlink: $OUTPUT" >&2
+	exit 2
+fi
+if [ -e "$OUTPUT" ] && [ ! -d "$OUTPUT" ]; then
+	echo "$PROG: output path exists and is not a directory: $OUTPUT" >&2
+	exit 2
+fi
+if [ -d "$OUTPUT" ] && [ -n "$(ls -A "$OUTPUT" 2>/dev/null)" ] && [ "$FORCE" -ne 1 ]; then
+	echo "$PROG: refusing to overwrite non-empty directory: $OUTPUT (use --force)" >&2
+	exit 2
+fi
+
+mkdir -p "$OUTPUT"
+chmod 700 "$OUTPUT" 2>/dev/null || true
+
+# --- helpers -----------------------------------------------------------------
+REQUIRED_FAIL=0
+MISSING_TSV="$OUTPUT/.missing.tsv"
+
+# run_oktsec wraps the binary so --config is applied consistently and exactly
+# once. Persistent flags must precede the subcommand.
+run_oktsec() {
+	if [ -n "$CONFIG" ]; then
+		"$BIN" --config "$CONFIG" "$@"
+	else
+		"$BIN" "$@"
+	fi
+}
+
+# scrub masks identifying filesystem roots (the username vector) in any
+# captured text: the config directory and the working directory first (more
+# specific), then the user home. Each root is regex-escaped and `|` is the sed
+# delimiter. SED_ARGS may legitimately be empty, hence the count-guarded
+# expansion (safe under `set -u`, including bash 3.2).
+SED_ARGS=()
+add_mask() {
+	local p="$1" label="$2" esc
+	[ -n "$p" ] || return 0
+	esc="$(printf '%s' "$p" | sed 's/[][\.*^$/|]/\\&/g')"
+	SED_ARGS+=(-e "s|$esc|$label|g")
+}
+CONFIG_DIR=""
+if [ -n "$CONFIG" ]; then
+	CONFIG_DIR="$(cd "$(dirname "$CONFIG")" 2>/dev/null && pwd || true)"
+fi
+add_mask "$CONFIG_DIR" "<CONFIG_DIR>"
+add_mask "$(pwd)" "<PWD>"
+add_mask "${HOME:-}" "<HOME>"
+scrub() {
+	if [ "${#SED_ARGS[@]}" -gt 0 ]; then
+		sed "${SED_ARGS[@]}"
+	else
+		cat
+	fi
+}
+
+# collect runs an oktsec command, scrubs its stdout into a bundle file, and
+# records failures. It never aborts the harness; the final exit code is decided
+# after all collection completes.
+#   collect <required|optional> <outfile> <oktsec args...>
+collect() {
+	local kind="$1" out="$2"
+	shift 2
+	local errf="$OUTPUT/.collect.err"
+	if run_oktsec "$@" 2>"$errf" | scrub >"$OUTPUT/$out"; then
+		rm -f "$errf"
+		echo "  ok        $out"
+		return 0
+	fi
+	local reason
+	reason="$(tr '\n' ' ' <"$errf" 2>/dev/null | cut -c1-200)"
+	rm -f "$errf" "$OUTPUT/$out"
+	printf '%s\t%s\n' "$out" "$reason" >>"$MISSING_TSV"
+	if [ "$kind" = required ]; then
+		REQUIRED_FAIL=1
+		echo "  FAIL req   $out: $reason" >&2
+	else
+		echo "  skip opt   $out: $reason" >&2
+	fi
+	return 0
+}
+
+compute_sha() { $SHACMD "$1" | awk '{print $1}'; }
+
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/ /g'; }
+
+# --- collection --------------------------------------------------------------
+echo "Collecting Startup / Team baseline into $OUTPUT"
+
+# Required: deployment posture. `audit --json`/`--sarif` exit 0 even with
+# high/critical findings, so a non-zero exit here means a real failure
+# (e.g. config could not be loaded).
+collect required audit.json audit --json
+collect required audit.sarif audit --sarif
+collect required status.txt status
+
+# Recommended but best-effort: node identity may be absent on a fresh install.
+# Per spec, that is recorded, not treated as a bundle failure.
+collect optional node-status.json node status --json
+collect optional node-snapshot.json node snapshot --json
+
+# --- redactions.json ---------------------------------------------------------
+{
+	printf '{\n'
+	printf '  "schema": "%s",\n' "$SCHEMA"
+	printf '  "redactions": [\n'
+	printf '    "raw prompts and tool payloads omitted (source commands do not emit them)",\n'
+	printf '    "private keys omitted",\n'
+	printf '    "API keys and secrets omitted",\n'
+	printf '    ".env files omitted",\n'
+	printf '    "full oktsec.yaml omitted",\n'
+	printf '    "raw audit database omitted",\n'
+	printf '    "identifying filesystem paths (config dir, working dir, user home) masked",\n'
+	printf '    "hostnames and usernames omitted (node identity uses hashed fingerprints)"\n'
+	printf '  ],\n'
+	printf '  "missing_or_partial": ['
+	if [ -f "$MISSING_TSV" ]; then
+		first=1
+		printf '\n'
+		while IFS="$(printf '\t')" read -r file reason; do
+			[ -n "$file" ] || continue
+			if [ $first -eq 1 ]; then first=0; else printf ',\n'; fi
+			printf '    { "file": "%s", "reason": "%s" }' "$(json_escape "$file")" "$(json_escape "$reason")"
+		done <"$MISSING_TSV"
+		printf '\n  '
+	fi
+	printf ']\n'
+	printf '}\n'
+} >"$OUTPUT/redactions.json"
+rm -f "$MISSING_TSV"
+
+# --- README.md (in-bundle, business-readable) --------------------------------
+cat >"$OUTPUT/README.md" <<'EOF'
+# Oktsec Startup / Team Baseline Bundle
+
+This bundle summarizes one local Oktsec runtime for Startup / Team onboarding.
+It is operational evidence, not a compliance certification.
+Only routed/configured surfaces are represented.
+Raw prompts, private keys, secrets and raw audit databases are omitted.
+
+## Files
+
+- `README.md` - this file.
+- `manifest.json` - schema, generation time, oktsec version, host os/arch, and
+  a SHA-256 for every other file in the bundle.
+- `audit.json` - deployment security audit findings (machine-readable).
+- `audit.sarif` - the same audit findings in SARIF v2.1.0.
+- `status.txt` - a human-readable runtime status summary (mode, agents,
+  message counts, health score, top issues).
+- `node-status.json` - local node identity status (hashed fingerprint only;
+  may report "absent" on a fresh install).
+- `node-snapshot.json` - read-only snapshot of what this node sees, controls
+  and can prove (coverage, posture, evidence; fingerprints and hashes only).
+- `redactions.json` - what was deliberately omitted, plus any missing or
+  partial files.
+
+## Safety
+
+This bundle is local-only and was produced without network access. Identifying
+filesystem paths (config directory, working directory, user home) are masked as
+`<CONFIG_DIR>`, `<PWD>` and `<HOME>`. Inspect every file before sharing.
+EOF
+
+# --- manifest.json -----------------------------------------------------------
+VER_OUT="$("$BIN" version 2>/dev/null || true)"
+VERSION="$(printf '%s\n' "$VER_OUT" | head -1 | awk '{print $2}')"
+[ -n "$VERSION" ] || VERSION="unknown"
+OSLINE="$(printf '%s\n' "$VER_OUT" | awk -F'os:' 'NF>1{print $2}' | tr -d ' ' | head -1)"
+HOST_OS="${OSLINE%%/*}"
+HOST_ARCH="${OSLINE##*/}"
+[ -n "$HOST_OS" ] || HOST_OS="$(uname -s 2>/dev/null || echo unknown)"
+[ -n "$HOST_ARCH" ] || HOST_ARCH="$(uname -m 2>/dev/null || echo unknown)"
+
+{
+	printf '{\n'
+	printf '  "schema": "%s",\n' "$SCHEMA"
+	printf '  "generated_at": "%s",\n' "$TS_ISO"
+	printf '  "oktsec_version": "%s",\n' "$(json_escape "$VERSION")"
+	printf '  "host": {\n'
+	printf '    "os": "%s",\n' "$(json_escape "$HOST_OS")"
+	printf '    "arch": "%s"\n' "$(json_escape "$HOST_ARCH")"
+	printf '  },\n'
+	printf '  "files": ['
+	first=1
+	for f in README.md redactions.json audit.json audit.sarif status.txt node-status.json node-snapshot.json; do
+		[ -f "$OUTPUT/$f" ] || continue
+		if [ $first -eq 1 ]; then
+			first=0
+			printf '\n'
+		else
+			printf ',\n'
+		fi
+		printf '    { "path": "%s", "sha256": "%s" }' "$f" "$(compute_sha "$OUTPUT/$f")"
+	done
+	printf '\n  ],\n'
+	printf '  "redactions": [\n'
+	printf '    "raw prompts omitted",\n'
+	printf '    "private keys omitted",\n'
+	printf '    "secrets and .env omitted",\n'
+	printf '    "full config omitted",\n'
+	printf '    "raw audit database omitted",\n'
+	printf '    "identifying paths masked"\n'
+	printf '  ]\n'
+	printf '}\n'
+} >"$OUTPUT/manifest.json"
+
+# --- secret self-scan (data files only; README/redactions/manifest disclose
+# these words on purpose and must not be scanned) -----------------------------
+scan_secrets() {
+	local pat='BEGIN OKTSEC ED25519 PRIVATE KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|hooks\.slack\.com|sk-[A-Za-z0-9]{16,}|xox[baprs]-'
+	local hit=0 f
+	for f in audit.json audit.sarif status.txt node-status.json node-snapshot.json; do
+		[ -f "$OUTPUT/$f" ] || continue
+		if grep -Eq "$pat" "$OUTPUT/$f"; then
+			echo "  LEAK       forbidden pattern detected in $f" >&2
+			hit=1
+		fi
+	done
+	return "$hit"
+}
+
+EXIT=0
+if ! scan_secrets; then
+	echo "$PROG: ERROR - bundle contains forbidden content and is NOT safe to share. Inspect $OUTPUT." >&2
+	EXIT=3
+fi
+if [ "$REQUIRED_FAIL" -eq 1 ]; then
+	echo "$PROG: ERROR - one or more required collection steps failed; bundle is incomplete." >&2
+	[ "$EXIT" -eq 0 ] && EXIT=1
+fi
+
+echo "Bundle written to $OUTPUT"
+exit "$EXIT"

--- a/examples/startup-team-baseline/run.sh
+++ b/examples/startup-team-baseline/run.sh
@@ -20,6 +20,21 @@ set -euo pipefail
 SCHEMA="oktsec_startup_team_baseline.v1"
 PROG="$(basename "$0")"
 
+# Files this harness is allowed to place in a bundle. Anything else present at
+# finish (e.g. a stale secret left in an existing dir reused with --force) makes
+# the bundle fail closed.
+EXPECTED_FILES="README.md manifest.json redactions.json audit.json audit.sarif status.txt node-status.json node-snapshot.json"
+# Generated files that intentionally describe what was omitted; excluded from
+# the secret scan so their disclosure text is not a false positive.
+DISCLOSURE_FILES="README.md manifest.json redactions.json"
+
+# SECRET_PAT is the canonical secret-value scan (grep -E). It targets token
+# *values* (key headers, provider token shapes, NAME=value assignments), not
+# bare env-var names, so a finding that merely reports the existence of a secret
+# env var is not flagged while a leaked value is. The smoke test extracts this
+# exact line, so keep it a single-quoted one-liner named SECRET_PAT.
+SECRET_PAT='BEGIN [A-Z0-9 ]*PRIVATE KEY|[A-Z0-9_]{2,}(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY)=[^[:space:]"]|sk-(ant-|proj-)?[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9]{20,}|gh[ousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|xox[baprs]-[A-Za-z0-9-]{8,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.|hooks\.slack\.com'
+
 usage() {
 	cat <<EOF
 $PROG - produce a redacted Startup / Team baseline evidence bundle
@@ -128,6 +143,14 @@ fi
 mkdir -p "$OUTPUT"
 chmod 700 "$OUTPUT" 2>/dev/null || true
 
+# Remove this harness's own prior outputs so a --force re-run cannot leave a
+# stale file from a previous run (e.g. a node-snapshot.json that fails to
+# regenerate this time). Files we do not own are left untouched and are caught
+# by the unexpected-file check at the end.
+for _f in $EXPECTED_FILES; do
+	rm -f "$OUTPUT/$_f"
+done
+
 # --- helpers -----------------------------------------------------------------
 REQUIRED_FAIL=0
 MISSING_TSV="$OUTPUT/.missing.tsv"
@@ -207,12 +230,18 @@ echo "Collecting Startup / Team baseline into $OUTPUT"
 # (e.g. config could not be loaded).
 collect required audit.json audit --json
 collect required audit.sarif audit --sarif
-collect required status.txt status
 
 # Recommended but best-effort: node identity may be absent on a fresh install.
-# Per spec, that is recorded, not treated as a bundle failure.
+# Per spec, that is recorded, not treated as a bundle failure. These are
+# read-only and collected before `status` so the snapshot reflects the node's
+# state independent of any other command.
 collect optional node-status.json node status --json
 collect optional node-snapshot.json node snapshot --json
+
+# `status` is read-only and does not create the audit DB, so ordering it last
+# is belt-and-suspenders against any future side effect bleeding into the
+# read-only snapshots above.
+collect required status.txt status
 
 # --- redactions.json ---------------------------------------------------------
 {
@@ -319,24 +348,47 @@ HOST_ARCH="${OSLINE##*/}"
 	printf '}\n'
 } >"$OUTPUT/manifest.json"
 
-# --- secret self-scan (data files only; README/redactions/manifest disclose
-# these words on purpose and must not be scanned) -----------------------------
-scan_secrets() {
-	local pat='BEGIN OKTSEC ED25519 PRIVATE KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|hooks\.slack\.com|sk-[A-Za-z0-9]{16,}|xox[baprs]-'
-	local hit=0 f
-	for f in audit.json audit.sarif status.txt node-status.json node-snapshot.json; do
-		[ -f "$OUTPUT/$f" ] || continue
-		if grep -Eq "$pat" "$OUTPUT/$f"; then
-			echo "  LEAK       forbidden pattern detected in $f" >&2
-			hit=1
+# --- final safety verification ----------------------------------------------
+# Scans every entry actually present in the bundle (not a fixed list) so stale
+# files reused via --force cannot slip through: rejects unexpected files and
+# key/cert/db/env artifacts, and scans data-bearing files for secret values.
+# Disclosure files (README/redactions/manifest) name these words on purpose and
+# are excluded from the secret scan.
+is_listed() { case " $2 " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+verify_bundle() {
+	local problem=0 entry base
+	for entry in "$OUTPUT"/* "$OUTPUT"/.[!.]*; do
+		[ -e "$entry" ] || continue
+		base="$(basename "$entry")"
+		if [ ! -f "$entry" ]; then
+			echo "  UNEXPECTED non-file entry in bundle: $base" >&2
+			problem=1
+			continue
+		fi
+		if ! is_listed "$base" "$EXPECTED_FILES"; then
+			echo "  UNEXPECTED file in bundle: $base" >&2
+			problem=1
+		fi
+		case "$base" in
+		*.key | *.pem | *.crt | *.db | .env | *.env)
+			echo "  FORBIDDEN artifact in bundle: $base" >&2
+			problem=1
+			;;
+		esac
+		if ! is_listed "$base" "$DISCLOSURE_FILES"; then
+			if grep -Eq "$SECRET_PAT" "$entry"; then
+				echo "  LEAK forbidden secret pattern detected in $base" >&2
+				problem=1
+			fi
 		fi
 	done
-	return "$hit"
+	return "$problem"
 }
 
 EXIT=0
-if ! scan_secrets; then
-	echo "$PROG: ERROR - bundle contains forbidden content and is NOT safe to share. Inspect $OUTPUT." >&2
+if ! verify_bundle; then
+	echo "$PROG: ERROR - bundle failed safety verification and is NOT safe to share. Inspect $OUTPUT." >&2
 	EXIT=3
 fi
 if [ "$REQUIRED_FAIL" -eq 1 ]; then

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -155,21 +155,21 @@ func (h *Hub) broadcast(entry Entry) {
 
 // Store manages the SQLite audit log.
 type Store struct {
-	db            *sql.DB
-	dialect       Dialect
-	writes        chan Entry
-	done          chan struct{}
-	logger        *slog.Logger
-	Hub           *Hub
-	ctx           context.Context
-	cancel        context.CancelFunc
-	retentionDays int
-	archiveDir    string             // directory where archive-before-delete writes; empty disables auto-purge
-	purgeWarnedNoArchive bool        // single-shot warning latch when retention>0 but archiveDir==""
-	proxyKey      ed25519.PrivateKey // proxy signing key for audit chain (nil = no signing)
-	lastHash      string             // last entry hash for chain continuity
-	lastHashMu    sync.Mutex
-	inflight      atomic.Int64 // entries being processed in writeLoop
+	db                   *sql.DB
+	dialect              Dialect
+	writes               chan Entry
+	done                 chan struct{}
+	logger               *slog.Logger
+	Hub                  *Hub
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	retentionDays        int
+	archiveDir           string             // directory where archive-before-delete writes; empty disables auto-purge
+	purgeWarnedNoArchive bool               // single-shot warning latch when retention>0 but archiveDir==""
+	proxyKey             ed25519.PrivateKey // proxy signing key for audit chain (nil = no signing)
+	lastHash             string             // last entry hash for chain continuity
+	lastHashMu           sync.Mutex
+	inflight             atomic.Int64 // entries being processed in writeLoop
 
 	// readOnly disables any path that can mutate entry_hash / prev_hash /
 	// proxy_signature or backfilled columns. It exists so the CLI
@@ -217,7 +217,7 @@ func (s *Store) DialectName() string {
 // freshly opened DB it's a no-op; on an old DB it adds any missing columns
 // but never touches entry_hash/prev_hash/proxy_signature.
 func NewStoreReadOnly(dbPath string, logger *slog.Logger) (*Store, error) {
-	s, err := openStore(dbPath, logger, true, 0)
+	s, err := openStore(dbPath, logger, true, 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -230,6 +230,26 @@ func NewStoreReadOnly(dbPath string, logger *slog.Logger) (*Store, error) {
 	return s, nil
 }
 
+// NewStoreReadOnlyStrict opens an existing audit DB for reads only and never
+// writes to the file: no schema creation, ANALYZE, or column migrations run,
+// and the sqlite connection is opened with query_only so even an accidental
+// write fails. Unlike NewStoreReadOnly (which is idempotently "repair-free" but
+// still creates/migrates schema, growing an empty or old DB), this constructor
+// observes the database exactly as it is on disk. Use it for evidence
+// collection where mutating the file would corrupt the evidence (e.g. baseline
+// bundles). On a missing/empty/corrupt DB, reads simply error and the caller
+// degrades; the file is never created or grown.
+func NewStoreReadOnlyStrict(dbPath string, logger *slog.Logger) (*Store, error) {
+	s, err := openStore(dbPath, logger, true, 0, true)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.db.Exec("PRAGMA query_only=ON"); err != nil {
+		logger.Warn("query_only pragma failed (strict read-only; DSN gate still active)", "error", err)
+	}
+	return s, nil
+}
+
 // NewStore opens (or creates) the SQLite audit database.
 // retentionDays controls automatic purging of old entries (0 = no purging).
 // If the database file or its parent directory is a symlink, it is rejected.
@@ -238,12 +258,15 @@ func NewStore(dbPath string, logger *slog.Logger, retentionDays ...int) (*Store,
 	if len(retentionDays) > 0 && retentionDays[0] > 0 {
 		retention = retentionDays[0]
 	}
-	return openStore(dbPath, logger, false, retention)
+	return openStore(dbPath, logger, false, retention, false)
 }
 
 // openStore is the shared open path. `readOnly` must be decided here — not
 // flipped afterwards — because it gates the migration-time repair logic.
-func openStore(dbPath string, logger *slog.Logger, readOnly bool, retentionDays int) (*Store, error) {
+// `strict` additionally forbids every write that even an ordinary read-only
+// open would perform (schema creation, ANALYZE, column migrations), so an
+// existing empty/old/partial DB is observed exactly as-is and never grown.
+func openStore(dbPath string, logger *slog.Logger, readOnly bool, retentionDays int, strict bool) (*Store, error) {
 	if dbPath != ":memory:" {
 		// Reject symlinked parent directory
 		parentDir := filepath.Dir(dbPath)
@@ -260,12 +283,16 @@ func openStore(dbPath string, logger *slog.Logger, readOnly bool, retentionDays 
 		}
 	}
 
-	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	dsn := sqliteDSN(dbPath)
+	if strict {
+		dsn = sqliteReadOnlyDSN(dbPath)
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening audit db: %w", err)
 	}
 
-	return newStore(db, SQLiteDialect{}, logger, retentionDays, readOnly)
+	return newStore(db, SQLiteDialect{}, logger, retentionDays, readOnly, strict)
 }
 
 // sqliteDSN appends per-connection PRAGMAs to the path so every
@@ -291,6 +318,24 @@ func sqliteDSN(dbPath string) string {
 		"&_pragma=synchronous(NORMAL)"
 }
 
+// sqliteReadOnlyDSN opens the database read-only at the SQLite level: every
+// pooled connection comes up under query_only, and no journal_mode(WAL) pragma
+// is requested (setting it is a write). Combined with skipping schema/migrate
+// in newStore, this guarantees the file is observed exactly as-is and never
+// created, migrated, or grown.
+func sqliteReadOnlyDSN(dbPath string) string {
+	if dbPath == ":memory:" {
+		return dbPath
+	}
+	sep := "?"
+	if strings.ContainsRune(dbPath, '?') {
+		sep = "&"
+	}
+	return dbPath + sep +
+		"_pragma=busy_timeout(5000)" +
+		"&_pragma=query_only(true)"
+}
+
 // NewStoreWithDB creates an audit store from an existing *sql.DB connection
 // and the specified dialect. Use this for Postgres, MySQL, or any database
 // reachable via database/sql.
@@ -298,30 +343,38 @@ func sqliteDSN(dbPath string) string {
 //	db, _ := sql.Open("pgx", "postgres://user:pass@localhost/oktsec")
 //	store, _ := audit.NewStoreWithDB(db, audit.PostgresDialect{}, logger, 90)
 func NewStoreWithDB(db *sql.DB, dialect Dialect, logger *slog.Logger, retentionDays int) (*Store, error) {
-	return newStore(db, dialect, logger, retentionDays, false)
+	return newStore(db, dialect, logger, retentionDays, false, false)
 }
 
-func newStore(db *sql.DB, dialect Dialect, logger *slog.Logger, retentionDays int, readOnly bool) (*Store, error) {
-	// Run dialect-specific initialization (PRAGMAs for SQLite, etc.)
-	for _, stmt := range dialect.InitPragmas() {
-		if _, err := db.Exec(stmt); err != nil {
-			logger.Warn("init statement failed", "stmt", stmt, "error", err)
+func newStore(db *sql.DB, dialect Dialect, logger *slog.Logger, retentionDays int, readOnly, strict bool) (*Store, error) {
+	// strict read-only must not write to the file at all: no init pragmas
+	// (journal_mode=WAL is a write), no schema creation, no ANALYZE, no
+	// migrations. The DB is observed exactly as it is on disk.
+	if !strict {
+		// Run dialect-specific initialization (PRAGMAs for SQLite, etc.)
+		for _, stmt := range dialect.InitPragmas() {
+			if _, err := db.Exec(stmt); err != nil {
+				logger.Warn("init statement failed", "stmt", stmt, "error", err)
+			}
+		}
+
+		// Create schema
+		if _, err := db.Exec(dialect.SchemaSQL()); err != nil {
+			if cerr := db.Close(); cerr != nil {
+				return nil, fmt.Errorf("creating schema: %w (also: close: %v)", err, cerr)
+			}
+			return nil, fmt.Errorf("creating schema: %w", err)
+		}
+
+		// Update query planner statistics
+		if _, err := db.Exec("ANALYZE"); err != nil {
+			logger.Warn("ANALYZE failed", "error", err)
 		}
 	}
 
-	// Create schema
-	if _, err := db.Exec(dialect.SchemaSQL()); err != nil {
-		if cerr := db.Close(); cerr != nil {
-			return nil, fmt.Errorf("creating schema: %w (also: close: %v)", err, cerr)
-		}
-		return nil, fmt.Errorf("creating schema: %w", err)
-	}
-
-	// Update query planner statistics
-	if _, err := db.Exec("ANALYZE"); err != nil {
-		logger.Warn("ANALYZE failed", "error", err)
-	}
-
+	// strict implies read-only; collapse them so the loop guard below and the
+	// write gate stay in sync.
+	ro := readOnly || strict
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Store{
 		db:            db,
@@ -333,19 +386,21 @@ func newStore(db *sql.DB, dialect Dialect, logger *slog.Logger, retentionDays in
 		ctx:           ctx,
 		cancel:        cancel,
 		retentionDays: retentionDays,
-		readOnly:      readOnly,
+		readOnly:      ro,
 	}
 
-	// Migrate schema: add columns if they don't exist (idempotent).
-	// migrateSchema consults s.readOnly internally to skip backfill/rebuild.
-	s.migrateSchema()
+	if !strict {
+		// Migrate schema: add columns if they don't exist (idempotent).
+		// migrateSchema consults s.readOnly internally to skip backfill/rebuild.
+		s.migrateSchema()
 
-	// Load last hash for chain continuity
-	s.loadLastHash()
+		// Load last hash for chain continuity
+		s.loadLastHash()
+	}
 
 	// Background loops don't run on a read-only store — nothing to write,
 	// and expiryLoop would try to DELETE.
-	if !readOnly {
+	if !ro {
 		go s.writeLoop()
 		go s.expiryLoop()
 	}


### PR DESCRIPTION
## Summary

Adds a local-only example harness (`examples/startup-team-baseline/run.sh`) that orchestrates existing read-only commands into a single redacted evidence bundle a small team can review and share by hand. It adds no new runtime, no network access, no accounts, no aggregation, and no remote collection, and it never mutates local config or services.

## What it produces

A bundle directory containing `README.md`, `manifest.json` (schema `oktsec_startup_team_baseline.v1`, SHA-256 per file), `audit.json`, `audit.sarif`, `status.txt`, `node-status.json`, `node-snapshot.json`, and `redactions.json`. Data is sourced from `oktsec audit --json/--sarif`, `oktsec status`, and `oktsec node status/snapshot`.

## Safety

- masks identifying filesystem paths (config dir, working dir, home), including inside failure reasons
- never copies raw keys, `.env`, the full config, or the raw audit database
- self-verifies the finished bundle: rejects unexpected files and key/cert/db/env artifacts, scans collected data for secret value shapes, and fails closed
- `oktsec status` now opens the audit database strictly read-only (no schema creation, ANALYZE, or migration), so producing a bundle never grows or migrates an existing database; an unreadable or older database is reported as unavailable rather than as zero or silently dropped

## Testing

- `make baseline-bundle-smoke` builds the binary and runs the harness against a hermetic HOME/config, asserting the bundle contract: required files present, manifest hashes match, boundary language present, no secrets or raw paths, strict read-only database behavior, and fail-closed on stale/unexpected files
- `make build`, `make test`, `make lint`, `make vet`