### PR TITLE
policy_bundle.v2 verification foundation (signed governance contract)

### DIFF
--- a/internal/policybundle/canonical_v2.go
+++ b/internal/policybundle/canonical_v2.go
@@ -1,0 +1,176 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// canonicalPolicyBodyBytesV2 returns the exact byte layout that policy_hash
+// and the Ed25519 signature cover for a v2 body: a typed-struct JSON
+// projection, HTML escaping off, no trailing newline. Encoding the typed
+// struct (never a map[string]any) fixes field order; map keys
+// (rules.overrides, selector.labels, tool_policies.by_tool, tool_constraint
+// params) serialize alphabetically under encoding/json, so the canonical bytes
+// are deterministic without explicit sorting.
+//
+// Timestamps are NOT normalized here (same rule as v1): the verifier hashes
+// the exact wire strings. validateCanonicalPolicyTimestamp enforces the single
+// accepted form before the hash is recomputed.
+//
+// Number canonicalization: monetary/limit values that are float64 in
+// config.ToolPolicy are carried as decimal STRINGS on the v2 wire, never JSON
+// numbers. Go's float formatting is not portably guaranteed to round-trip to a
+// single byte sequence, so a float in the signed body would be a stable-hash
+// hazard. Integer counts stay JSON integers, which encoding/json formats
+// deterministically.
+func canonicalPolicyBodyBytesV2(body PolicyBodyV2) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body); err != nil {
+		return nil, fmt.Errorf("encode canonical v2 body: %w", err)
+	}
+	// Encode appends a trailing newline; strip it so the hashed bytes are
+	// exactly the marshaled JSON.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// policyHashHexV2 returns the sha256 hex of the canonical v2 body bytes with
+// the "sha256:" wire prefix, plus the canonical bytes themselves.
+func policyHashHexV2(body PolicyBodyV2) (string, []byte, error) {
+	canon, err := canonicalPolicyBodyBytesV2(body)
+	if err != nil {
+		return "", nil, err
+	}
+	sum := sha256.Sum256(canon)
+	return "sha256:" + hex.EncodeToString(sum[:]), canon, nil
+}
+
+// policyBundleV2SigningPayload returns the exact bytes the Ed25519 signature
+// covers for a v2 bundle: domain-separated labeled lines, newline-joined, no
+// trailing newline. Beyond the v1 fields it binds the assignment, target,
+// sequence, issued_at, and rollback_of, so a store cannot rewrite a signed
+// bundle's binding or anti-rollback metadata without breaking the signature.
+// signed_at is NOT part of this payload (it lives in the v1 payload but v2
+// binds issued_at instead as the authoritative time). The signer and this
+// verifier MUST produce identical bytes or every signature fails to verify.
+func policyBundleV2SigningPayload(
+	policyID, policyVersion, policyHash,
+	assignmentID, targetScope, targetNodeID, issuedAt string,
+	sequence int64,
+	rollbackOf, keyID, publicKeyFingerprint string,
+) []byte {
+	lines := []string{
+		"oktsec." + SchemaVersionV2,
+		fmt.Sprintf("bundle_version:%d", BundleVersionV2),
+		"policy_id:" + policyID,
+		"policy_version:" + policyVersion,
+		"policy_hash:" + policyHash,
+		"canonicalization:" + CanonicalizationV2,
+		"assignment_id:" + assignmentID,
+		"target_scope:" + targetScope,
+		"target_node_id:" + targetNodeID,
+		"issued_at:" + issuedAt,
+		"sequence:" + strconv.FormatInt(sequence, 10),
+		"rollback_of:" + rollbackOf,
+		"signature_key_id:" + keyID,
+		"signature_public_key_fingerprint:" + publicKeyFingerprint,
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// policy_bundle.v2 enum value sets for fields that are part of the signed
+// policy model. An out-of-set value is policy_schema_invalid: the verifier
+// must not label a bundle "verified" with a value the v2 schema does not
+// define, since apply (or a reader) could otherwise fail open.
+//
+// validDimModes deliberately omits "merge": merge semantics are DEFERRED in
+// 9A. A bundle declaring mode "merge" anywhere is rejected as out-of-range
+// until the merge contract is designed.
+var (
+	validDimModes    = map[string]bool{"unmanaged": true, "replace": true, "clear": true}
+	validTargetScope = map[string]bool{"fleet": true, "node": true}
+)
+
+// canonicalDecimal is the single accepted decimal-string wire form for v2
+// monetary/limit values: an optional minus, integer part with no leading
+// zeros (or a single "0"), and an optional fractional part with at least one
+// digit. No exponent, no thousands separators, no leading "+". This is a
+// stable byte form so the hash is deterministic; numeric interpretation is
+// deferred to 9A.2 apply.
+var canonicalDecimal = regexp.MustCompile(`^-?(0|[1-9][0-9]*)(\.[0-9]+)?$`)
+
+// validateCanonicalDecimal rejects a v2 decimal-string value that is not in
+// the single canonical wire form. An empty string is allowed and means
+// "unset" (the field carries no value); a present value must be canonical.
+func validateCanonicalDecimal(field, s string) error {
+	if s == "" {
+		return nil // unset
+	}
+	if !canonicalDecimal.MatchString(s) {
+		return fmt.Errorf("%s %q is not a canonical decimal string", field, s)
+	}
+	return nil
+}
+
+// validateCanonicalPolicyContainersV2 requires every list/map container in the
+// v2 body to be present in its canonical empty form ([] / {}), never null or
+// omitted. The official signer always emits []/{} for empty sections, so the
+// verifier refuses a null or absent container as a non-canonical artifact
+// (policy_schema_invalid). This covers ALL v2 containers, including the
+// per-agent governance sub-containers.
+func validateCanonicalPolicyContainersV2(body PolicyBodyV2) error {
+	var nilFields []string
+	add := func(cond bool, name string) {
+		if cond {
+			nilFields = append(nilFields, name)
+		}
+	}
+
+	add(body.Rules.Enabled == nil, "rules.enabled")
+	add(body.Rules.Disabled == nil, "rules.disabled")
+	add(body.Rules.Overrides == nil, "rules.overrides")
+	add(body.Gateway.ToolsAllowed == nil, "gateway.tools_allowed")
+	add(body.Gateway.ToolsDenied == nil, "gateway.tools_denied")
+	add(body.Egress.DomainsAllowed == nil, "egress.domains_allowed")
+	add(body.Egress.DomainsDenied == nil, "egress.domains_denied")
+	add(body.Governance.Agents == nil, "governance.agents")
+
+	for i := range body.Governance.Agents {
+		a := &body.Governance.Agents[i]
+		p := fmt.Sprintf("governance.agents[%d]", i)
+		add(a.Selector.Labels == nil, p+".selector.labels")
+		add(a.ACLs.AllowedRecipients == nil, p+".acls.allowed_recipients")
+		add(a.ACLs.BlockedRecipients == nil, p+".acls.blocked_recipients")
+		add(a.AllowedTools.Values == nil, p+".allowed_tools.values")
+		add(a.ToolPolicies.ByTool == nil, p+".tool_policies.by_tool")
+		add(a.ToolConstraints.Items == nil, p+".tool_constraints.items")
+		add(a.ToolChainRules.Items == nil, p+".tool_chain_rules.items")
+		add(a.BlockedContent.Values == nil, p+".blocked_content.values")
+
+		for j := range a.ToolConstraints.Items {
+			c := &a.ToolConstraints.Items[j]
+			cp := fmt.Sprintf("%s.tool_constraints.items[%d]", p, j)
+			add(c.Params == nil, cp+".params")
+			for name, pc := range c.Params {
+				add(pc.Enum == nil, fmt.Sprintf("%s.params[%q].enum", cp, name))
+			}
+		}
+		for j := range a.ToolChainRules.Items {
+			r := &a.ToolChainRules.Items[j]
+			add(r.Blocks == nil, fmt.Sprintf("%s.tool_chain_rules.items[%d].blocks", p, j))
+		}
+	}
+
+	if len(nilFields) > 0 {
+		return fmt.Errorf("container(s) must be present as [] or {}, not null or omitted: %s",
+			strings.Join(nilFields, ", "))
+	}
+	return nil
+}

--- a/internal/policybundle/canonical_v2.go
+++ b/internal/policybundle/canonical_v2.go
@@ -16,8 +16,9 @@ import (
 // projection, HTML escaping off, no trailing newline. Encoding the typed
 // struct (never a map[string]any) fixes field order; map keys
 // (rules.overrides, selector.labels, tool_policies.by_tool, tool_constraint
-// params) serialize alphabetically under encoding/json, so the canonical bytes
-// are deterministic without explicit sorting.
+// parameters, per-agent egress.tool_restrictions) serialize alphabetically
+// under encoding/json, so the canonical bytes are deterministic without explicit
+// sorting.
 //
 // Timestamps are NOT normalized here (same rule as v1): the verifier hashes
 // the exact wire strings. validateCanonicalPolicyTimestamp enforces the single
@@ -96,6 +97,16 @@ func policyBundleV2SigningPayload(
 var (
 	validDimModes    = map[string]bool{"unmanaged": true, "replace": true, "clear": true}
 	validTargetScope = map[string]bool{"fleet": true, "node": true}
+	// validTriState is the closed-set string form for config.EgressPolicy's
+	// *bool fields (scan_requests, scan_responses), carried on the v2 wire as a
+	// string so the canonical bytes never contain null. "unset" preserves the
+	// nil-pointer (fall back to global) semantics; apply is 9A.2.
+	validTriState = map[string]bool{"unset": true, "true": true, "false": true}
+	// validScanProfileValues is the closed set of agent scan_profile values the
+	// runtime accepts (config ScanProfile* constants), plus "" for unset. A v2
+	// bundle declaring an out-of-set scan_profile cannot be safely projected, so
+	// the verifier rejects it rather than label it verified.
+	validScanProfileValues = map[string]bool{"": true, "strict": true, "content-aware": true, "minimal": true}
 )
 
 // canonicalDecimal is the single accepted decimal-string wire form for v2
@@ -109,12 +120,22 @@ var canonicalDecimal = regexp.MustCompile(`^-?(0|[1-9][0-9]*)(\.[0-9]+)?$`)
 // validateCanonicalDecimal rejects a v2 decimal-string value that is not in
 // the single canonical wire form. An empty string is allowed and means
 // "unset" (the field carries no value); a present value must be canonical.
+//
+// Non-negative is also required for the monetary/limit fields it guards: the
+// runtime tool-policy enforcer treats a non-positive limit as "unset", so a
+// signed bundle carrying a negative limit would silently DISABLE a limit if
+// applied. Rejecting it at verify time keeps a "verified" bundle from meaning
+// the opposite of what it declares. (A leading "-" is the only way to express a
+// negative here; canonicalDecimal already forbids "-0".)
 func validateCanonicalDecimal(field, s string) error {
 	if s == "" {
 		return nil // unset
 	}
 	if !canonicalDecimal.MatchString(s) {
 		return fmt.Errorf("%s %q is not a canonical decimal string", field, s)
+	}
+	if strings.HasPrefix(s, "-") {
+		return fmt.Errorf("%s %q must not be negative", field, s)
 	}
 	return nil
 }
@@ -153,18 +174,27 @@ func validateCanonicalPolicyContainersV2(body PolicyBodyV2) error {
 		add(a.ToolConstraints.Items == nil, p+".tool_constraints.items")
 		add(a.ToolChainRules.Items == nil, p+".tool_chain_rules.items")
 		add(a.BlockedContent.Values == nil, p+".blocked_content.values")
+		add(a.Egress.AllowedDomains == nil, p+".egress.allowed_domains")
+		add(a.Egress.BlockedDomains == nil, p+".egress.blocked_domains")
+		add(a.Egress.ToolRestrictions == nil, p+".egress.tool_restrictions")
+		add(a.Egress.BlockedCategories == nil, p+".egress.blocked_categories")
+		add(a.Egress.Integrations == nil, p+".egress.integrations")
+		for dom, vals := range a.Egress.ToolRestrictions {
+			add(vals == nil, fmt.Sprintf("%s.egress.tool_restrictions[%q]", p, dom))
+		}
 
 		for j := range a.ToolConstraints.Items {
 			c := &a.ToolConstraints.Items[j]
 			cp := fmt.Sprintf("%s.tool_constraints.items[%d]", p, j)
-			add(c.Params == nil, cp+".params")
-			for name, pc := range c.Params {
-				add(pc.Enum == nil, fmt.Sprintf("%s.params[%q].enum", cp, name))
+			add(c.Parameters == nil, cp+".parameters")
+			for name, pc := range c.Parameters {
+				add(pc.AllowedPatterns == nil, fmt.Sprintf("%s.parameters[%q].allowed_patterns", cp, name))
+				add(pc.BlockedPatterns == nil, fmt.Sprintf("%s.parameters[%q].blocked_patterns", cp, name))
 			}
 		}
 		for j := range a.ToolChainRules.Items {
 			r := &a.ToolChainRules.Items[j]
-			add(r.Blocks == nil, fmt.Sprintf("%s.tool_chain_rules.items[%d].blocks", p, j))
+			add(r.Then == nil, fmt.Sprintf("%s.tool_chain_rules.items[%d].then", p, j))
 		}
 	}
 

--- a/internal/policybundle/canonical_v2.go
+++ b/internal/policybundle/canonical_v2.go
@@ -56,14 +56,20 @@ func policyHashHexV2(body PolicyBodyV2) (string, []byte, error) {
 // policyBundleV2SigningPayload returns the exact bytes the Ed25519 signature
 // covers for a v2 bundle: domain-separated labeled lines, newline-joined, no
 // trailing newline. Beyond the v1 fields it binds the assignment, target,
-// sequence, issued_at, and rollback_of, so a store cannot rewrite a signed
-// bundle's binding or anti-rollback metadata without breaking the signature.
-// signed_at is NOT part of this payload (it lives in the v1 payload but v2
-// binds issued_at instead as the authoritative time). The signer and this
-// verifier MUST produce identical bytes or every signature fails to verify.
+// sequence, issued_at, signed_at, and rollback_of, so a store cannot rewrite a
+// signed bundle's binding, timing, or anti-rollback metadata without breaking
+// the signature. v2 uses issued_at as the authoritative time, but signed_at is
+// inherited from the v1 PolicySignature struct and is therefore also bound here
+// (immediately after issued_at): leaving it unbound would let an intermediary
+// rewrite signature.signed_at to a different canonical timestamp and still
+// verify, which is unacceptable for an evidence contract. The exact wire bytes
+// of signed_at are hashed (already validated canonical in the verify step); we
+// do NOT parse and reformat, same discipline as every other timestamp. The
+// signer and this verifier MUST produce identical bytes or every signature
+// fails to verify.
 func policyBundleV2SigningPayload(
 	policyID, policyVersion, policyHash,
-	assignmentID, targetScope, targetNodeID, issuedAt string,
+	assignmentID, targetScope, targetNodeID, issuedAt, signedAt string,
 	sequence int64,
 	rollbackOf, keyID, publicKeyFingerprint string,
 ) []byte {
@@ -78,6 +84,7 @@ func policyBundleV2SigningPayload(
 		"target_scope:" + targetScope,
 		"target_node_id:" + targetNodeID,
 		"issued_at:" + issuedAt,
+		"signed_at:" + signedAt,
 		"sequence:" + strconv.FormatInt(sequence, 10),
 		"rollback_of:" + rollbackOf,
 		"signature_key_id:" + keyID,

--- a/internal/policybundle/canonical_v2.go
+++ b/internal/policybundle/canonical_v2.go
@@ -124,16 +124,27 @@ var (
 // deferred to 9A.2 apply.
 var canonicalDecimal = regexp.MustCompile(`^-?(0|[1-9][0-9]*)(\.[0-9]+)?$`)
 
+// allZeroDecimal matches the all-zero canonical decimal forms ("0", "0.0",
+// "0.00", ...). Because canonicalDecimal already forbids leading zeros (the
+// integer part is "0" or starts 1-9), a value whose integer part is "0" can
+// only be zero, and any nonzero value has at least one nonzero digit, so a
+// value is zero iff its integer part is "0" and every fractional digit is "0".
+// This lets the strictly-positive check stay pure-stdlib and float-free.
+var allZeroDecimal = regexp.MustCompile(`^0(\.0+)?$`)
+
 // validateCanonicalDecimal rejects a v2 decimal-string value that is not in
 // the single canonical wire form. An empty string is allowed and means
-// "unset" (the field carries no value); a present value must be canonical.
+// "unset" (the field carries no value), which is the only way to express
+// "no limit"; a present value must be canonical AND strictly positive.
 //
-// Non-negative is also required for the monetary/limit fields it guards: the
-// runtime tool-policy enforcer treats a non-positive limit as "unset", so a
-// signed bundle carrying a negative limit would silently DISABLE a limit if
-// applied. Rejecting it at verify time keeps a "verified" bundle from meaning
-// the opposite of what it declares. (A leading "-" is the only way to express a
-// negative here; canonicalDecimal already forbids "-0".)
+// Strictly positive is required for the monetary/limit fields it guards: the
+// runtime tool-policy enforcer treats a non-positive limit as "unset"
+// (unlimited), so a signed bundle carrying "0" or a negative limit would look
+// restrictive while actually REMOVING the cap if applied. v2's central rule is
+// no silent widening, so rejecting non-positive values at verify time keeps a
+// "verified" bundle from meaning the opposite of what it declares. (A leading
+// "-" is the only way to express a negative here; canonicalDecimal already
+// forbids "-0". Zero is rejected via the all-zero canonical forms.)
 func validateCanonicalDecimal(field, s string) error {
 	if s == "" {
 		return nil // unset
@@ -143,6 +154,9 @@ func validateCanonicalDecimal(field, s string) error {
 	}
 	if strings.HasPrefix(s, "-") {
 		return fmt.Errorf("%s %q must not be negative", field, s)
+	}
+	if allZeroDecimal.MatchString(s) {
+		return fmt.Errorf("%s %q must be strictly positive (zero means unset, which would widen access; use \"\" to express no limit)", field, s)
 	}
 	return nil
 }

--- a/internal/policybundle/dispatch.go
+++ b/internal/policybundle/dispatch.go
@@ -1,0 +1,69 @@
+package policybundle
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// schemaDiscriminator is the minimal shape used to peek a bundle's declared
+// schema_version before committing to a typed verifier. It is a structural
+// sniff only: it does not validate anything else, and an unknown or absent
+// schema_version routes nowhere (RejectUnsupportedBundle).
+type schemaDiscriminator struct {
+	SchemaVersion string `json:"schema_version"`
+}
+
+// peekSchemaVersion decodes just the schema_version field from a bundle. A
+// decode error is surfaced as a decode reject so callers get a stable
+// RejectCode rather than a raw json error.
+func peekSchemaVersion(raw []byte) (string, error) {
+	var d schemaDiscriminator
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&d); err != nil {
+		return "", reject(RejectDecode, "decode schema_version discriminator: %s", err)
+	}
+	return d.SchemaVersion, nil
+}
+
+// VerifyResult is the schema-tagged result of Verify. Exactly one of V1 or V2
+// is non-nil, matching SchemaVersion. Callers that already know the schema can
+// keep using VerifyBundle / VerifyBundleV2 directly; Verify is the dispatch
+// entry point for callers handed an artifact of unknown version.
+type VerifyResult struct {
+	SchemaVersion string
+	V1            *VerifiedBundle
+	V2            *VerifiedBundleV2
+}
+
+// Verify peeks the declared schema_version and routes to the matching typed
+// verifier. A v1 body reaches only the v1 verifier and a v2 body only the v2
+// verifier, so a body of one schema can never be accepted by the other: each
+// typed verifier re-checks the schema constant and rejects a mismatch. An
+// unrecognized schema_version is RejectUnsupportedBundle.
+//
+// This does not change VerifyBundle (v1) or VerifyBundleV2: both remain
+// exported and behaviorally unchanged for callers that know the schema.
+func Verify(raw []byte, trustFingerprint string) (*VerifyResult, error) {
+	if trustFingerprint == "" {
+		return nil, ErrTrustFingerprintRequired
+	}
+	sv, err := peekSchemaVersion(raw)
+	if err != nil {
+		return nil, err
+	}
+	switch sv {
+	case SchemaVersion:
+		v, err := VerifyBundle(raw, trustFingerprint)
+		if err != nil {
+			return nil, err
+		}
+		return &VerifyResult{SchemaVersion: sv, V1: v}, nil
+	case SchemaVersionV2:
+		v, err := VerifyBundleV2(raw, trustFingerprint)
+		if err != nil {
+			return nil, err
+		}
+		return &VerifyResult{SchemaVersion: sv, V2: v}, nil
+	default:
+		return nil, reject(RejectUnsupportedBundle, "unsupported schema_version %q", sv)
+	}
+}

--- a/internal/policybundle/policy_bundle_v2_fixture.json
+++ b/internal/policybundle/policy_bundle_v2_fixture.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": "policy_bundle.v2",
+  "bundle_version": 2,
+  "policy_hash": "sha256:91a0912e05868740e939256fc0b58498ff1ae4b19a5d5fbf7b18730d8b9f5300",
+  "canonicalization": "oktsec-policy-v2-typed-utc-json",
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "mode": "enforce",
+    "assignment": {
+      "assignment_id": "assign-0001",
+      "target": {
+        "scope": "node",
+        "node_id": "node-east-1"
+      },
+      "issued_at": "2026-05-23T12:00:00Z",
+      "sequence": 1,
+      "rollback_of": ""
+    },
+    "rules": {
+      "mode": "replace",
+      "enabled": [
+        "IAP-001",
+        "IAP-003",
+        "IAP-007"
+      ],
+      "disabled": [
+        "IAP-004"
+      ],
+      "overrides": {
+        "IAP-007": {
+          "action": "block"
+        }
+      }
+    },
+    "gateway": {
+      "mode": "replace",
+      "tools_allowed": [
+        "calendar.read",
+        "voice.dial"
+      ],
+      "tools_denied": [
+        "shell.exec"
+      ]
+    },
+    "egress": {
+      "mode": "replace",
+      "domains_allowed": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "domains_denied": [
+        "*.suspicious.example"
+      ]
+    },
+    "governance": {
+      "server": {
+        "mode": "replace",
+        "require_intent": true,
+        "rate_limit_max": 100,
+        "rate_limit_window_s": 60
+      },
+      "agents": [
+        {
+          "selector": {
+            "name": "voice-agent",
+            "labels": {
+              "env": "prod",
+              "tier": "critical"
+            }
+          },
+          "acls": {
+            "mode": "replace",
+            "allowed_recipients": [
+              "billing-agent",
+              "calendar-agent"
+            ],
+            "blocked_recipients": [
+              "untrusted-agent"
+            ]
+          },
+          "allowed_tools": {
+            "mode": "replace",
+            "values": [
+              "calendar.read",
+              "voice.dial"
+            ]
+          },
+          "tool_policies": {
+            "mode": "replace",
+            "by_tool": {
+              "voice.dial": {
+                "max_amount": "100.00",
+                "daily_limit": "1000.00",
+                "require_approval_above": "500.00",
+                "rate_limit": 20
+              }
+            }
+          },
+          "tool_constraints": {
+            "mode": "replace",
+            "items": [
+              {
+                "tool_name": "voice.dial",
+                "max_calls": 50,
+                "window_secs": 3600,
+                "params": {
+                  "number": {
+                    "max_length": 20,
+                    "pattern": "^[0-9+]+$",
+                    "enum": [],
+                    "required": true
+                  }
+                }
+              }
+            ]
+          },
+          "tool_chain_rules": {
+            "mode": "clear",
+            "items": [
+              {
+                "trigger": "voice.dial",
+                "blocks": [
+                  "shell.exec"
+                ],
+                "reason": "no shell after a dial"
+              }
+            ]
+          },
+          "blocked_content": {
+            "mode": "replace",
+            "values": [
+              "secrets",
+              "credentials"
+            ]
+          },
+          "scan_profile": {
+            "mode": "replace",
+            "value": "strict"
+          },
+          "suspended": {
+            "mode": "replace",
+            "value": false
+          }
+        }
+      ]
+    },
+    "redaction": {
+      "mode": "replace",
+      "level": "analyst"
+    },
+    "metadata": {
+      "created_at": "2026-05-23T12:00:00Z",
+      "created_by": "fixture-generator",
+      "reason": "Vendored test fixture for policy_bundle.v2 schema drift guard."
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "key_id": "enterprise-policy-fixture-v2",
+    "public_key": "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",
+    "public_key_fingerprint": "sha256:65b60673d6ed884bf01c2c222d82ada0740f29ac3355d6a925c81f17f47a27b8",
+    "signed_at": "2026-05-23T12:00:01Z",
+    "value": "5H1st3G0BP9ZJyU3I2QCDxdytN8G8aPH+ChC9ui7iLpKcWHUUknHCr6GL8nM9MrYzPmbLXOKep6vPFu3wKUoBg=="
+  }
+}

--- a/internal/policybundle/policy_bundle_v2_fixture.json
+++ b/internal/policybundle/policy_bundle_v2_fixture.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "policy_bundle.v2",
   "bundle_version": 2,
-  "policy_hash": "sha256:91a0912e05868740e939256fc0b58498ff1ae4b19a5d5fbf7b18730d8b9f5300",
+  "policy_hash": "sha256:304e887278c6d571daa9e2b4e68aa4e41fee9850e837196da27d97845de95cf2",
   "canonicalization": "oktsec-policy-v2-typed-utc-json",
   "policy": {
     "policy_id": "voice-ai-prod",
@@ -101,17 +101,21 @@
             "mode": "replace",
             "items": [
               {
-                "tool_name": "voice.dial",
-                "max_calls": 50,
-                "window_secs": 3600,
-                "params": {
+                "tool": "voice.dial",
+                "parameters": {
                   "number": {
-                    "max_length": 20,
-                    "pattern": "^[0-9+]+$",
-                    "enum": [],
-                    "required": true
+                    "allowed_patterns": [
+                      "+1*",
+                      "+44*"
+                    ],
+                    "blocked_patterns": [
+                      "+1900*"
+                    ],
+                    "max_length": 20
                   }
-                }
+                },
+                "max_response_bytes": 4096,
+                "cooldown_secs": 30
               }
             ]
           },
@@ -119,11 +123,11 @@
             "mode": "clear",
             "items": [
               {
-                "trigger": "voice.dial",
-                "blocks": [
+                "if": "voice.dial",
+                "then": [
                   "shell.exec"
                 ],
-                "reason": "no shell after a dial"
+                "cooldown_secs": 300
               }
             ]
           },
@@ -141,6 +145,34 @@
           "suspended": {
             "mode": "replace",
             "value": false
+          },
+          "egress": {
+            "mode": "replace",
+            "allowed_domains": [
+              "api.openai.com",
+              "api.anthropic.com"
+            ],
+            "blocked_domains": [
+              "*.suspicious.example"
+            ],
+            "scope": "internal+api.openai.com",
+            "tool_restrictions": {
+              "voice.dial": [
+                "api.twilio.com"
+              ]
+            },
+            "scan_requests": "true",
+            "scan_responses": "false",
+            "blocked_categories": [
+              "secrets",
+              "pii"
+            ],
+            "rate_limit": 100,
+            "rate_window": 60,
+            "integrations": [
+              "slack",
+              "github"
+            ]
           }
         }
       ]
@@ -161,6 +193,6 @@
     "public_key": "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",
     "public_key_fingerprint": "sha256:65b60673d6ed884bf01c2c222d82ada0740f29ac3355d6a925c81f17f47a27b8",
     "signed_at": "2026-05-23T12:00:01Z",
-    "value": "5H1st3G0BP9ZJyU3I2QCDxdytN8G8aPH+ChC9ui7iLpKcWHUUknHCr6GL8nM9MrYzPmbLXOKep6vPFu3wKUoBg=="
+    "value": "irqOgoWb1nDyeNMzPDt3C/oIavVPmnnzCG/euyi/HDv9LVCbqHFG9cKeWpVj/AVbGbsaaYkT8KyJk0dPmk8FDA=="
   }
 }

--- a/internal/policybundle/policy_bundle_v2_fixture.json
+++ b/internal/policybundle/policy_bundle_v2_fixture.json
@@ -193,6 +193,6 @@
     "public_key": "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",
     "public_key_fingerprint": "sha256:65b60673d6ed884bf01c2c222d82ada0740f29ac3355d6a925c81f17f47a27b8",
     "signed_at": "2026-05-23T12:00:01Z",
-    "value": "irqOgoWb1nDyeNMzPDt3C/oIavVPmnnzCG/euyi/HDv9LVCbqHFG9cKeWpVj/AVbGbsaaYkT8KyJk0dPmk8FDA=="
+    "value": "0kluhegBEV5F/l2a8KlblR/827WqKvoCOkTqxPgRlPWYx+FXYSIdZEPN11SUgI7FKOAAfPOU2S/UEvzvKNUgCA=="
   }
 }

--- a/internal/policybundle/presence_v2.go
+++ b/internal/policybundle/presence_v2.go
@@ -1,0 +1,417 @@
+package policybundle
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// validateScalarPresenceV2 walks the RAW JSON of a policy_bundle.v2 and fails
+// if any SIGNED SCALAR field is omitted or present as JSON null. It runs after
+// rejectDuplicateKeys and before the typed struct is trusted, alongside the
+// other canonical-form guards (strict decode, duplicate keys, container
+// presence). It does NOT reserialize: it walks raw bytes into
+// map[string]json.RawMessage / []json.RawMessage so it can distinguish an
+// ABSENT key (missing from the map) from a PRESENT-null key (RawMessage with
+// the literal bytes "null").
+//
+// Why this exists: a scalar omitted or set to null in the JSON decodes to Go's
+// zero value before the canonical hash is recomputed, so suspended.value
+// omitted would verify identically to suspended.value:false, rollback_of
+// omitted identically to "", an omitted numeric identically to 0. That gives
+// the contract two verifiable byte-representations for one meaning, which
+// contradicts the strictness already enforced for containers (present as []/{}),
+// timestamps (exact wire bytes), and decimals (strictly positive). v2 freezes
+// the contract requiring every signed scalar to be explicitly present.
+//
+// Scope boundary: this validator handles SCALARS only (strings, bools, numbers,
+// and the closed-set tri-state/enum strings). Containers (slices/maps) keep
+// their own presence rule in validateCanonicalPolicyContainersV2 (present as
+// []/{} not null). At a mixed boundary the two cooperate without overlap: e.g.
+// tool_policies.by_tool is a MAP (container rule), but each entry's max_amount
+// is a SCALAR (this rule); governance.agents is an ARRAY (container), but each
+// agent's suspended.value is a SCALAR (this rule).
+//
+// The walker is driven by the body's own structure: it descends fixed object
+// fields, EVERY element of arrays, and EVERY value of maps, asserting the
+// required scalar keys at each node. A scalar is "present" iff its key exists
+// AND its value is not the JSON literal null.
+func validateScalarPresenceV2(raw []byte) error {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		// Structural problems are the strict decoder's concern; this guard only
+		// runs after a successful typed decode, so a parse error here would be a
+		// programming error rather than a bundle defect. Surface it conservatively.
+		return fmt.Errorf("scalar presence: parse bundle: %s", err)
+	}
+
+	policy, err := childObject(top, "policy")
+	if err != nil {
+		return err
+	}
+
+	// Body-level scalars.
+	if err := requireScalars("policy", policy, "policy_id", "policy_version", "mode"); err != nil {
+		return err
+	}
+
+	// assignment + assignment.target.
+	assignment, err := childObject(policy, "policy.assignment", "assignment")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars("policy.assignment", assignment,
+		"assignment_id", "issued_at", "sequence", "rollback_of"); err != nil {
+		return err
+	}
+	target, err := childObject(assignment, "policy.assignment.target", "target")
+	if err != nil {
+		return err
+	}
+	// node_id may be "" for fleet scope (valid), but the KEY must be present.
+	if err := requireScalars("policy.assignment.target", target, "scope", "node_id"); err != nil {
+		return err
+	}
+
+	// Top-level dimension modes (the scalar in each dimension; the dimension's
+	// containers are validated by validateCanonicalPolicyContainersV2).
+	if err := requireDimMode(policy, "policy.rules", "rules"); err != nil {
+		return err
+	}
+	if err := requireDimMode(policy, "policy.gateway", "gateway"); err != nil {
+		return err
+	}
+	if err := requireDimMode(policy, "policy.egress", "egress"); err != nil {
+		return err
+	}
+
+	// rules.overrides is a MAP (container rule) whose every entry carries a
+	// scalar "action".
+	rules, err := childObject(policy, "policy.rules", "rules")
+	if err != nil {
+		return err
+	}
+	if overrides, present, err := optionalChildMap(rules, "policy.rules.overrides", "overrides"); err != nil {
+		return err
+	} else if present {
+		for id, ovRaw := range overrides {
+			ov, err := asObject(fmt.Sprintf("policy.rules.overrides[%q]", id), ovRaw)
+			if err != nil {
+				return err
+			}
+			if err := requireScalars(fmt.Sprintf("policy.rules.overrides[%q]", id), ov, "action"); err != nil {
+				return err
+			}
+		}
+	}
+
+	// redaction + metadata.
+	redaction, err := childObject(policy, "policy.redaction", "redaction")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars("policy.redaction", redaction, "mode", "level"); err != nil {
+		return err
+	}
+	metadata, err := childObject(policy, "policy.metadata", "metadata")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars("policy.metadata", metadata, "created_at", "created_by", "reason"); err != nil {
+		return err
+	}
+
+	// governance.server + governance.agents[*].
+	governance, err := childObject(policy, "policy.governance", "governance")
+	if err != nil {
+		return err
+	}
+	server, err := childObject(governance, "policy.governance.server", "server")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars("policy.governance.server", server,
+		"mode", "require_intent", "rate_limit_max", "rate_limit_window_s"); err != nil {
+		return err
+	}
+
+	agents, present, err := optionalChildArray(governance, "policy.governance.agents", "agents")
+	if err != nil {
+		return err
+	}
+	if present {
+		for i, agentRaw := range agents {
+			if err := validateAgentScalarPresenceV2(i, agentRaw); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateAgentScalarPresenceV2 asserts every signed scalar on one
+// governance.agents[i] entry is present and non-null, descending into its
+// map-keyed (tool_policies.by_tool, tool_constraints[].parameters) and
+// array-element (tool_constraints.items, tool_chain_rules.items) sub-surfaces.
+func validateAgentScalarPresenceV2(i int, agentRaw json.RawMessage) error {
+	p := fmt.Sprintf("policy.governance.agents[%d]", i)
+	agent, err := asObject(p, agentRaw)
+	if err != nil {
+		return err
+	}
+
+	// selector.name (selector.labels is a container; its string VALUES, when
+	// present, are guaranteed non-null by the JSON grammar for a string map and
+	// are covered by the container null-entry rule, so labels are not walked here).
+	selector, err := childObject(agent, p+".selector", "selector")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".selector", selector, "name"); err != nil {
+		return err
+	}
+
+	// Simple dimension modes.
+	for _, dim := range []string{"acls", "allowed_tools", "blocked_content"} {
+		if err := requireDimMode(agent, p+"."+dim, dim); err != nil {
+			return err
+		}
+	}
+
+	// scan_profile: mode + value (closed-set string).
+	scanProfile, err := childObject(agent, p+".scan_profile", "scan_profile")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".scan_profile", scanProfile, "mode", "value"); err != nil {
+		return err
+	}
+
+	// suspended: mode + value (bool; false valid only if present).
+	suspended, err := childObject(agent, p+".suspended", "suspended")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".suspended", suspended, "mode", "value"); err != nil {
+		return err
+	}
+
+	// tool_policies: mode scalar + by_tool MAP whose every entry carries scalar
+	// limits. max_amount/daily_limit/require_approval_above are decimal strings:
+	// "" is a valid (explicit unset) VALUE, but the KEY must be present.
+	tp, err := childObject(agent, p+".tool_policies", "tool_policies")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".tool_policies", tp, "mode"); err != nil {
+		return err
+	}
+	if byTool, present, err := optionalChildMap(tp, p+".tool_policies.by_tool", "by_tool"); err != nil {
+		return err
+	} else if present {
+		for tool, tpRaw := range byTool {
+			tpName := fmt.Sprintf("%s.tool_policies.by_tool[%q]", p, tool)
+			tpObj, err := asObject(tpName, tpRaw)
+			if err != nil {
+				return err
+			}
+			if err := requireScalars(tpName, tpObj,
+				"max_amount", "daily_limit", "require_approval_above", "rate_limit"); err != nil {
+				return err
+			}
+		}
+	}
+
+	// tool_constraints: mode scalar + items ARRAY; each item carries scalars and
+	// a parameters MAP whose every entry carries a scalar max_length.
+	tc, err := childObject(agent, p+".tool_constraints", "tool_constraints")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".tool_constraints", tc, "mode"); err != nil {
+		return err
+	}
+	if items, present, err := optionalChildArray(tc, p+".tool_constraints.items", "items"); err != nil {
+		return err
+	} else if present {
+		for j, itemRaw := range items {
+			cp := fmt.Sprintf("%s.tool_constraints.items[%d]", p, j)
+			item, err := asObject(cp, itemRaw)
+			if err != nil {
+				return err
+			}
+			if err := requireScalars(cp, item, "tool", "max_response_bytes", "cooldown_secs"); err != nil {
+				return err
+			}
+			if params, present, err := optionalChildMap(item, cp+".parameters", "parameters"); err != nil {
+				return err
+			} else if present {
+				for name, pcRaw := range params {
+					pcName := fmt.Sprintf("%s.parameters[%q]", cp, name)
+					pc, err := asObject(pcName, pcRaw)
+					if err != nil {
+						return err
+					}
+					if err := requireScalars(pcName, pc, "max_length"); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// tool_chain_rules: mode scalar + items ARRAY; each item carries scalar
+	// "if" and "cooldown_secs" ("then" is a container).
+	tcr, err := childObject(agent, p+".tool_chain_rules", "tool_chain_rules")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".tool_chain_rules", tcr, "mode"); err != nil {
+		return err
+	}
+	if items, present, err := optionalChildArray(tcr, p+".tool_chain_rules.items", "items"); err != nil {
+		return err
+	} else if present {
+		for j, itemRaw := range items {
+			rp := fmt.Sprintf("%s.tool_chain_rules.items[%d]", p, j)
+			item, err := asObject(rp, itemRaw)
+			if err != nil {
+				return err
+			}
+			if err := requireScalars(rp, item, "if", "cooldown_secs"); err != nil {
+				return err
+			}
+		}
+	}
+
+	// egress: mode + scope + tri-state strings + integer counts. allowed_domains,
+	// blocked_domains, tool_restrictions, blocked_categories, integrations are
+	// containers (handled by the container validator).
+	egress, err := childObject(agent, p+".egress", "egress")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".egress", egress,
+		"mode", "scope", "scan_requests", "scan_responses", "rate_limit", "rate_window"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// requireDimMode asserts a dimension object exists and carries a present,
+// non-null scalar "mode". It is the common case for the many wrapper dimensions
+// whose only scalar is the mode.
+func requireDimMode(parent map[string]json.RawMessage, path, key string) error {
+	dim, err := childObject(parent, path, key)
+	if err != nil {
+		return err
+	}
+	return requireScalars(path, dim, "mode")
+}
+
+// requireScalars asserts each named key exists in obj AND is not JSON null.
+// "present" iff the key is in the map and its raw value is not the literal
+// bytes "null" (absent keys are simply missing from the map after Unmarshal).
+func requireScalars(path string, obj map[string]json.RawMessage, keys ...string) error {
+	for _, k := range keys {
+		v, ok := obj[k]
+		if !ok {
+			return fmt.Errorf("%s.%s: required scalar field is absent or null", path, k)
+		}
+		if isJSONNull(v) {
+			return fmt.Errorf("%s.%s: required scalar field is absent or null", path, k)
+		}
+	}
+	return nil
+}
+
+// childObject decodes a REQUIRED child object at key. The optional name
+// overrides the default path-derived name in the error. A missing, null, or
+// non-object child is an error (its absence is itself a presence violation for
+// the scalars it would contain). Container-typed children (arrays/maps that the
+// container validator owns) are NOT decoded through here.
+func childObject(parent map[string]json.RawMessage, pathOrKey string, key ...string) (map[string]json.RawMessage, error) {
+	path := pathOrKey
+	k := pathOrKey
+	if len(key) == 1 {
+		k = key[0]
+	}
+	v, ok := parent[k]
+	if !ok || isJSONNull(v) {
+		return nil, fmt.Errorf("%s: required object is absent or null", path)
+	}
+	return asObject(path, v)
+}
+
+// asObject decodes raw as a JSON object map. A non-object (or null) is an error.
+func asObject(path string, raw json.RawMessage) (map[string]json.RawMessage, error) {
+	if isJSONNull(raw) {
+		return nil, fmt.Errorf("%s: required object is absent or null", path)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("%s: not a JSON object: %s", path, err)
+	}
+	if m == nil {
+		return nil, fmt.Errorf("%s: required object is absent or null", path)
+	}
+	return m, nil
+}
+
+// optionalChildMap decodes a map-typed container child if present and non-null.
+// Presence/null of the container itself is the container validator's concern;
+// this only walks INTO it to reach scalar leaves. Returns present=false when
+// the key is absent or null so the caller skips it without error.
+func optionalChildMap(parent map[string]json.RawMessage, path, key string) (map[string]json.RawMessage, bool, error) {
+	v, ok := parent[key]
+	if !ok || isJSONNull(v) {
+		return nil, false, nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(v, &m); err != nil {
+		return nil, false, fmt.Errorf("%s: not a JSON object: %s", path, err)
+	}
+	return m, true, nil
+}
+
+// optionalChildArray decodes an array-typed container child if present and
+// non-null. Same division of labor as optionalChildMap.
+func optionalChildArray(parent map[string]json.RawMessage, path, key string) ([]json.RawMessage, bool, error) {
+	v, ok := parent[key]
+	if !ok || isJSONNull(v) {
+		return nil, false, nil
+	}
+	var a []json.RawMessage
+	if err := json.Unmarshal(v, &a); err != nil {
+		return nil, false, fmt.Errorf("%s: not a JSON array: %s", path, err)
+	}
+	return a, true, nil
+}
+
+// isJSONNull reports whether a raw value is the JSON literal null. A present
+// key whose value is null is treated identically to an absent key: a scalar
+// must be explicitly present with a non-null value.
+func isJSONNull(raw json.RawMessage) bool {
+	return string(jsonTrimSpace(raw)) == "null"
+}
+
+// jsonTrimSpace trims the insignificant JSON whitespace bytes around a raw
+// value so a null surrounded by spaces is still recognized. json.RawMessage for
+// a field captures the value bytes including any surrounding whitespace the
+// source had; the JSON grammar's insignificant whitespace is space, tab, CR, LF.
+func jsonTrimSpace(raw json.RawMessage) []byte {
+	start := 0
+	for start < len(raw) && isJSONSpace(raw[start]) {
+		start++
+	}
+	end := len(raw)
+	for end > start && isJSONSpace(raw[end-1]) {
+		end--
+	}
+	return raw[start:end]
+}
+
+func isJSONSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}

--- a/internal/policybundle/presence_v2.go
+++ b/internal/policybundle/presence_v2.go
@@ -23,13 +23,18 @@ import (
 // timestamps (exact wire bytes), and decimals (strictly positive). v2 freezes
 // the contract requiring every signed scalar to be explicitly present.
 //
-// Scope boundary: this validator handles SCALARS only (strings, bools, numbers,
-// and the closed-set tri-state/enum strings). Containers (slices/maps) keep
-// their own presence rule in validateCanonicalPolicyContainersV2 (present as
-// []/{} not null). At a mixed boundary the two cooperate without overlap: e.g.
-// tool_policies.by_tool is a MAP (container rule), but each entry's max_amount
-// is a SCALAR (this rule); governance.agents is an ARRAY (container), but each
-// agent's suspended.value is a SCALAR (this rule).
+// Scope boundary: this validator handles SCALARS (strings, bools, numbers, and
+// the closed-set tri-state/enum strings) AND scalar leaves inside containers -
+// i.e. null ELEMENTS of signed string arrays and null VALUES of signed string
+// maps. The CONTAINER's own presence (present as []/{} not null) stays with
+// validateCanonicalPolicyContainersV2; this validator only refuses null at the
+// scalar leaf so a null cannot decode to "" and share a hash with an explicit
+// "". At a mixed boundary the two cooperate without overlap: e.g.
+// tool_policies.by_tool is a MAP (container rule for the map, scalar rule for
+// each entry's max_amount); governance.agents is an ARRAY (container rule for
+// the array, scalar rule for each agent's suspended.value);
+// gateway.tools_allowed is a string array (container rule for [], this rule for
+// each element being non-null).
 //
 // The walker is driven by the body's own structure: it descends fixed object
 // fields, EVERY element of arrays, and EVERY value of maps, asserting the
@@ -84,12 +89,39 @@ func validateScalarPresenceV2(raw []byte) error {
 		return err
 	}
 
-	// rules.overrides is a MAP (container rule) whose every entry carries a
-	// scalar "action".
+	// Top-level signed string-array containers: reject null ELEMENTS (the empty
+	// container itself is the container validator's concern). A null element
+	// decodes to "" and would otherwise share a hash with an explicit "".
+	gateway, err := childObject(policy, "policy.gateway", "gateway")
+	if err != nil {
+		return err
+	}
+	egress, err := childObject(policy, "policy.egress", "egress")
+	if err != nil {
+		return err
+	}
 	rules, err := childObject(policy, "policy.rules", "rules")
 	if err != nil {
 		return err
 	}
+	for _, sa := range []struct {
+		parent    map[string]json.RawMessage
+		path, key string
+	}{
+		{rules, "policy.rules.enabled", "enabled"},
+		{rules, "policy.rules.disabled", "disabled"},
+		{gateway, "policy.gateway.tools_allowed", "tools_allowed"},
+		{gateway, "policy.gateway.tools_denied", "tools_denied"},
+		{egress, "policy.egress.domains_allowed", "domains_allowed"},
+		{egress, "policy.egress.domains_denied", "domains_denied"},
+	} {
+		if err := rejectNullStringArrayElems(sa.parent, sa.path, sa.key); err != nil {
+			return err
+		}
+	}
+
+	// rules.overrides is a MAP (container rule) whose every entry carries a
+	// scalar "action".
 	if overrides, present, err := optionalChildMap(rules, "policy.rules.overrides", "overrides"); err != nil {
 		return err
 	} else if present {
@@ -160,9 +192,10 @@ func validateAgentScalarPresenceV2(i int, agentRaw json.RawMessage) error {
 		return err
 	}
 
-	// selector.name (selector.labels is a container; its string VALUES, when
-	// present, are guaranteed non-null by the JSON grammar for a string map and
-	// are covered by the container null-entry rule, so labels are not walked here).
+	// selector.name (scalar) + selector.labels (a string-VALUE map: the map's
+	// own presence is the container validator's concern, but a null VALUE decodes
+	// to "" and would share a hash with an explicit "", so null values are
+	// rejected here).
 	selector, err := childObject(agent, p+".selector", "selector")
 	if err != nil {
 		return err
@@ -170,10 +203,35 @@ func validateAgentScalarPresenceV2(i int, agentRaw json.RawMessage) error {
 	if err := requireScalars(p+".selector", selector, "name"); err != nil {
 		return err
 	}
+	if err := rejectNullStringMapValues(selector, p+".selector.labels", "labels"); err != nil {
+		return err
+	}
 
-	// Simple dimension modes.
-	for _, dim := range []string{"acls", "allowed_tools", "blocked_content"} {
-		if err := requireDimMode(agent, p+"."+dim, dim); err != nil {
+	// acls: mode scalar + two string-array containers (null elements rejected).
+	acls, err := childObject(agent, p+".acls", "acls")
+	if err != nil {
+		return err
+	}
+	if err := requireScalars(p+".acls", acls, "mode"); err != nil {
+		return err
+	}
+	if err := rejectNullStringArrayElems(acls, p+".acls.allowed_recipients", "allowed_recipients"); err != nil {
+		return err
+	}
+	if err := rejectNullStringArrayElems(acls, p+".acls.blocked_recipients", "blocked_recipients"); err != nil {
+		return err
+	}
+
+	// allowed_tools / blocked_content: mode scalar + a "values" string array.
+	for _, dim := range []string{"allowed_tools", "blocked_content"} {
+		d, err := childObject(agent, p+"."+dim, dim)
+		if err != nil {
+			return err
+		}
+		if err := requireScalars(p+"."+dim, d, "mode"); err != nil {
+			return err
+		}
+		if err := rejectNullStringArrayElems(d, p+"."+dim+".values", "values"); err != nil {
 			return err
 		}
 	}
@@ -255,13 +313,19 @@ func validateAgentScalarPresenceV2(i int, agentRaw json.RawMessage) error {
 					if err := requireScalars(pcName, pc, "max_length"); err != nil {
 						return err
 					}
+					if err := rejectNullStringArrayElems(pc, pcName+".allowed_patterns", "allowed_patterns"); err != nil {
+						return err
+					}
+					if err := rejectNullStringArrayElems(pc, pcName+".blocked_patterns", "blocked_patterns"); err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
 
 	// tool_chain_rules: mode scalar + items ARRAY; each item carries scalar
-	// "if" and "cooldown_secs" ("then" is a container).
+	// "if" and "cooldown_secs" plus a "then" string array (null elements rejected).
 	tcr, err := childObject(agent, p+".tool_chain_rules", "tool_chain_rules")
 	if err != nil {
 		return err
@@ -281,18 +345,36 @@ func validateAgentScalarPresenceV2(i int, agentRaw json.RawMessage) error {
 			if err := requireScalars(rp, item, "if", "cooldown_secs"); err != nil {
 				return err
 			}
+			if err := rejectNullStringArrayElems(item, rp+".then", "then"); err != nil {
+				return err
+			}
 		}
 	}
 
-	// egress: mode + scope + tri-state strings + integer counts. allowed_domains,
-	// blocked_domains, tool_restrictions, blocked_categories, integrations are
-	// containers (handled by the container validator).
+	// egress: scalars (mode, scope, tri-state strings, integer counts) plus the
+	// string-array containers (allowed_domains, blocked_domains, blocked_categories,
+	// integrations) and the string-array MAP (tool_restrictions). The containers'
+	// own presence is the container validator's concern; here we reject null
+	// string ELEMENTS / values so they cannot collide with an explicit "".
 	egress, err := childObject(agent, p+".egress", "egress")
 	if err != nil {
 		return err
 	}
 	if err := requireScalars(p+".egress", egress,
 		"mode", "scope", "scan_requests", "scan_responses", "rate_limit", "rate_window"); err != nil {
+		return err
+	}
+	for _, sa := range []struct{ path, key string }{
+		{p + ".egress.allowed_domains", "allowed_domains"},
+		{p + ".egress.blocked_domains", "blocked_domains"},
+		{p + ".egress.blocked_categories", "blocked_categories"},
+		{p + ".egress.integrations", "integrations"},
+	} {
+		if err := rejectNullStringArrayElems(egress, sa.path, sa.key); err != nil {
+			return err
+		}
+	}
+	if err := rejectNullStringMapOfArrays(egress, p+".egress.tool_restrictions", "tool_restrictions"); err != nil {
 		return err
 	}
 
@@ -387,6 +469,82 @@ func optionalChildArray(parent map[string]json.RawMessage, path, key string) ([]
 		return nil, false, fmt.Errorf("%s: not a JSON array: %s", path, err)
 	}
 	return a, true, nil
+}
+
+// rejectNullStringArrayElems rejects a JSON null ELEMENT inside a signed
+// string-array container (e.g. gateway.tools_allowed, acls.allowed_recipients,
+// a parameter's allowed_patterns). encoding/json decodes a null element of a
+// []string to "", so a bundle signed with [""] and a wire bundle with [null]
+// recompute the SAME hash and both verify - the same dual-byte-representation
+// defect this PR freezes out, one level inside the container. The container's
+// own presence ([] not null) stays with validateCanonicalPolicyContainersV2;
+// this only refuses null ELEMENTS so every string element is explicit on the
+// wire. Absent/null container itself is skipped here (container validator owns it).
+func rejectNullStringArrayElems(parent map[string]json.RawMessage, path, key string) error {
+	elems, present, err := optionalChildArray(parent, path, key)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
+	}
+	for i, e := range elems {
+		if isJSONNull(e) {
+			return fmt.Errorf("%s[%d]: string element must not be null", path, i)
+		}
+	}
+	return nil
+}
+
+// rejectNullStringMapValues rejects a JSON null VALUE inside a signed map whose
+// values are strings (selector.labels). Same reasoning as
+// rejectNullStringArrayElems: a null value decodes to "" and would collide with
+// an explicit "" on the hash. The map's own presence ({} not null) stays with
+// the container validator.
+func rejectNullStringMapValues(parent map[string]json.RawMessage, path, key string) error {
+	m, present, err := optionalChildMap(parent, path, key)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
+	}
+	for k, v := range m {
+		if isJSONNull(v) {
+			return fmt.Errorf("%s[%q]: string value must not be null", path, k)
+		}
+	}
+	return nil
+}
+
+// rejectNullStringMapOfArrays rejects a JSON null ELEMENT inside a map whose
+// values are string arrays (egress.tool_restrictions). The map and each array's
+// own presence stay with the container validator; this refuses null string
+// elements so every restriction domain is explicit.
+func rejectNullStringMapOfArrays(parent map[string]json.RawMessage, path, key string) error {
+	m, present, err := optionalChildMap(parent, path, key)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
+	}
+	for k, vRaw := range m {
+		if isJSONNull(vRaw) {
+			// The container validator rejects a null array value; nothing to walk.
+			continue
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(vRaw, &arr); err != nil {
+			return fmt.Errorf("%s[%q]: not a JSON array: %s", path, k, err)
+		}
+		for i, e := range arr {
+			if isJSONNull(e) {
+				return fmt.Errorf("%s[%q][%d]: string element must not be null", path, k, i)
+			}
+		}
+	}
+	return nil
 }
 
 // isJSONNull reports whether a raw value is the JSON literal null. A present

--- a/internal/policybundle/types_v2.go
+++ b/internal/policybundle/types_v2.go
@@ -60,7 +60,9 @@ type AssignmentV2 struct {
 }
 
 // TargetV2 binds an assignment to a scope. scope is "fleet" or "node";
-// node_id is the node it targets, or "" for a fleet-wide assignment.
+// node_id is the node it targets (required, non-empty) for a node assignment,
+// and MUST be "" for a fleet-wide assignment, so a signed bundle binds to
+// exactly one unambiguous target (enforced by the verifier).
 type TargetV2 struct {
 	Scope  string `json:"scope"`
 	NodeID string `json:"node_id"`

--- a/internal/policybundle/types_v2.go
+++ b/internal/policybundle/types_v2.go
@@ -1,0 +1,225 @@
+package policybundle
+
+// Frozen constants of the policy_bundle.v2 signing contract. These sit
+// ALONGSIDE the v1 constants and never reuse or modify them. A change to any
+// of these is a v2 contract change: it must be matched on the signing side,
+// and the vendored v2 fixture must be regenerated. Drift here surfaces as a
+// broken signature on every v2 bundle. SignatureAlg is shared with v1 and is
+// not redeclared.
+const (
+	SchemaVersionV2    = "policy_bundle.v2"
+	BundleVersionV2    = 2
+	CanonicalizationV2 = "oktsec-policy-v2-typed-utc-json"
+)
+
+// PolicyBundleV2 is the signed JSON artifact for the v2 governance contract:
+// the outer envelope carries the declared hash and the signature; the inner
+// PolicyBodyV2 is the signed content. The envelope shape mirrors v1 so the
+// same signature block layout is reused; only the body and the bound
+// assignment metadata differ.
+type PolicyBundleV2 struct {
+	SchemaVersion    string          `json:"schema_version"`
+	BundleVersion    int             `json:"bundle_version"`
+	PolicyHash       string          `json:"policy_hash"`
+	Canonicalization string          `json:"canonicalization"`
+	Policy           PolicyBodyV2    `json:"policy"`
+	Signature        PolicySignature `json:"signature"`
+}
+
+// PolicyBodyV2 is the v2 content covered by policy_hash and the Ed25519
+// signature. Field order IS the canonical projection order: the signed bytes
+// are produced by encoding this struct exactly as declared. The FULL
+// governance surface is defined now, even though apply/projection is 9A.2 -
+// the hash must cover the entire surface from day one, or a later PR adding a
+// field would change the canonical body and break the pinned fixture. Never
+// reorder these fields or change a json tag without changing CanonicalizationV2
+// and regenerating the fixture.
+type PolicyBodyV2 struct {
+	PolicyID      string         `json:"policy_id"`
+	PolicyVersion string         `json:"policy_version"`
+	Mode          string         `json:"mode"` // "enforce" | "observe", bundle-wide (as v1)
+	Assignment    AssignmentV2   `json:"assignment"`
+	Rules         DimRulesV2     `json:"rules"`
+	Gateway       DimGatewayV2   `json:"gateway"`
+	Egress        DimEgressV2    `json:"egress"`
+	Governance    GovernanceV2   `json:"governance"`
+	Redaction     DimRedactionV2 `json:"redaction"`
+	Metadata      PolicyMetadata `json:"metadata"` // reuse v1 shape
+}
+
+// AssignmentV2 binds the bundle to a target and carries anti-rollback
+// metadata. Every field here is folded into the signing payload (not just the
+// body hash) so a store cannot rewrite the target, sequence, or issued_at of
+// a signed bundle without breaking the signature.
+type AssignmentV2 struct {
+	AssignmentID string   `json:"assignment_id"`
+	Target       TargetV2 `json:"target"`
+	IssuedAt     string   `json:"issued_at"` // canonical UTC timestamp
+	Sequence     int64    `json:"sequence"`  // base-10, >= 1
+	RollbackOf   string   `json:"rollback_of"`
+}
+
+// TargetV2 binds an assignment to a scope. scope is "fleet" or "node";
+// node_id is the node it targets, or "" for a fleet-wide assignment.
+type TargetV2 struct {
+	Scope  string `json:"scope"`
+	NodeID string `json:"node_id"`
+}
+
+// DimRulesV2 wraps the v1 rule-ID layer with a dimension mode. Overrides keys
+// map a rule id to its action; map keys serialize alphabetically under
+// encoding/json, so the canonical bytes are deterministic without explicit
+// sorting (verified by test).
+type DimRulesV2 struct {
+	Mode      string                        `json:"mode"`
+	Enabled   []string                      `json:"enabled"`
+	Disabled  []string                      `json:"disabled"`
+	Overrides map[string]PolicyRuleOverride `json:"overrides"` // reuse v1 override shape
+}
+
+type DimGatewayV2 struct {
+	Mode         string   `json:"mode"`
+	ToolsAllowed []string `json:"tools_allowed"`
+	ToolsDenied  []string `json:"tools_denied"`
+}
+
+type DimEgressV2 struct {
+	Mode           string   `json:"mode"`
+	DomainsAllowed []string `json:"domains_allowed"`
+	DomainsDenied  []string `json:"domains_denied"`
+}
+
+// DimRedactionV2 carries the redaction dimension mode plus the level. level
+// is "full" | "analyst" | "external", as v1.
+type DimRedactionV2 struct {
+	Mode  string `json:"mode"`
+	Level string `json:"level"`
+}
+
+// GovernanceV2 is the full per-agent governance surface. server is the
+// server-level governance dimension; agents is the ordered list of per-agent
+// governance entries (declaration order in the JSON array IS the canonical
+// order - it is hashed as authored).
+type GovernanceV2 struct {
+	Server ServerGovernanceV2  `json:"server"`
+	Agents []AgentGovernanceV2 `json:"agents"`
+}
+
+// ServerGovernanceV2 mirrors the small set of server-level proxy settings that
+// a policy bundle can govern (see config.ServerConfig). It is intentionally
+// minimal but fully typed so canonicalization is deterministic. require_intent
+// and the rate-limit pair are the governable knobs; apply logic is 9A.2.
+type ServerGovernanceV2 struct {
+	Mode            string `json:"mode"`
+	RequireIntent   bool   `json:"require_intent"`
+	RateLimitMax    int64  `json:"rate_limit_max"`      // max messages per window (config.RateLimitConfig)
+	RateLimitWindow int64  `json:"rate_limit_window_s"` // window seconds
+}
+
+// AgentGovernanceV2 is the per-agent governance surface. Every Community
+// per-agent config knob (config.Agent) is represented as a dimension so the
+// hash covers the whole surface. selector binds the entry to an agent.
+type AgentGovernanceV2 struct {
+	Selector        SelectorV2           `json:"selector"`
+	ACLs            DimACLsV2            `json:"acls"`
+	AllowedTools    DimStringSetV2       `json:"allowed_tools"`
+	ToolPolicies    DimToolPoliciesV2    `json:"tool_policies"`
+	ToolConstraints DimToolConstraintsV2 `json:"tool_constraints"`
+	ToolChainRules  DimToolChainRulesV2  `json:"tool_chain_rules"`
+	BlockedContent  DimStringSetV2       `json:"blocked_content"`
+	ScanProfile     DimScalarStringV2    `json:"scan_profile"`
+	Suspended       DimScalarBoolV2      `json:"suspended"`
+}
+
+// SelectorV2 selects the agent a governance entry applies to. name is the
+// primary key; labels is an optional label match (map keys serialize
+// alphabetically, so the canonical bytes are deterministic).
+type SelectorV2 struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+}
+
+// DimACLsV2 mirrors the agent ACL surface (config.Agent.CanMessage /
+// BlockedContent split into recipient allow/deny here).
+type DimACLsV2 struct {
+	Mode              string   `json:"mode"`
+	AllowedRecipients []string `json:"allowed_recipients"`
+	BlockedRecipients []string `json:"blocked_recipients"`
+}
+
+// DimStringSetV2 is a string-list dimension (allowed_tools, blocked_content).
+type DimStringSetV2 struct {
+	Mode   string   `json:"mode"`
+	Values []string `json:"values"`
+}
+
+// DimToolPoliciesV2 maps a tool name to its policy (config.Agent.ToolPolicies).
+// Map keys serialize alphabetically, so the canonical bytes are deterministic.
+type DimToolPoliciesV2 struct {
+	Mode   string                  `json:"mode"`
+	ByTool map[string]ToolPolicyV2 `json:"by_tool"`
+}
+
+// ToolPolicyV2 mirrors config.ToolPolicy. Monetary/limit values that are
+// float64 in config are carried as STRINGS on the v2 wire (see canonical_v2.go
+// for the rationale): a base-10 decimal string has one exact representation, so
+// the hash is stable, whereas float JSON formatting is not portably
+// deterministic. rate_limit is an integer count and stays an int (integer JSON
+// encoding is deterministic). Decimal-string validation happens at verify time;
+// numeric interpretation is deferred to 9A.2 apply.
+type ToolPolicyV2 struct {
+	MaxAmount            string `json:"max_amount"`             // decimal string, e.g. "100.00"
+	DailyLimit           string `json:"daily_limit"`            // decimal string
+	RequireApprovalAbove string `json:"require_approval_above"` // decimal string
+	RateLimit            int64  `json:"rate_limit"`             // integer calls per hour
+}
+
+// DimToolConstraintsV2 mirrors config.Agent.ToolConstraints. The list order is
+// canonical (hashed as authored).
+type DimToolConstraintsV2 struct {
+	Mode  string             `json:"mode"`
+	Items []ToolConstraintV2 `json:"items"`
+}
+
+// ToolConstraintV2 mirrors config.ToolConstraintConfig. params map keys
+// serialize alphabetically.
+type ToolConstraintV2 struct {
+	ToolName   string                       `json:"tool_name"`
+	MaxCalls   int64                        `json:"max_calls"`
+	WindowSecs int64                        `json:"window_secs"`
+	Params     map[string]ParamConstraintV2 `json:"params"`
+}
+
+// ParamConstraintV2 mirrors config.ParamConstraintConfig.
+type ParamConstraintV2 struct {
+	MaxLength int64    `json:"max_length"`
+	Pattern   string   `json:"pattern"`
+	Enum      []string `json:"enum"`
+	Required  bool     `json:"required"`
+}
+
+// DimToolChainRulesV2 mirrors config.Agent.ToolChainRules. List order is
+// canonical.
+type DimToolChainRulesV2 struct {
+	Mode  string            `json:"mode"`
+	Items []ToolChainRuleV2 `json:"items"`
+}
+
+// ToolChainRuleV2 mirrors config.ToolChainRuleConfig.
+type ToolChainRuleV2 struct {
+	Trigger string   `json:"trigger"`
+	Blocks  []string `json:"blocks"`
+	Reason  string   `json:"reason"`
+}
+
+// DimScalarStringV2 is a single-string dimension (scan_profile).
+type DimScalarStringV2 struct {
+	Mode  string `json:"mode"`
+	Value string `json:"value"`
+}
+
+// DimScalarBoolV2 is a single-bool dimension (suspended).
+type DimScalarBoolV2 struct {
+	Mode  string `json:"mode"`
+	Value bool   `json:"value"`
+}

--- a/internal/policybundle/types_v2.go
+++ b/internal/policybundle/types_v2.go
@@ -85,6 +85,14 @@ type DimGatewayV2 struct {
 	ToolsDenied  []string `json:"tools_denied"`
 }
 
+// DimEgressV2 is the FLEET/GLOBAL egress dimension on the body: the
+// gateway-wide domain allow/deny lists (config.ForwardProxy global scope). It
+// is intentionally NOT the rich per-agent egress policy. Per-agent egress lives
+// on AgentGovernanceV2.Egress (DimAgentEgressV2) and mirrors
+// config.EgressPolicy field-for-field. Both scopes are kept on purpose: this
+// one governs the global forward-proxy domain lists, the per-agent one governs a
+// single agent's outbound controls (config.Agent.Egress). They are different
+// scopes and must not be collapsed.
 type DimEgressV2 struct {
 	Mode           string   `json:"mode"`
 	DomainsAllowed []string `json:"domains_allowed"`
@@ -131,6 +139,42 @@ type AgentGovernanceV2 struct {
 	BlockedContent  DimStringSetV2       `json:"blocked_content"`
 	ScanProfile     DimScalarStringV2    `json:"scan_profile"`
 	Suspended       DimScalarBoolV2      `json:"suspended"`
+	Egress          DimAgentEgressV2     `json:"egress"`
+}
+
+// DimAgentEgressV2 is the PER-AGENT egress dimension, mirroring
+// config.Agent.Egress (config.EgressPolicy) so 9A.2 can project it onto a
+// single agent's outbound controls. This is distinct from the body-level
+// DimEgressV2, which carries only the fleet/global forward-proxy domain lists.
+// The same unmanaged|replace|clear mode discipline used by every other
+// dimension applies; apply semantics are 9A.2.
+//
+// Wire-safety notes:
+//   - rate_limit and rate_window are integer counts (config int), carried as
+//     int64 so JSON encoding is deterministic. No float fields exist on
+//     config.EgressPolicy, so no decimal-string convention is needed here.
+//   - config.EgressPolicy.ScanRequests/ScanResponses are *bool (tri-state:
+//     unset, true, false). They are carried as a closed-set STRING enum
+//     ("unset"|"true"|"false") rather than a JSON null/bool, so the canonical
+//     bytes never contain null (which the container discipline forbids) and the
+//     tri-state is preserved without a pointer in the signed body.
+//   - tool_restrictions mirrors config map[string][]string; map keys serialize
+//     alphabetically, so the canonical bytes are deterministic.
+//
+// Omitted from config.EgressPolicy: nothing operator-relevant is dropped. Every
+// EgressPolicy field is represented.
+type DimAgentEgressV2 struct {
+	Mode              string              `json:"mode"`
+	AllowedDomains    []string            `json:"allowed_domains"`
+	BlockedDomains    []string            `json:"blocked_domains"`
+	Scope             string              `json:"scope"`
+	ToolRestrictions  map[string][]string `json:"tool_restrictions"`
+	ScanRequests      string              `json:"scan_requests"`  // tri-state: "unset" | "true" | "false"
+	ScanResponses     string              `json:"scan_responses"` // tri-state: "unset" | "true" | "false"
+	BlockedCategories []string            `json:"blocked_categories"`
+	RateLimit         int64               `json:"rate_limit"`
+	RateWindow        int64               `json:"rate_window"`
+	Integrations      []string            `json:"integrations"`
 }
 
 // SelectorV2 selects the agent a governance entry applies to. name is the
@@ -183,21 +227,25 @@ type DimToolConstraintsV2 struct {
 	Items []ToolConstraintV2 `json:"items"`
 }
 
-// ToolConstraintV2 mirrors config.ToolConstraintConfig. params map keys
-// serialize alphabetically.
+// ToolConstraintV2 mirrors config.ToolConstraintConfig field-for-field so 9A.2
+// maps it 1:1: tool name, the per-parameter constraint map, the max response
+// size, and the cooldown. parameters map keys serialize alphabetically, so the
+// canonical bytes are deterministic. max_response_bytes and cooldown_secs are
+// integer counts (config int), carried as int64 for deterministic JSON.
 type ToolConstraintV2 struct {
-	ToolName   string                       `json:"tool_name"`
-	MaxCalls   int64                        `json:"max_calls"`
-	WindowSecs int64                        `json:"window_secs"`
-	Params     map[string]ParamConstraintV2 `json:"params"`
+	Tool             string                       `json:"tool"`
+	Parameters       map[string]ParamConstraintV2 `json:"parameters"`
+	MaxResponseBytes int64                        `json:"max_response_bytes"`
+	CooldownSecs     int64                        `json:"cooldown_secs"`
 }
 
-// ParamConstraintV2 mirrors config.ParamConstraintConfig.
+// ParamConstraintV2 mirrors config.ParamConstraintConfig field-for-field:
+// allowed/blocked glob patterns and a max length. max_length is an integer
+// count carried as int64 for deterministic JSON.
 type ParamConstraintV2 struct {
-	MaxLength int64    `json:"max_length"`
-	Pattern   string   `json:"pattern"`
-	Enum      []string `json:"enum"`
-	Required  bool     `json:"required"`
+	AllowedPatterns []string `json:"allowed_patterns"`
+	BlockedPatterns []string `json:"blocked_patterns"`
+	MaxLength       int64    `json:"max_length"`
 }
 
 // DimToolChainRulesV2 mirrors config.Agent.ToolChainRules. List order is
@@ -207,11 +255,14 @@ type DimToolChainRulesV2 struct {
 	Items []ToolChainRuleV2 `json:"items"`
 }
 
-// ToolChainRuleV2 mirrors config.ToolChainRuleConfig.
+// ToolChainRuleV2 mirrors config.ToolChainRuleConfig field-for-field so 9A.2
+// maps it 1:1: the triggering tool (if), the tools that become blocked (then),
+// and how long the block lasts (cooldown_secs). cooldown_secs is an integer
+// count (config int) carried as int64 for deterministic JSON.
 type ToolChainRuleV2 struct {
-	Trigger string   `json:"trigger"`
-	Blocks  []string `json:"blocks"`
-	Reason  string   `json:"reason"`
+	If           string   `json:"if"`
+	Then         []string `json:"then"`
+	CooldownSecs int64    `json:"cooldown_secs"`
 }
 
 // DimScalarStringV2 is a single-string dimension (scan_profile).

--- a/internal/policybundle/verify_v2.go
+++ b/internal/policybundle/verify_v2.go
@@ -140,9 +140,9 @@ func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, err
 	}
 
 	// (8) signature value + Ed25519 verify over the v2 canonical payload. The
-	// payload binds the assignment, target, sequence, issued_at, and
-	// rollback_of as exact wire bytes (issued_at already validated canonical in
-	// step 3), so any edit to those breaks the signature.
+	// payload binds the assignment, target, sequence, issued_at, signed_at, and
+	// rollback_of as exact wire bytes (both issued_at and signed_at already
+	// validated canonical in step 3), so any edit to those breaks the signature.
 	sigBytes, err := base64.StdEncoding.DecodeString(b.Signature.Value)
 	if err != nil || len(sigBytes) != ed25519.SignatureSize {
 		return nil, reject(RejectSignatureInvalid, "signature.value is not a valid Ed25519 signature")
@@ -151,6 +151,7 @@ func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, err
 		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
 		b.Policy.Assignment.AssignmentID, b.Policy.Assignment.Target.Scope,
 		b.Policy.Assignment.Target.NodeID, b.Policy.Assignment.IssuedAt,
+		b.Signature.SignedAt,
 		b.Policy.Assignment.Sequence, b.Policy.Assignment.RollbackOf,
 		b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
 	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigBytes) {

--- a/internal/policybundle/verify_v2.go
+++ b/internal/policybundle/verify_v2.go
@@ -72,6 +72,19 @@ func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, err
 		return nil, reject(RejectSchemaInvalid, "%s", err)
 	}
 
+	// Scalar presence: every SIGNED SCALAR must be explicitly present and
+	// non-null in the raw JSON. A scalar omitted or set to null decodes to Go's
+	// zero value BEFORE the hash is recomputed, so an omitted suspended.value
+	// would verify identically to false, an omitted rollback_of identically to
+	// "", an omitted numeric identically to 0 - two verifiable byte forms for one
+	// meaning. This walks the raw JSON (no reserialize) so it can tell an absent
+	// key from a present-null one, and runs before any typed field is trusted.
+	// Containers keep their own []/{} presence rule in
+	// validateCanonicalPolicyContainersV2; this guard owns scalars only.
+	if err := validateScalarPresenceV2(raw); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
+	}
+
 	// (2) schema constant tags.
 	switch {
 	case b.SchemaVersion != SchemaVersionV2:

--- a/internal/policybundle/verify_v2.go
+++ b/internal/policybundle/verify_v2.go
@@ -261,10 +261,28 @@ func validatePolicySchemaV2(b *PolicyBundleV2) error {
 			{p + ".blocked_content.mode", a.BlockedContent.Mode},
 			{p + ".scan_profile.mode", a.ScanProfile.Mode},
 			{p + ".suspended.mode", a.Suspended.Mode},
+			{p + ".egress.mode", a.Egress.Mode},
 		} {
 			if err := checkDimMode(d.name, d.mode); err != nil {
 				return err
 			}
+		}
+		// Per-agent egress tri-state enums: config.EgressPolicy's *bool fields
+		// are carried as a closed-set string on the wire, so an out-of-set value
+		// must be rejected before the bundle is labeled verified.
+		for _, ts := range []struct{ name, val string }{
+			{p + ".egress.scan_requests", a.Egress.ScanRequests},
+			{p + ".egress.scan_responses", a.Egress.ScanResponses},
+		} {
+			if !validTriState[ts.val] {
+				return fmt.Errorf("%s %q not in {unset, true, false}", ts.name, ts.val)
+			}
+		}
+		// scan_profile.value is a closed set (config ScanProfile* constants plus
+		// ""): an out-of-set value cannot be safely projected, so it is a schema
+		// reject rather than a verified bundle. The mode is validated above.
+		if !validScanProfileValues[a.ScanProfile.Value] {
+			return fmt.Errorf("%s.scan_profile.value %q not in {\"\", strict, content-aware, minimal}", p, a.ScanProfile.Value)
 		}
 		for tool, tp := range a.ToolPolicies.ByTool {
 			tpName := fmt.Sprintf("%s.tool_policies.by_tool[%q]", p, tool)
@@ -277,7 +295,55 @@ func validatePolicySchemaV2(b *PolicyBundleV2) error {
 			if err := validateCanonicalDecimal(tpName+".require_approval_above", tp.RequireApprovalAbove); err != nil {
 				return err
 			}
+			// rate_limit is an integer guardrail: the enforcer only activates it
+			// when > 0, so a negative value would silently disable a signed limit
+			// if applied. A "verified" bundle must not mean the opposite of what
+			// it declares.
+			if err := nonNegInt(tpName+".rate_limit", tp.RateLimit); err != nil {
+				return err
+			}
 		}
+
+		// Remaining integer guardrails across the agent surface. Same fail-open
+		// reasoning: the runtime only activates these when > 0 (or treats <0 as
+		// unbounded), so a signed negative value cannot be safely projected. All
+		// are non-negative counts in config (int), so verify rejects negatives.
+		for j := range a.ToolConstraints.Items {
+			c := &a.ToolConstraints.Items[j]
+			cp := fmt.Sprintf("%s.tool_constraints.items[%d]", p, j)
+			if err := nonNegInt(cp+".max_response_bytes", c.MaxResponseBytes); err != nil {
+				return err
+			}
+			if err := nonNegInt(cp+".cooldown_secs", c.CooldownSecs); err != nil {
+				return err
+			}
+			for name, pc := range c.Parameters {
+				if err := nonNegInt(fmt.Sprintf("%s.parameters[%q].max_length", cp, name), pc.MaxLength); err != nil {
+					return err
+				}
+			}
+		}
+		for j := range a.ToolChainRules.Items {
+			if err := nonNegInt(fmt.Sprintf("%s.tool_chain_rules.items[%d].cooldown_secs", p, j), a.ToolChainRules.Items[j].CooldownSecs); err != nil {
+				return err
+			}
+		}
+		if err := nonNegInt(p+".egress.rate_limit", a.Egress.RateLimit); err != nil {
+			return err
+		}
+		if err := nonNegInt(p+".egress.rate_window", a.Egress.RateWindow); err != nil {
+			return err
+		}
+	}
+
+	// Server-level integer guardrails (config.RateLimitConfig): the enforcer
+	// only activates per-agent rate limiting when > 0, so a negative signed
+	// value would fail open if applied.
+	if err := nonNegInt("policy.governance.server.rate_limit_max", b.Policy.Governance.Server.RateLimitMax); err != nil {
+		return err
+	}
+	if err := nonNegInt("policy.governance.server.rate_limit_window_s", b.Policy.Governance.Server.RateLimitWindow); err != nil {
+		return err
 	}
 
 	return nil
@@ -288,6 +354,17 @@ func validatePolicySchemaV2(b *PolicyBundleV2) error {
 func checkDimMode(field, mode string) error {
 	if !validDimModes[mode] {
 		return fmt.Errorf("%s %q not in {unmanaged, replace, clear}", field, mode)
+	}
+	return nil
+}
+
+// nonNegInt rejects a negative v2 integer guardrail. These map to non-negative
+// counts in config; a negative value would fail open when projected (the
+// runtime activates the guardrail only when positive), so the verifier refuses
+// it rather than label such a bundle verified.
+func nonNegInt(field string, v int64) error {
+	if v < 0 {
+		return fmt.Errorf("%s %d must not be negative", field, v)
 	}
 	return nil
 }

--- a/internal/policybundle/verify_v2.go
+++ b/internal/policybundle/verify_v2.go
@@ -1,0 +1,266 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// VerifiedBundleV2 is the typed result of a successful VerifyBundleV2. The
+// caller gets the decoded bundle, the recomputed canonical body bytes, the
+// recomputed policy hash, and the matched key fingerprint. issued_at is
+// already validated canonical, so it is exposed verbatim as the authoritative
+// time of the assignment.
+type VerifiedBundleV2 struct {
+	Bundle           *PolicyBundleV2
+	CanonicalBody    []byte
+	PolicyHash       string
+	TrustFingerprint string
+	IssuedAtUTC      string
+}
+
+// VerifyBundleV2 decodes and verifies a signed policy_bundle.v2 strongly
+// enough to apply it. It mirrors VerifyBundle's fixed check order over the v2
+// body, reusing the v1 RejectCode set. No apply/projection happens here - that
+// is 9A.2. The checks fire cheapest-first:
+//
+//  1. strict JSON decode + EOF (rejects unknown fields and trailing tokens)
+//     and duplicate-object-key rejection
+//  2. schema_version / bundle_version / canonicalization / signature.alg
+//     (all the v2 constants)
+//  3. canonical-form + schema checks (all policy_schema_invalid): timestamps
+//     (created_at, issued_at) canonical; ALL containers present as []/{};
+//     required scalar fields non-empty; signed-model enums in range (bundle
+//     mode, every dimension mode incl. rejecting "merge", redaction.level,
+//     override actions, target.scope); sequence >= 1; decimal strings canonical
+//  4. body re-canonicalization + policy hash recompute over exact wire strings
+//  5. signature public key shape (base64 + Ed25519 length)
+//  6. signature self-consistency (sha256(public_key) == claimed fingerprint)
+//  7. trust fingerprint match (the operator's apply trust decision)
+//  8. Ed25519 verify over the v2 signing payload, binding assignment, target,
+//     sequence, issued_at, and rollback_of
+func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, error) {
+	if trustFingerprint == "" {
+		return nil, ErrTrustFingerprintRequired
+	}
+
+	// (1) strict decode + EOF.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var b PolicyBundleV2
+	if err := dec.Decode(&b); err != nil {
+		return nil, reject(RejectDecode, "decode: %s", err)
+	}
+	var trailing json.RawMessage
+	switch err := dec.Decode(&trailing); {
+	case errors.Is(err, io.EOF):
+		// clean termination - the only acceptable path
+	case err == nil:
+		return nil, reject(RejectDecode, "trailing JSON content after the bundle")
+	default:
+		return nil, reject(RejectDecode, "trailing content after the bundle: %s", err)
+	}
+
+	// Duplicate object keys: encoding/json keeps the last value silently, so a
+	// signed bundle could show one value to a reader and another to the
+	// verifier. Reject before trusting any field. Reuses the v1 scanner.
+	if err := rejectDuplicateKeys(raw); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
+	}
+
+	// (2) schema constant tags.
+	switch {
+	case b.SchemaVersion != SchemaVersionV2:
+		return nil, reject(RejectSchemaInvalid, "schema_version=%q, want %q", b.SchemaVersion, SchemaVersionV2)
+	case b.BundleVersion != BundleVersionV2:
+		return nil, reject(RejectSchemaInvalid, "bundle_version=%d, want %d", b.BundleVersion, BundleVersionV2)
+	case b.Canonicalization != CanonicalizationV2:
+		return nil, reject(RejectSchemaInvalid, "canonicalization=%q, want %q", b.Canonicalization, CanonicalizationV2)
+	case b.Signature.Alg != SignatureAlg:
+		return nil, reject(RejectSchemaInvalid, "signature.alg=%q, want %q", b.Signature.Alg, SignatureAlg)
+	}
+
+	// (3) canonical-form checks. created_at and issued_at are both required and
+	// must be in the single canonical wire form (a byte-different but parseable
+	// timestamp is rejected here, before the hash). Containers must be []/{}.
+	// Enums and sequence are range-checked. Decimal strings must be canonical.
+	if err := validateCanonicalPolicyTimestamp(b.Policy.Metadata.CreatedAt); err != nil {
+		return nil, reject(RejectSchemaInvalid, "policy.metadata.created_at %s", err)
+	}
+	if err := validateCanonicalPolicyTimestamp(b.Policy.Assignment.IssuedAt); err != nil {
+		return nil, reject(RejectSchemaInvalid, "policy.assignment.issued_at %s", err)
+	}
+	if err := validateCanonicalPolicyContainersV2(b.Policy); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
+	}
+	if err := validatePolicySchemaV2(&b); err != nil {
+		return nil, reject(RejectSchemaInvalid, "%s", err)
+	}
+
+	// (4) re-canonicalize and recompute the hash from EXACT wire strings.
+	computed, canonical, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		return nil, reject(RejectSchemaInvalid, "canonicalize body: %s", err)
+	}
+	if computed != b.PolicyHash {
+		return nil, reject(RejectHashMismatch, "claimed=%s computed=%s", b.PolicyHash, computed)
+	}
+
+	// (5) public key shape.
+	pub, err := base64.StdEncoding.DecodeString(b.Signature.PublicKey)
+	if err != nil {
+		return nil, reject(RejectUnsupportedBundle, "signature.public_key base64 decode: %s", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, reject(RejectUnsupportedBundle, "signature.public_key length=%d, want %d", len(pub), ed25519.PublicKeySize)
+	}
+
+	// (6) self-consistency: the embedded key must hash to the claimed fingerprint.
+	derivedFP := publicKeyFingerprint(ed25519.PublicKey(pub))
+	if derivedFP != b.Signature.PublicKeyFingerprint {
+		return nil, reject(RejectUnsupportedBundle,
+			"signature.public_key_fingerprint claimed=%s computed=%s", b.Signature.PublicKeyFingerprint, derivedFP)
+	}
+
+	// (7) trust fingerprint match - the operator's apply trust decision.
+	if derivedFP != trustFingerprint {
+		return nil, reject(RejectSigningKeyMismatch,
+			"bundle signing key %s does not match trust fingerprint %s", derivedFP, trustFingerprint)
+	}
+
+	// (8) signature value + Ed25519 verify over the v2 canonical payload. The
+	// payload binds the assignment, target, sequence, issued_at, and
+	// rollback_of as exact wire bytes (issued_at already validated canonical in
+	// step 3), so any edit to those breaks the signature.
+	sigBytes, err := base64.StdEncoding.DecodeString(b.Signature.Value)
+	if err != nil || len(sigBytes) != ed25519.SignatureSize {
+		return nil, reject(RejectSignatureInvalid, "signature.value is not a valid Ed25519 signature")
+	}
+	payload := policyBundleV2SigningPayload(
+		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
+		b.Policy.Assignment.AssignmentID, b.Policy.Assignment.Target.Scope,
+		b.Policy.Assignment.Target.NodeID, b.Policy.Assignment.IssuedAt,
+		b.Policy.Assignment.Sequence, b.Policy.Assignment.RollbackOf,
+		b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
+	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigBytes) {
+		return nil, reject(RejectSignatureInvalid, "signature does not verify over the policy_bundle.v2 signing payload")
+	}
+
+	return &VerifiedBundleV2{
+		Bundle:           &b,
+		CanonicalBody:    canonical,
+		PolicyHash:       computed,
+		TrustFingerprint: derivedFP,
+		IssuedAtUTC:      b.Policy.Assignment.IssuedAt,
+	}, nil
+}
+
+// validatePolicySchemaV2 enforces required-non-empty scalar fields, the
+// signed-model enum value sets (including every dimension mode and rejecting
+// "merge"), sequence range, and decimal-string form. Returns an error (mapped
+// to policy_schema_invalid by the caller) on the first violation. Fields
+// covered by other checks are not re-validated here: schema/canonicalization/
+// alg tags, policy_hash, created_at/issued_at, public_key/fingerprint/value,
+// and container presence.
+func validatePolicySchemaV2(b *PolicyBundleV2) error {
+	for _, f := range []struct{ name, val string }{
+		{"policy.policy_id", b.Policy.PolicyID},
+		{"policy.policy_version", b.Policy.PolicyVersion},
+		{"policy.assignment.assignment_id", b.Policy.Assignment.AssignmentID},
+		{"policy.metadata.created_by", b.Policy.Metadata.CreatedBy},
+		{"policy.metadata.reason", b.Policy.Metadata.Reason},
+		{"signature.key_id", b.Signature.KeyID},
+	} {
+		if f.val == "" {
+			return fmt.Errorf("%s must not be empty", f.name)
+		}
+	}
+
+	// Bundle-wide mode (reuses the v1 enforce/observe set).
+	if !validModes[b.Policy.Mode] {
+		return fmt.Errorf("policy.mode %q not in {enforce, observe}", b.Policy.Mode)
+	}
+
+	// Assignment binding.
+	if !validTargetScope[b.Policy.Assignment.Target.Scope] {
+		return fmt.Errorf("policy.assignment.target.scope %q not in {fleet, node}", b.Policy.Assignment.Target.Scope)
+	}
+	if b.Policy.Assignment.Sequence < 1 {
+		return fmt.Errorf("policy.assignment.sequence %d must be >= 1", b.Policy.Assignment.Sequence)
+	}
+
+	// Top-level dimension modes.
+	for _, d := range []struct{ name, mode string }{
+		{"policy.rules.mode", b.Policy.Rules.Mode},
+		{"policy.gateway.mode", b.Policy.Gateway.Mode},
+		{"policy.egress.mode", b.Policy.Egress.Mode},
+		{"policy.redaction.mode", b.Policy.Redaction.Mode},
+		{"policy.governance.server.mode", b.Policy.Governance.Server.Mode},
+	} {
+		if err := checkDimMode(d.name, d.mode); err != nil {
+			return err
+		}
+	}
+
+	// redaction.level reuses the v1 set.
+	if !validRedactionLevels[b.Policy.Redaction.Level] {
+		return fmt.Errorf("policy.redaction.level %q not in {full, analyst, external}", b.Policy.Redaction.Level)
+	}
+
+	// Rule overrides reuse the v1 action set.
+	for id, ov := range b.Policy.Rules.Overrides {
+		if !validOverrideActions[ov.Action] {
+			return fmt.Errorf("policy.rules.overrides[%q].action %q not in {flag, quarantine, block}", id, ov.Action)
+		}
+	}
+
+	// Per-agent governance dimensions.
+	for i := range b.Policy.Governance.Agents {
+		a := &b.Policy.Governance.Agents[i]
+		p := fmt.Sprintf("policy.governance.agents[%d]", i)
+		if a.Selector.Name == "" {
+			return fmt.Errorf("%s.selector.name must not be empty", p)
+		}
+		for _, d := range []struct{ name, mode string }{
+			{p + ".acls.mode", a.ACLs.Mode},
+			{p + ".allowed_tools.mode", a.AllowedTools.Mode},
+			{p + ".tool_policies.mode", a.ToolPolicies.Mode},
+			{p + ".tool_constraints.mode", a.ToolConstraints.Mode},
+			{p + ".tool_chain_rules.mode", a.ToolChainRules.Mode},
+			{p + ".blocked_content.mode", a.BlockedContent.Mode},
+			{p + ".scan_profile.mode", a.ScanProfile.Mode},
+			{p + ".suspended.mode", a.Suspended.Mode},
+		} {
+			if err := checkDimMode(d.name, d.mode); err != nil {
+				return err
+			}
+		}
+		for tool, tp := range a.ToolPolicies.ByTool {
+			tpName := fmt.Sprintf("%s.tool_policies.by_tool[%q]", p, tool)
+			if err := validateCanonicalDecimal(tpName+".max_amount", tp.MaxAmount); err != nil {
+				return err
+			}
+			if err := validateCanonicalDecimal(tpName+".daily_limit", tp.DailyLimit); err != nil {
+				return err
+			}
+			if err := validateCanonicalDecimal(tpName+".require_approval_above", tp.RequireApprovalAbove); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkDimMode validates a dimension mode against the v2 set. "merge" is
+// deliberately out of range in 9A (deferred), so it is rejected here.
+func checkDimMode(field, mode string) error {
+	if !validDimModes[mode] {
+		return fmt.Errorf("%s %q not in {unmanaged, replace, clear}", field, mode)
+	}
+	return nil
+}

--- a/internal/policybundle/verify_v2.go
+++ b/internal/policybundle/verify_v2.go
@@ -33,7 +33,7 @@ type VerifiedBundleV2 struct {
 //  2. schema_version / bundle_version / canonicalization / signature.alg
 //     (all the v2 constants)
 //  3. canonical-form + schema checks (all policy_schema_invalid): timestamps
-//     (created_at, issued_at) canonical; ALL containers present as []/{};
+//     (created_at, issued_at, signed_at) canonical; ALL containers present as []/{};
 //     required scalar fields non-empty; signed-model enums in range (bundle
 //     mode, every dimension mode incl. rejecting "merge", redaction.level,
 //     override actions, target.scope); sequence >= 1; decimal strings canonical
@@ -86,13 +86,20 @@ func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, err
 
 	// (3) canonical-form checks. created_at and issued_at are both required and
 	// must be in the single canonical wire form (a byte-different but parseable
-	// timestamp is rejected here, before the hash). Containers must be []/{}.
+	// timestamp is rejected here, before the hash). signed_at is validated for
+	// canonical form too: unlike v1 it is NOT bound by the v2 signature (v2 binds
+	// issued_at instead), so a malformed or mutable signed_at would otherwise ride
+	// through to a "verified" bundle. Catching it here as a schema reject keeps
+	// every timestamp the verifier exposes canonical. Containers must be []/{}.
 	// Enums and sequence are range-checked. Decimal strings must be canonical.
 	if err := validateCanonicalPolicyTimestamp(b.Policy.Metadata.CreatedAt); err != nil {
 		return nil, reject(RejectSchemaInvalid, "policy.metadata.created_at %s", err)
 	}
 	if err := validateCanonicalPolicyTimestamp(b.Policy.Assignment.IssuedAt); err != nil {
 		return nil, reject(RejectSchemaInvalid, "policy.assignment.issued_at %s", err)
+	}
+	if err := validateCanonicalPolicyTimestamp(b.Signature.SignedAt); err != nil {
+		return nil, reject(RejectSchemaInvalid, "signature.signed_at %s", err)
 	}
 	if err := validateCanonicalPolicyContainersV2(b.Policy); err != nil {
 		return nil, reject(RejectSchemaInvalid, "%s", err)
@@ -167,6 +174,8 @@ func VerifyBundleV2(raw []byte, trustFingerprint string) (*VerifiedBundleV2, err
 // alg tags, policy_hash, created_at/issued_at, public_key/fingerprint/value,
 // and container presence.
 func validatePolicySchemaV2(b *PolicyBundleV2) error {
+	// TODO(9A.2): reject self-referential rollback_of (rollback_of ==
+	// assignment_id) at apply validation; it has no verify-time effect here.
 	for _, f := range []struct{ name, val string }{
 		{"policy.policy_id", b.Policy.PolicyID},
 		{"policy.policy_version", b.Policy.PolicyVersion},
@@ -185,10 +194,28 @@ func validatePolicySchemaV2(b *PolicyBundleV2) error {
 		return fmt.Errorf("policy.mode %q not in {enforce, observe}", b.Policy.Mode)
 	}
 
-	// Assignment binding.
-	if !validTargetScope[b.Policy.Assignment.Target.Scope] {
-		return fmt.Errorf("policy.assignment.target.scope %q not in {fleet, node}", b.Policy.Assignment.Target.Scope)
+	// Assignment binding. scope is closed-set; node_id is bound to scope so a
+	// node assignment names its node and a fleet assignment carries none. A
+	// stray node_id on a fleet bundle is still signed, so it is not a forgery,
+	// but it lets two byte-different signed artifacts mean the same thing and
+	// muddies the target contract 9A.2 apply builds on, so it is rejected.
+	scope := b.Policy.Assignment.Target.Scope
+	nodeID := b.Policy.Assignment.Target.NodeID
+	if !validTargetScope[scope] {
+		return fmt.Errorf("policy.assignment.target.scope %q not in {fleet, node}", scope)
 	}
+	switch scope {
+	case "node":
+		if nodeID == "" {
+			return fmt.Errorf("policy.assignment.target.node_id must not be empty when scope is node")
+		}
+	case "fleet":
+		if nodeID != "" {
+			return fmt.Errorf("policy.assignment.target.node_id must be empty when scope is fleet, got %q", nodeID)
+		}
+	}
+	// TODO(9A.2): normalize/validate target.node_id charset and shape at apply,
+	// where it is compared to the local node id.
 	if b.Policy.Assignment.Sequence < 1 {
 		return fmt.Errorf("policy.assignment.sequence %d must be >= 1", b.Policy.Assignment.Sequence)
 	}

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -408,13 +408,26 @@ func TestV2_NullContainersRejected(t *testing.T) {
 		"agent.tool_constraints": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Items = nil },
 		"agent.tool_chain_rules": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolChainRules.Items = nil },
 		"agent.blocked_content":  func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].BlockedContent.Values = nil },
-		"constraint.params":      func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params = nil },
-		"constraint.param.enum": func(b *PolicyBundleV2) {
-			p := b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params["number"]
-			p.Enum = nil
-			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params["number"] = p
+		"constraint.parameters":  func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters = nil },
+		"constraint.param.allowed_patterns": func(b *PolicyBundleV2) {
+			p := b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"]
+			p.AllowedPatterns = nil
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"] = p
 		},
-		"chainrule.blocks": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolChainRules.Items[0].Blocks = nil },
+		"constraint.param.blocked_patterns": func(b *PolicyBundleV2) {
+			p := b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"]
+			p.BlockedPatterns = nil
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"] = p
+		},
+		"chainrule.then":             func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolChainRules.Items[0].Then = nil },
+		"agent.egress.allowed":       func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Egress.AllowedDomains = nil },
+		"agent.egress.blocked":       func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Egress.BlockedDomains = nil },
+		"agent.egress.tool_restrict": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Egress.ToolRestrictions = nil },
+		"agent.egress.categories":    func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Egress.BlockedCategories = nil },
+		"agent.egress.integrations":  func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Egress.Integrations = nil },
+		"agent.egress.tool_restrict.entry": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.ToolRestrictions["voice.dial"] = nil
+		},
 	}
 	for name, mut := range cases {
 		raw := remarshalV2(t, mut)
@@ -541,5 +554,173 @@ func TestV2_MapCanonicalizationDeterministic(t *testing.T) {
 	}
 	if h1 != h2 {
 		t.Fatalf("map insertion order changed the hash: %s != %s", h1, h2)
+	}
+}
+
+// Per-agent egress dimension mode: unmanaged/replace/clear are all accepted at
+// the verify level (apply semantics are 9A.2; the verifier only validates the
+// closed-set mode). The fixture carries egress in "replace" mode; switching the
+// mode keeps the bundle structurally valid through the egress check, so it fails
+// later at the hash recompute, which is the contract this asserts.
+func TestV2_AgentEgressModeAccepted(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	for _, mode := range []string{"unmanaged", "replace", "clear"} {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.Mode = mode
+		})
+		// A no-op remarshal that keeps "replace" (the fixture's mode) must verify
+		// end to end; the other two change the body, so the hash recompute (a
+		// later check than the egress mode validation) catches them. Either way
+		// the egress mode check itself accepts the value (no schema reject).
+		_, err := VerifyBundleV2(raw, fp)
+		if mode == "replace" {
+			if err != nil {
+				t.Fatalf("egress mode %q must verify end to end: %v", mode, err)
+			}
+			continue
+		}
+		wantReject(t, err, RejectHashMismatch)
+	}
+}
+
+// Per-agent egress scan_requests/scan_responses are a closed-set tri-state
+// string ("unset"|"true"|"false"). An out-of-set value is a schema reject,
+// before the bundle is labeled verified.
+func TestV2_AgentEgressTriStateRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	bad := []string{"", "yes", "True", "1", "null", "maybe"}
+	for _, v := range bad {
+		rawReq := remarshalV2(t, func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.ScanRequests = v
+		})
+		_, err := VerifyBundleV2(rawReq, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "scan_requests "+v)
+
+		rawResp := remarshalV2(t, func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.ScanResponses = v
+		})
+		_, err = VerifyBundleV2(rawResp, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "scan_responses "+v)
+	}
+}
+
+// Negative monetary/limit decimal strings in a tool policy are rejected: the
+// runtime treats a non-positive limit as unset, so a verified bundle must not
+// carry a negative limit (it would silently disable the limit if applied).
+func TestV2_NegativeDecimalRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	fields := []struct {
+		name string
+		set  func(*ToolPolicyV2, string)
+	}{
+		{"max_amount", func(tp *ToolPolicyV2, v string) { tp.MaxAmount = v }},
+		{"daily_limit", func(tp *ToolPolicyV2, v string) { tp.DailyLimit = v }},
+		{"require_approval_above", func(tp *ToolPolicyV2, v string) { tp.RequireApprovalAbove = v }},
+	}
+	for _, f := range fields {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) {
+			tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
+			f.set(&tp, "-1")
+			b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
+		})
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "negative "+f.name)
+	}
+}
+
+// Negative integer guardrails across the agent surface are rejected: the
+// runtime activates these only when positive, so a signed negative value would
+// fail open if applied. Covers tool_policies.rate_limit, tool_constraints
+// max_response_bytes/cooldown_secs/parameters.max_length,
+// tool_chain_rules.cooldown_secs, and per-agent egress rate_limit/rate_window.
+func TestV2_NegativeIntGuardrailsRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	cases := map[string]func(*PolicyBundleV2){
+		"tool_policy.rate_limit": func(b *PolicyBundleV2) {
+			tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
+			tp.RateLimit = -1
+			b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
+		},
+		"constraint.max_response_bytes": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].MaxResponseBytes = -1
+		},
+		"constraint.cooldown_secs": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].CooldownSecs = -1
+		},
+		"param.max_length": func(b *PolicyBundleV2) {
+			pc := b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"]
+			pc.MaxLength = -1
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Parameters["number"] = pc
+		},
+		"chainrule.cooldown_secs": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].ToolChainRules.Items[0].CooldownSecs = -1
+		},
+		"egress.rate_limit": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.RateLimit = -1
+		},
+		"egress.rate_window": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].Egress.RateWindow = -1
+		},
+		"server.rate_limit_max": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Server.RateLimitMax = -1
+		},
+		"server.rate_limit_window_s": func(b *PolicyBundleV2) {
+			b.Policy.Governance.Server.RateLimitWindow = -1
+		},
+	}
+	for name, mut := range cases {
+		raw := remarshalV2(t, mut)
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "negative "+name)
+	}
+}
+
+// scan_profile.value is a closed set; an out-of-set value is a schema reject.
+func TestV2_InvalidScanProfileRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	for _, v := range []string{"off", "STRICT", "aggressive", "none"} {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) {
+			b.Policy.Governance.Agents[0].ScanProfile.Value = v
+		})
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "scan_profile "+v)
+	}
+}
+
+// The realigned tool_constraints / tool_chain_rules / per-agent egress fields
+// round-trip through canonicalization deterministically: re-encoding the same
+// body (including the egress.tool_restrictions and constraint.parameters maps in
+// a different insertion order) yields the identical hash. This guards the
+// config-aligned field names against accidental non-determinism.
+func TestV2_RealignedFieldsCanonicalDeterministic(t *testing.T) {
+	raw, _ := loadFixtureV2(t)
+	var b PolicyBundleV2
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	h1, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("hash1: %v", err)
+	}
+	// Rebuild the egress tool_restrictions map fresh (different backing map, same
+	// contents) and a constraint parameters map fresh.
+	eg := &b.Policy.Governance.Agents[0].Egress
+	rebuilt := map[string][]string{}
+	for k, v := range eg.ToolRestrictions {
+		rebuilt[k] = v
+	}
+	eg.ToolRestrictions = rebuilt
+	c := &b.Policy.Governance.Agents[0].ToolConstraints.Items[0]
+	rebuiltParams := map[string]ParamConstraintV2{}
+	for k, v := range c.Parameters {
+		rebuiltParams[k] = v
+	}
+	c.Parameters = rebuiltParams
+	h2, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("hash2: %v", err)
+	}
+	if h1 != h2 {
+		t.Fatalf("realigned-field canonicalization not deterministic: %s != %s", h1, h2)
 	}
 }

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -654,6 +654,53 @@ func TestV2_NegativeDecimalRejected(t *testing.T) {
 	}
 }
 
+// Monetary guardrail decimals must be STRICTLY POSITIVE when present. The
+// runtime treats a non-positive limit as "unset" (unlimited), so a "verified"
+// bundle carrying "0" would look restrictive while actually removing the cap
+// (silent widening). "" still means explicit unset (the only way to express no
+// limit). Accept cases pass schema validation and then fail at the hash check
+// (the body changed); reject cases fail earlier as schema-invalid.
+func TestV2_MonetaryGuardrailsStrictlyPositive(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	fields := []struct {
+		name string
+		set  func(*ToolPolicyV2, string)
+	}{
+		{"max_amount", func(tp *ToolPolicyV2, v string) { tp.MaxAmount = v }},
+		{"daily_limit", func(tp *ToolPolicyV2, v string) { tp.DailyLimit = v }},
+		{"require_approval_above", func(tp *ToolPolicyV2, v string) { tp.RequireApprovalAbove = v }},
+	}
+	apply := func(set func(*ToolPolicyV2, string), v string) []byte {
+		return remarshalV2(t, func(b *PolicyBundleV2) {
+			tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
+			set(&tp, v)
+			b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
+		})
+	}
+
+	// Schema-accepted values: "" (explicit unset) and strictly-positive
+	// decimals. Schema passes, so verification proceeds to the hash check and
+	// fails there because the body bytes no longer match the signed hash.
+	accept := []string{"", "0.01", "1", "1.00", "250", "1000.50"}
+	for _, f := range fields {
+		for _, v := range accept {
+			_, err := VerifyBundleV2(apply(f.set, v), fp)
+			wantRejectMsg(t, err, RejectHashMismatch, f.name+"="+v)
+		}
+	}
+
+	// Schema-rejected values: zero (the silent-unset/widen value, the core
+	// fix), negatives (regression of prior behavior), and a non-canonical form
+	// already rejected before.
+	reject := []string{"0", "0.0", "0.00", "-1", "01"}
+	for _, f := range fields {
+		for _, v := range reject {
+			_, err := VerifyBundleV2(apply(f.set, v), fp)
+			wantRejectMsg(t, err, RejectSchemaInvalid, f.name+"="+v)
+		}
+	}
+}
+
 // Negative integer guardrails across the agent surface are rejected: the
 // runtime activates these only when positive, so a signed negative value would
 // fail open if applied. Covers tool_policies.rate_limit, tool_constraints

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -875,3 +875,56 @@ func TestV2_ScalarPresenceRequired(t *testing.T) {
 		wantReject(t, err, RejectHashMismatch)
 	}
 }
+
+// TestV2_NullStringElementsRejected locks the companion rule to scalar
+// presence: a JSON null ELEMENT of a signed string array, or a null VALUE of a
+// signed string map, must be rejected. encoding/json decodes such a null to "",
+// so a bundle signed with [""] / {"k":""} and a wire bundle with [null] /
+// {"k":null} recompute the same hash and both verify - the same
+// dual-byte-representation defect this PR freezes out, one level inside the
+// container. The container's own []/{} presence stays with the container
+// validator; this asserts every string LEAF is explicit on the wire. Each case
+// surgically rewrites one element/value to null in the fixture bytes.
+func TestV2_NullStringElementsRejected(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	cases := map[string][]byte{
+		// top-level string arrays
+		"gateway.tools_allowed[null]": bytesReplaceOnce(t, raw, `"calendar.read",
+        "voice.dial"`, `null,
+        "voice.dial"`),
+		"egress.domains_allowed[null]": bytesReplaceOnce(t, raw, `"api.openai.com",
+        "api.anthropic.com"`, `null,
+        "api.anthropic.com"`),
+		"rules.enabled[null]": bytesReplaceOnce(t, raw, `"IAP-001",`, `null,`),
+		// per-agent string map value
+		"selector.labels value null": bytesReplaceOnce(t, raw, `"env": "prod"`, `"env": null`),
+		// per-agent string arrays
+		"acls.allowed_recipients[null]": bytesReplaceOnce(t, raw, `"billing-agent",`, `null,`),
+		"allowed_tools.values[null]": bytesReplaceOnce(t, raw, `"calendar.read",
+              "voice.dial"`, `null,
+              "voice.dial"`),
+		"blocked_content.values[null]": bytesReplaceOnce(t, raw, `"secrets",
+              "credentials"`, `null,
+              "credentials"`),
+		// nested param pattern arrays
+		"allowed_patterns[null]": bytesReplaceOnce(t, raw, `"+1*",`, `null,`),
+		"blocked_patterns[null]": bytesReplaceOnce(t, raw, `"+1900*"`, `null`),
+		// chain rule then array
+		"chain.then[null]": bytesReplaceOnce(t, raw, `"shell.exec"
+                ]`, `null
+                ]`),
+		// per-agent egress arrays + map-of-arrays
+		"egress.blocked_categories[null]": bytesReplaceOnce(t, raw, `"secrets",
+              "pii"`, `null,
+              "pii"`),
+		"egress.integrations[null]":            bytesReplaceOnce(t, raw, `"slack",`, `null,`),
+		"egress.tool_restrictions value[null]": bytesReplaceOnce(t, raw, `"api.twilio.com"`, `null`),
+	}
+	for name, bad := range cases {
+		_, err := VerifyBundleV2(bad, fp)
+		if err == nil {
+			t.Fatalf("[%s] expected reject, got nil", name)
+		}
+		wantRejectMsg(t, err, RejectSchemaInvalid, name)
+	}
+}

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -322,6 +322,7 @@ func TestV2_AssignmentBoundInSigningPayload(t *testing.T) {
 		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
 		"assign-DIFFERENT", b.Policy.Assignment.Target.Scope,
 		b.Policy.Assignment.Target.NodeID, b.Policy.Assignment.IssuedAt,
+		b.Signature.SignedAt,
 		b.Policy.Assignment.Sequence, b.Policy.Assignment.RollbackOf,
 		b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
 	pub, _ := base64.StdEncoding.DecodeString(b.Signature.PublicKey)
@@ -341,12 +342,35 @@ func TestV2_IssuedAtCovered(t *testing.T) {
 	wantReject(t, err, RejectHashMismatch)
 }
 
+// TestV2_SignedAtBoundInSigningPayload proves signature.signed_at is bound by
+// the Ed25519 signing payload: mutating it to a DIFFERENT but still-canonical
+// timestamp must fail at the signature-verify step, not pass through. Before
+// signed_at was bound this mutation verified; after, it cannot.
+func TestV2_SignedAtBoundInSigningPayload(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	// Baseline: the unmodified fixture verifies.
+	if _, err := VerifyBundleV2(raw, fp); err != nil {
+		t.Fatalf("baseline fixture must verify: %v", err)
+	}
+	// Bump signed_at by one second; still a canonical UTC timestamp, body
+	// unchanged (signed_at is not in the body, so policy_hash still matches),
+	// only the bound timing metadata differs.
+	mutated := remarshalV2(t, func(b *PolicyBundleV2) {
+		if b.Signature.SignedAt != "2026-05-23T12:00:01Z" {
+			t.Fatalf("fixture signed_at changed unexpectedly: %q", b.Signature.SignedAt)
+		}
+		b.Signature.SignedAt = "2026-05-23T12:00:02Z"
+	})
+	_, err := VerifyBundleV2(mutated, fp)
+	wantReject(t, err, RejectSignatureInvalid)
+}
+
 // (12) verifier does NOT normalize timestamp bytes before hashing: a
 // non-canonical-but-parseable timestamp is rejected at the canonical-form
-// check, before the hash. Covers created_at, issued_at, and signed_at.
-// signed_at is not bound by the v2 signature (v2 binds issued_at), so without
-// this check a malformed signed_at would ride through to a verified bundle; the
-// canonical-form check is what stops it.
+// check, before the hash. Covers created_at, issued_at, and signed_at. signed_at
+// is now bound by the v2 signature (in addition to the canonical-form check), so
+// a canonical change to it fails the signature; a NON-canonical signed_at is
+// caught earlier here, at the canonical-form check.
 func TestV2_NonCanonicalTimestampsRejected(t *testing.T) {
 	_, fp := loadFixtureV2(t)
 	for _, ts := range nonCanonicalTimestamps {
@@ -507,6 +531,7 @@ func TestV2_SigningPayloadStable(t *testing.T) {
 	got := string(policyBundleV2SigningPayload(
 		"voice-ai-prod", "1", "sha256:abc",
 		"assign-0001", "node", "node-east-1", "2026-01-01T00:00:00Z",
+		"2026-01-02T00:00:00Z",
 		1, "", "kid", "sha256:fp"))
 	want := "oktsec.policy_bundle.v2\n" +
 		"bundle_version:2\n" +
@@ -518,6 +543,7 @@ func TestV2_SigningPayloadStable(t *testing.T) {
 		"target_scope:node\n" +
 		"target_node_id:node-east-1\n" +
 		"issued_at:2026-01-01T00:00:00Z\n" +
+		"signed_at:2026-01-02T00:00:00Z\n" +
 		"sequence:1\n" +
 		"rollback_of:\n" +
 		"signature_key_id:kid\n" +

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -1,0 +1,478 @@
+package policybundle
+
+import (
+	"crypto/ed25519"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// fixtureBytesV2 is a deterministically signed policy_bundle.v2 produced by the
+// in-package generator (deleted after vendoring), embedded verbatim. It guards
+// the v2 canonicalization + signing payload against drift on every CI run: if
+// any of them diverge from the contract the fixture's signature stops
+// verifying.
+//
+//go:embed policy_bundle_v2_fixture.json
+var fixtureBytesV2 []byte
+
+func loadFixtureV2(t *testing.T) (raw []byte, trustFP string) {
+	t.Helper()
+	var b PolicyBundleV2
+	if err := json.Unmarshal(fixtureBytesV2, &b); err != nil {
+		t.Fatalf("decode v2 fixture: %v", err)
+	}
+	return fixtureBytesV2, b.Signature.PublicKeyFingerprint
+}
+
+// remarshalV2 mutates the v2 fixture's typed form and returns valid JSON the
+// strict verifier accepts structurally (so a check past decode can fire).
+func remarshalV2(t *testing.T, mutate func(b *PolicyBundleV2)) []byte {
+	t.Helper()
+	raw, _ := loadFixtureV2(t)
+	var b PolicyBundleV2
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	mutate(&b)
+	out, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}
+
+// (1) v1 fixture STILL verifies byte-identically (v1 frozen).
+func TestV2_V1FixtureStillVerifies(t *testing.T) {
+	raw, fp := loadFixture(t)
+	v, err := VerifyBundle(raw, fp)
+	if err != nil {
+		t.Fatalf("v1 fixture must still verify after v2 lands: %v", err)
+	}
+	if v.Bundle.PolicyHash != v.PolicyHash {
+		t.Fatalf("v1 declared %s != recomputed %s", v.Bundle.PolicyHash, v.PolicyHash)
+	}
+}
+
+// (2) v2 fixture verifies (trust fingerprint = its signing key fp).
+func TestV2_FixtureVerifies(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	v, err := VerifyBundleV2(raw, fp)
+	if err != nil {
+		t.Fatalf("v2 fixture must verify: %v", err)
+	}
+	if v.Bundle.PolicyHash != v.PolicyHash {
+		t.Fatalf("declared %s != recomputed %s", v.Bundle.PolicyHash, v.PolicyHash)
+	}
+	if len(v.CanonicalBody) == 0 {
+		t.Fatal("canonical body must be returned")
+	}
+	if v.TrustFingerprint != fp {
+		t.Fatalf("trust fingerprint = %q, want %q", v.TrustFingerprint, fp)
+	}
+	if v.IssuedAtUTC != v.Bundle.Policy.Assignment.IssuedAt {
+		t.Fatalf("issued_at = %q, want %q", v.IssuedAtUTC, v.Bundle.Policy.Assignment.IssuedAt)
+	}
+}
+
+// TestV2_HashMatchesContract is the anti-drift guard: the Community v2
+// canonicalizer must reproduce, byte-for-byte, the policy hash the signer
+// declared.
+func TestV2_HashMatchesContract(t *testing.T) {
+	raw, _ := loadFixtureV2(t)
+	var b PolicyBundleV2
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	computed, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	if computed != b.PolicyHash {
+		t.Fatalf("v2 canonicalizer drift: declared=%s computed=%s", b.PolicyHash, computed)
+	}
+}
+
+// (3) v2 hash changes on any signed-body change.
+func TestV2_TamperedBody(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Mode = "observe" })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+// (4) unknown field -> reject.
+func TestV2_UnknownField(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	injected := append([]byte(`{"x_unknown_field": 1,`), raw[1:]...)
+	_, err := VerifyBundleV2(injected, fp)
+	wantReject(t, err, RejectDecode)
+}
+
+// (5) duplicate object key -> reject.
+func TestV2_DuplicateKeysRejected(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	dup := append([]byte(`{"policy_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",`), raw[1:]...)
+	_, err := VerifyBundleV2(dup, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+
+	nested := bytesReplaceOnce(t, raw, `"created_by"`, `"created_by":"x","created_by"`)
+	_, err = VerifyBundleV2(nested, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+}
+
+// (6) trailing JSON after the bundle -> reject.
+func TestV2_TrailingJSON(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+	withTrailing := append(append([]byte{}, raw...), []byte("\n{}\n")...)
+	_, err := VerifyBundleV2(withTrailing, fp)
+	wantReject(t, err, RejectDecode)
+}
+
+// (7) trust fingerprint mismatch -> reject.
+func TestV2_WrongTrustFingerprint(t *testing.T) {
+	raw, _ := loadFixtureV2(t)
+	other := publicKeyFingerprint(make(ed25519.PublicKey, ed25519.PublicKeySize))
+	_, err := VerifyBundleV2(raw, other)
+	wantReject(t, err, RejectSigningKeyMismatch)
+}
+
+// Signature byte-flip remains a signature failure (self-consistent shape).
+func TestV2_SignatureMismatch(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) {
+		sig, _ := base64.StdEncoding.DecodeString(b.Signature.Value)
+		sig[0] ^= 0xff
+		b.Signature.Value = base64.StdEncoding.EncodeToString(sig)
+	})
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectSignatureInvalid)
+}
+
+// Self-inconsistent embedded key vs claimed fingerprint.
+func TestV2_SelfInconsistentKey(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) {
+		b.Signature.PublicKeyFingerprint = publicKeyFingerprint(make(ed25519.PublicKey, ed25519.PublicKeySize))
+	})
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectUnsupportedBundle)
+}
+
+// (8) schema_version mismatch both directions, via dispatch and via the typed
+// verifiers directly.
+func TestV2_SchemaVersionMismatchBothDirections(t *testing.T) {
+	v1raw, v1fp := loadFixture(t)
+	v2raw, v2fp := loadFixtureV2(t)
+
+	// v1 body to the v2 verifier -> schema invalid (constant tag check).
+	_, err := VerifyBundleV2(v1raw, v1fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "v1 body to v2 verifier")
+
+	// v2 body to the v1 verifier -> rejected. The v1 verifier's strict decode
+	// (DisallowUnknownFields) trips on the v2-only "assignment" field before the
+	// schema-constant check runs, so this surfaces as policy_decode. Either way
+	// a v2 body is never accepted by the v1 verifier, which is the contract.
+	_, err = VerifyBundle(v2raw, v2fp)
+	wantRejectMsg(t, err, RejectDecode, "v2 body to v1 verifier")
+
+	// Dispatch routes each to the right verifier and accepts both.
+	r1, err := Verify(v1raw, v1fp)
+	if err != nil {
+		t.Fatalf("dispatch v1: %v", err)
+	}
+	if r1.SchemaVersion != SchemaVersion || r1.V1 == nil || r1.V2 != nil {
+		t.Fatalf("dispatch v1 result wrong: %+v", r1)
+	}
+	r2, err := Verify(v2raw, v2fp)
+	if err != nil {
+		t.Fatalf("dispatch v2: %v", err)
+	}
+	if r2.SchemaVersion != SchemaVersionV2 || r2.V2 == nil || r2.V1 != nil {
+		t.Fatalf("dispatch v2 result wrong: %+v", r2)
+	}
+}
+
+// Dispatch rejects an unknown schema_version.
+func TestV2_DispatchUnknownSchema(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.SchemaVersion = "policy_bundle.v9" })
+	_, err := Verify(raw, fp)
+	wantReject(t, err, RejectUnsupportedBundle)
+}
+
+// (9) assignment fields covered by the signed artifact: mutating assignment_id
+// fails verification. assignment_id is bound by BOTH the body hash (it lives in
+// the signed body) and the signing payload, so the hash recompute (step 4)
+// catches the edit before the signature check (step 8) runs. The point of the
+// test is coverage: the edit cannot pass, and it is the hash that proves it.
+func TestV2_AssignmentIDCovered(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.AssignmentID = "assign-9999" })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+// (10) target fields covered: mutating target.node_id fails. node_id is in the
+// signed body, so the hash recompute catches it first.
+func TestV2_TargetNodeIDCovered(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.Target.NodeID = "node-west-9" })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+// (11) sequence covered: mutating sequence fails. sequence is in the signed
+// body, so the hash recompute catches it first.
+func TestV2_SequenceCovered(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.Sequence = 2 })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+// To prove the SIGNING PAYLOAD independently binds the assignment metadata
+// (not just the body hash), re-sign a body whose hash matches but whose payload
+// binding is wrong: keep the body's assignment_id but sign a payload with a
+// different assignment_id. The hash passes, the signature fails. This is the
+// guarantee a store cannot satisfy by recomputing the hash after rewriting the
+// binding.
+func TestV2_AssignmentBoundInSigningPayload(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw, _ := loadFixtureV2(t)
+	var b PolicyBundleV2
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Recompute the real body hash (unchanged body), then sign a payload that
+	// claims a different assignment_id. A verifier that only checked the body
+	// hash would accept this; ours must not.
+	computed, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	b.PolicyHash = computed
+	// We cannot re-sign without the private key, so assert directly that the
+	// real signature does NOT verify over a payload with a mutated binding (a
+	// different assignment_id). A verifier that bound the assignment only via
+	// the body hash would miss this; ours binds it in the signing payload too.
+	badPayload := policyBundleV2SigningPayload(
+		b.Policy.PolicyID, b.Policy.PolicyVersion, b.PolicyHash,
+		"assign-DIFFERENT", b.Policy.Assignment.Target.Scope,
+		b.Policy.Assignment.Target.NodeID, b.Policy.Assignment.IssuedAt,
+		b.Policy.Assignment.Sequence, b.Policy.Assignment.RollbackOf,
+		b.Signature.KeyID, b.Signature.PublicKeyFingerprint)
+	pub, _ := base64.StdEncoding.DecodeString(b.Signature.PublicKey)
+	sig, _ := base64.StdEncoding.DecodeString(b.Signature.Value)
+	if ed25519.Verify(ed25519.PublicKey(pub), badPayload, sig) {
+		t.Fatal("signature must NOT verify over a payload with a rewritten assignment_id")
+	}
+	_ = fp
+}
+
+func TestV2_IssuedAtCovered(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	// issued_at is in the body (hashed) AND in the signing payload. A canonical
+	// change is caught by the hash recompute first.
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.IssuedAt = "2030-01-01T00:00:00Z" })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectHashMismatch)
+}
+
+// (12) verifier does NOT normalize timestamp bytes before hashing: a
+// non-canonical-but-parseable timestamp is rejected at the canonical-form
+// check, before the hash. Covers both created_at and issued_at.
+func TestV2_NonCanonicalTimestampsRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	for _, ts := range nonCanonicalTimestamps {
+		rawC := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Metadata.CreatedAt = ts })
+		_, err := VerifyBundleV2(rawC, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "created_at "+ts)
+
+		rawI := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.IssuedAt = ts })
+		_, err = VerifyBundleV2(rawI, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "issued_at "+ts)
+	}
+}
+
+// (13) "merge" as a DimMode -> rejected as out-of-range enum (deferred in 9A).
+func TestV2_MergeModeRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	cases := map[string]func(*PolicyBundleV2){
+		"rules":                  func(b *PolicyBundleV2) { b.Policy.Rules.Mode = "merge" },
+		"gateway":                func(b *PolicyBundleV2) { b.Policy.Gateway.Mode = "merge" },
+		"egress":                 func(b *PolicyBundleV2) { b.Policy.Egress.Mode = "merge" },
+		"redaction":              func(b *PolicyBundleV2) { b.Policy.Redaction.Mode = "merge" },
+		"governance.server":      func(b *PolicyBundleV2) { b.Policy.Governance.Server.Mode = "merge" },
+		"agent.acls":             func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ACLs.Mode = "merge" },
+		"agent.tool_policies":    func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolPolicies.Mode = "merge" },
+		"agent.tool_constraints": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Mode = "merge" },
+	}
+	for name, mut := range cases {
+		raw := remarshalV2(t, mut)
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "merge "+name)
+	}
+}
+
+// Other dimension modes outside the set are also rejected.
+func TestV2_InvalidDimModeRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Rules.Mode = "overwrite" })
+	_, err := VerifyBundleV2(raw, fp)
+	wantReject(t, err, RejectSchemaInvalid)
+}
+
+// (14) a container present as null/omitted -> rejected. Covers top-level and
+// nested per-agent governance containers.
+func TestV2_NullContainersRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	cases := map[string]func(*PolicyBundleV2){
+		"rules.overrides":        func(b *PolicyBundleV2) { b.Policy.Rules.Overrides = nil },
+		"gateway.tools_allowed":  func(b *PolicyBundleV2) { b.Policy.Gateway.ToolsAllowed = nil },
+		"egress.domains_denied":  func(b *PolicyBundleV2) { b.Policy.Egress.DomainsDenied = nil },
+		"governance.agents":      func(b *PolicyBundleV2) { b.Policy.Governance.Agents = nil },
+		"agent.selector.labels":  func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Selector.Labels = nil },
+		"agent.acls.allowed":     func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ACLs.AllowedRecipients = nil },
+		"agent.allowed_tools":    func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].AllowedTools.Values = nil },
+		"agent.tool_policies":    func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolPolicies.ByTool = nil },
+		"agent.tool_constraints": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Items = nil },
+		"agent.tool_chain_rules": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolChainRules.Items = nil },
+		"agent.blocked_content":  func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].BlockedContent.Values = nil },
+		"constraint.params":      func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params = nil },
+		"constraint.param.enum": func(b *PolicyBundleV2) {
+			p := b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params["number"]
+			p.Enum = nil
+			b.Policy.Governance.Agents[0].ToolConstraints.Items[0].Params["number"] = p
+		},
+		"chainrule.blocks": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].ToolChainRules.Items[0].Blocks = nil },
+	}
+	for name, mut := range cases {
+		raw := remarshalV2(t, mut)
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "null "+name)
+	}
+}
+
+// (15) sequence < 1 -> rejected.
+func TestV2_SequenceBelowOneRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	for _, seq := range []int64{0, -1, -100} {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.Sequence = seq })
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "sequence")
+	}
+}
+
+// (16) target.scope outside {fleet,node} -> rejected.
+func TestV2_InvalidTargetScopeRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	for _, scope := range []string{"", "cluster", "global", "Node"} {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.Target.Scope = scope })
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "scope "+scope)
+	}
+}
+
+// Required scalar fields rejected when empty.
+func TestV2_RequiredScalarsRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	cases := map[string]func(*PolicyBundleV2){
+		"policy_id":      func(b *PolicyBundleV2) { b.Policy.PolicyID = "" },
+		"policy_version": func(b *PolicyBundleV2) { b.Policy.PolicyVersion = "" },
+		"assignment_id":  func(b *PolicyBundleV2) { b.Policy.Assignment.AssignmentID = "" },
+		"created_by":     func(b *PolicyBundleV2) { b.Policy.Metadata.CreatedBy = "" },
+		"reason":         func(b *PolicyBundleV2) { b.Policy.Metadata.Reason = "" },
+		"key_id":         func(b *PolicyBundleV2) { b.Signature.KeyID = "" },
+		"agent.selector": func(b *PolicyBundleV2) { b.Policy.Governance.Agents[0].Selector.Name = "" },
+	}
+	for name, mut := range cases {
+		raw := remarshalV2(t, mut)
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "empty "+name)
+	}
+}
+
+// Non-canonical decimal strings in a tool policy are rejected.
+func TestV2_NonCanonicalDecimalRejected(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+	bad := []string{"1,000.00", "100.", "+5", "0x10", "1e3", " 5", "abc", "01.5"}
+	for _, v := range bad {
+		raw := remarshalV2(t, func(b *PolicyBundleV2) {
+			tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
+			tp.MaxAmount = v
+			b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
+		})
+		_, err := VerifyBundleV2(raw, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "decimal "+v)
+	}
+}
+
+// empty trust fingerprint is a usage error on both the v2 verifier and dispatch.
+func TestV2_EmptyTrustIsUsageError(t *testing.T) {
+	raw, _ := loadFixtureV2(t)
+	if _, err := VerifyBundleV2(raw, ""); !errors.Is(err, ErrTrustFingerprintRequired) {
+		t.Fatalf("v2 empty trust must be usage error, got %v", err)
+	}
+	if _, err := Verify(raw, ""); !errors.Is(err, ErrTrustFingerprintRequired) {
+		t.Fatalf("dispatch empty trust must be usage error, got %v", err)
+	}
+}
+
+// TestV2_SigningPayloadStable locks the cross-repo byte layout of the v2
+// signing payload. The signer and this verifier must agree exactly.
+func TestV2_SigningPayloadStable(t *testing.T) {
+	got := string(policyBundleV2SigningPayload(
+		"voice-ai-prod", "1", "sha256:abc",
+		"assign-0001", "node", "node-east-1", "2026-01-01T00:00:00Z",
+		1, "", "kid", "sha256:fp"))
+	want := "oktsec.policy_bundle.v2\n" +
+		"bundle_version:2\n" +
+		"policy_id:voice-ai-prod\n" +
+		"policy_version:1\n" +
+		"policy_hash:sha256:abc\n" +
+		"canonicalization:oktsec-policy-v2-typed-utc-json\n" +
+		"assignment_id:assign-0001\n" +
+		"target_scope:node\n" +
+		"target_node_id:node-east-1\n" +
+		"issued_at:2026-01-01T00:00:00Z\n" +
+		"sequence:1\n" +
+		"rollback_of:\n" +
+		"signature_key_id:kid\n" +
+		"signature_public_key_fingerprint:sha256:fp"
+	if got != want {
+		t.Fatalf("v2 signing payload layout drift:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+// Map determinism: re-encoding the body with shuffled-in map entries produces
+// the same canonical bytes (encoding/json sorts map keys), so the hash is
+// stable across map insertion order.
+func TestV2_MapCanonicalizationDeterministic(t *testing.T) {
+	raw, _ := loadFixtureV2(t)
+	var b PolicyBundleV2
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	h1, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("hash1: %v", err)
+	}
+	// Rebuild the labels map in a different insertion order.
+	old := b.Policy.Governance.Agents[0].Selector.Labels
+	reordered := map[string]string{}
+	keys := []string{"tier", "env"}
+	for _, k := range keys {
+		reordered[k] = old[k]
+	}
+	b.Policy.Governance.Agents[0].Selector.Labels = reordered
+	h2, _, err := policyHashHexV2(b.Policy)
+	if err != nil {
+		t.Fatalf("hash2: %v", err)
+	}
+	if h1 != h2 {
+		t.Fatalf("map insertion order changed the hash: %s != %s", h1, h2)
+	}
+}

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -852,28 +852,28 @@ func TestV2_ScalarPresenceRequired(t *testing.T) {
 
 	// (6b) positive: max_amount present as explicit empty string ("" = unset) is
 	// VALID - presence is satisfied by the key existing with a non-null value.
-	// remarshalV2 re-emits all keys, so the body stays fully present; this also
-	// exercises the verify path end to end (decimal "" is the canonical unset).
+	// remarshalV2 re-emits all keys, so the body stays fully present. Changing
+	// max_amount changes the signed body, so the EXPECTED outcome is a hash
+	// mismatch (NOT a schema/presence reject): "" present passes the presence
+	// gate. Asserting wantReject unconditionally means an unexpected successful
+	// verification (err == nil) fails the test rather than passing silently.
 	okEmptyMaxAmount := remarshalV2(t, func(b *PolicyBundleV2) {
 		tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
 		tp.MaxAmount = ""
 		b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
 	})
-	if _, err := VerifyBundleV2(okEmptyMaxAmount, fp); err != nil {
-		// Changing max_amount changes the body, so a hash mismatch is the expected
-		// outcome - but it must NOT be a schema/presence reject: "" present is valid.
-		wantReject(t, err, RejectHashMismatch)
-	}
+	_, err := VerifyBundleV2(okEmptyMaxAmount, fp)
+	wantReject(t, err, RejectHashMismatch)
 
 	// (8b) positive: scan_requests present as "unset" is VALID (tri-state). Same
-	// reasoning: the key is present with a closed-set value, so presence passes;
-	// the body changes, so a hash mismatch (not a presence/schema reject) is fine.
+	// reasoning: the key is present with a closed-set value, so the presence gate
+	// passes; the body changes, so the expected (and asserted) outcome is a hash
+	// mismatch, never a silent success.
 	okUnsetScan := remarshalV2(t, func(b *PolicyBundleV2) {
 		b.Policy.Governance.Agents[0].Egress.ScanRequests = "unset"
 	})
-	if _, err := VerifyBundleV2(okUnsetScan, fp); err != nil {
-		wantReject(t, err, RejectHashMismatch)
-	}
+	_, err = VerifyBundleV2(okUnsetScan, fp)
+	wantReject(t, err, RejectHashMismatch)
 }
 
 // TestV2_NullStringElementsRejected locks the companion rule to scalar

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -111,7 +111,12 @@ func TestV2_UnknownField(t *testing.T) {
 	wantReject(t, err, RejectDecode)
 }
 
-// (5) duplicate object key -> reject.
+// (5) duplicate object key -> reject. A duplicated key defeats the v2 signed
+// body's guarantees, since encoding/json silently keeps the last value while a
+// JSON reader may take the first; the verifier and a reader could then disagree
+// on exactly the anti-rollback/target fields the signature is meant to bind.
+// Cover a top-level key, a nested metadata key, and the security-critical
+// anti-rollback/target fields (sequence, assignment_id, target.scope).
 func TestV2_DuplicateKeysRejected(t *testing.T) {
 	raw, fp := loadFixtureV2(t)
 	dup := append([]byte(`{"policy_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",`), raw[1:]...)
@@ -121,6 +126,61 @@ func TestV2_DuplicateKeysRejected(t *testing.T) {
 	nested := bytesReplaceOnce(t, raw, `"created_by"`, `"created_by":"x","created_by"`)
 	_, err = VerifyBundleV2(nested, fp)
 	wantReject(t, err, RejectSchemaInvalid)
+
+	// Anti-rollback field: a second "sequence" inside the assignment object.
+	seqDup := bytesReplaceOnce(t, raw, `"sequence": 1`, `"sequence": 999,"sequence": 1`)
+	_, err = VerifyBundleV2(seqDup, fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "duplicate sequence")
+
+	// Target-binding field: a second "assignment_id" inside the assignment object.
+	aidDup := bytesReplaceOnce(t, raw, `"assignment_id": "assign-0001"`, `"assignment_id": "assign-evil","assignment_id": "assign-0001"`)
+	_, err = VerifyBundleV2(aidDup, fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "duplicate assignment_id")
+
+	// Target scope is also part of the signed binding.
+	scopeDup := bytesReplaceOnce(t, raw, `"scope": "node"`, `"scope": "fleet","scope": "node"`)
+	_, err = VerifyBundleV2(scopeDup, fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "duplicate target scope")
+}
+
+// (5b) target.node_id must be bound to scope: a fleet assignment must carry no
+// node_id, a node assignment must carry one, so a signed bundle names exactly
+// one unambiguous target. The fixture is node-scoped with a real node_id and
+// stays valid; fleet+empty stays valid; only fleet+non-empty is rejected.
+func TestV2_FleetScopeRejectsNodeID(t *testing.T) {
+	_, fp := loadFixtureV2(t)
+
+	// fleet + stray node_id -> rejected.
+	bad := remarshalV2(t, func(b *PolicyBundleV2) {
+		b.Policy.Assignment.Target.Scope = "fleet"
+		b.Policy.Assignment.Target.NodeID = "node-east-1"
+	})
+	_, err := VerifyBundleV2(bad, fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "fleet scope with node_id")
+
+	// fleet + empty node_id is structurally valid (it fails later at the hash
+	// recompute, not at the scope/node_id check, which is the contract we assert).
+	fleetOK := remarshalV2(t, func(b *PolicyBundleV2) {
+		b.Policy.Assignment.Target.Scope = "fleet"
+		b.Policy.Assignment.Target.NodeID = ""
+	})
+	_, err = VerifyBundleV2(fleetOK, fp)
+	wantReject(t, err, RejectHashMismatch)
+
+	// node + non-empty node_id is structurally valid (the fixture's own shape);
+	// the no-op remarshal still passes scope/node_id and verifies end to end.
+	nodeOK := remarshalV2(t, func(b *PolicyBundleV2) {})
+	if _, err := VerifyBundleV2(nodeOK, fp); err != nil {
+		t.Fatalf("node scope with node_id must stay valid: %v", err)
+	}
+
+	// node + empty node_id -> rejected.
+	nodeBad := remarshalV2(t, func(b *PolicyBundleV2) {
+		b.Policy.Assignment.Target.Scope = "node"
+		b.Policy.Assignment.Target.NodeID = ""
+	})
+	_, err = VerifyBundleV2(nodeBad, fp)
+	wantRejectMsg(t, err, RejectSchemaInvalid, "node scope without node_id")
 }
 
 // (6) trailing JSON after the bundle -> reject.
@@ -283,7 +343,10 @@ func TestV2_IssuedAtCovered(t *testing.T) {
 
 // (12) verifier does NOT normalize timestamp bytes before hashing: a
 // non-canonical-but-parseable timestamp is rejected at the canonical-form
-// check, before the hash. Covers both created_at and issued_at.
+// check, before the hash. Covers created_at, issued_at, and signed_at.
+// signed_at is not bound by the v2 signature (v2 binds issued_at), so without
+// this check a malformed signed_at would ride through to a verified bundle; the
+// canonical-form check is what stops it.
 func TestV2_NonCanonicalTimestampsRejected(t *testing.T) {
 	_, fp := loadFixtureV2(t)
 	for _, ts := range nonCanonicalTimestamps {
@@ -294,6 +357,10 @@ func TestV2_NonCanonicalTimestampsRejected(t *testing.T) {
 		rawI := remarshalV2(t, func(b *PolicyBundleV2) { b.Policy.Assignment.IssuedAt = ts })
 		_, err = VerifyBundleV2(rawI, fp)
 		wantRejectMsg(t, err, RejectSchemaInvalid, "issued_at "+ts)
+
+		rawS := remarshalV2(t, func(b *PolicyBundleV2) { b.Signature.SignedAt = ts })
+		_, err = VerifyBundleV2(rawS, fp)
+		wantRejectMsg(t, err, RejectSchemaInvalid, "signed_at "+ts)
 	}
 }
 

--- a/internal/policybundle/verify_v2_test.go
+++ b/internal/policybundle/verify_v2_test.go
@@ -797,3 +797,81 @@ func TestV2_RealignedFieldsCanonicalDeterministic(t *testing.T) {
 		t.Fatalf("realigned-field canonicalization not deterministic: %s != %s", h1, h2)
 	}
 }
+
+// TestV2_ScalarPresenceRequired locks the v2 rule that every SIGNED SCALAR
+// must be explicitly present and non-null in the raw JSON. An omitted or null
+// scalar decodes to Go's zero value before the hash is recomputed, which would
+// give one meaning two verifiable byte forms; the presence walker rejects it as
+// policy_schema_invalid. Each case starts from the valid fixture bytes and
+// removes or nulls exactly one scalar (or, for the optional-string and
+// tri-state positive controls, sets an explicit-but-empty/"unset" value that
+// must STILL verify). The surgical byte edits match the fixture's exact
+// formatting so the test fails loudly if the fixture is reflowed.
+func TestV2_ScalarPresenceRequired(t *testing.T) {
+	raw, fp := loadFixtureV2(t)
+
+	// (10) positive control: the unmodified fixture (all scalars present) verifies.
+	if _, err := VerifyBundleV2(raw, fp); err != nil {
+		t.Fatalf("unmodified fixture must verify: %v", err)
+	}
+
+	// Negative cases: each removes or nulls one scalar key.
+	negatives := map[string][]byte{
+		// (1) omit policy.assignment.rollback_of (last key in assignment).
+		"omit rollback_of": bytesReplaceOnce(t, raw, `"sequence": 1,
+      "rollback_of": ""`, `"sequence": 1`),
+		// (2) rollback_of: null.
+		"null rollback_of": bytesReplaceOnce(t, raw, `"rollback_of": ""`, `"rollback_of": null`),
+		// (3) omit governance.agents[0].suspended.value.
+		"omit suspended.value": bytesReplaceOnce(t, raw, `"mode": "replace",
+            "value": false`, `"mode": "replace"`),
+		// (4) suspended.value: null.
+		"null suspended.value": bytesReplaceOnce(t, raw, `"value": false`, `"value": null`),
+		// (5) omit governance.server.rate_limit_max.
+		"omit rate_limit_max": bytesReplaceOnce(t, raw, `"rate_limit_max": 100,
+        `, ``),
+		// (6) omit a tool_policies.by_tool.<tool>.max_amount.
+		"omit max_amount": bytesReplaceOnce(t, raw, `"max_amount": "100.00",
+                `, ``),
+		// (7) max_amount: null.
+		"null max_amount": bytesReplaceOnce(t, raw, `"max_amount": "100.00"`, `"max_amount": null`),
+		// (8) omit egress scan_requests.
+		"omit scan_requests": bytesReplaceOnce(t, raw, `"scan_requests": "true",
+            `, ``),
+		// (9) omit a nested tool_constraints[0].parameters.<k>.max_length.
+		"omit max_length": bytesReplaceOnce(t, raw, `,
+                    "max_length": 20`, ``),
+	}
+	for name, bad := range negatives {
+		if _, err := VerifyBundleV2(bad, fp); err == nil {
+			t.Fatalf("[%s] expected reject, got nil", name)
+		} else {
+			wantRejectMsg(t, err, RejectSchemaInvalid, name)
+		}
+	}
+
+	// (6b) positive: max_amount present as explicit empty string ("" = unset) is
+	// VALID - presence is satisfied by the key existing with a non-null value.
+	// remarshalV2 re-emits all keys, so the body stays fully present; this also
+	// exercises the verify path end to end (decimal "" is the canonical unset).
+	okEmptyMaxAmount := remarshalV2(t, func(b *PolicyBundleV2) {
+		tp := b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"]
+		tp.MaxAmount = ""
+		b.Policy.Governance.Agents[0].ToolPolicies.ByTool["voice.dial"] = tp
+	})
+	if _, err := VerifyBundleV2(okEmptyMaxAmount, fp); err != nil {
+		// Changing max_amount changes the body, so a hash mismatch is the expected
+		// outcome - but it must NOT be a schema/presence reject: "" present is valid.
+		wantReject(t, err, RejectHashMismatch)
+	}
+
+	// (8b) positive: scan_requests present as "unset" is VALID (tri-state). Same
+	// reasoning: the key is present with a closed-set value, so presence passes;
+	// the body changes, so a hash mismatch (not a presence/schema reject) is fine.
+	okUnsetScan := remarshalV2(t, func(b *PolicyBundleV2) {
+		b.Policy.Governance.Agents[0].Egress.ScanRequests = "unset"
+	})
+	if _, err := VerifyBundleV2(okUnsetScan, fp); err != nil {
+		wantReject(t, err, RejectHashMismatch)
+	}
+}


### PR DESCRIPTION
## What

Introduces the `policy_bundle.v2` cryptographic verification foundation: the signed contract that lets the control plane express the full agent-governance surface (not only detection rules). Verification only - no apply/projection logic in this PR.

This is additive. `policy_bundle.v1` is byte-frozen: its types, canonicalization, signing payload, and vendored fixture are unchanged, and v1 bundles verify identically. v2 is a separate, parallel path dispatched by `schema_version`.

## Contract

- New schema constants: `policy_bundle.v2`, bundle_version 2, canonicalization `oktsec-policy-v2-typed-utc-json`.
- The signed body (`PolicyBodyV2`) covers the complete governance surface up front - assignment binding, rules, gateway tools, egress (global and per-agent), and per-agent governance (ACLs, tool policies, tool constraints, tool chain rules, blocked content, scan profile, suspension) - so later apply work adds no signed fields.
- Per-dimension intent via an explicit `mode` of `unmanaged`, `replace`, or `clear`. `merge` is rejected as out of range for now. This removes the ambiguity where an empty list could mean both "not governed" and "all allowed", and makes deny-all explicitly expressible.
- Anti-rollback and target binding live in the signed body: `assignment_id`, `target` (scope + node_id), `issued_at`, `sequence`, `rollback_of`. The Ed25519 signing payload binds all of these, so a distribution point cannot rewrite the target or replay an older assignment.
- Verification mirrors v1's fixed check order: strict decode (unknown-field, trailing-content, and duplicate-key rejection), schema constants, canonical-form checks (timestamps as exact wire bytes, containers present as `[]`/`{}`, enum ranges including scope/node_id consistency), hash recompute over canonical bytes, key shape, fingerprint self-consistency, trust-fingerprint match, Ed25519 verify.
- Monetary and limit values are carried as canonical decimal strings rather than JSON floats to keep the hash deterministic.

## Drift guard

A vendored signed fixture (`policy_bundle_v2_fixture.json`) is verified end to end by the real verifier, so any divergence between signer and verifier breaks the build.

## Tests

Full table-driven coverage: v1 regression (frozen), v2 verify, tamper-detection across the body, unknown-field / duplicate-key / trailing-content rejection, trust mismatch, schema dispatch in both directions, assignment/target/sequence/issued_at binding, no timestamp normalization before hashing, merge rejection, container-null rejection, scope/node_id consistency, and the new per-agent egress / tool-constraint / chain-rule fields.

`make build`, `make test` (race detector on), `make lint`, and `make vet` are all green.

## Scope boundary

Verify only. No config projection or mutation, no node contact. Apply semantics are a separate follow-up.