### PR TITLE
policy_bundle.v2 apply semantics (per-dimension modes, widening guard, anti-rollback)

### DIFF
--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -216,7 +216,27 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 		return perr
 	}
 
-	// Anti-rollback: read state BEFORE writing; advance it only after success.
+	// Acquire the exclusive apply lock that spans the ENTIRE anti-rollback
+	// critical section: re-read state -> evaluate the rollback decision ->
+	// write config (CommitV2) -> persist state (SavePolicyState). Without it,
+	// two concurrent applies starting from the same prior state could read the
+	// same sequence, both pass the gate, and a LOWER sequence could land last,
+	// rolling the node back. The lock makes the read-decide-write-persist
+	// sequence atomic for this config/state pair. Released in every path
+	// (success, refusal, error) via defer.
+	//
+	// The projection above (DryRunV2) only READS the config for reporting and
+	// writes nothing, so it is safe before the lock; the AUTHORITATIVE gating
+	// state read is the LoadPolicyState below, which is now post-lock.
+	lock, lerr := apply.AcquireApplyLock(cfgFile)
+	if lerr != nil {
+		return emitApplyFailure(cmd, jsonOut, false, lerr)
+	}
+	defer func() { _ = lock.Release() }()
+
+	// Anti-rollback: read state AFTER the lock is held (never a pre-lock
+	// snapshot), evaluate the decision from this read, and advance it only
+	// after a successful write.
 	state, serr := apply.LoadPolicyState(cfgFile)
 	if serr != nil {
 		return emitApplyFailure(cmd, jsonOut, false, serr)
@@ -257,17 +277,32 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 
 	// Advance the anti-rollback state ONLY after CommitV2 succeeded.
 	state.Record(plan.Scope, plan.NodeID, plan.AssignmentID, time.Now().UTC().Format(time.RFC3339), plan.Sequence)
-	if err := apply.SavePolicyState(cfgFile, state); err != nil {
-		// The config was written but the state failed to persist. Surface it
-		// loudly: a re-apply of the same bundle is idempotent, and a later stale
-		// bundle is still refused on the NEXT successful state write, but the
-		// operator must know the state file did not advance.
+	if err := savePolicyStateAfterCommit(cfgFile, state); err != nil {
+		// The config was written but the high-water state failed to persist.
+		// Leaving the new config in place while the recorded sequence stayed low
+		// would let a later LOWER sequence apply (it would be > the stale state),
+		// defeating anti-rollback. Recovery: restore the config from the backup
+		// CommitV2 just made, so config AND state stay at the prior sequence and
+		// no lower sequence can ever win. Whatever the outcome, never report
+		// success: return a non-nil error naming the inconsistency.
+		if rerr := apply.RestoreConfigV2FromBackup(cfgFile, backupPath); rerr != nil {
+			return emitApplyFailure(cmd, jsonOut, false,
+				fmt.Errorf("anti-rollback state write failed (%v) AND config rollback failed (%v): config and apply state are inconsistent; restore config from backup %q manually", err, rerr, backupPath))
+		}
 		return emitApplyFailure(cmd, jsonOut, false,
-			fmt.Errorf("config applied (backup %q) but anti-rollback state write failed: %w", backupPath, err))
+			fmt.Errorf("anti-rollback state write failed; config rolled back to the prior sequence from backup %q: %w", backupPath, err))
 	}
 	emitApplyResultV2(cmd, jsonOut, plan, backupPath, true)
 	return nil
 }
+
+// savePolicyStateAfterCommit persists the v2 anti-rollback state on the
+// real-change path, AFTER CommitV2 has written the config. It is a package
+// variable, not a direct call, solely so a test can inject a state-write
+// failure that occurs after the config write, exercising the config-rollback
+// recovery. The default is the real persistence function and is never replaced
+// outside tests.
+var savePolicyStateAfterCommit = apply.SavePolicyState
 
 // emitPlanV2 prints the v2 dry-run plan as JSON (when --json) or a short summary.
 func emitPlanV2(cmd *cobra.Command, jsonOut bool, p *apply.PlanV2) {

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/oktsec/oktsec/internal/apply"
 	"github.com/oktsec/oktsec/internal/config"
@@ -34,6 +35,7 @@ func newPolicyApplyCmd() *cobra.Command {
 		bundlePath   string
 		trustFP      string
 		agent        string
+		nodeID       string
 		dryRun       bool
 		jsonOut      bool
 		allowPartial bool
@@ -53,9 +55,6 @@ func newPolicyApplyCmd() *cobra.Command {
 			"    --agent voice-ai --dry-run --json",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if agent == "" {
-				return fmt.Errorf("--agent <name> is required (apply targets exactly one agent for gateway/egress scope)")
-			}
 			if bundlePath == "" {
 				return fmt.Errorf("--bundle <path> is required")
 			}
@@ -74,10 +73,22 @@ func newPolicyApplyCmd() *cobra.Command {
 				return fmt.Errorf("read bundle: %w", err)
 			}
 
-			v, verr := policybundle.VerifyBundle(raw, trustFP)
+			// Dispatch by schema_version: a v1 bundle takes the unchanged v1 path
+			// (which requires --agent); a v2 bundle takes the v2 path (governance
+			// carries selectors, so --agent is ignored and --node-id binds the
+			// target).
+			res, verr := policybundle.Verify(raw, trustFP)
 			if verr != nil {
 				return emitApplyFailure(cmd, jsonOut, dryRun, verr)
 			}
+			if res.SchemaVersion == policybundle.SchemaVersionV2 {
+				return runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, allowPartial)
+			}
+
+			if agent == "" {
+				return fmt.Errorf("--agent <name> is required (apply targets exactly one agent for gateway/egress scope)")
+			}
+			v := res.V1
 
 			// cfgFile is the root's cascading-resolved config path (honors
 			// --config, $OKTSEC_CONFIG, and the home default) set by
@@ -144,11 +155,206 @@ func newPolicyApplyCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&bundlePath, "bundle", "", "path to the signed policy_bundle.v1 JSON")
 	f.StringVar(&trustFP, "trust-fingerprint", "", "sha256:<fp> the bundle's signing key must match")
-	f.StringVar(&agent, "agent", "", "the single agent gateway/egress changes apply to")
+	f.StringVar(&agent, "agent", "", "v1 only: the single agent gateway/egress changes apply to (ignored for v2 bundles, which carry selectors)")
+	f.StringVar(&nodeID, "node-id", "", "v2 only: this node's id, used to bind a node-scoped bundle's target (required when the bundle is node-scoped)")
 	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing; omit to apply in place")
 	f.BoolVar(&jsonOut, "json", false, "emit the plan/result as JSON")
 	f.BoolVar(&allowPartial, "allow-partial", false, "dry-run only: exit 0 even when the bundle has unsupported semantics")
 	return cmd
+}
+
+// runPolicyApplyV2 handles a verified policy_bundle.v2: target binding,
+// projection, anti-rollback against the adjacent state file, no-partial apply,
+// and the post-success state write. Same flag contract as v1 (--dry-run,
+// --allow-partial dry-run only, --json), plus --node-id for target binding.
+func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, nodeID string, dryRun, jsonOut, allowPartial bool) error {
+	if cfgFile == "" {
+		return fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
+	}
+	if !dryRun {
+		if !cfgFileExplicit {
+			return fmt.Errorf("real apply requires an explicit, non-empty --config <path> (refusing to mutate a cascaded default config)")
+		}
+		if err := ensureWritableConfigPath(cfgFile); err != nil {
+			return emitApplyFailure(cmd, jsonOut, false, err)
+		}
+	}
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("load config %q: %w", cfgFile, err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
+	}
+
+	// Projection. Target binding (scope/node_id) is checked inside DryRunV2
+	// before any work, so a mismatch yields no plan and no write.
+	plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
+	if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
+		// Target mismatch, missing agent, or invalid projected config: no plan.
+		return emitApplyFailure(cmd, jsonOut, dryRun, perr)
+	}
+
+	if dryRun {
+		emitPlanV2(cmd, jsonOut, plan)
+		if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
+			return perr
+		}
+		return nil
+	}
+
+	// Real apply. Unsupported semantics always fail with no write.
+	if errors.Is(perr, apply.ErrUnsupported) {
+		emitApplyResultV2(cmd, jsonOut, plan, "", false)
+		return perr
+	}
+
+	// Anti-rollback: read state BEFORE writing; advance it only after success.
+	state, serr := apply.LoadPolicyState(cfgFile)
+	if serr != nil {
+		return emitApplyFailure(cmd, jsonOut, false, serr)
+	}
+	switch state.EvaluateRollback(plan.Scope, plan.NodeID, plan.AssignmentID, plan.RollbackOf, plan.Sequence) {
+	case apply.RollbackRefuse:
+		// Emit a single structured failure (no preceding result object), so
+		// --json stdout stays one JSON document.
+		err := fmt.Errorf("%w: sequence %d is not greater than the last applied sequence for this target and rollback_of does not name the current assignment",
+			apply.ErrPolicyRollbackRefused, plan.Sequence)
+		return emitApplyFailure(cmd, jsonOut, false, err)
+	default:
+		// fresh, advance, signed rollback, or idempotent reapply: proceed.
+	}
+
+	// No config change: write no config and no backup, but STILL advance the
+	// anti-rollback state. The bundle passed the rollback gate (it is
+	// target-bound and at or above the recorded sequence), so the assignment was
+	// accepted; if the persisted sequence did not advance here, a later bundle
+	// with a sequence lower than this accepted no-op but higher than the stale
+	// state could pass EvaluateRollback and overwrite the policy. Advancing on a
+	// no-op writes only the state file (atomic, 0600), never the config. A failed
+	// state write is surfaced loudly.
+	if len(plan.Changes) == 0 {
+		state.Record(plan.Scope, plan.NodeID, plan.AssignmentID, time.Now().UTC().Format(time.RFC3339), plan.Sequence)
+		if err := apply.SavePolicyState(cfgFile, state); err != nil {
+			return emitApplyFailure(cmd, jsonOut, false,
+				fmt.Errorf("no config change, but anti-rollback state write failed: %w", err))
+		}
+		emitApplyResultV2(cmd, jsonOut, plan, "", false)
+		return nil
+	}
+
+	backupPath, cerr := apply.CommitV2(plan, cfgFile)
+	if cerr != nil {
+		return emitApplyFailure(cmd, jsonOut, false, cerr)
+	}
+
+	// Advance the anti-rollback state ONLY after CommitV2 succeeded.
+	state.Record(plan.Scope, plan.NodeID, plan.AssignmentID, time.Now().UTC().Format(time.RFC3339), plan.Sequence)
+	if err := apply.SavePolicyState(cfgFile, state); err != nil {
+		// The config was written but the state failed to persist. Surface it
+		// loudly: a re-apply of the same bundle is idempotent, and a later stale
+		// bundle is still refused on the NEXT successful state write, but the
+		// operator must know the state file did not advance.
+		return emitApplyFailure(cmd, jsonOut, false,
+			fmt.Errorf("config applied (backup %q) but anti-rollback state write failed: %w", backupPath, err))
+	}
+	emitApplyResultV2(cmd, jsonOut, plan, backupPath, true)
+	return nil
+}
+
+// emitPlanV2 prints the v2 dry-run plan as JSON (when --json) or a short summary.
+func emitPlanV2(cmd *cobra.Command, jsonOut bool, p *apply.PlanV2) {
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(p)
+		return
+	}
+	fmt.Fprintf(out, "dry-run (v2): %s v%s (%s) -> %s\n", p.PolicyID, p.PolicyVersion, p.Mode, p.TargetConfig)
+	fmt.Fprintf(out, "  assignment %s, scope %s, node %q, sequence %d\n", p.AssignmentID, p.Scope, p.NodeID, p.Sequence)
+	fmt.Fprintf(out, "  %d change(s), %d unsupported\n", len(p.Changes), len(p.Unsupported))
+	for _, c := range p.Changes {
+		switch c.Kind {
+		case "rule_override":
+			fmt.Fprintf(out, "  - [%s] rule %s -> %s\n", c.DimMode, c.ID, c.Action)
+		case "rule_reset_default":
+			fmt.Fprintf(out, "  - [%s] rule %s -> severity default (local override removed)\n", c.DimMode, c.ID)
+		case "agent_suspended":
+			fmt.Fprintf(out, "  - [%s] %s (agent %s): %v\n", c.DimMode, c.Kind, c.Agent, c.BoolValue)
+		case "agent_scan_profile":
+			fmt.Fprintf(out, "  - [%s] %s (agent %s): %s\n", c.DimMode, c.Kind, c.Agent, c.Value)
+		default:
+			fmt.Fprintf(out, "  - [%s] %s (agent %s): %d\n", c.DimMode, c.Kind, c.Agent, c.Count)
+		}
+	}
+	for _, u := range p.Unsupported {
+		fmt.Fprintf(out, "  ! unsupported: %s - %s\n", u.Kind, u.Detail)
+	}
+}
+
+// applyOutcomeV2 is the JSON contract for a real v2 `policy apply`.
+type applyOutcomeV2 struct {
+	Applied       bool                `json:"applied"`
+	DryRun        bool                `json:"dry_run"`
+	Changed       bool                `json:"changed"`
+	SchemaVersion string              `json:"schema_version"`
+	PolicyHash    string              `json:"policy_hash"`
+	PolicyID      string              `json:"policy_id"`
+	PolicyVersion string              `json:"policy_version"`
+	Mode          string              `json:"mode"`
+	TargetConfig  string              `json:"target_config"`
+	AssignmentID  string              `json:"assignment_id"`
+	Scope         string              `json:"scope"`
+	NodeID        string              `json:"node_id"`
+	Sequence      int64               `json:"sequence"`
+	BackupPath    string              `json:"backup_path"`
+	Changes       []apply.ChangeV2    `json:"changes"`
+	Unsupported   []apply.Unsupported `json:"unsupported"`
+}
+
+// emitApplyResultV2 prints the real v2-apply outcome as JSON or a human summary.
+func emitApplyResultV2(cmd *cobra.Command, jsonOut bool, p *apply.PlanV2, backupPath string, applied bool) {
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(applyOutcomeV2{
+			Applied:       applied,
+			DryRun:        false,
+			Changed:       applied,
+			SchemaVersion: p.SchemaVersion,
+			PolicyHash:    p.PolicyHash,
+			PolicyID:      p.PolicyID,
+			PolicyVersion: p.PolicyVersion,
+			Mode:          p.Mode,
+			TargetConfig:  p.TargetConfig,
+			AssignmentID:  p.AssignmentID,
+			Scope:         p.Scope,
+			NodeID:        p.NodeID,
+			Sequence:      p.Sequence,
+			BackupPath:    backupPath,
+			Changes:       p.Changes,
+			Unsupported:   p.Unsupported,
+		})
+		return
+	}
+	if !applied {
+		if len(p.Unsupported) > 0 {
+			fmt.Fprintf(out, "not applied: %d unsupported semantic(s), config unchanged\n", len(p.Unsupported))
+			for _, u := range p.Unsupported {
+				fmt.Fprintf(out, "  ! %s - %s\n", u.Kind, u.Detail)
+			}
+			return
+		}
+		fmt.Fprintf(out, "no changes: config already on policy %s v%s, nothing written\n", p.PolicyID, p.PolicyVersion)
+		return
+	}
+	fmt.Fprintf(out, "policy applied (v2)\n")
+	fmt.Fprintf(out, "  policy_hash: %s\n", p.PolicyHash)
+	fmt.Fprintf(out, "  assignment: %s (seq %d)\n", p.AssignmentID, p.Sequence)
+	fmt.Fprintf(out, "  backup_path: %s\n", backupPath)
+	fmt.Fprintf(out, "  changes: %d\n", len(p.Changes))
 }
 
 // ensureWritableConfigPath checks the config path is a writable regular file
@@ -196,7 +402,7 @@ func emitPlan(cmd *cobra.Command, jsonOut bool, p *apply.Plan) {
 		}
 	}
 	for _, u := range p.Unsupported {
-		fmt.Fprintf(out, "  ! unsupported: %s — %s\n", u.Kind, u.Detail)
+		fmt.Fprintf(out, "  ! unsupported: %s - %s\n", u.Kind, u.Detail)
 	}
 }
 
@@ -244,7 +450,7 @@ func emitApplyResult(cmd *cobra.Command, jsonOut bool, p *apply.Plan, backupPath
 		if len(p.Unsupported) > 0 {
 			fmt.Fprintf(out, "not applied: %d unsupported semantic(s), config unchanged\n", len(p.Unsupported))
 			for _, u := range p.Unsupported {
-				fmt.Fprintf(out, "  ! %s — %s\n", u.Kind, u.Detail)
+				fmt.Fprintf(out, "  ! %s - %s\n", u.Kind, u.Detail)
 			}
 			return
 		}

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -194,6 +194,13 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 		// Target mismatch, missing agent, or invalid projected config: no plan.
 		return emitApplyFailure(cmd, jsonOut, dryRun, perr)
 	}
+	// Some ErrUnsupported failures occur BEFORE a plan is built (the deny-all
+	// sentinel collision in the local config fails closed in DryRunV2 and returns
+	// nil, ErrUnsupported). The plan emitters below dereference plan, so route a
+	// nil plan through emitApplyFailure rather than panicking.
+	if plan == nil {
+		return emitApplyFailure(cmd, jsonOut, dryRun, perr)
+	}
 
 	if dryRun {
 		emitPlanV2(cmd, jsonOut, plan)

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -179,30 +179,32 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 			return emitApplyFailure(cmd, jsonOut, false, err)
 		}
 	}
-	cfg, err := config.Load(cfgFile)
-	if err != nil {
-		return fmt.Errorf("load config %q: %w", cfgFile, err)
-	}
-	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
-	}
-
-	// Projection. Target binding (scope/node_id) is checked inside DryRunV2
-	// before any work, so a mismatch yields no plan and no write.
-	plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
-	if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
-		// Target mismatch, missing agent, or invalid projected config: no plan.
-		return emitApplyFailure(cmd, jsonOut, dryRun, perr)
-	}
-	// Some ErrUnsupported failures occur BEFORE a plan is built (the deny-all
-	// sentinel collision in the local config fails closed in DryRunV2 and returns
-	// nil, ErrUnsupported). The plan emitters below dereference plan, so route a
-	// nil plan through emitApplyFailure rather than panicking.
-	if plan == nil {
-		return emitApplyFailure(cmd, jsonOut, dryRun, perr)
-	}
-
+	// --- Dry-run path: project against the current config and report, writing
+	// nothing. A dry-run has no critical section, so it takes no lock and never
+	// touches config or state; the pre-lock projection is authoritative for
+	// reporting only. ---
 	if dryRun {
+		cfg, err := config.Load(cfgFile)
+		if err != nil {
+			return fmt.Errorf("load config %q: %w", cfgFile, err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
+		}
+		// Target binding (scope/node_id) is checked inside DryRunV2 before any
+		// work, so a mismatch yields no plan and no write.
+		plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
+		if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
+			// Target mismatch, missing agent, or invalid projected config: no plan.
+			return emitApplyFailure(cmd, jsonOut, true, perr)
+		}
+		// Some ErrUnsupported failures occur BEFORE a plan is built (the deny-all
+		// sentinel collision fails closed in DryRunV2 and returns nil,
+		// ErrUnsupported). Route a nil plan through emitApplyFailure so the plan
+		// emitters never dereference nil.
+		if plan == nil {
+			return emitApplyFailure(cmd, jsonOut, true, perr)
+		}
 		emitPlanV2(cmd, jsonOut, plan)
 		if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
 			return perr
@@ -210,29 +212,56 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 		return nil
 	}
 
-	// Real apply. Unsupported semantics always fail with no write.
-	if errors.Is(perr, apply.ErrUnsupported) {
-		emitApplyResultV2(cmd, jsonOut, plan, "", false)
-		return perr
-	}
-
-	// Acquire the exclusive apply lock that spans the ENTIRE anti-rollback
-	// critical section: re-read state -> evaluate the rollback decision ->
-	// write config (CommitV2) -> persist state (SavePolicyState). Without it,
-	// two concurrent applies starting from the same prior state could read the
-	// same sequence, both pass the gate, and a LOWER sequence could land last,
-	// rolling the node back. The lock makes the read-decide-write-persist
-	// sequence atomic for this config/state pair. Released in every path
-	// (success, refusal, error) via defer.
+	// --- Real apply path. The lock must cover the FULL critical section: load
+	// the current config -> project it (the no-op-vs-commit decision) -> load
+	// state -> evaluate the rollback gate -> write config (CommitV2) -> persist
+	// state.
 	//
-	// The projection above (DryRunV2) only READS the config for reporting and
-	// writes nothing, so it is safe before the lock; the AUTHORITATIVE gating
-	// state read is the LoadPolicyState below, which is now post-lock.
+	// The projection MUST be computed UNDER the lock against the config as it
+	// exists on disk now. Two concurrent applies from the same file could
+	// otherwise each project against a stale pre-lock config snapshot where their
+	// desired value already matched, both take the no-op path, and advance the
+	// anti-rollback state to a higher sequence WITHOUT writing the config,
+	// leaving config and state diverged (config at the first apply's policy,
+	// state claiming the second apply's higher sequence). Projecting under the
+	// lock guarantees the plan CommitV2 writes and the plan the no-op decision
+	// uses are BOTH derived from the config observed under the lock, so the config
+	// the recorded sequence corresponds to is always the config on disk. Released
+	// in every path (success, refusal, error) via defer. ---
 	lock, lerr := apply.AcquireApplyLock(cfgFile)
 	if lerr != nil {
 		return emitApplyFailure(cmd, jsonOut, false, lerr)
 	}
 	defer func() { _ = lock.Release() }()
+
+	// Re-load the config from disk UNDER the lock: this is the authoritative
+	// config the projection and the no-op decision are computed against.
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("load config %q: %w", cfgFile, err))
+	}
+	if err := cfg.Validate(); err != nil {
+		return emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("current config %q is invalid: %w", cfgFile, err))
+	}
+
+	// Authoritative projection under the lock. Target binding (scope/node_id) is
+	// re-checked here against the fresh config, and unsupported dimensions still
+	// fail closed with no write.
+	plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
+	if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
+		// Target mismatch, missing agent, or invalid projected config: no plan.
+		return emitApplyFailure(cmd, jsonOut, false, perr)
+	}
+	// A nil plan (e.g. the deny-all sentinel collision fails closed in DryRunV2)
+	// must not reach the plan emitters; route it through emitApplyFailure.
+	if plan == nil {
+		return emitApplyFailure(cmd, jsonOut, false, perr)
+	}
+	// Unsupported semantics always fail with no write.
+	if errors.Is(perr, apply.ErrUnsupported) {
+		emitApplyResultV2(cmd, jsonOut, plan, "", false)
+		return perr
+	}
 
 	// Anti-rollback: read state AFTER the lock is held (never a pre-lock
 	// snapshot), evaluate the decision from this read, and advance it only
@@ -304,6 +333,25 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 // outside tests.
 var savePolicyStateAfterCommit = apply.SavePolicyState
 
+// derefBool and derefInt render a ChangeV2's pointer count/bool for the human
+// summary. The pointer is always set on the change kinds that print it
+// (agent_suspended sets BoolValue, list changes set Count), so a nil here only
+// occurs defensively and prints the zero value, matching the prior int/bool
+// output exactly.
+func derefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
+func derefInt(n *int) int {
+	if n == nil {
+		return 0
+	}
+	return *n
+}
+
 // emitPlanV2 prints the v2 dry-run plan as JSON (when --json) or a short summary.
 func emitPlanV2(cmd *cobra.Command, jsonOut bool, p *apply.PlanV2) {
 	out := cmd.OutOrStdout()
@@ -323,11 +371,11 @@ func emitPlanV2(cmd *cobra.Command, jsonOut bool, p *apply.PlanV2) {
 		case "rule_reset_default":
 			fmt.Fprintf(out, "  - [%s] rule %s -> severity default (local override removed)\n", c.DimMode, c.ID)
 		case "agent_suspended":
-			fmt.Fprintf(out, "  - [%s] %s (agent %s): %v\n", c.DimMode, c.Kind, c.Agent, c.BoolValue)
+			fmt.Fprintf(out, "  - [%s] %s (agent %s): %v\n", c.DimMode, c.Kind, c.Agent, derefBool(c.BoolValue))
 		case "agent_scan_profile":
 			fmt.Fprintf(out, "  - [%s] %s (agent %s): %s\n", c.DimMode, c.Kind, c.Agent, c.Value)
 		default:
-			fmt.Fprintf(out, "  - [%s] %s (agent %s): %d\n", c.DimMode, c.Kind, c.Agent, c.Count)
+			fmt.Fprintf(out, "  - [%s] %s (agent %s): %d\n", c.DimMode, c.Kind, c.Agent, derefInt(c.Count))
 		}
 	}
 	for _, u := range p.Unsupported {

--- a/cmd/oktsec/commands/policy_v2_apply_lock_test.go
+++ b/cmd/oktsec/commands/policy_v2_apply_lock_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/apply"
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/policybundle"
 )
 
@@ -250,5 +251,110 @@ func TestPolicyApplyV2_HeldLockBlocksConcurrentApply(t *testing.T) {
 	// After release a fresh apply succeeds.
 	if err := applyFleetSeq(t, dir, configPath, 1, "afterrelease"); err != nil {
 		t.Fatalf("apply after release: %v", err)
+	}
+}
+
+// fleetBundleSuspend builds a fleet-scoped v2 bundle at seq that sets voice-ai's
+// suspended flag to the given value (a real change when it differs from config).
+func fleetBundleSuspend(t *testing.T, dir string, seq int64, assignID string, suspended bool) (bundlePath, fp string) {
+	t.Helper()
+	body := supportedAgentBodyV2("fleet", "")
+	body.Assignment.Sequence = seq
+	body.Assignment.AssignmentID = assignID
+	g := agentGovV2cmd("voice-ai")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: "replace", Value: suspended}
+	body.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	raw, trustFP := signV2Bundle(t, body)
+	p := filepath.Join(dir, "suspend-"+assignID+".signed.json")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return p, trustFP
+}
+
+// TestPolicyApplyV2_ProjectionUnderLock_ConfigAndStateNeverDiverge is the FIX A
+// (P1) regression: the no-op-vs-commit decision and the committed projection
+// must BOTH be derived from the config observed UNDER the lock, so the config
+// the recorded sequence corresponds to is always the config on disk.
+//
+// Deterministic construction of the Codex race. The baseline config has voice-ai
+// NOT suspended. Apply a lower-seq bundle (seq 5) that suspends it -> commits,
+// config suspended=true, floor 5. Then apply a HIGHER-seq bundle (seq 10) whose
+// desired suspended value is false -- i.e. exactly the baseline's original value,
+// so projected against the BASELINE it would be a no-op. Because the projection
+// now runs under the lock against the on-disk (post-seq-5) config, the higher
+// bundle sees suspended=true and actually applies suspended=false, committing the
+// config AND advancing the floor to 10. Config and state agree.
+//
+// Before FIX A the higher bundle, projected against a stale baseline snapshot,
+// would have taken the no-op path: the floor would advance to 10 while the config
+// stayed suspended=true (seq 5's policy) -- a divergence that this test forbids.
+func TestPolicyApplyV2_ProjectionUnderLock_ConfigAndStateNeverDiverge(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	// Sanity: baseline voice-ai is not suspended (the value the higher bundle
+	// will request, so it would be a no-op against the baseline).
+	base, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if base.Agents["voice-ai"].Suspended {
+		t.Fatalf("baseline voice-ai must start not suspended for this race construction")
+	}
+
+	// Lower seq 5: suspend voice-ai (real change true).
+	lowPath, lowFP := fleetBundleSuspend(t, dir, 5, "low", true)
+	if _, err := runPolicyApply(t,
+		"--bundle", lowPath, "--trust-fingerprint", lowFP,
+		"--config", configPath, "--json",
+	); err != nil {
+		t.Fatalf("low apply (seq 5): %v", err)
+	}
+	if got := fleetReplayFloor(t, configPath); got != 5 {
+		t.Fatalf("floor after seq 5 = %d, want 5", got)
+	}
+
+	// Higher seq 10: desired suspended=false == baseline value. A no-op vs the
+	// baseline, a real change vs the on-disk post-seq-5 config.
+	highPath, highFP := fleetBundleSuspend(t, dir, 10, "high", false)
+	if _, err := runPolicyApply(t,
+		"--bundle", highPath, "--trust-fingerprint", highFP,
+		"--config", configPath, "--json",
+	); err != nil {
+		t.Fatalf("high apply (seq 10): %v", err)
+	}
+
+	// Config must reflect the higher bundle's desired value: suspended=false.
+	after, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if after.Agents["voice-ai"].Suspended {
+		t.Fatalf("config and state diverged: config shows suspended=true (seq-5 policy) but the higher seq-10 bundle desired suspended=false")
+	}
+
+	// State must record the higher sequence, corresponding to the config on disk.
+	if got := fleetReplayFloor(t, configPath); got != 10 {
+		t.Fatalf("floor after seq 10 = %d, want 10", got)
+	}
+}
+
+// TestPolicyApplyV2_RealApplyHonorsMalformedStateFailClosed exercises FIX A + B
+// together at the command layer: a present-but-malformed state file makes a real
+// apply refuse with no config write and no state advance (the loader fails
+// closed under the lock).
+func TestPolicyApplyV2_RealApplyHonorsMalformedStateFailClosed(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	before, _ := os.ReadFile(configPath)
+	// Seed a present-but-malformed state file (wrong version).
+	if err := os.WriteFile(apply.PolicyStatePath(configPath), []byte(`{"version": 99, "targets": {}}`), 0o600); err != nil {
+		t.Fatalf("seed malformed state: %v", err)
+	}
+	if err := applyFleetSeq(t, dir, configPath, 1, "one"); err == nil {
+		t.Fatalf("apply must refuse on a malformed state file")
+	}
+	after, _ := os.ReadFile(configPath)
+	if string(before) != string(after) {
+		t.Fatalf("config must be unchanged when the state is malformed")
 	}
 }

--- a/cmd/oktsec/commands/policy_v2_apply_lock_test.go
+++ b/cmd/oktsec/commands/policy_v2_apply_lock_test.go
@@ -1,0 +1,245 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/apply"
+)
+
+// errAfterCommitInjected is the sentinel a test injects through the
+// savePolicyStateAfterCommit seam to simulate a state-write failure that occurs
+// after CommitV2 has written the config.
+var errAfterCommitInjected = errors.New("injected state persist failure")
+
+// fleetBundleAtSeq builds, signs, and writes a fleet-scoped v2 bundle at the
+// given sequence with a unique assignment id, returning its on-disk path and
+// the trust fingerprint to verify it.
+func fleetBundleAtSeq(t *testing.T, dir string, seq int64, assignID string) (bundlePath, fp string) {
+	t.Helper()
+	body := supportedAgentBodyV2("fleet", "")
+	body.Assignment.Sequence = seq
+	body.Assignment.AssignmentID = assignID
+	raw, trustFP := signV2Bundle(t, body)
+	p := filepath.Join(dir, "bundle-"+assignID+".signed.json")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return p, trustFP
+}
+
+// applyFleetSeq applies a fleet bundle at seq against configPath and returns the
+// command error (nil on success).
+func applyFleetSeq(t *testing.T, dir, configPath string, seq int64, assignID string) error {
+	t.Helper()
+	bundlePath, fp := fleetBundleAtSeq(t, dir, seq, assignID)
+	_, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	)
+	return err
+}
+
+// fleetReplayFloor reads the persisted anti-rollback ReplayFloor for the fleet
+// target. The floor is the monotonic high-water that gates plain applies.
+func fleetReplayFloor(t *testing.T, configPath string) int64 {
+	t.Helper()
+	st, err := apply.LoadPolicyState(configPath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	rec, ok := st.Targets[apply.TargetKey("fleet", "")]
+	if !ok {
+		return -1
+	}
+	return rec.ReplayFloor
+}
+
+// persistFleetSeqOutOfBand records a fleet apply at seq directly, simulating a
+// concurrent apply that landed between a stale pre-lock snapshot and our lock
+// acquisition.
+func persistFleetSeqOutOfBand(t *testing.T, configPath string, seq int64, assignID string) {
+	t.Helper()
+	st, err := apply.LoadPolicyState(configPath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	st.Record("fleet", "", assignID, "2026-01-01T00:00:00Z", seq)
+	if err := apply.SavePolicyState(configPath, st); err != nil {
+		t.Fatalf("save out-of-band state: %v", err)
+	}
+}
+
+// Regression 1: a stale pre-lock snapshot must not let a lower sequence roll the
+// node back. We seed the baseline, take a snapshot as a pre-lock reader would,
+// land seq 10 out-of-band (a concurrent apply that won the race), then run the
+// seq 9 apply. The real apply re-reads state UNDER the lock, sees seq 10, and
+// refuses. Final floor is never 9 after a 10 has landed.
+func TestPolicyApplyV2_StaleSnapshotCannotRollBack(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	if err := applyFleetSeq(t, dir, configPath, 1, "seq1"); err != nil {
+		t.Fatalf("baseline seq 1: %v", err)
+	}
+
+	// Stale snapshot a pre-lock reader would hold (floor == 1).
+	if got := fleetReplayFloor(t, configPath); got != 1 {
+		t.Fatalf("snapshot floor = %d, want 1", got)
+	}
+
+	// Out-of-band, a concurrent apply lands seq 10 after the snapshot.
+	persistFleetSeqOutOfBand(t, configPath, 10, "seq10")
+
+	// The seq 9 apply must be refused by the post-lock re-read (9 < floor 10),
+	// not accepted from the stale snapshot (9 > stale 1).
+	err := applyFleetSeq(t, dir, configPath, 9, "seq9")
+	if err == nil {
+		t.Fatal("seq 9 must be refused after seq 10 landed")
+	}
+	if got := fleetReplayFloor(t, configPath); got != 10 {
+		t.Fatalf("final floor = %d, want 10 (a lower sequence won)", got)
+	}
+}
+
+// Regression 2: a lower sequence after a higher one is rejected by the post-lock
+// re-read (state actually persisted between the two real applies).
+func TestPolicyApplyV2_LowerAfterHigherRejected(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	if err := applyFleetSeq(t, dir, configPath, 10, "hi"); err != nil {
+		t.Fatalf("apply seq 10: %v", err)
+	}
+	if err := applyFleetSeq(t, dir, configPath, 9, "lo"); err == nil {
+		t.Fatal("seq 9 must be refused after seq 10")
+	}
+	if got := fleetReplayFloor(t, configPath); got != 10 {
+		t.Fatalf("final floor = %d, want 10", got)
+	}
+}
+
+// Regression 3: a higher sequence after a lower one succeeds and advances the
+// high-water.
+func TestPolicyApplyV2_HigherAfterLowerSucceeds(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	if err := applyFleetSeq(t, dir, configPath, 2, "two"); err != nil {
+		t.Fatalf("apply seq 2: %v", err)
+	}
+	if err := applyFleetSeq(t, dir, configPath, 7, "seven"); err != nil {
+		t.Fatalf("apply seq 7: %v", err)
+	}
+	if got := fleetReplayFloor(t, configPath); got != 7 {
+		t.Fatalf("final floor = %d, want 7", got)
+	}
+}
+
+// Regression 4 + 5: a state-persistence failure AFTER the config write must not
+// advance the high-water, must roll the config back, and must never report
+// success. The failure is injected through the savePolicyStateAfterCommit seam
+// (a package var that wraps the real persist on the real-change path), which
+// fires only AFTER CommitV2 has written the config, exactly the partial-failure
+// window we must recover from.
+func TestPolicyApplyV2_StatePersistFailureRollsBackConfigNoAdvance(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	// Land a baseline at seq 3.
+	if err := applyFleetSeq(t, dir, configPath, 3, "base3"); err != nil {
+		t.Fatalf("baseline seq 3: %v", err)
+	}
+	configBefore, err := os.ReadFile(configPath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read config before: %v", err)
+	}
+	floorBefore := fleetReplayFloor(t, configPath)
+
+	// Inject a state-persist failure for the next apply (seq 8).
+	orig := savePolicyStateAfterCommit
+	savePolicyStateAfterCommit = func(string, *apply.PolicyState) error {
+		return errAfterCommitInjected
+	}
+	defer func() { savePolicyStateAfterCommit = orig }()
+
+	bundlePath, fp := fleetBundleAtSeq(t, dir, 8, "seq8")
+	out, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	)
+	if err == nil {
+		t.Fatal("apply must return an error when state persistence fails")
+	}
+	if applied, _ := out["applied"].(bool); applied {
+		t.Fatalf("must not report applied:true on state-persist failure: %v", out)
+	}
+
+	// High-water must NOT have advanced.
+	if got := fleetReplayFloor(t, configPath); got != floorBefore {
+		t.Fatalf("floor advanced to %d on persist failure, want %d", got, floorBefore)
+	}
+	// Config must have been rolled back to the prior contents.
+	configAfter, err := os.ReadFile(configPath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read config after: %v", err)
+	}
+	if string(configAfter) != string(configBefore) {
+		t.Fatal("config must be rolled back to prior contents after persist failure")
+	}
+	// The lock must have been released despite the error.
+	if _, err := os.Lstat(apply.ApplyLockPath(configPath)); !os.IsNotExist(err) {
+		t.Fatalf("lock must be released after persist failure, lstat err=%v", err)
+	}
+}
+
+// Regression 6: a refused or errored apply releases the lock so the next
+// legitimate apply can acquire it. After a refusal there must be no leftover
+// lock file, and a subsequent valid apply must succeed.
+func TestPolicyApplyV2_LockReleasedAfterRefusal(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	lockPath := apply.ApplyLockPath(configPath)
+
+	if err := applyFleetSeq(t, dir, configPath, 5, "five"); err != nil {
+		t.Fatalf("apply seq 5: %v", err)
+	}
+	// Refused lower sequence.
+	if err := applyFleetSeq(t, dir, configPath, 4, "four"); err == nil {
+		t.Fatal("seq 4 must be refused")
+	}
+	if _, err := os.Lstat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("no leftover lock expected after refusal, lstat err=%v", err)
+	}
+	// A subsequent legitimate apply acquires the lock and succeeds.
+	if err := applyFleetSeq(t, dir, configPath, 6, "six"); err != nil {
+		t.Fatalf("apply seq 6 must succeed after lock release: %v", err)
+	}
+	if got := fleetReplayFloor(t, configPath); got != 6 {
+		t.Fatalf("final floor = %d, want 6", got)
+	}
+}
+
+// Concurrency smoke: while one apply holds the lock, a concurrent apply attempt
+// for the same target fails to acquire it rather than interleaving. Holding the
+// lock directly and attempting the apply synchronously is fully deterministic.
+func TestPolicyApplyV2_HeldLockBlocksConcurrentApply(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	lock, err := apply.AcquireApplyLock(configPath)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+
+	if err := applyFleetSeq(t, dir, configPath, 1, "blocked"); err == nil {
+		t.Fatal("apply must fail while the lock is held")
+	} else if !strings.Contains(err.Error(), "another apply holds the lock") {
+		t.Fatalf("expected held-lock error, got %v", err)
+	}
+
+	if err := lock.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	// After release a fresh apply succeeds.
+	if err := applyFleetSeq(t, dir, configPath, 1, "afterrelease"); err != nil {
+		t.Fatalf("apply after release: %v", err)
+	}
+}

--- a/cmd/oktsec/commands/policy_v2_apply_lock_test.go
+++ b/cmd/oktsec/commands/policy_v2_apply_lock_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/apply"
+	"github.com/oktsec/oktsec/internal/policybundle"
 )
 
 // errAfterCommitInjected is the sentinel a test injects through the
@@ -17,12 +18,20 @@ var errAfterCommitInjected = errors.New("injected state persist failure")
 
 // fleetBundleAtSeq builds, signs, and writes a fleet-scoped v2 bundle at the
 // given sequence with a unique assignment id, returning its on-disk path and
-// the trust fingerprint to verify it.
+// the trust fingerprint to verify it. The bundle's voice-ai allowed_tools is set
+// to a value unique to the assignment id, so each distinct apply produces a real
+// config change (not a no-op), exercising the real-change persist path.
 func fleetBundleAtSeq(t *testing.T, dir string, seq int64, assignID string) (bundlePath, fp string) {
 	t.Helper()
 	body := supportedAgentBodyV2("fleet", "")
 	body.Assignment.Sequence = seq
 	body.Assignment.AssignmentID = assignID
+	// Make the projected change unique per assignment so the apply is never a
+	// no-op (which would skip the real-change persist path and its lock-spanned
+	// recovery).
+	g := agentGovV2cmd("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: "replace", Values: []string{"tool." + assignID}}
+	body.Governance.Agents = []policybundle.AgentGovernanceV2{g}
 	raw, trustFP := signV2Bundle(t, body)
 	p := filepath.Join(dir, "bundle-"+assignID+".signed.json")
 	if err := os.WriteFile(p, raw, 0o600); err != nil {

--- a/cmd/oktsec/commands/policy_v2_test.go
+++ b/cmd/oktsec/commands/policy_v2_test.go
@@ -1,0 +1,572 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+)
+
+// These are COMMAND-LEVEL (CLI integration) tests for `oktsec policy apply`
+// against a policy_bundle.v2. They invoke the REAL root command through
+// runPolicyApply (defined in policy_test.go), so they exercise the actual
+// dispatch by schema_version, the v2 --node-id target binding, the
+// <config>.policy-state.json file, and the no-partial contract at the command
+// boundary - not the internal projector directly.
+//
+// The command calls policybundle.Verify, so each test needs a genuinely SIGNED
+// v2 bundle. The upstream signer/generator was deleted after the fixture was
+// vendored and its signing helpers are unexported, so a small test-only signer
+// is reproduced here from the EXPORTED policybundle types and frozen constants.
+// It mirrors the canonical body encoding (typed-struct JSON, HTML escaping off,
+// trailing newline trimmed) and the v2 signing-payload byte layout exactly; the
+// in-package TestV2_SigningPayloadStable / TestV2_HashMatchesContract tests are
+// the source of truth those bytes must match. Reusing the vendored node-scoped
+// fixture is not enough here: the cases need a fleet-scoped bundle, a wrong-node
+// target, a supported-only bundle, and a bundle that governs an unsupported
+// dimension, each requiring a distinct signed body.
+
+// v2SignerKey is a deterministic Ed25519 key seeded with bytes 1..32, matching
+// the seed convention used elsewhere in the repo's v2 tests, so the signer is
+// reproducible and self-describing.
+func v2SignerKey(t *testing.T) (ed25519.PrivateKey, string) {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	sum := sha256.Sum256(pub)
+	return priv, "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// canonicalBodyV2 reproduces policybundle.canonicalPolicyBodyBytesV2: the typed
+// struct encoded with HTML escaping off and the trailing newline trimmed. This
+// is the exact byte layout policy_hash and the signature cover.
+func canonicalBodyV2(t *testing.T, body policybundle.PolicyBodyV2) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body); err != nil {
+		t.Fatalf("encode canonical v2 body: %v", err)
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+// signingPayloadV2 reproduces policybundle.policyBundleV2SigningPayload byte for
+// byte (see TestV2_SigningPayloadStable for the frozen layout).
+func signingPayloadV2(body policybundle.PolicyBodyV2, policyHash, signedAt, keyID, fp string) []byte {
+	lines := []string{
+		"oktsec." + policybundle.SchemaVersionV2,
+		"bundle_version:2",
+		"policy_id:" + body.PolicyID,
+		"policy_version:" + body.PolicyVersion,
+		"policy_hash:" + policyHash,
+		"canonicalization:" + policybundle.CanonicalizationV2,
+		"assignment_id:" + body.Assignment.AssignmentID,
+		"target_scope:" + body.Assignment.Target.Scope,
+		"target_node_id:" + body.Assignment.Target.NodeID,
+		"issued_at:" + body.Assignment.IssuedAt,
+		"signed_at:" + signedAt,
+		"sequence:" + strconv.FormatInt(body.Assignment.Sequence, 10),
+		"rollback_of:" + body.Assignment.RollbackOf,
+		"signature_key_id:" + keyID,
+		"signature_public_key_fingerprint:" + fp,
+	}
+	out := lines[0]
+	for _, l := range lines[1:] {
+		out += "\n" + l
+	}
+	return []byte(out)
+}
+
+// signV2Bundle marshals a fully-populated PolicyBodyV2 into a signed
+// policy_bundle.v2 JSON artifact and returns it plus the trust fingerprint the
+// command must be given.
+func signV2Bundle(t *testing.T, body policybundle.PolicyBodyV2) (raw []byte, trustFP string) {
+	t.Helper()
+	priv, fp := v2SignerKey(t)
+	pub := priv.Public().(ed25519.PublicKey)
+	const (
+		keyID    = "command-test-v2-key"
+		signedAt = "2026-05-30T12:00:01Z"
+	)
+	canon := canonicalBodyV2(t, body)
+	sum := sha256.Sum256(canon)
+	policyHash := "sha256:" + hex.EncodeToString(sum[:])
+
+	payload := signingPayloadV2(body, policyHash, signedAt, keyID, fp)
+	sig := ed25519.Sign(priv, payload)
+
+	bundle := policybundle.PolicyBundleV2{
+		SchemaVersion:    policybundle.SchemaVersionV2,
+		BundleVersion:    policybundle.BundleVersionV2,
+		PolicyHash:       policyHash,
+		Canonicalization: policybundle.CanonicalizationV2,
+		Policy:           body,
+		Signature: policybundle.PolicySignature{
+			Alg:                  "Ed25519",
+			KeyID:                keyID,
+			PublicKey:            base64.StdEncoding.EncodeToString(pub),
+			PublicKeyFingerprint: fp,
+			SignedAt:             signedAt,
+			Value:                base64.StdEncoding.EncodeToString(sig),
+		},
+	}
+	out, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal signed v2 bundle: %v", err)
+	}
+	// Sanity: the freshly minted bundle must verify against its own fingerprint
+	// before any test relies on it, so a signer drift fails here, not deep in a
+	// case assertion.
+	if _, err := policybundle.Verify(out, fp); err != nil {
+		t.Fatalf("minted v2 bundle must verify: %v", err)
+	}
+	return out, fp
+}
+
+// baseBodyV2 returns a canonical-shape PolicyBodyV2 with every dimension
+// unmanaged and every container present as []/{} (the verifier rejects nil
+// containers). Callers set the target scope and a per-agent change per case.
+func baseBodyV2() policybundle.PolicyBodyV2 {
+	return policybundle.PolicyBodyV2{
+		PolicyID:      "voice-ai-prod",
+		PolicyVersion: "1",
+		Mode:          "enforce",
+		Assignment: policybundle.AssignmentV2{
+			AssignmentID: "assign-cmd-1",
+			Target:       policybundle.TargetV2{Scope: "fleet"},
+			IssuedAt:     "2026-05-30T12:00:00Z",
+			Sequence:     1,
+			RollbackOf:   "",
+		},
+		Rules:   policybundle.DimRulesV2{Mode: "unmanaged", Enabled: []string{}, Disabled: []string{}, Overrides: map[string]policybundle.PolicyRuleOverride{}},
+		Gateway: policybundle.DimGatewayV2{Mode: "unmanaged", ToolsAllowed: []string{}, ToolsDenied: []string{}},
+		Egress:  policybundle.DimEgressV2{Mode: "unmanaged", DomainsAllowed: []string{}, DomainsDenied: []string{}},
+		Governance: policybundle.GovernanceV2{
+			Server: policybundle.ServerGovernanceV2{Mode: "unmanaged"},
+			Agents: []policybundle.AgentGovernanceV2{},
+		},
+		Redaction: policybundle.DimRedactionV2{Mode: "unmanaged", Level: "analyst"},
+		Metadata:  policybundle.PolicyMetadata{CreatedAt: "2026-05-30T12:00:00Z", CreatedBy: "command-test", Reason: "command-level v2 apply test"},
+	}
+}
+
+// agentGovV2cmd returns a per-agent governance entry for name with every
+// dimension unmanaged and every container present as []/{}.
+func agentGovV2cmd(name string) policybundle.AgentGovernanceV2 {
+	return policybundle.AgentGovernanceV2{
+		Selector:        policybundle.SelectorV2{Name: name, Labels: map[string]string{}},
+		ACLs:            policybundle.DimACLsV2{Mode: "unmanaged", AllowedRecipients: []string{}, BlockedRecipients: []string{}},
+		AllowedTools:    policybundle.DimStringSetV2{Mode: "unmanaged", Values: []string{}},
+		ToolPolicies:    policybundle.DimToolPoliciesV2{Mode: "unmanaged", ByTool: map[string]policybundle.ToolPolicyV2{}},
+		ToolConstraints: policybundle.DimToolConstraintsV2{Mode: "unmanaged", Items: []policybundle.ToolConstraintV2{}},
+		ToolChainRules:  policybundle.DimToolChainRulesV2{Mode: "unmanaged", Items: []policybundle.ToolChainRuleV2{}},
+		BlockedContent:  policybundle.DimStringSetV2{Mode: "unmanaged", Values: []string{}},
+		ScanProfile:     policybundle.DimScalarStringV2{Mode: "unmanaged"},
+		Suspended:       policybundle.DimScalarBoolV2{Mode: "unmanaged"},
+		Egress: policybundle.DimAgentEgressV2{
+			Mode: "unmanaged", AllowedDomains: []string{}, BlockedDomains: []string{},
+			ToolRestrictions: map[string][]string{}, ScanRequests: "unset", ScanResponses: "unset",
+			BlockedCategories: []string{}, Integrations: []string{},
+		},
+	}
+}
+
+// supportedAgentBodyV2 returns a body that, projected against the test config's
+// voice-ai agent, yields a real, SUPPORTED change (allowed_tools replace).
+// scope/nodeID set the assignment target.
+func supportedAgentBodyV2(scope, nodeID string) policybundle.PolicyBodyV2 {
+	b := baseBodyV2()
+	b.Assignment.Target = policybundle.TargetV2{Scope: scope, NodeID: nodeID}
+	g := agentGovV2cmd("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: "replace", Values: []string{"calendar.read", "voice.dial"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	return b
+}
+
+// writeV2ApplyConfig writes a minimal valid config with a voice-ai agent and
+// returns the temp dir and config path. The header comment lets the
+// preserve-on-commit behavior be observable, mirroring the apply package tests.
+func writeV2ApplyConfig(t *testing.T) (dir, configPath string) {
+	t.Helper()
+	dir = t.TempDir()
+	configPath = filepath.Join(dir, "oktsec.yaml")
+	cfg := []byte("# operator config\nversion: \"1\"\nserver:\n  port: 8080\nidentity:\n  require_signature: false\nagents:\n  voice-ai:\n    allowed_tools: [old.tool]\nrules: []\n")
+	if err := os.WriteFile(configPath, cfg, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return dir, configPath
+}
+
+func writeBundle(t *testing.T, dir string, raw []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, "bundle.signed.json")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return p
+}
+
+// statePath returns the adjacent <config>.policy-state.json path.
+func statePath(configPath string) string { return configPath + ".policy-state.json" }
+
+// backupCount returns how many timestamped backup files exist next to the config
+// (apply writes "<config>.bak.<timestamp>" on a real config rewrite).
+func backupCount(t *testing.T, configPath string) int {
+	t.Helper()
+	matches, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backups: %v", err)
+	}
+	return len(matches)
+}
+
+// 1. v2 dry-run via CLI does NOT require --agent: a v2 bundle dry-run is not
+// rejected for a missing --agent (v2 scopes agents via in-bundle selectors), it
+// prints the plan, and it writes nothing (no config change, no state file).
+func TestPolicyApplyV2_DryRunNoAgentRequiredWritesNothing(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	bundlePath := writeBundle(t, dir, raw)
+	before, _ := os.ReadFile(configPath)
+
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--dry-run", "--json",
+	)
+	if err != nil {
+		t.Fatalf("v2 dry-run without --agent must succeed: %v", err)
+	}
+	if changes, ok := got["changes"].([]any); !ok || len(changes) == 0 {
+		t.Fatalf("v2 dry-run must print a plan with changes: %v", got["changes"])
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("v2 dry-run modified the config")
+	}
+	if _, err := os.Stat(statePath(configPath)); !os.IsNotExist(err) {
+		t.Fatal("v2 dry-run must not create a policy-state file")
+	}
+	if backupCount(t, configPath) != 0 {
+		t.Fatal("v2 dry-run must not create a backup")
+	}
+}
+
+// 2. v2 node-scoped real apply WITHOUT --node-id fails and writes nothing.
+func TestPolicyApplyV2_NodeScopedWithoutNodeIDFailsNoWrite(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", "node-east-1"))
+	bundlePath := writeBundle(t, dir, raw)
+	before, _ := os.ReadFile(configPath)
+
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json", // no --node-id
+	); err == nil {
+		t.Fatal("node-scoped v2 apply without --node-id must fail")
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("failed node-scoped apply must not modify the config")
+	}
+	if _, err := os.Stat(statePath(configPath)); !os.IsNotExist(err) {
+		t.Fatal("failed node-scoped apply must not create a policy-state file")
+	}
+	if backupCount(t, configPath) != 0 {
+		t.Fatal("failed node-scoped apply must not create a backup")
+	}
+}
+
+// 3. v2 target mismatch (--node-id != bundle's node target) fails, writes
+// nothing: config unchanged, no state file, no backup.
+func TestPolicyApplyV2_TargetMismatchFailsNoWrite(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", "node-east-1"))
+	bundlePath := writeBundle(t, dir, raw)
+	before, _ := os.ReadFile(configPath)
+
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--node-id", "node-west-9", "--json",
+	); err == nil {
+		t.Fatal("v2 apply with a mismatched --node-id must fail")
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("target-mismatch apply must not modify the config")
+	}
+	if _, err := os.Stat(statePath(configPath)); !os.IsNotExist(err) {
+		t.Fatal("target-mismatch apply must not create a policy-state file")
+	}
+	if backupCount(t, configPath) != 0 {
+		t.Fatal("target-mismatch apply must not create a backup")
+	}
+}
+
+// 4. v2 real apply success (node-scoped, correct --node-id) writes config +
+// creates <config>.policy-state.json (0600, records the applied sequence and
+// assignment) + a backup.
+func TestPolicyApplyV2_NodeScopedSuccessWritesConfigAndState(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	original, _ := os.ReadFile(configPath)
+	body := supportedAgentBodyV2("node", "node-east-1")
+	body.Assignment.AssignmentID = "assign-cmd-4"
+	body.Assignment.Sequence = 7
+	raw, fp := signV2Bundle(t, body)
+	bundlePath := writeBundle(t, dir, raw)
+
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--node-id", "node-east-1", "--json",
+	)
+	if err != nil {
+		t.Fatalf("node-scoped v2 apply must succeed: %v", err)
+	}
+	if got["applied"] != true || got["changed"] != true || got["dry_run"] != false {
+		t.Fatalf("applied/changed/dry_run = %v/%v/%v, want true/true/false", got["applied"], got["changed"], got["dry_run"])
+	}
+	if got["node_id"] != "node-east-1" || got["scope"] != "node" {
+		t.Fatalf("result scope/node = %v/%v, want node/node-east-1", got["scope"], got["node_id"])
+	}
+	bp, _ := got["backup_path"].(string)
+	if bp == "" {
+		t.Fatal("real v2 apply must report a backup_path")
+	}
+	if backupCount(t, configPath) != 1 {
+		t.Fatalf("real v2 apply must create exactly one backup, got %d", backupCount(t, configPath))
+	}
+	if backup, _ := os.ReadFile(bp); !bytes.Equal(backup, original) {
+		t.Fatal("backup must hold the exact original config")
+	}
+
+	// Config changed and still loads + validates.
+	after, _ := os.ReadFile(configPath)
+	if bytes.Equal(after, original) {
+		t.Fatal("real v2 apply did not modify the config")
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("applied config must load: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("applied config must validate: %v", err)
+	}
+
+	// State file exists, is 0600, and records the applied sequence/assignment.
+	sp := statePath(configPath)
+	info, err := os.Stat(sp)
+	if err != nil {
+		t.Fatalf("state file must exist: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state file mode = %v, want 0600", info.Mode().Perm())
+	}
+	var st struct {
+		Version int `json:"version"`
+		Targets map[string]struct {
+			LastSequence     int64  `json:"last_sequence"`
+			LastAssignmentID string `json:"last_assignment_id"`
+		} `json:"targets"`
+	}
+	data, _ := os.ReadFile(sp)
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("decode state file: %v", err)
+	}
+	rec, ok := st.Targets["node:node-east-1"]
+	if !ok {
+		t.Fatalf("state file missing node target, got %+v", st.Targets)
+	}
+	if rec.LastSequence != 7 || rec.LastAssignmentID != "assign-cmd-4" {
+		t.Fatalf("state record = seq %d / %q, want 7 / assign-cmd-4", rec.LastSequence, rec.LastAssignmentID)
+	}
+}
+
+// 5. v2 no-op real apply (re-applying the same bundle) advances/refreshes the
+// policy-state but does NOT rewrite the config and does NOT create a new backup.
+func TestPolicyApplyV2_NoopAdvancesStateNoConfigRewriteNoBackup(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	body := supportedAgentBodyV2("fleet", "")
+	body.Assignment.AssignmentID = "assign-cmd-5"
+	body.Assignment.Sequence = 3
+	raw, fp := signV2Bundle(t, body)
+	bundlePath := writeBundle(t, dir, raw)
+
+	// First apply writes the config + state + one backup.
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	); err != nil {
+		t.Fatalf("first v2 apply must succeed: %v", err)
+	}
+	afterFirst, _ := os.ReadFile(configPath)
+	if backupCount(t, configPath) != 1 {
+		t.Fatalf("first apply must create one backup, got %d", backupCount(t, configPath))
+	}
+
+	// Second apply of the SAME bundle is a no-op: config already on policy.
+	got2, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	)
+	if err != nil {
+		t.Fatalf("second (no-op) v2 apply must succeed: %v", err)
+	}
+	if got2["applied"] != false || got2["changed"] != false {
+		t.Fatalf("no-op apply: applied/changed = %v/%v, want false/false", got2["applied"], got2["changed"])
+	}
+	if bp, _ := got2["backup_path"].(string); bp != "" {
+		t.Fatalf("no-op apply must not report a backup_path, got %q", bp)
+	}
+	// Config bytes unchanged and no NEW backup created.
+	afterSecond, _ := os.ReadFile(configPath)
+	if !bytes.Equal(afterFirst, afterSecond) {
+		t.Fatal("no-op v2 apply rewrote the config")
+	}
+	if backupCount(t, configPath) != 1 {
+		t.Fatalf("no-op apply must not create a new backup, total = %d", backupCount(t, configPath))
+	}
+	// State still reflects the (re)applied assignment at its sequence.
+	var st struct {
+		Targets map[string]struct {
+			LastSequence     int64  `json:"last_sequence"`
+			LastAssignmentID string `json:"last_assignment_id"`
+		} `json:"targets"`
+	}
+	data, _ := os.ReadFile(statePath(configPath))
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("decode state file: %v", err)
+	}
+	rec, ok := st.Targets["fleet:"]
+	if !ok || rec.LastSequence != 3 || rec.LastAssignmentID != "assign-cmd-5" {
+		t.Fatalf("no-op state record = %+v, want seq 3 / assign-cmd-5", st.Targets)
+	}
+}
+
+// 6. v2 unsupported-dimension real apply fails, writes no config, no backup, and
+// does NOT create the policy-state file (the unsupported check precedes the state
+// read/write). Uses an ACLs replace, which the projector fails closed on.
+func TestPolicyApplyV2_UnsupportedDimensionFailsNoWriteNoState(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+	b := baseBodyV2()
+	b.Assignment.Target = policybundle.TargetV2{Scope: "fleet"}
+	g := agentGovV2cmd("voice-ai")
+	g.ACLs = policybundle.DimACLsV2{Mode: "replace", AllowedRecipients: []string{"billing-agent"}, BlockedRecipients: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	raw, fp := signV2Bundle(t, b)
+	bundlePath := writeBundle(t, dir, raw)
+	before, _ := os.ReadFile(configPath)
+
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	); err == nil {
+		t.Fatal("v2 apply governing an unsupported dimension must fail")
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("unsupported-dimension apply must not modify the config")
+	}
+	if backupCount(t, configPath) != 0 {
+		t.Fatal("unsupported-dimension apply must not create a backup")
+	}
+	if _, err := os.Stat(statePath(configPath)); !os.IsNotExist(err) {
+		t.Fatal("unsupported-dimension apply must not create a policy-state file")
+	}
+}
+
+// 6b. If the state file already exists from a prior successful apply, an
+// unsupported-dimension apply must NOT advance its sequence (fails before the
+// state write).
+func TestPolicyApplyV2_UnsupportedDoesNotAdvanceExistingState(t *testing.T) {
+	dir, configPath := writeV2ApplyConfig(t)
+
+	// Prior successful fleet apply records seq 2.
+	good := supportedAgentBodyV2("fleet", "")
+	good.Assignment.AssignmentID = "assign-good"
+	good.Assignment.Sequence = 2
+	goodRaw, fp := signV2Bundle(t, good)
+	goodPath := writeBundle(t, dir, goodRaw)
+	if _, err := runPolicyApply(t,
+		"--bundle", goodPath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	); err != nil {
+		t.Fatalf("seed apply must succeed: %v", err)
+	}
+	stateBefore, _ := os.ReadFile(statePath(configPath))
+
+	// A later unsupported-dimension bundle at a higher sequence must fail and
+	// leave the state untouched.
+	bad := baseBodyV2()
+	bad.Assignment.Target = policybundle.TargetV2{Scope: "fleet"}
+	bad.Assignment.AssignmentID = "assign-bad"
+	bad.Assignment.Sequence = 5
+	g := agentGovV2cmd("voice-ai")
+	g.ACLs = policybundle.DimACLsV2{Mode: "replace", AllowedRecipients: []string{"x"}, BlockedRecipients: []string{}}
+	bad.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	badRaw, _ := signV2Bundle(t, bad)
+	badPath := writeBundle(t, dir, badRaw)
+	if _, err := runPolicyApply(t,
+		"--bundle", badPath, "--trust-fingerprint", fp,
+		"--config", configPath, "--json",
+	); err == nil {
+		t.Fatal("unsupported-dimension apply must fail")
+	}
+	stateAfter, _ := os.ReadFile(statePath(configPath))
+	if !bytes.Equal(stateBefore, stateAfter) {
+		t.Fatal("unsupported-dimension apply advanced the existing policy-state")
+	}
+}
+
+// 7. v1 unchanged regression: a v1 bundle still REQUIRES --agent and does not
+// require/use --node-id. This confirms the v1 path is behaviorally identical to
+// before the v2 branch.
+func TestPolicyApplyV1_StillRequiresAgentIgnoresNodeID(t *testing.T) {
+	bundlePath, configPath := writePolicyApplyInputs(t)
+
+	// v1 dry-run without --agent still fails (even with a --node-id present,
+	// which the v1 path ignores).
+	if _, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--node-id", "node-east-1", "--dry-run", "--json",
+	); err == nil {
+		t.Fatal("v1 apply without --agent must still fail")
+	}
+
+	// v1 dry-run WITH --agent still succeeds and a stray --node-id is ignored
+	// (no node binding on the v1 path), proving behavior is unchanged.
+	before, _ := os.ReadFile(configPath)
+	got, err := runPolicyApply(t,
+		"--bundle", bundlePath, "--trust-fingerprint", fixtureTrustFP(t),
+		"--config", configPath, "--agent", "voice-ai", "--node-id", "node-east-1", "--dry-run", "--json",
+	)
+	if err != nil {
+		t.Fatalf("v1 dry-run with --agent (and a stray --node-id) must succeed: %v", err)
+	}
+	if got["agent"] != "voice-ai" {
+		t.Fatalf("v1 plan agent = %v, want voice-ai", got["agent"])
+	}
+	if _, hasNode := got["node_id"]; hasNode {
+		t.Fatal("v1 plan must not carry a node_id field")
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("v1 dry-run modified the config")
+	}
+	// v1 never writes a v2-style policy-state file.
+	if _, err := os.Stat(statePath(configPath)); !os.IsNotExist(err) {
+		t.Fatal("v1 path must not create a policy-state file")
+	}
+}

--- a/internal/apply/fix_correctness_test.go
+++ b/internal/apply/fix_correctness_test.go
@@ -1,0 +1,309 @@
+package apply
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+	"github.com/oktsec/oktsec/internal/policysign"
+)
+
+// ---- FIX B: LoadPolicyState fails closed on a present-but-malformed state ----
+
+// stateTestConfigPath writes a minimal config to a temp dir and returns its
+// path; the state file lives beside it.
+func stateTestConfigPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "oktsec.yaml")
+}
+
+func TestLoadPolicyState_PresentButMalformedFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty_object", `{}`},
+		{"targets_null", `{"version": 1, "targets": null}`},
+		{"wrong_version", `{"version": 99, "targets": {}}`},
+		{"missing_version", `{"targets": {}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := stateTestConfigPath(t)
+			if err := os.WriteFile(PolicyStatePath(cfgPath), []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write state: %v", err)
+			}
+			st, err := LoadPolicyState(cfgPath)
+			if err == nil {
+				t.Fatalf("present-but-malformed state must fail closed, got state %#v", st)
+			}
+			if st != nil {
+				t.Fatalf("a failed load must return a nil state, got %#v", st)
+			}
+		})
+	}
+}
+
+func TestLoadPolicyState_TruncatedGarbageFailsClosed(t *testing.T) {
+	cfgPath := stateTestConfigPath(t)
+	if err := os.WriteFile(PolicyStatePath(cfgPath), []byte(`{"version": 1, "targets": {`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	if _, err := LoadPolicyState(cfgPath); err == nil {
+		t.Fatalf("truncated state must fail closed")
+	}
+}
+
+func TestLoadPolicyState_AbsentStartsFresh(t *testing.T) {
+	cfgPath := stateTestConfigPath(t)
+	st, err := LoadPolicyState(cfgPath)
+	if err != nil {
+		t.Fatalf("absent state must start fresh, got err: %v", err)
+	}
+	if st == nil || st.Targets == nil {
+		t.Fatalf("fresh state must have a usable targets map, got %#v", st)
+	}
+	if len(st.Targets) != 0 {
+		t.Fatalf("fresh state must be empty, got %#v", st.Targets)
+	}
+}
+
+func TestLoadPolicyState_ValidPresentStillLoads(t *testing.T) {
+	cfgPath := stateTestConfigPath(t)
+	if err := os.WriteFile(PolicyStatePath(cfgPath), []byte(`{"version": 1, "targets": {}}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	st, err := LoadPolicyState(cfgPath)
+	if err != nil {
+		t.Fatalf("valid present state should load, got err: %v", err)
+	}
+	if st == nil || st.Targets == nil {
+		t.Fatalf("want a usable state with a targets map, got %#v", st)
+	}
+}
+
+// ---- FIX C: v1 DryRun clears ManagedByPolicy when it rewrites a rule ----
+
+// v1OverrideBody builds a v1 PolicyBody (enforce mode) whose only rule action is
+// an override of ruleID to "block". The projector consumes the verified body, so
+// no signing is needed (verifiedV1Bundle is the shared in-package helper).
+func v1OverrideBody(ruleID string) policysign.PolicyBody {
+	return policysign.PolicyBody{
+		SchemaVersion: "policy_bundle.v1",
+		PolicyID:      "pol-1",
+		PolicyVersion: "1",
+		Mode:          ModeEnforce,
+		Rules: policysign.RuleSet{
+			Enabled:   []string{},
+			Disabled:  []string{},
+			Overrides: map[string]policysign.RuleOverride{ruleID: {Action: "block"}},
+		},
+	}
+}
+
+// saveTestConfig writes cfg to a temp file (apply never creates a config, so the
+// file must exist before Commit) and returns its path.
+func saveTestConfig(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "oktsec.yaml")
+	if err := cfg.Save(p); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return p
+}
+
+func TestV1DryRun_ClearsManagedByPolicyMarker(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
+		Rules: []config.RuleAction{
+			{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: true},
+			{ID: "OP-LOCAL", Action: "block"}, // operator rule, never marked
+		},
+	}
+	plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), cfg, "voice-ai", "/tmp/x.yaml")
+	if err != nil {
+		t.Fatalf("v1 dry-run: %v", err)
+	}
+	proj := plan.Projected()
+	if proj == nil {
+		t.Fatalf("expected a projected config")
+	}
+	var got *config.RuleAction
+	for i := range proj.Rules {
+		if proj.Rules[i].ID == "IAP-001" {
+			got = &proj.Rules[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("IAP-001 should still exist after v1 override")
+	}
+	if got.Action != "block" {
+		t.Fatalf("want action block, got %q", got.Action)
+	}
+	if got.ManagedByPolicy {
+		t.Fatalf("v1 must clear ManagedByPolicy when it takes over a rule")
+	}
+}
+
+// TestV1ThenV2Replace_DoesNotReapV1OwnedRule asserts the end-to-end FIX C
+// invariant: a rule first marked by v2, then rewritten by a v1 apply (which
+// clears the marker and Commit-writes it), is NOT silently reaped by a later v2
+// replace that omits the rule. Because the rule is now unmarked (operator/local)
+// and unnamed by the bundle, the v2 replace must FAIL CLOSED (unowned local
+// rule) rather than treat it as policy-owned and delete it.
+func TestV1ThenV2Replace_DoesNotReapV1OwnedRule(t *testing.T) {
+	start := &config.Config{
+		Version: 1,
+		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
+		Rules: []config.RuleAction{
+			{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: true},
+		},
+	}
+	cfgPath := saveTestConfig(t, start)
+
+	// v1 takes over IAP-001 (override to block). This clears the marker.
+	v1cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	v1plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), v1cfg, "voice-ai", cfgPath)
+	if err != nil {
+		t.Fatalf("v1 dry-run: %v", err)
+	}
+	if _, err := Commit(v1plan, cfgPath); err != nil {
+		t.Fatalf("v1 commit: %v", err)
+	}
+
+	// Confirm on disk the marker is gone (FIX C clear persisted by Commit).
+	afterV1, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload after v1: %v", err)
+	}
+	for _, r := range afterV1.Rules {
+		if r.ID == "IAP-001" && r.ManagedByPolicy {
+			t.Fatalf("v1 commit must persist a cleared marker on IAP-001")
+		}
+	}
+
+	// v2 replace that does NOT name IAP-001. Since IAP-001 is now unowned (marker
+	// cleared) the replace must fail closed, not reap it.
+	v2plan, err := DryRunV2(verifiedV2(rulesReplaceBody("IAP-OTHER")), afterV1, "", cfgPath)
+	if err == nil {
+		t.Fatalf("v2 replace over a now-unowned rule must fail closed (ErrUnsupported), got nil")
+	}
+	if !hasUnsupportedV2(v2plan, "rules_replace_unowned_local_rule") {
+		t.Fatalf("expected rules_replace_unowned_local_rule unsupported entry; got %+v", v2plan.Unsupported)
+	}
+}
+
+func TestV1YAMLByteFrozenWithMarker(t *testing.T) {
+	mk := func(marked bool) string {
+		cfg := &config.Config{
+			Version: 1,
+			Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
+			Rules:   []config.RuleAction{{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: marked}},
+		}
+		p := saveTestConfig(t, cfg)
+		c, err := config.Load(p)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), c, "voice-ai", p)
+		if err != nil {
+			t.Fatalf("v1 dry-run: %v", err)
+		}
+		if _, err := Commit(plan, p); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		return string(b)
+	}
+	withMarker := mk(true)
+	without := mk(false)
+	if withMarker != without {
+		t.Fatalf("v1 YAML must be byte-identical regardless of the input marker:\n--- marked ---\n%s\n--- unmarked ---\n%s", withMarker, without)
+	}
+	if strings.Contains(withMarker, "managed_by_policy") {
+		t.Fatalf("v1 output must never emit managed_by_policy")
+	}
+}
+
+// ---- FIX D: explicit false/0 v2 change values are emitted, not omitted ----
+
+func TestChangeV2_ExplicitFalseAndZeroAreEmitted(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Agents: map[string]config.Agent{
+			"voice-ai": {AllowedTools: []string{"a"}, Suspended: true, BlockedContent: []string{"pii"}},
+		},
+		Rules: []config.RuleAction{},
+	}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: false}
+	g.BlockedContent = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+
+	plan, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+
+	var sawSuspendFalse, sawClearZero bool
+	for _, c := range plan.Changes {
+		switch c.Kind {
+		case "agent_suspended":
+			if c.BoolValue == nil {
+				t.Fatalf("suspended change must carry an explicit bool_value pointer, got nil")
+			}
+			if !*c.BoolValue {
+				sawSuspendFalse = true
+			}
+		case "agent_blocked_content":
+			if c.DimMode == "clear" {
+				if c.Count == nil {
+					t.Fatalf("clear change must carry an explicit count pointer, got nil")
+				}
+				if *c.Count == 0 {
+					sawClearZero = true
+				}
+			}
+		}
+	}
+	if !sawSuspendFalse {
+		t.Fatalf("expected an agent_suspended change with explicit false; changes=%#v", plan.Changes)
+	}
+	if !sawClearZero {
+		t.Fatalf("expected an agent_blocked_content clear with explicit count 0; changes=%#v", plan.Changes)
+	}
+}
+
+func TestChangeV2_JSONEmitsExplicitFalseAndZero(t *testing.T) {
+	suspend := ChangeV2{Kind: "agent_suspended", DimMode: "replace", Agent: "voice-ai", BoolValue: boolVal(false)}
+	clear := ChangeV2{Kind: "agent_blocked_content", DimMode: "clear", Agent: "voice-ai", Count: intVal(0)}
+
+	bs, err := json.Marshal(suspend)
+	if err != nil {
+		t.Fatalf("marshal suspend: %v", err)
+	}
+	if !strings.Contains(string(bs), `"bool_value":false`) {
+		t.Fatalf("explicit false must be emitted, got %s", bs)
+	}
+	bc, err := json.Marshal(clear)
+	if err != nil {
+		t.Fatalf("marshal clear: %v", err)
+	}
+	if !strings.Contains(string(bc), `"count":0`) {
+		t.Fatalf("explicit 0 count must be emitted, got %s", bc)
+	}
+}

--- a/internal/apply/fix_correctness_test.go
+++ b/internal/apply/fix_correctness_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/policybundle"
-	"github.com/oktsec/oktsec/internal/policysign"
 )
 
 // ---- FIX B: LoadPolicyState fails closed on a present-but-malformed state ----
@@ -91,19 +90,12 @@ func TestLoadPolicyState_ValidPresentStillLoads(t *testing.T) {
 
 // v1OverrideBody builds a v1 PolicyBody (enforce mode) whose only rule action is
 // an override of ruleID to "block". The projector consumes the verified body, so
-// no signing is needed (verifiedV1Bundle is the shared in-package helper).
-func v1OverrideBody(ruleID string) policysign.PolicyBody {
-	return policysign.PolicyBody{
-		SchemaVersion: "policy_bundle.v1",
-		PolicyID:      "pol-1",
-		PolicyVersion: "1",
-		Mode:          ModeEnforce,
-		Rules: policysign.RuleSet{
-			Enabled:   []string{},
-			Disabled:  []string{},
-			Overrides: map[string]policysign.RuleOverride{ruleID: {Action: "block"}},
-		},
-	}
+// no signing is needed (verified is the shared in-package helper).
+func v1OverrideBody(ruleID string) policybundle.PolicyBody {
+	b := body()
+	b.PolicyID = "pol-1"
+	b.Rules.Overrides = map[string]policybundle.PolicyRuleOverride{ruleID: {Action: "block"}}
+	return b
 }
 
 // saveTestConfig writes cfg to a temp file (apply never creates a config, so the
@@ -120,14 +112,15 @@ func saveTestConfig(t *testing.T, cfg *config.Config) string {
 
 func TestV1DryRun_ClearsManagedByPolicyMarker(t *testing.T) {
 	cfg := &config.Config{
-		Version: 1,
+		Version: "1",
+		Server:  config.ServerConfig{Port: 8080},
 		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
 		Rules: []config.RuleAction{
 			{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: true},
 			{ID: "OP-LOCAL", Action: "block"}, // operator rule, never marked
 		},
 	}
-	plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), cfg, "voice-ai", "/tmp/x.yaml")
+	plan, err := DryRun(verified(v1OverrideBody("IAP-001")), cfg, "voice-ai", "/tmp/x.yaml")
 	if err != nil {
 		t.Fatalf("v1 dry-run: %v", err)
 	}
@@ -160,7 +153,8 @@ func TestV1DryRun_ClearsManagedByPolicyMarker(t *testing.T) {
 // rule) rather than treat it as policy-owned and delete it.
 func TestV1ThenV2Replace_DoesNotReapV1OwnedRule(t *testing.T) {
 	start := &config.Config{
-		Version: 1,
+		Version: "1",
+		Server:  config.ServerConfig{Port: 8080},
 		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
 		Rules: []config.RuleAction{
 			{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: true},
@@ -173,7 +167,7 @@ func TestV1ThenV2Replace_DoesNotReapV1OwnedRule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	v1plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), v1cfg, "voice-ai", cfgPath)
+	v1plan, err := DryRun(verified(v1OverrideBody("IAP-001")), v1cfg, "voice-ai", cfgPath)
 	if err != nil {
 		t.Fatalf("v1 dry-run: %v", err)
 	}
@@ -206,7 +200,8 @@ func TestV1ThenV2Replace_DoesNotReapV1OwnedRule(t *testing.T) {
 func TestV1YAMLByteFrozenWithMarker(t *testing.T) {
 	mk := func(marked bool) string {
 		cfg := &config.Config{
-			Version: 1,
+			Version: "1",
+			Server:  config.ServerConfig{Port: 8080},
 			Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
 			Rules:   []config.RuleAction{{ID: "IAP-001", Action: "allow-and-flag", ManagedByPolicy: marked}},
 		}
@@ -215,7 +210,7 @@ func TestV1YAMLByteFrozenWithMarker(t *testing.T) {
 		if err != nil {
 			t.Fatalf("load: %v", err)
 		}
-		plan, err := DryRun(verifiedV1Bundle(t, v1OverrideBody("IAP-001")), c, "voice-ai", p)
+		plan, err := DryRun(verified(v1OverrideBody("IAP-001")), c, "voice-ai", p)
 		if err != nil {
 			t.Fatalf("v1 dry-run: %v", err)
 		}
@@ -242,7 +237,8 @@ func TestV1YAMLByteFrozenWithMarker(t *testing.T) {
 
 func TestChangeV2_ExplicitFalseAndZeroAreEmitted(t *testing.T) {
 	cfg := &config.Config{
-		Version: 1,
+		Version: "1",
+		Server:  config.ServerConfig{Port: 8080},
 		Agents: map[string]config.Agent{
 			"voice-ai": {AllowedTools: []string{"a"}, Suspended: true, BlockedContent: []string{"pii"}},
 		},

--- a/internal/apply/lock.go
+++ b/internal/apply/lock.go
@@ -1,0 +1,102 @@
+package apply
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ApplyLock is an exclusive, file-based advisory lock that scopes the full
+// policy_bundle.v2 apply critical section (load state, evaluate sequence,
+// write config, persist state) to a single in-flight apply for a given
+// config/state target.
+//
+// The lock is implemented as an O_CREATE|O_EXCL lock file placed next to the
+// config path. Exclusive creation is atomic on the target platforms (this is a
+// pure-Go, no-CGO project), so two concurrent applies cannot both observe the
+// lock as free. A leftover lock from a crashed prior apply is NOT auto-stolen,
+// because auto-stealing would reintroduce the very race the lock prevents.
+// Instead acquisition fails with a clear message naming the lock path so an
+// operator can remove it after confirming no apply is running. The lock file
+// records the owning pid and an RFC3339 timestamp to aid that decision.
+type ApplyLock struct {
+	path     string
+	released bool
+}
+
+// ApplyLockPath returns the lock file path that sits next to the config file.
+func ApplyLockPath(configPath string) string {
+	return configPath + ".policy-apply.lock"
+}
+
+// AcquireApplyLock acquires the exclusive apply lock for configPath. It must be
+// released via Release in all paths (success, refusal, error, panic) using a
+// defer at the call site. The lock file is created with O_CREATE|O_EXCL so the
+// acquisition is atomic; if it already exists, acquisition fails rather than
+// waiting or stealing it.
+func AcquireApplyLock(configPath string) (*ApplyLock, error) {
+	lockPath := ApplyLockPath(configPath)
+
+	// Reject a symlink at the lock path before creating, mirroring the
+	// symlink discipline used for the config and state files in write.go and
+	// state_v2.go. We do not want an attacker-planted symlink to redirect the
+	// lock file (or its later removal) outside the intended directory.
+	if info, err := os.Lstat(lockPath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("apply lock %q is a symlink", lockPath)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("apply lock %q is not a regular file", lockPath)
+		}
+		// A regular lock file already exists: another apply holds the lock,
+		// or a prior apply crashed without releasing it. Do not steal it.
+		return nil, fmt.Errorf(
+			"another apply holds the lock %q; if none is running, remove that file and retry",
+			lockPath,
+		)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat apply lock: %w", err)
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			// Lost the create race to a concurrent apply.
+			return nil, fmt.Errorf(
+				"another apply holds the lock %q; if none is running, remove that file and retry",
+				lockPath,
+			)
+		}
+		return nil, fmt.Errorf("create apply lock: %w", err)
+	}
+	// Record owner pid and timestamp so a stale lock can be reasoned about.
+	contents := "pid=" + strconv.Itoa(os.Getpid()) + " acquired=" + time.Now().UTC().Format(time.RFC3339) + "\n"
+	if _, werr := f.WriteString(contents); werr != nil {
+		_ = f.Close()
+		_ = os.Remove(lockPath)
+		return nil, fmt.Errorf("write apply lock: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		_ = os.Remove(lockPath)
+		return nil, fmt.Errorf("close apply lock: %w", cerr)
+	}
+	return &ApplyLock{path: lockPath}, nil
+}
+
+// Release removes the lock file. It is safe to call multiple times and is a
+// no-op after the first successful removal, so it can be deferred and also
+// called explicitly. A removal error is returned so callers can surface a
+// leaked lock, but Release marks the lock released regardless to keep the
+// no-op-on-repeat contract.
+func (l *ApplyLock) Release() error {
+	if l == nil || l.released {
+		return nil
+	}
+	l.released = true
+	if err := os.Remove(l.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove apply lock: %w", err)
+	}
+	return nil
+}

--- a/internal/apply/lock_test.go
+++ b/internal/apply/lock_test.go
@@ -1,0 +1,102 @@
+package apply
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAcquireApplyLock_ExclusiveAndRelease(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "oktsec.yaml")
+
+	l1, err := AcquireApplyLock(cfg)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	// Second acquire while held must fail (exclusive).
+	if _, err := AcquireApplyLock(cfg); err == nil {
+		t.Fatal("second acquire must fail while the lock is held")
+	} else if !strings.Contains(err.Error(), "another apply holds the lock") {
+		t.Fatalf("expected held-lock message, got %v", err)
+	}
+	// The lock file is mode 0600.
+	if info, err := os.Lstat(ApplyLockPath(cfg)); err != nil {
+		t.Fatalf("lstat lock: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("lock mode = %v, want 0600", info.Mode().Perm())
+	}
+	// Release frees the lock file.
+	if err := l1.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if _, err := os.Lstat(ApplyLockPath(cfg)); !os.IsNotExist(err) {
+		t.Fatalf("lock file should be gone after release, lstat err=%v", err)
+	}
+	// Release again is a no-op.
+	if err := l1.Release(); err != nil {
+		t.Fatalf("second release must be a no-op, got %v", err)
+	}
+	// A fresh acquire succeeds after release.
+	l2, err := AcquireApplyLock(cfg)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	if err := l2.Release(); err != nil {
+		t.Fatalf("release l2: %v", err)
+	}
+}
+
+func TestAcquireApplyLock_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "oktsec.yaml")
+	lockPath := ApplyLockPath(cfg)
+
+	target := filepath.Join(dir, "elsewhere")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, lockPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if _, err := AcquireApplyLock(cfg); err == nil {
+		t.Fatal("a symlink at the lock path must be rejected")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestRestoreConfigV2FromBackup_RestoresPriorBytes(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "oktsec.yaml")
+	backup := filepath.Join(dir, "oktsec.yaml.bak.20260101T000000Z")
+
+	if err := os.WriteFile(backup, []byte("prior\n"), 0o600); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	if err := os.WriteFile(cfg, []byte("changed\n"), 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	if err := RestoreConfigV2FromBackup(cfg, backup); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, err := os.ReadFile(cfg) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read restored cfg: %v", err)
+	}
+	if string(got) != "prior\n" {
+		t.Fatalf("restored contents = %q, want %q", string(got), "prior\n")
+	}
+}
+
+func TestRestoreConfigV2FromBackup_EmptyBackupIsError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(cfg, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	if err := RestoreConfigV2FromBackup(cfg, ""); err == nil {
+		t.Fatal("restore with empty backup path must error")
+	}
+}

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -178,6 +178,14 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 			target.Rules[i].Action = action
 			target.Rules[i].ApplyToTools = nil
 			target.Rules[i].ExemptTools = nil
+			// v1 is marker-agnostic by design: it never SETS ManagedByPolicy, but
+			// when it rewrites a rule that a prior v2 apply owned, that rule becomes
+			// operator/v1-owned, which under v2 means unowned. Clear the marker so a
+			// later v2 replace fails closed on it (treats it as unowned/local)
+			// instead of reaping a v1-applied override as policy-owned. This does NOT
+			// change v1's externally-observable YAML: ManagedByPolicy is omitempty,
+			// so false is absent, exactly as for any rule v1 writes itself.
+			target.Rules[i].ManagedByPolicy = false
 		} else {
 			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
 			idx[id] = len(target.Rules) - 1

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -40,6 +40,14 @@ var (
 	// narrow apply projection cannot express. The returned Plan still lists
 	// them under Unsupported; the caller refuses by default.
 	ErrUnsupported = errors.New("apply: bundle contains semantics not supported by the narrow apply projection")
+	// ErrPolicyTargetMismatch (v2): a node-scoped bundle does not target this
+	// node, or carries a self-referential rollback. Checked before projection,
+	// so it never produces a plan or touches the config.
+	ErrPolicyTargetMismatch = errors.New("apply: policy_target_mismatch")
+	// ErrPolicyRollbackRefused (v2): the bundle's sequence is not greater than
+	// the last applied sequence for this target and is not a signed rollback of
+	// the currently-applied assignment. Evaluated against the state file.
+	ErrPolicyRollbackRefused = errors.New("apply: policy_rollback_refused")
 )
 
 // mapAction maps an Enterprise override action to a Community rule action.

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -1,0 +1,835 @@
+package apply
+
+// Order 9A.2: project a verified policy_bundle.v2 onto the local Oktsec config
+// with explicit per-dimension modes (unmanaged | replace | clear), an
+// anti-widening guard, selector matching, target binding, and no-partial apply.
+//
+// This is a SEPARATE projector from the v1 DryRun/Commit path: v1 stays
+// byte-frozen and behaviorally unchanged. The v2 projector reuses the v1 Plan/
+// Change/Unsupported types and the v1 Commit safety protocol (backup + atomic
+// replace) by extending the patch coverage in write.go, never by rewriting it.
+//
+// Dimensions PROJECTED in this PR (the cheap, config-aligned set):
+//   - rules (global): enabled/disabled/overrides via DimRulesV2, mode-aware
+//   - gateway tools (agent-scoped via selectors): DimGatewayV2 -> AllowedTools
+//   - per-agent egress domains: AgentEgressV2 allowed/blocked -> Egress
+//   - agent suspension: DimScalarBoolV2 -> Suspended
+//   - blocked content categories: DimStringSetV2 -> BlockedContent
+//   - scan profile: DimScalarStringV2 -> ScanProfile
+//
+// Dimensions that FAIL CLOSED (reported unsupported, refuse the apply) when
+// governed (mode != unmanaged) but not yet implemented:
+//   - body-level egress (fleet/global forward-proxy domain lists)
+//   - server governance (require_intent, rate limits)
+//   - redaction (Enterprise report concern, but a managed mode is refused so it
+//     is never silently dropped)
+//   - per-agent acls, tool_policies, tool_constraints, tool_chain_rules, and
+//     per-agent egress fields beyond allowed/blocked domains (scope,
+//     tool_restrictions, scan_requests/responses, blocked_categories, rate
+//     limits, integrations)
+//
+// Every refusal is fail-closed: a governed dimension this PR does not project,
+// a merge mode, an ambiguous selector, a would-widen result, or a scalar clear
+// that would widen is added to plan.Unsupported and DryRunV2 returns
+// ErrUnsupported. A real apply with any unsupported item writes nothing.
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+)
+
+// DimMode values carried by the v2 signed body. Kept local to apply so the
+// projector reads as policy intent, not raw strings.
+const (
+	dimUnmanaged = "unmanaged"
+	dimReplace   = "replace"
+	dimClear     = "clear"
+)
+
+// PlanV2 is the dry-run result for a v2 bundle. It embeds the v1-shaped header
+// plus the assignment/target/sequence binding metadata the operator needs to
+// see, and reuses the v1 Change/Unsupported vocabulary. Its JSON shape is the
+// stable v2 contract; it extends the v1 Plan shape additively (a v2 consumer
+// sees the extra assignment block, a v1 consumer ignores it).
+type PlanV2 struct {
+	Applied       bool   `json:"applied"`
+	DryRun        bool   `json:"dry_run"`
+	SchemaVersion string `json:"schema_version"`
+	PolicyHash    string `json:"policy_hash"`
+	PolicyID      string `json:"policy_id"`
+	PolicyVersion string `json:"policy_version"`
+	Mode          string `json:"mode"`
+	TargetConfig  string `json:"target_config"`
+
+	// Assignment binding the operator and automation branch on.
+	AssignmentID string `json:"assignment_id"`
+	Scope        string `json:"scope"`
+	NodeID       string `json:"node_id"`
+	Sequence     int64  `json:"sequence"`
+	RollbackOf   string `json:"rollback_of"`
+	IssuedAt     string `json:"issued_at"`
+
+	Changes     []ChangeV2    `json:"changes"`
+	Unsupported []Unsupported `json:"unsupported"`
+
+	projected *config.Config // computed target; consumed by CommitV2, not serialized
+}
+
+// Projected returns the in-memory target config the v2 projection computed.
+func (p *PlanV2) Projected() *config.Config { return p.projected }
+
+// ChangeV2 is one concrete edit the v2 projection would make. It extends the v1
+// Change with an explicit DimMode label so the operator sees intent (REPLACE vs
+// CLEAR) in the plan, which the spec requires for v2.
+type ChangeV2 struct {
+	Kind     string `json:"kind"`
+	DimMode  string `json:"dim_mode"`        // replace | clear (unmanaged never emits a change)
+	ID       string `json:"id,omitempty"`    // rule id
+	Action   string `json:"action,omitempty"`
+	Agent    string `json:"agent,omitempty"`
+	Count    int    `json:"count,omitempty"` // list cardinality after the change
+	Value    string `json:"value,omitempty"` // scalar value (scan_profile)
+	BoolValue bool  `json:"bool_value,omitempty"` // scalar bool (suspended)
+}
+
+// DryRunV2 projects a verified v2 bundle onto a copy of cfg. nodeID is the local
+// node identity used for target binding (required when the bundle is node
+// scoped; ignored for fleet scope). It writes nothing. It returns:
+//   - ErrPolicyTargetMismatch  : node-scoped bundle whose node_id != nodeID
+//   - ErrUnsupported           : any dimension this PR cannot safely project
+//   - ErrMissingAgent          : a selector names an agent absent from config
+//
+// Target binding is checked BEFORE projection so a mismatch never produces a
+// plan or touches the config. Anti-rollback (sequence) is enforced by the
+// command layer against the persisted state file, not here, because it needs
+// the on-disk last-applied sequence; DryRunV2 carries the binding fields so the
+// command can evaluate it.
+func DryRunV2(verified *policybundle.VerifiedBundleV2, cfg *config.Config, nodeID, targetConfig string) (*PlanV2, error) {
+	body := verified.Bundle.Policy
+	plan := &PlanV2{
+		DryRun:        true,
+		SchemaVersion: policybundle.SchemaVersionV2,
+		PolicyHash:    verified.PolicyHash,
+		PolicyID:      body.PolicyID,
+		PolicyVersion: body.PolicyVersion,
+		Mode:          body.Mode,
+		TargetConfig:  targetConfig,
+		AssignmentID:  body.Assignment.AssignmentID,
+		Scope:         body.Assignment.Target.Scope,
+		NodeID:        body.Assignment.Target.NodeID,
+		Sequence:      body.Assignment.Sequence,
+		RollbackOf:    body.Assignment.RollbackOf,
+		IssuedAt:      body.Assignment.IssuedAt,
+		Changes:       []ChangeV2{},
+		Unsupported:   []Unsupported{},
+	}
+
+	// --- Target binding (cheap, decisive, before any projection). A node-scoped
+	// bundle applies only on its named node; a fleet-scoped bundle applies
+	// anywhere. A self-referential rollback (rollback_of == assignment_id) is
+	// nonsensical and is refused here (the verifier left it as a TODO for apply).
+	if body.Assignment.RollbackOf != "" && body.Assignment.RollbackOf == body.Assignment.AssignmentID {
+		return nil, fmt.Errorf("%w: rollback_of names the assignment itself", ErrPolicyTargetMismatch)
+	}
+	switch body.Assignment.Target.Scope {
+	case "node":
+		if nodeID == "" {
+			return nil, fmt.Errorf("%w: bundle is node-scoped (node_id %q) but no local node id was provided (pass --node-id)",
+				ErrPolicyTargetMismatch, body.Assignment.Target.NodeID)
+		}
+		if body.Assignment.Target.NodeID != nodeID {
+			return nil, fmt.Errorf("%w: bundle targets node %q, this node is %q",
+				ErrPolicyTargetMismatch, body.Assignment.Target.NodeID, nodeID)
+		}
+	case "fleet":
+		// applies anywhere
+	default:
+		// The verifier already closes the scope set; defend anyway.
+		return nil, fmt.Errorf("%w: unknown target scope %q", ErrUnsupported, body.Assignment.Target.Scope)
+	}
+
+	target, err := cloneConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Body-level dimensions that are NOT projected in this PR fail closed
+	// when governed. unmanaged is the only "not governed" meaning. ---
+	projectRulesV2(plan, target, body)
+	// Body-level gateway governs the GLOBAL gateway tool lists, which this PR
+	// does not project (per-agent allowed_tools is projected via the agent
+	// governance selector instead). A governed body gateway must fail closed so
+	// a signed global gateway policy is never silently dropped.
+	failClosedIfManaged(plan, "body_gateway", body.Gateway.Mode,
+		"global gateway tool lists are not projected by Community apply in this PR (use per-agent allowed_tools governance)")
+	failClosedIfManaged(plan, "body_egress", body.Egress.Mode,
+		"fleet/global egress domain lists are not projected by Community apply in this PR")
+	failClosedIfManaged(plan, "server_governance", body.Governance.Server.Mode,
+		"server governance (require_intent, rate limits) is not projected by Community apply in this PR")
+	failClosedIfManaged(plan, "redaction", body.Redaction.Mode,
+		"redaction is an Enterprise report concern and is not projected onto Community runtime")
+
+	// --- Per-agent governance via selectors. Selector overlap on the SAME
+	// dimension fails closed; matched agents are projected. ---
+	if err := projectAgentsV2(plan, target, body); err != nil {
+		return nil, err // ErrMissingAgent
+	}
+
+	// Validate the computed target before returning it.
+	if err := target.Validate(); err != nil {
+		return nil, fmt.Errorf("apply: projected config is invalid: %w", err)
+	}
+	plan.projected = target
+
+	if len(plan.Unsupported) > 0 {
+		return plan, ErrUnsupported
+	}
+	return plan, nil
+}
+
+// failClosedIfManaged records an unsupported entry when a not-yet-projected
+// dimension is governed (mode != unmanaged). unmanaged is a silent no-op.
+func failClosedIfManaged(plan *PlanV2, kind, mode, detail string) {
+	if mode == dimUnmanaged {
+		return
+	}
+	plan.Unsupported = append(plan.Unsupported, Unsupported{Kind: kind, Detail: detail})
+}
+
+// projectRulesV2 projects the global rules dimension. unmanaged leaves rules
+// untouched. replace governs the enabled/disabled/overrides exactly as v1 does
+// (reusing the same severity-default / observe / mapAction semantics). clear is
+// not a meaningful rules operation here (Community rules are active by default
+// and a config rules entry is an override) and there is no enumerated empty
+// form that does not widen, so a rules clear fails closed.
+func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.PolicyBodyV2) {
+	switch body.Rules.Mode {
+	case dimUnmanaged:
+		return
+	case dimClear:
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "rules_clear_unsupported",
+			Detail: "clearing the global rules dimension has no safe Community form (rules are active by default; an empty override set would widen high/critical rules), use replace",
+		})
+		return
+	case dimReplace:
+		// fall through
+	default:
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "rules_mode_unsupported",
+			Detail: fmt.Sprintf("rules.mode %q is not projectable (merge is rejected)", body.Rules.Mode),
+		})
+		return
+	}
+
+	observe := body.Mode == ModeObserve
+
+	idx := make(map[string]int, len(target.Rules))
+	for i, ra := range target.Rules {
+		idx[ra.ID] = i
+	}
+	upsert := func(id, action string) {
+		if i, ok := idx[id]; ok {
+			scoped := len(target.Rules[i].ApplyToTools) > 0 || len(target.Rules[i].ExemptTools) > 0
+			if target.Rules[i].Action == action && !scoped {
+				return
+			}
+			target.Rules[i].Action = action
+			target.Rules[i].ApplyToTools = nil
+			target.Rules[i].ExemptTools = nil
+		} else {
+			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
+			idx[id] = len(target.Rules) - 1
+		}
+		plan.Changes = append(plan.Changes, ChangeV2{Kind: "rule_override", DimMode: dimReplace, ID: id, Action: action})
+	}
+	resetToDefault := func(id string) {
+		i, ok := idx[id]
+		if !ok {
+			return
+		}
+		target.Rules = append(target.Rules[:i], target.Rules[i+1:]...)
+		delete(idx, id)
+		for j := i; j < len(target.Rules); j++ {
+			idx[target.Rules[j].ID] = j
+		}
+		plan.Changes = append(plan.Changes, ChangeV2{Kind: "rule_reset_default", DimMode: dimReplace, ID: id})
+	}
+
+	disabledSet := make(map[string]struct{}, len(body.Rules.Disabled))
+	for _, id := range body.Rules.Disabled {
+		disabledSet[id] = struct{}{}
+	}
+	governed := make(map[string]struct{}, len(body.Rules.Enabled)+len(body.Rules.Overrides))
+	for _, id := range body.Rules.Enabled {
+		governed[id] = struct{}{}
+	}
+	for id := range body.Rules.Overrides {
+		governed[id] = struct{}{}
+	}
+	active := make([]string, 0, len(governed))
+	for id := range governed {
+		if _, off := disabledSet[id]; off {
+			continue
+		}
+		active = append(active, id)
+	}
+	sort.Strings(active)
+	for _, id := range active {
+		if observe {
+			upsert(id, "allow-and-flag")
+			continue
+		}
+		ov, ok := body.Rules.Overrides[id]
+		if !ok {
+			resetToDefault(id)
+			continue
+		}
+		m, mok := mapAction(ov.Action)
+		if !mok {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "rule_override_action",
+				Detail: fmt.Sprintf("rule %q has unmappable action %q", id, ov.Action),
+			})
+			continue
+		}
+		upsert(id, m)
+	}
+
+	disabled := append([]string(nil), body.Rules.Disabled...)
+	sort.Strings(disabled)
+	for _, id := range disabled {
+		upsert(id, "ignore")
+	}
+}
+
+// projectAgentsV2 matches each governance entry to config agents and projects
+// the implemented per-agent dimensions. It enforces selector overlap fail-closed
+// per dimension. A selector that matches no agent by name is ErrMissingAgent
+// (the operator named an agent the config does not have, same contract as v1).
+func projectAgentsV2(plan *PlanV2, target *config.Config, body policybundle.PolicyBodyV2) error {
+	// dimensionTouched[agentName][dimension] guards selector overlap: two
+	// governance entries governing the same dimension of the same agent is
+	// ambiguous and fails closed (Phase A rule).
+	dimensionTouched := map[string]map[string]bool{}
+	mark := func(agentName, dim string) bool {
+		m := dimensionTouched[agentName]
+		if m == nil {
+			m = map[string]bool{}
+			dimensionTouched[agentName] = m
+		}
+		if m[dim] {
+			return false
+		}
+		m[dim] = true
+		return true
+	}
+
+	for i := range body.Governance.Agents {
+		gov := &body.Governance.Agents[i]
+		matches, err := matchAgents(plan, target, gov.Selector)
+		if err != nil {
+			return err
+		}
+		for _, name := range matches {
+			agent := target.Agents[name]
+
+			// Each implemented dimension: guard overlap, then project per mode.
+			projectAgentAllowedToolsV2(plan, &agent, name, gov, mark)
+			projectAgentEgressV2(plan, target, &agent, name, gov, mark)
+			projectAgentSuspendedV2(plan, &agent, name, gov, mark)
+			projectAgentBlockedContentV2(plan, &agent, name, gov, mark)
+			projectAgentScanProfileV2(plan, &agent, name, gov, mark)
+
+			// Per-agent dimensions NOT implemented in this PR: fail closed when
+			// governed. These map onto config but are deferred; never silently
+			// ignored.
+			failAgentDimIfManaged(plan, name, "acls", gov.ACLs.Mode)
+			failAgentDimIfManaged(plan, name, "tool_policies", gov.ToolPolicies.Mode)
+			failAgentDimIfManaged(plan, name, "tool_constraints", gov.ToolConstraints.Mode)
+			failAgentDimIfManaged(plan, name, "tool_chain_rules", gov.ToolChainRules.Mode)
+
+			target.Agents[name] = agent
+		}
+	}
+	return nil
+}
+
+// unknownManagedMode fails closed when a dimension's mode is managed but not
+// one this projector acts on (replace/clear). In practice that is "merge"
+// (deferred) or any value the verifier somehow let through. unmanaged is
+// handled by the caller before this is reached. Returns true when it recorded
+// an unsupported entry (the caller must then return without projecting).
+func unknownManagedMode(plan *PlanV2, agent, dim, mode string) bool {
+	switch mode {
+	case dimReplace, dimClear:
+		return false
+	default:
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_" + dim + "_mode_unsupported",
+			Detail: fmt.Sprintf("agent %q dimension %q has mode %q which Community apply does not support (merge is deferred)", agent, dim, mode),
+		})
+		return true
+	}
+}
+
+func failAgentDimIfManaged(plan *PlanV2, agent, dim, mode string) {
+	if mode == dimUnmanaged {
+		return
+	}
+	plan.Unsupported = append(plan.Unsupported, Unsupported{
+		Kind:   "agent_" + dim + "_unsupported",
+		Detail: fmt.Sprintf("agent %q dimension %q is governed (mode %q) but not projected by Community apply in this PR", agent, dim, mode),
+	})
+}
+
+// projectAgentAllowedToolsV2 projects allowed_tools (config.Agent.AllowedTools).
+//   - unmanaged: untouched.
+//   - replace: set exactly to the bundle values. An EMPTY replace value is a
+//     hard error (it would resolve to Community "all tools allowed", a widen),
+//     so it is refused. deny-all goes through clear.
+//   - clear: the genuine zero-access form. Community reads an empty allowlist as
+//     "all", so the zero form is a single sentinel tool that matches nothing.
+func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, gov *policybundle.AgentGovernanceV2, mark func(string, string) bool) {
+	mode := gov.AllowedTools.Mode
+	if mode == dimUnmanaged {
+		return
+	}
+	if !mark(name, "allowed_tools") {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_allowed_tools_ambiguous_selector",
+			Detail: fmt.Sprintf("agent %q allowed_tools governed by more than one selector", name),
+		})
+		return
+	}
+	if badMode := unknownManagedMode(plan, name, "allowed_tools", mode); badMode {
+		return
+	}
+	switch mode {
+	case dimReplace:
+		vals := gov.AllowedTools.Values
+		if len(vals) == 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_allowed_tools_empty_replace",
+				Detail: fmt.Sprintf("agent %q allowed_tools replace has an empty value, which Community reads as 'all tools' (a widen); use clear for deny-all", name),
+			})
+			return
+		}
+		// The deny-all sentinel is reserved for the clear form; a replace value
+		// must never contain it, or a bundle could smuggle "deny-all" through
+		// replace (or, conversely, defeat a later clear comparison). Refuse it.
+		if slices.Contains(vals, denyAllToolsSentinel) {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_allowed_tools_reserved_value",
+				Detail: fmt.Sprintf("agent %q allowed_tools replace contains the reserved deny-all sentinel %q; use clear for deny-all", name, denyAllToolsSentinel),
+			})
+			return
+		}
+		next := append([]string(nil), vals...)
+		if !slices.Equal(agent.AllowedTools, next) {
+			agent.AllowedTools = next
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimReplace, Agent: name, Count: len(next)})
+		}
+	case dimClear:
+		// Genuine zero-access form: a single sentinel that matches no real tool.
+		// Community's empty allowlist means "all", so we cannot use []; the
+		// sentinel yields zero callable tools without widening.
+		zero := []string{denyAllToolsSentinel}
+		if !slices.Equal(agent.AllowedTools, zero) {
+			agent.AllowedTools = zero
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimClear, Agent: name, Count: 0})
+		}
+	}
+}
+
+// denyAllToolsSentinel is the genuine zero-access allowlist value. Community
+// treats an empty allowlist as "all tools allowed", so deny-all must be a
+// non-empty list that matches no real tool. This name is RESERVED: a replace
+// value containing it is refused (see projectAgentAllowedToolsV2), so a real
+// tool can never carry it and the clear form can never be defeated.
+const denyAllToolsSentinel = "__oktsec_deny_all__"
+
+// projectAgentEgressV2 projects the per-agent egress allowed/blocked domains.
+// Only those two fields are implemented; any OTHER governed egress field (scope,
+// tool_restrictions, scan_requests/responses, blocked_categories, rate limits,
+// integrations) makes the whole egress dimension fail closed, because projecting
+// only part of a governed egress policy could change its meaning.
+//   - unmanaged: untouched.
+//   - replace: allowed/blocked set exactly. An empty allowed under replace is
+//     a hard error (empty allowed_domains unions with global/presets and does
+//     not restrict, i.e. it does not express deny-all here) -> use clear.
+//   - clear: zero allowed domains (the restrictive empty form for this agent).
+func projectAgentEgressV2(plan *PlanV2, target *config.Config, agent *config.Agent, name string, gov *policybundle.AgentGovernanceV2, mark func(string, string) bool) {
+	eg := gov.Egress
+	if eg.Mode == dimUnmanaged {
+		return
+	}
+	if !mark(name, "egress") {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_egress_ambiguous_selector",
+			Detail: fmt.Sprintf("agent %q egress governed by more than one selector", name),
+		})
+		return
+	}
+	if unknownManagedMode(plan, name, "egress", eg.Mode) {
+		return
+	}
+	// Reject if any unimplemented egress sub-field is set, so a governed egress
+	// policy is never partially projected.
+	if eg.Scope != "" || len(eg.ToolRestrictions) > 0 || eg.ScanRequests != "unset" ||
+		eg.ScanResponses != "unset" || len(eg.BlockedCategories) > 0 ||
+		eg.RateLimit != 0 || eg.RateWindow != 0 || len(eg.Integrations) > 0 {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_egress_unsupported_fields",
+			Detail: fmt.Sprintf("agent %q egress sets fields beyond allowed/blocked domains (scope/tool_restrictions/scan_*/blocked_categories/rate/integrations) which Community apply does not project in this PR", name),
+		})
+		return
+	}
+
+	switch eg.Mode {
+	case dimReplace:
+		if len(eg.AllowedDomains) == 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_empty_replace",
+				Detail: fmt.Sprintf("agent %q egress replace has empty allowed_domains, which does not restrict (it unions with global/preset domains); use clear for zero egress", name),
+			})
+			return
+		}
+		if slices.Contains(eg.AllowedDomains, denyAllDomainsSentinel) {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_reserved_value",
+				Detail: fmt.Sprintf("agent %q egress replace contains the reserved zero-egress sentinel %q; use clear for zero egress", name, denyAllDomainsSentinel),
+			})
+			return
+		}
+		// Additive-source guard (mirrors v1): the egress resolver UNIONS the
+		// agent's allowed_domains with the global forward_proxy allowlist and any
+		// integration presets the agent already carries. Setting the agent's list
+		// to the bundle's only equals the bundle's intended restriction when those
+		// other sources add nothing outside it. If a source additively permits a
+		// domain the policy excludes (and the policy/agent does not also deny it),
+		// the restriction is not expressible here, so refuse rather than report a
+		// success that still permits that domain. (blocked is checked before
+		// allowed at runtime, so a domain the policy or agent denies is not a
+		// widener.)
+		if outside := egressAdditiveWideners(target, agent, eg); len(outside) > 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_allowed_not_restrictable",
+				Detail: fmt.Sprintf("agent %q egress.allowed_domains cannot restrict it: a global forward_proxy allowlist or the agent's integration presets additively permit domain(s) outside the policy: %v", name, outside),
+			})
+			return
+		}
+		ensureEgress(agent)
+		if !slices.Equal(agent.Egress.AllowedDomains, eg.AllowedDomains) {
+			agent.Egress.AllowedDomains = append([]string(nil), eg.AllowedDomains...)
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimReplace, Agent: name, Count: len(eg.AllowedDomains)})
+		}
+		// blocked under replace is additive-faithful (deny is monotonic).
+		if !slices.Equal(agent.Egress.BlockedDomains, eg.BlockedDomains) {
+			agent.Egress.BlockedDomains = append([]string(nil), eg.BlockedDomains...)
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_denied_domains", DimMode: dimReplace, Agent: name, Count: len(eg.BlockedDomains)})
+		}
+	case dimClear:
+		// Zero egress: setting the agent's allowed_domains to the sentinel only
+		// produces genuine zero egress when no OTHER source still permits a
+		// domain. The runtime egress resolver unions the agent allowlist with the
+		// global forward_proxy allowlist and the agent's integration presets, and
+		// a per-tool egress.tool_restrictions entry bypasses the allowlist
+		// entirely. If any of those additive sources is present, the sentinel does
+		// not achieve deny-all, so refuse rather than report a misleading clear.
+		// (egressAdditiveWideners with an empty policy set treats EVERY additive
+		// domain as outside, and flags a non-empty scope / tool_restrictions.)
+		if outside := egressAdditiveWideners(target, agent, policybundle.DimAgentEgressV2{}); len(outside) > 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_clear_not_zeroable",
+				Detail: fmt.Sprintf("agent %q egress clear cannot yield zero egress: a global forward_proxy allowlist, integration preset, scope, or tool restriction additively permits domain(s): %v; remove those sources first", name, outside),
+			})
+			return
+		}
+		ensureEgress(agent)
+		// No additive source remains, so the deny-all sentinel (matches nothing)
+		// plus an empty blocked list yields zero permitted domains for this agent.
+		zero := []string{denyAllDomainsSentinel}
+		if !slices.Equal(agent.Egress.AllowedDomains, zero) || len(agent.Egress.BlockedDomains) != 0 {
+			agent.Egress.AllowedDomains = zero
+			agent.Egress.BlockedDomains = nil
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimClear, Agent: name, Count: 0})
+		}
+	}
+}
+
+// denyAllDomainsSentinel is the genuine zero-egress allowed-domain value for an
+// agent. An empty allowed_domains list unions with global/preset domains, so it
+// does not deny; a reserved domain that matches no real host yields zero egress.
+const denyAllDomainsSentinel = "deny-all.invalid"
+
+// projectAgentSuspendedV2 projects suspension.
+//   - unmanaged: untouched.
+//   - replace: set exactly to the bundle bool.
+//   - clear: FORBIDDEN. clear -> false un-suspends, which widens safety posture.
+//     Use replace with the explicit value.
+func projectAgentSuspendedV2(plan *PlanV2, agent *config.Agent, name string, gov *policybundle.AgentGovernanceV2, mark func(string, string) bool) {
+	mode := gov.Suspended.Mode
+	if mode == dimUnmanaged {
+		return
+	}
+	if !mark(name, "suspended") {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_suspended_ambiguous_selector",
+			Detail: fmt.Sprintf("agent %q suspended governed by more than one selector", name),
+		})
+		return
+	}
+	if unknownManagedMode(plan, name, "suspended", mode) {
+		return
+	}
+	switch mode {
+	case dimReplace:
+		if agent.Suspended != gov.Suspended.Value {
+			agent.Suspended = gov.Suspended.Value
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_suspended", DimMode: dimReplace, Agent: name, BoolValue: gov.Suspended.Value})
+		}
+	case dimClear:
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_suspended_clear_widens",
+			Detail: fmt.Sprintf("agent %q suspended clear resets to false (un-suspends), which widens safety posture; use replace with an explicit value", name),
+		})
+	}
+}
+
+// projectAgentBlockedContentV2 projects blocked content categories.
+//   - unmanaged: untouched.
+//   - replace: set exactly. An empty replace is a hard error (use clear to mean
+//     "block no categories"); empty under replace must never be a silent no-op.
+//   - clear: empty list (block no categories). This is the safe, narrowing
+//     empty form for a denylist: it never adds capability.
+func projectAgentBlockedContentV2(plan *PlanV2, agent *config.Agent, name string, gov *policybundle.AgentGovernanceV2, mark func(string, string) bool) {
+	mode := gov.BlockedContent.Mode
+	if mode == dimUnmanaged {
+		return
+	}
+	if !mark(name, "blocked_content") {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_blocked_content_ambiguous_selector",
+			Detail: fmt.Sprintf("agent %q blocked_content governed by more than one selector", name),
+		})
+		return
+	}
+	if unknownManagedMode(plan, name, "blocked_content", mode) {
+		return
+	}
+	switch mode {
+	case dimReplace:
+		vals := gov.BlockedContent.Values
+		if len(vals) == 0 {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_blocked_content_empty_replace",
+				Detail: fmt.Sprintf("agent %q blocked_content replace is empty; use clear to mean 'block no categories' (empty replace is never a silent no-op)", name),
+			})
+			return
+		}
+		next := append([]string(nil), vals...)
+		if !slices.Equal(agent.BlockedContent, next) {
+			agent.BlockedContent = next
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimReplace, Agent: name, Count: len(next)})
+		}
+	case dimClear:
+		if len(agent.BlockedContent) != 0 {
+			agent.BlockedContent = []string{}
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimClear, Agent: name, Count: 0})
+		}
+	}
+}
+
+// projectAgentScanProfileV2 projects scan_profile.
+//   - unmanaged: untouched.
+//   - replace: set exactly. The value must be a Community-valid profile (the
+//     verifier already closes this, but the projector re-checks defensively and
+//     refuses an empty replace, which would reset to the strict default and is
+//     ambiguous with clear).
+//   - clear: FORBIDDEN. clear -> "" resets scan_profile to the strict default;
+//     since a stricter-than-current profile cannot be guaranteed (e.g. current
+//     is already strict, target default is strict -> fine, but current minimal
+//     -> strict is a tightening yet current strict -> default strict is a no-op,
+//     and resetting away from a stricter explicit profile could widen), we
+//     forbid clear and require an explicit replace value. This matches the
+//     scalar-clear-widens rule.
+func projectAgentScanProfileV2(plan *PlanV2, agent *config.Agent, name string, gov *policybundle.AgentGovernanceV2, mark func(string, string) bool) {
+	mode := gov.ScanProfile.Mode
+	if mode == dimUnmanaged {
+		return
+	}
+	if !mark(name, "scan_profile") {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_scan_profile_ambiguous_selector",
+			Detail: fmt.Sprintf("agent %q scan_profile governed by more than one selector", name),
+		})
+		return
+	}
+	if unknownManagedMode(plan, name, "scan_profile", mode) {
+		return
+	}
+	switch mode {
+	case dimReplace:
+		v := gov.ScanProfile.Value
+		switch v {
+		case config.ScanProfileStrict, config.ScanProfileContentAware, config.ScanProfileMinimal:
+			// ok
+		default:
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_scan_profile_invalid",
+				Detail: fmt.Sprintf("agent %q scan_profile replace value %q is not a Community profile (strict|content-aware|minimal); empty is not allowed under replace", name, v),
+			})
+			return
+		}
+		if agent.ScanProfile != v {
+			agent.ScanProfile = v
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_scan_profile", DimMode: dimReplace, Agent: name, Value: v})
+		}
+	case dimClear:
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_scan_profile_clear_unsupported",
+			Detail: fmt.Sprintf("agent %q scan_profile clear resets to the default profile and may widen scanning posture; use replace with an explicit value", name),
+		})
+	}
+}
+
+func ensureEgress(agent *config.Agent) {
+	if agent.Egress == nil {
+		agent.Egress = &config.EgressPolicy{}
+	}
+}
+
+// egressAdditiveWideners returns the domains an additive egress source (the
+// global forward_proxy allowlist or the agent's integration presets) would
+// still permit but the bundle's replace allowlist excludes, after accounting
+// for deny lists (blocked wins over allowed at runtime). An empty result means
+// the bundle's allowlist faithfully restricts the agent. A non-empty agent
+// egress.scope is itself an additive source the projector cannot reason about,
+// so it is reported as a single opaque widener "(scope)". This mirrors v1's
+// agent_egress_allowed_not_restrictable check.
+func egressAdditiveWideners(target *config.Config, agent *config.Agent, eg policybundle.DimAgentEgressV2) []string {
+	policySet := make(map[string]struct{}, len(eg.AllowedDomains))
+	for _, d := range eg.AllowedDomains {
+		policySet[d] = struct{}{}
+	}
+	// Effective deny set = bundle denied ∪ global blocked. A denied domain is
+	// blocked regardless of any additive allow, so it is not a widener.
+	denySet := make(map[string]struct{})
+	for _, d := range target.ForwardProxy.BlockedDomains {
+		denySet[d] = struct{}{}
+	}
+	for _, d := range eg.BlockedDomains {
+		denySet[d] = struct{}{}
+	}
+
+	var additive []string
+	additive = append(additive, target.ForwardProxy.AllowedDomains...)
+	if agent.Egress != nil && len(agent.Egress.Integrations) > 0 {
+		additive = append(additive, config.ResolveIntegrationDomains(agent.Egress.Integrations)...)
+	}
+
+	var outside []string
+	seen := map[string]struct{}{}
+	for _, d := range additive {
+		if _, ok := policySet[d]; ok {
+			continue // within the policy allowlist
+		}
+		if _, denied := denySet[d]; denied {
+			continue // blocked wins
+		}
+		if _, dup := seen[d]; dup {
+			continue
+		}
+		seen[d] = struct{}{}
+		outside = append(outside, d)
+	}
+	// A pre-existing agent egress.scope opens internal/named domains the
+	// projector cannot enumerate; treat it as a widener so a governed restrict
+	// fails closed rather than silently leaving the scope in place.
+	if agent.Egress != nil && agent.Egress.Scope != "" {
+		outside = append(outside, "(scope)")
+	}
+	// A pre-existing per-tool egress.tool_restrictions entry bypasses the
+	// resolved AllowedDomains (the runtime checks ToolDomainAllowed separately),
+	// so a restrict that only rewrites allowed_domains leaves those tool-scoped
+	// domains reachable. The projector does not rewrite tool_restrictions, so
+	// treat any existing entry as a widener and fail closed.
+	if agent.Egress != nil && len(agent.Egress.ToolRestrictions) > 0 {
+		outside = append(outside, "(tool_restrictions)")
+	}
+	// Pre-existing scan overrides and blocked categories on the agent are part of
+	// its egress posture that the projector does NOT rewrite when it governs only
+	// the domain lists. Leaving them in place means the projected egress policy is
+	// a mix of the signed domain lists and stale local fields, so the result is
+	// not faithfully the signed egress dimension. Fail closed when any are present
+	// so the operator removes them first rather than getting a partial projection.
+	if agent.Egress != nil {
+		if agent.Egress.ScanRequests != nil || agent.Egress.ScanResponses != nil {
+			outside = append(outside, "(scan_overrides)")
+		}
+		if len(agent.Egress.BlockedCategories) > 0 {
+			outside = append(outside, "(blocked_categories)")
+		}
+		if agent.Egress.RateLimit != 0 || agent.Egress.RateWindow != 0 {
+			outside = append(outside, "(rate_limit)")
+		}
+	}
+	return outside
+}
+
+// matchAgents resolves a selector to config agent names. The verifier
+// (validatePolicySchemaV2) already requires selector.name to be non-empty for
+// every governance entry, so the production apply path never sees a label-only
+// selector; this projector enforces the same contract defensively. A name
+// selector is an exact match and the agent MUST exist (ErrMissingAgent
+// otherwise, mirroring v1). When labels are also present, the named agent must
+// additionally carry every label (label k=v matches a config Tags entry "k=v",
+// or a bare tag "k" when v is empty); a named agent that lacks a required label
+// matches nothing (not an error). A label-only selector (empty name) is itself
+// unsupported and reported, never silently treated as "match all".
+func matchAgents(plan *PlanV2, cfg *config.Config, sel policybundle.SelectorV2) ([]string, error) {
+	if sel.Name == "" {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_selector_name_required",
+			Detail: "a governance selector with no name is not supported by Community apply; name the agent the entry governs (labels narrow a named selector)",
+		})
+		return nil, nil
+	}
+	agent, ok := cfg.Agents[sel.Name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrMissingAgent, sel.Name)
+	}
+	if !agentHasLabels(agent, sel.Labels) {
+		// Named agent that does not carry the required labels matches nothing.
+		return nil, nil
+	}
+	return []string{sel.Name}, nil
+}
+
+// agentHasLabels reports whether agent carries every required label. A label
+// "k=v" must appear verbatim in Tags, or "k" alone when the required value is
+// empty. The matching is deliberately simple and explicit.
+func agentHasLabels(agent config.Agent, labels map[string]string) bool {
+	if len(labels) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(agent.Tags))
+	for _, t := range agent.Tags {
+		have[t] = struct{}{}
+	}
+	for k, v := range labels {
+		want := k
+		if v != "" {
+			want = k + "=" + v
+		}
+		if _, ok := have[want]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -176,10 +176,11 @@ func DryRunV2(verified *policybundle.VerifiedBundleV2, cfg *config.Config, nodeI
 	// from this apply context (DryRunV2 takes only the loaded config). The
 	// observed-inventory collision check therefore belongs where that inventory is
 	// available (the gateway / runtime, which actually sees backend tool names).
-	// TODO(9A.x): when the apply path gains access to the observed tool inventory,
-	// extend collideToolSentinel to also scan it. The hard deny-all representation
-	// (a runtime-recognized flag, not a sentinel tool name) is a separate
-	// gateway-enforcement follow-up, out of scope for 9A.2.
+	// That runtime guarantee is now enforced: the gateway and stdio proxy
+	// special-case config.DenyAllToolsSentinel BEFORE name matching so the sentinel
+	// can never execute as a tool, and gateway discovery excludes any backend tool
+	// that uses the reserved name. This apply-time check is the LOCAL-config half;
+	// the runtime is the inventory half.
 	if where := collideToolSentinel(target); where != "" {
 		return nil, fmt.Errorf("%w: a real tool in the local config uses the reserved deny-all sentinel name %q (%s); rename that tool before applying a policy",
 			ErrUnsupported, denyAllToolsSentinel, where)

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -230,10 +230,14 @@ func failClosedIfManaged(plan *PlanV2, kind, mode, detail string) {
 
 // projectRulesV2 projects the global rules dimension. unmanaged leaves rules
 // untouched. replace governs the enabled/disabled/overrides exactly as v1 does
-// (reusing the same severity-default / observe / mapAction semantics). clear is
-// not a meaningful rules operation here (Community rules are active by default
-// and a config rules entry is an override) and there is no enumerated empty
-// form that does not widen, so a rules clear fails closed.
+// (reusing the same severity-default / observe / mapAction semantics) and treats
+// the bundle's named set as a HARD CLAIM over the node's governed rule set: any
+// pre-existing local rule not named by the bundle is either reaped (if it is a
+// stale policy-owned rule, marked managed_by_policy) or blocks the apply closed
+// (if its ownership is unknown, i.e. unmarked). clear is not a meaningful rules
+// operation here (Community rules are active by default and a config rules entry
+// is an override) and there is no enumerated empty form that does not widen, so
+// a rules clear fails closed.
 func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.PolicyBodyV2) {
 	switch body.Rules.Mode {
 	case dimUnmanaged:
@@ -261,10 +265,11 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 		idx[ra.ID] = i
 	}
 	// governedWritten records every rule id the bundle's signed desired set writes
-	// or marks during this replace. It is the authoritative GOVERNED set: after the
-	// upserts and resets run, any EXISTING rule still marked managed_by_policy that
-	// is NOT in this set is a prior policy-owned override the new bundle no longer
-	// declares, so it is reaped (honest replace of the governed subset).
+	// or marks during this replace (it is "named by the bundle"). It is the
+	// authoritative GOVERNED set: after the upserts and resets run, any EXISTING
+	// local rule NOT in this set is reconciled against ownership below: a stale
+	// policy-owned (marked) rule is reaped, an unmarked rule of unknown ownership
+	// fails the apply closed.
 	governedWritten := map[string]struct{}{}
 	// upsert writes (or updates) a rule id to action and marks it
 	// managed_by_policy: this rule is now owned by the signed policy. It records the
@@ -350,22 +355,46 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 		upsert(id, "ignore")
 	}
 
-	// Honest replace of the GOVERNED set: a rule that a PRIOR policy apply marked
-	// managed_by_policy but which this bundle no longer declares must be reaped, so
-	// the node never enforces a policy-owned override the signed desired state has
-	// dropped. Operator-authored rules (no marker) are PRESERVED, never touched. v1
-	// apply never writes the marker, so a rule v1 wrote is operator-authored from
-	// v2's perspective and is safely preserved here (v2 only reaps what v2 marked).
+	// Honest replace of the GOVERNED rule set, fail closed on unknown ownership.
+	// A v2 replace is a HARD CLAIM that the node's governed rule set equals the
+	// signed set. So for every EXISTING local rule not named by this bundle:
+	//   - marked managed_by_policy -> it is a stale policy-owned override the new
+	//     bundle no longer declares; REAP it (reset to severity default).
+	//   - NOT marked (unknown ownership) -> we cannot prove it is policy-owned and
+	//     we will not silently keep it (that would leave the node above the signed
+	//     set) nor blindly delete it (that would destroy operator config). FAIL
+	//     CLOSED: record an unsupported entry naming the rule so the apply refuses
+	//     with no config write and no state advance. The operator reconciles by
+	//     naming the rule in the policy or removing it locally first.
+	// v1 apply never writes the marker, so a rule v1 wrote is unmarked and BLOCKS
+	// under v2 replace as unknown ownership; that is the correct, safe behavior.
+	// We only ever REMOVE rules that carry the marker, so operator-authored config
+	// can never be deleted by a policy apply: unknown rules block, never vanish.
 	// Collect ids first (reaping mutates target.Rules / idx) and process them in a
-	// deterministic order so the plan is stable.
+	// deterministic order so the plan and any error are stable.
 	var reap []string
+	var unowned []string
 	for id, i := range idx {
 		if _, kept := governedWritten[id]; kept {
 			continue
 		}
 		if target.Rules[i].ManagedByPolicy {
 			reap = append(reap, id)
+		} else {
+			unowned = append(unowned, id)
 		}
+	}
+	if len(unowned) > 0 {
+		sort.Strings(unowned)
+		for _, id := range unowned {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "rules_replace_unowned_local_rule",
+				Detail: fmt.Sprintf("rule %q is a local rule of unknown ownership (not named by the bundle and not marked managed_by_policy); a v2 rules replace claims the node's governed rule set equals the signed set, so it fails closed rather than silently keep or delete it; name %q in the policy or remove it locally first", id, id),
+			})
+		}
+		// Do not reap when we are failing closed: a fail-closed apply writes
+		// nothing, so the projection must not mutate the rule set either.
+		return
 	}
 	sort.Strings(reap)
 	for _, id := range reap {
@@ -530,8 +559,10 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 // value containing it is refused on every path (see projectAgentAllowedToolsV2),
 // and a real tool in the local config carrying it fails the apply closed (see
 // collideToolSentinel), so the sentinel can never be a real tool and the clear
-// (deny-all) form can never be defeated.
-const denyAllToolsSentinel = "__oktsec_deny_all__"
+// (deny-all) form can never be defeated. The canonical name lives in
+// internal/config so the runtime enforcement (gateway + stdio proxy) and
+// discovery rejection share one source of truth with the apply projector.
+const denyAllToolsSentinel = config.DenyAllToolsSentinel
 
 // collideToolSentinel returns a non-empty location description when a REAL tool
 // name in the local config equals the reserved deny-all sentinel. The only tool

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -157,6 +157,34 @@ func DryRunV2(verified *policybundle.VerifiedBundleV2, cfg *config.Config, nodeI
 		return nil, err
 	}
 
+	// --- Deny-all sentinel collision (FIX 2, fail closed). The deny-all form for
+	// allowed_tools is the reserved sentinel name denyAllToolsSentinel written into
+	// the agent's allowlist (Community reads an empty allowlist as "all tools", so
+	// zero access must be a non-empty list that matches no real tool). That only
+	// works if no REAL tool is ever named denyAllToolsSentinel. If a real tool in
+	// the local config carries that name, a deny-all (clear) would still allow it,
+	// silently defeating the zero-access representation. So if ANY real tool name in
+	// the local config (an agent's existing allowed_tools, or the global gateway
+	// allow/deny lists) equals the sentinel, refuse the whole apply with a visible
+	// fail-closed error rather than risk a silent deny-all bypass.
+	//
+	// The bundle-side reservation (a bundle value that contains the sentinel is
+	// refused on ALL paths, replace and otherwise) lives in the per-dimension
+	// projectors below; this is the LOCAL-config / inventory half.
+	//
+	// Observed inventory: a node snapshot's observed tool inventory is NOT reachable
+	// from this apply context (DryRunV2 takes only the loaded config). The
+	// observed-inventory collision check therefore belongs where that inventory is
+	// available (the gateway / runtime, which actually sees backend tool names).
+	// TODO(9A.x): when the apply path gains access to the observed tool inventory,
+	// extend collideToolSentinel to also scan it. The hard deny-all representation
+	// (a runtime-recognized flag, not a sentinel tool name) is a separate
+	// gateway-enforcement follow-up, out of scope for 9A.2.
+	if where := collideToolSentinel(target); where != "" {
+		return nil, fmt.Errorf("%w: a real tool in the local config uses the reserved deny-all sentinel name %q (%s); rename that tool before applying a policy",
+			ErrUnsupported, denyAllToolsSentinel, where)
+	}
+
 	// --- Body-level dimensions that are NOT projected in this PR fail closed
 	// when governed. unmanaged is the only "not governed" meaning. ---
 	projectRulesV2(plan, target, body)
@@ -232,22 +260,38 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 	for i, ra := range target.Rules {
 		idx[ra.ID] = i
 	}
+	// governedWritten records every rule id the bundle's signed desired set writes
+	// or marks during this replace. It is the authoritative GOVERNED set: after the
+	// upserts and resets run, any EXISTING rule still marked managed_by_policy that
+	// is NOT in this set is a prior policy-owned override the new bundle no longer
+	// declares, so it is reaped (honest replace of the governed subset).
+	governedWritten := map[string]struct{}{}
+	// upsert writes (or updates) a rule id to action and marks it
+	// managed_by_policy: this rule is now owned by the signed policy. It records the
+	// id in governedWritten so the reap step never removes a rule the bundle just
+	// declared.
 	upsert := func(id, action string) {
+		governedWritten[id] = struct{}{}
 		if i, ok := idx[id]; ok {
 			scoped := len(target.Rules[i].ApplyToTools) > 0 || len(target.Rules[i].ExemptTools) > 0
-			if target.Rules[i].Action == action && !scoped {
+			if target.Rules[i].Action == action && !scoped && target.Rules[i].ManagedByPolicy {
 				return
 			}
 			target.Rules[i].Action = action
 			target.Rules[i].ApplyToTools = nil
 			target.Rules[i].ExemptTools = nil
+			target.Rules[i].ManagedByPolicy = true
 		} else {
-			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
+			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action, ManagedByPolicy: true})
 			idx[id] = len(target.Rules) - 1
 		}
 		plan.Changes = append(plan.Changes, ChangeV2{Kind: "rule_override", DimMode: dimReplace, ID: id, Action: action})
 	}
+	// resetToDefault removes a rule override so the rule runs at its severity
+	// default. The id is still part of the governed set (the bundle enabled it with
+	// no override), so it is recorded in governedWritten and never reaped.
 	resetToDefault := func(id string) {
+		governedWritten[id] = struct{}{}
 		i, ok := idx[id]
 		if !ok {
 			return
@@ -304,6 +348,37 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 	sort.Strings(disabled)
 	for _, id := range disabled {
 		upsert(id, "ignore")
+	}
+
+	// Honest replace of the GOVERNED set: a rule that a PRIOR policy apply marked
+	// managed_by_policy but which this bundle no longer declares must be reaped, so
+	// the node never enforces a policy-owned override the signed desired state has
+	// dropped. Operator-authored rules (no marker) are PRESERVED, never touched. v1
+	// apply never writes the marker, so a rule v1 wrote is operator-authored from
+	// v2's perspective and is safely preserved here (v2 only reaps what v2 marked).
+	// Collect ids first (reaping mutates target.Rules / idx) and process them in a
+	// deterministic order so the plan is stable.
+	var reap []string
+	for id, i := range idx {
+		if _, kept := governedWritten[id]; kept {
+			continue
+		}
+		if target.Rules[i].ManagedByPolicy {
+			reap = append(reap, id)
+		}
+	}
+	sort.Strings(reap)
+	for _, id := range reap {
+		i, ok := idx[id]
+		if !ok {
+			continue
+		}
+		target.Rules = append(target.Rules[:i], target.Rules[i+1:]...)
+		delete(idx, id)
+		for j := i; j < len(target.Rules); j++ {
+			idx[target.Rules[j].ID] = j
+		}
+		plan.Changes = append(plan.Changes, ChangeV2{Kind: "rule_reset_default", DimMode: dimReplace, ID: id})
 	}
 }
 
@@ -409,6 +484,19 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 	if badMode := unknownManagedMode(plan, name, "allowed_tools", mode); badMode {
 		return
 	}
+	// The deny-all sentinel name is RESERVED on EVERY path, not just replace: any
+	// bundle allowed_tools value that contains it is refused (unsupported),
+	// regardless of mode. A bundle could otherwise smuggle "deny-all" through a
+	// non-clear path, or (under replace) defeat a later clear comparison. clear
+	// carries no bundle values, so this guard is a no-op there, but checking
+	// unconditionally keeps the reservation total and future-proof.
+	if slices.Contains(gov.AllowedTools.Values, denyAllToolsSentinel) {
+		plan.Unsupported = append(plan.Unsupported, Unsupported{
+			Kind:   "agent_allowed_tools_reserved_value",
+			Detail: fmt.Sprintf("agent %q allowed_tools value contains the reserved deny-all sentinel %q; use clear for deny-all", name, denyAllToolsSentinel),
+		})
+		return
+	}
 	switch mode {
 	case dimReplace:
 		vals := gov.AllowedTools.Values
@@ -416,16 +504,6 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 			plan.Unsupported = append(plan.Unsupported, Unsupported{
 				Kind:   "agent_allowed_tools_empty_replace",
 				Detail: fmt.Sprintf("agent %q allowed_tools replace has an empty value, which Community reads as 'all tools' (a widen); use clear for deny-all", name),
-			})
-			return
-		}
-		// The deny-all sentinel is reserved for the clear form; a replace value
-		// must never contain it, or a bundle could smuggle "deny-all" through
-		// replace (or, conversely, defeat a later clear comparison). Refuse it.
-		if slices.Contains(vals, denyAllToolsSentinel) {
-			plan.Unsupported = append(plan.Unsupported, Unsupported{
-				Kind:   "agent_allowed_tools_reserved_value",
-				Detail: fmt.Sprintf("agent %q allowed_tools replace contains the reserved deny-all sentinel %q; use clear for deny-all", name, denyAllToolsSentinel),
 			})
 			return
 		}
@@ -448,10 +526,35 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 
 // denyAllToolsSentinel is the genuine zero-access allowlist value. Community
 // treats an empty allowlist as "all tools allowed", so deny-all must be a
-// non-empty list that matches no real tool. This name is RESERVED: a replace
-// value containing it is refused (see projectAgentAllowedToolsV2), so a real
-// tool can never carry it and the clear form can never be defeated.
+// non-empty list that matches no real tool. This name is RESERVED: a bundle
+// value containing it is refused on every path (see projectAgentAllowedToolsV2),
+// and a real tool in the local config carrying it fails the apply closed (see
+// collideToolSentinel), so the sentinel can never be a real tool and the clear
+// (deny-all) form can never be defeated.
 const denyAllToolsSentinel = "__oktsec_deny_all__"
+
+// collideToolSentinel returns a non-empty location description when any REAL tool
+// name in the local config equals the reserved deny-all sentinel. The only tool
+// names the config itself can express are each agent's allowed_tools (the gateway
+// has no static tool list in config: it discovers backend tool names at runtime,
+// which is the observed-inventory check that lives in the gateway, not here). A
+// collision means the sentinel-based deny-all form would not actually deny that
+// tool, so the caller fails the apply closed rather than risk a silent deny-all
+// bypass. Agents are scanned in sorted order so the reported location is
+// deterministic.
+func collideToolSentinel(cfg *config.Config) string {
+	names := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if slices.Contains(cfg.Agents[name].AllowedTools, denyAllToolsSentinel) {
+			return fmt.Sprintf("agent %q allowed_tools", name)
+		}
+	}
+	return ""
+}
 
 // projectAgentEgressV2 projects the per-agent egress allowed/blocked domains.
 // Only those two fields are implemented; any OTHER governed egress field (scope,

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -86,14 +86,14 @@ func (p *PlanV2) Projected() *config.Config { return p.projected }
 // Change with an explicit DimMode label so the operator sees intent (REPLACE vs
 // CLEAR) in the plan, which the spec requires for v2.
 type ChangeV2 struct {
-	Kind     string `json:"kind"`
-	DimMode  string `json:"dim_mode"`        // replace | clear (unmanaged never emits a change)
-	ID       string `json:"id,omitempty"`    // rule id
-	Action   string `json:"action,omitempty"`
-	Agent    string `json:"agent,omitempty"`
-	Count    int    `json:"count,omitempty"` // list cardinality after the change
-	Value    string `json:"value,omitempty"` // scalar value (scan_profile)
-	BoolValue bool  `json:"bool_value,omitempty"` // scalar bool (suspended)
+	Kind      string `json:"kind"`
+	DimMode   string `json:"dim_mode"`     // replace | clear (unmanaged never emits a change)
+	ID        string `json:"id,omitempty"` // rule id
+	Action    string `json:"action,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Count     int    `json:"count,omitempty"`      // list cardinality after the change
+	Value     string `json:"value,omitempty"`      // scalar value (scan_profile)
+	BoolValue bool   `json:"bool_value,omitempty"` // scalar bool (suspended)
 }
 
 // DryRunV2 projects a verified v2 bundle onto a copy of cfg. nodeID is the local
@@ -265,6 +265,50 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 	for i, ra := range target.Rules {
 		idx[ra.ID] = i
 	}
+
+	// PREFLIGHT: fail closed on unknown-ownership rules BEFORE any mutation.
+	// A v2 replace is a HARD CLAIM that the node's governed rule set equals the
+	// signed set, named by the bundle (enabled + overrides keys + disabled). Any
+	// EXISTING local rule NOT named and NOT marked managed_by_policy is of unknown
+	// provenance: we will not silently keep it (that would leave the node above the
+	// signed set) nor blindly delete it (that would destroy operator config). We
+	// detect this BEFORE running any upsert/reset so a fail-closed apply leaves the
+	// projection byte-unchanged (no partial mutation in plan.Projected or
+	// plan.Changes) and DryRunV2 returns ErrUnsupported with no state advance.
+	// v1 apply never writes the marker, so a rule v1 wrote is unmarked and BLOCKS
+	// here; that is the correct, safe behavior. The operator reconciles by naming
+	// the rule in the policy or removing it locally first.
+	named := make(map[string]struct{}, len(body.Rules.Enabled)+len(body.Rules.Overrides)+len(body.Rules.Disabled))
+	for _, id := range body.Rules.Enabled {
+		named[id] = struct{}{}
+	}
+	for id := range body.Rules.Overrides {
+		named[id] = struct{}{}
+	}
+	for _, id := range body.Rules.Disabled {
+		named[id] = struct{}{}
+	}
+	var unowned []string
+	for _, ra := range target.Rules {
+		if _, ok := named[ra.ID]; ok {
+			continue
+		}
+		if !ra.ManagedByPolicy {
+			unowned = append(unowned, ra.ID)
+		}
+	}
+	if len(unowned) > 0 {
+		sort.Strings(unowned)
+		for _, id := range unowned {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "rules_replace_unowned_local_rule",
+				Detail: fmt.Sprintf("rule %q is a local rule of unknown ownership (not named by the bundle and not marked managed_by_policy); a v2 rules replace claims the node's governed rule set equals the signed set, so it fails closed rather than silently keep or delete it; name %q in the policy or remove it locally first", id, id),
+			})
+		}
+		// Fail closed without mutating the projection: no upsert, no reap.
+		return
+	}
+
 	// governedWritten records every rule id the bundle's signed desired set writes
 	// or marks during this replace (it is "named by the bundle"). It is the
 	// authoritative GOVERNED set: after the upserts and resets run, any EXISTING
@@ -356,46 +400,22 @@ func projectRulesV2(plan *PlanV2, target *config.Config, body policybundle.Polic
 		upsert(id, "ignore")
 	}
 
-	// Honest replace of the GOVERNED rule set, fail closed on unknown ownership.
-	// A v2 replace is a HARD CLAIM that the node's governed rule set equals the
-	// signed set. So for every EXISTING local rule not named by this bundle:
-	//   - marked managed_by_policy -> it is a stale policy-owned override the new
-	//     bundle no longer declares; REAP it (reset to severity default).
-	//   - NOT marked (unknown ownership) -> we cannot prove it is policy-owned and
-	//     we will not silently keep it (that would leave the node above the signed
-	//     set) nor blindly delete it (that would destroy operator config). FAIL
-	//     CLOSED: record an unsupported entry naming the rule so the apply refuses
-	//     with no config write and no state advance. The operator reconciles by
-	//     naming the rule in the policy or removing it locally first.
-	// v1 apply never writes the marker, so a rule v1 wrote is unmarked and BLOCKS
-	// under v2 replace as unknown ownership; that is the correct, safe behavior.
-	// We only ever REMOVE rules that carry the marker, so operator-authored config
-	// can never be deleted by a policy apply: unknown rules block, never vanish.
-	// Collect ids first (reaping mutates target.Rules / idx) and process them in a
-	// deterministic order so the plan and any error are stable.
+	// Reap stale policy-owned rules. The preflight above already failed closed on
+	// any unmarked local rule the bundle does not name, so every EXISTING local
+	// rule still not in governedWritten here is one a PRIOR policy apply marked
+	// managed_by_policy that this bundle no longer declares: reap it (reset to
+	// severity default) so the node converges exactly to the signed governed set.
+	// We only ever REMOVE rules carrying the marker, so operator-authored config is
+	// never deleted by a policy apply. Collect ids first (reaping mutates
+	// target.Rules / idx) and process them in deterministic order for a stable plan.
 	var reap []string
-	var unowned []string
 	for id, i := range idx {
 		if _, kept := governedWritten[id]; kept {
 			continue
 		}
 		if target.Rules[i].ManagedByPolicy {
 			reap = append(reap, id)
-		} else {
-			unowned = append(unowned, id)
 		}
-	}
-	if len(unowned) > 0 {
-		sort.Strings(unowned)
-		for _, id := range unowned {
-			plan.Unsupported = append(plan.Unsupported, Unsupported{
-				Kind:   "rules_replace_unowned_local_rule",
-				Detail: fmt.Sprintf("rule %q is a local rule of unknown ownership (not named by the bundle and not marked managed_by_policy); a v2 rules replace claims the node's governed rule set equals the signed set, so it fails closed rather than silently keep or delete it; name %q in the policy or remove it locally first", id, id),
-			})
-		}
-		// Do not reap when we are failing closed: a fail-closed apply writes
-		// nothing, so the projection must not mutate the rule set either.
-		return
 	}
 	sort.Strings(reap)
 	for _, id := range reap {

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -86,15 +86,25 @@ func (p *PlanV2) Projected() *config.Config { return p.projected }
 // Change with an explicit DimMode label so the operator sees intent (REPLACE vs
 // CLEAR) in the plan, which the spec requires for v2.
 type ChangeV2 struct {
-	Kind      string `json:"kind"`
-	DimMode   string `json:"dim_mode"`     // replace | clear (unmanaged never emits a change)
-	ID        string `json:"id,omitempty"` // rule id
-	Action    string `json:"action,omitempty"`
-	Agent     string `json:"agent,omitempty"`
-	Count     int    `json:"count,omitempty"`      // list cardinality after the change
+	Kind    string `json:"kind"`
+	DimMode string `json:"dim_mode"`     // replace | clear (unmanaged never emits a change)
+	ID      string `json:"id,omitempty"` // rule id
+	Action  string `json:"action,omitempty"`
+	Agent   string `json:"agent,omitempty"`
+	// Count and BoolValue are POINTERS so an explicit, meaningful zero/false is
+	// always emitted in --json (a clear-to-0 list, or an unsuspend to false),
+	// while staying ABSENT (nil) on change kinds where they do not apply. A plain
+	// int/bool with omitempty would hide a real 0/false from automation; without
+	// omitempty it would emit a spurious 0/false on unrelated change kinds.
+	Count     *int   `json:"count,omitempty"`      // list cardinality after the change
 	Value     string `json:"value,omitempty"`      // scalar value (scan_profile)
-	BoolValue bool   `json:"bool_value,omitempty"` // scalar bool (suspended)
+	BoolValue *bool  `json:"bool_value,omitempty"` // scalar bool (suspended)
 }
+
+// intVal and boolVal wrap an explicit count/bool so the value is always emitted
+// in --json (even 0/false), distinguishing an explicit value from an absent one.
+func intVal(n int) *int    { return &n }
+func boolVal(b bool) *bool { return &b }
 
 // DryRunV2 projects a verified v2 bundle onto a copy of cfg. nodeID is the local
 // node identity used for target binding (required when the bundle is node
@@ -560,7 +570,7 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 		next := append([]string(nil), vals...)
 		if !slices.Equal(agent.AllowedTools, next) {
 			agent.AllowedTools = next
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimReplace, Agent: name, Count: len(next)})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimReplace, Agent: name, Count: intVal(len(next))})
 		}
 	case dimClear:
 		// Genuine zero-access form: a single sentinel that matches no real tool.
@@ -569,7 +579,7 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 		zero := []string{denyAllToolsSentinel}
 		if !slices.Equal(agent.AllowedTools, zero) {
 			agent.AllowedTools = zero
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimClear, Agent: name, Count: 0})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_allowed_tools", DimMode: dimClear, Agent: name, Count: intVal(0)})
 		}
 	}
 }
@@ -695,12 +705,12 @@ func projectAgentEgressV2(plan *PlanV2, target *config.Config, agent *config.Age
 		ensureEgress(agent)
 		if !slices.Equal(agent.Egress.AllowedDomains, eg.AllowedDomains) {
 			agent.Egress.AllowedDomains = append([]string(nil), eg.AllowedDomains...)
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimReplace, Agent: name, Count: len(eg.AllowedDomains)})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimReplace, Agent: name, Count: intVal(len(eg.AllowedDomains))})
 		}
 		// blocked under replace is additive-faithful (deny is monotonic).
 		if !slices.Equal(agent.Egress.BlockedDomains, eg.BlockedDomains) {
 			agent.Egress.BlockedDomains = append([]string(nil), eg.BlockedDomains...)
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_denied_domains", DimMode: dimReplace, Agent: name, Count: len(eg.BlockedDomains)})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_denied_domains", DimMode: dimReplace, Agent: name, Count: intVal(len(eg.BlockedDomains))})
 		}
 	case dimClear:
 		// Zero egress: setting the agent's allowed_domains to the sentinel only
@@ -726,7 +736,7 @@ func projectAgentEgressV2(plan *PlanV2, target *config.Config, agent *config.Age
 		if !slices.Equal(agent.Egress.AllowedDomains, zero) || len(agent.Egress.BlockedDomains) != 0 {
 			agent.Egress.AllowedDomains = zero
 			agent.Egress.BlockedDomains = nil
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimClear, Agent: name, Count: 0})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_egress_allowed_domains", DimMode: dimClear, Agent: name, Count: intVal(0)})
 		}
 	}
 }
@@ -760,7 +770,7 @@ func projectAgentSuspendedV2(plan *PlanV2, agent *config.Agent, name string, gov
 	case dimReplace:
 		if agent.Suspended != gov.Suspended.Value {
 			agent.Suspended = gov.Suspended.Value
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_suspended", DimMode: dimReplace, Agent: name, BoolValue: gov.Suspended.Value})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_suspended", DimMode: dimReplace, Agent: name, BoolValue: boolVal(gov.Suspended.Value)})
 		}
 	case dimClear:
 		plan.Unsupported = append(plan.Unsupported, Unsupported{
@@ -804,12 +814,12 @@ func projectAgentBlockedContentV2(plan *PlanV2, agent *config.Agent, name string
 		next := append([]string(nil), vals...)
 		if !slices.Equal(agent.BlockedContent, next) {
 			agent.BlockedContent = next
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimReplace, Agent: name, Count: len(next)})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimReplace, Agent: name, Count: intVal(len(next))})
 		}
 	case dimClear:
 		if len(agent.BlockedContent) != 0 {
 			agent.BlockedContent = []string{}
-			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimClear, Agent: name, Count: 0})
+			plan.Changes = append(plan.Changes, ChangeV2{Kind: "agent_blocked_content", DimMode: dimClear, Agent: name, Count: intVal(0)})
 		}
 	}
 }

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -533,15 +533,23 @@ func projectAgentAllowedToolsV2(plan *PlanV2, agent *config.Agent, name string, 
 // (deny-all) form can never be defeated.
 const denyAllToolsSentinel = "__oktsec_deny_all__"
 
-// collideToolSentinel returns a non-empty location description when any REAL tool
+// collideToolSentinel returns a non-empty location description when a REAL tool
 // name in the local config equals the reserved deny-all sentinel. The only tool
 // names the config itself can express are each agent's allowed_tools (the gateway
 // has no static tool list in config: it discovers backend tool names at runtime,
 // which is the observed-inventory check that lives in the gateway, not here). A
 // collision means the sentinel-based deny-all form would not actually deny that
 // tool, so the caller fails the apply closed rather than risk a silent deny-all
-// bypass. Agents are scanned in sorted order so the reported location is
-// deterministic.
+// bypass.
+//
+// The CANONICAL deny-all form an apply itself writes is an allowlist of EXACTLY
+// the lone sentinel ([sentinel]); that is the zero-access representation, not a
+// real tool, so it is NOT a collision. Treating it as one would make a clear
+// non-idempotent (reapplying the same deny-all bundle, or any later v2 apply,
+// would be refused because the config it produced still carries the sentinel). A
+// genuine collision is the sentinel appearing ALONGSIDE other tool names: an
+// allowlist where the sentinel is present but the list is not exactly [sentinel].
+// Agents are scanned in sorted order so the reported location is deterministic.
 func collideToolSentinel(cfg *config.Config) string {
 	names := make([]string, 0, len(cfg.Agents))
 	for name := range cfg.Agents {
@@ -549,9 +557,15 @@ func collideToolSentinel(cfg *config.Config) string {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		if slices.Contains(cfg.Agents[name].AllowedTools, denyAllToolsSentinel) {
-			return fmt.Sprintf("agent %q allowed_tools", name)
+		tools := cfg.Agents[name].AllowedTools
+		if !slices.Contains(tools, denyAllToolsSentinel) {
+			continue
 		}
+		// Lone sentinel == the canonical deny-all form this apply writes; allowed.
+		if len(tools) == 1 {
+			continue
+		}
+		return fmt.Sprintf("agent %q allowed_tools", name)
 	}
 	return ""
 }

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -1073,14 +1073,13 @@ func TestV2_RulesReplaceDroppedOverrideDisappears(t *testing.T) {
 // seeded with an operator-authored rule (OPER-1, no marker) so we prove operator
 // config is preserved through the real write path, not just in memory.
 func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
+	// Reuse the proven-stable origConfigYAML fixture (identical to the reliable
+	// CommitV2 test) but with an operator-authored rule instead of an empty rules
+	// list, so the round-trip proves operator config survives the real write path.
+	seeded := strings.Replace(origConfigYAML, "rules: []\n",
+		"rules:\n  - id: OPER-1\n    action: quarantine\n    severity: high\n", 1)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "oktsec.yaml")
-	const seeded = "# operator config\n" +
-		"server:\n  port: 8080\n" +
-		"identity:\n  require_signature: false\n" +
-		"agents:\n  voice-ai:\n    can_message: []\n    blocked_content: []\n" +
-		"rules:\n" +
-		"  - id: OPER-1\n    action: quarantine\n    severity: high\n"
 	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
 		t.Fatalf("seed config: %v", err)
 	}
@@ -1119,16 +1118,9 @@ func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
 // NOT refused as a sentinel collision (the lone sentinel is the canonical
 // deny-all form, not a real tool).
 func TestV2_DenyAllClearIsIdempotentAcrossApplies(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "oktsec.yaml")
-	const seeded = "# operator config\n" +
-		"server:\n  port: 8080\n" +
-		"identity:\n  require_signature: false\n" +
-		"agents:\n  voice-ai:\n    can_message: []\n    blocked_content: []\n    allowed_tools: [old.tool]\n" +
-		"rules: []\n"
-	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
-		t.Fatalf("seed config: %v", err)
-	}
+	// origConfigYAML already carries voice-ai with allowed_tools: [old.tool], the
+	// reliable fixture the other CommitV2 tests use.
+	path := writeOrigConfig(t, 0o600)
 	// First apply: clear -> lone sentinel written.
 	b := bodyV2()
 	g := agentGovV2("voice-ai")

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -999,24 +999,93 @@ func TestV2_RulesReplaceReapsStalePolicyOwnedRule(t *testing.T) {
 	}
 }
 
-// FIX 1 test 2: replace with an OPERATOR-AUTHORED rule (unmarked) absent from the
-// bundle -> it is PRESERVED, never touched.
-func TestV2_RulesReplacePreservesOperatorAuthoredRule(t *testing.T) {
+// FIX 1 test 2 (architect cut): replace with a local rule of UNKNOWN ownership
+// (unmarked) absent from the bundle -> the apply FAILS CLOSED. A v2 replace is a
+// hard claim that the node's governed rule set equals the signed set, so an
+// unmarked local rule the bundle does not name blocks: no config write, no state
+// advance, and the error names the blocking rule clearly. Silent preservation is
+// no longer the contract. (This is also the first-apply reality: before any v2
+// apply no rule is marked, so a node with pre-existing local rules not in the
+// bundle fails closed on first replace until the operator reconciles.)
+func TestV2_RulesReplaceUnownedRuleFailsClosed(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Rules = []config.RuleAction{
-		{ID: "OPER-1", Action: "quarantine", Severity: "high"}, // no marker
+		{ID: "OPER-1", Action: "quarantine", Severity: "high"}, // no marker = unknown ownership
+	}
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("unowned local rule must fail closed with ErrUnsupported, got %v", err)
+	}
+	if !hasUnsupportedV2(p, "rules_replace_unowned_local_rule") {
+		t.Fatalf("expected rules_replace_unowned_local_rule unsupported, got %+v", p.Unsupported)
+	}
+	// Architect regression 5: the error names the blocking rule clearly.
+	named := false
+	for _, u := range p.Unsupported {
+		if u.Kind == "rules_replace_unowned_local_rule" && strings.Contains(u.Detail, "OPER-1") {
+			named = true
+		}
+	}
+	if !named {
+		t.Fatalf("unsupported detail must name the blocking rule OPER-1, got %+v", p.Unsupported)
+	}
+}
+
+// FIX 1 test (architect regression 4): a CLEAN replace, where every local rule
+// is either named by the bundle or marked policy-owned, leaves EXACTLY the
+// signed desired rule set (governed rules written+marked, stale policy-owned
+// rules reaped, nothing of unknown ownership left to block).
+func TestV2_RulesReplaceCleanLeavesExactlySignedSet(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Rules = []config.RuleAction{
+		// Named by the bundle (will be written+marked).
+		{ID: "IAP-003", Action: "ignore", Severity: "high", ManagedByPolicy: true},
+		// Stale policy-owned, not named -> reaped.
+		{ID: "STALE-9", Action: "ignore", Severity: "low", ManagedByPolicy: true},
+	}
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("clean replace must succeed, got %v", err)
+	}
+	got := p.Projected().Rules
+	if len(got) != 1 {
+		t.Fatalf("clean replace must leave exactly the signed set (1 rule), got %+v", got)
+	}
+	ra, ok := ruleByID(p.Projected(), "IAP-003")
+	if !ok || !ra.ManagedByPolicy || ra.Action != "block" {
+		t.Fatalf("the only remaining rule must be the signed governed rule, got %+v ok=%v", ra, ok)
+	}
+	if _, ok := ruleByID(p.Projected(), "STALE-9"); ok {
+		t.Fatalf("stale policy-owned rule must be reaped in a clean replace, rules=%+v", got)
+	}
+}
+
+// FIX 1 test (architect regression 3): a named rule replacement clears the old
+// scoped fields (apply_to_tools/exempt_tools widened to global, as the upsert
+// does), so the projected rule is exactly the signed global override.
+func TestV2_RulesReplaceClearsScopedFields(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Rules = []config.RuleAction{
+		{ID: "IAP-003", Action: "ignore", Severity: "high",
+			ApplyToTools: []string{"calendar.read"}, ExemptTools: []string{"mail.send"},
+			ManagedByPolicy: true},
 	}
 	b := rulesReplaceBody("IAP-003")
 	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
 	if err != nil {
 		t.Fatalf("DryRunV2: %v", err)
 	}
-	ra, ok := ruleByID(p.Projected(), "OPER-1")
+	ra, ok := ruleByID(p.Projected(), "IAP-003")
 	if !ok {
-		t.Fatalf("operator-authored rule must be preserved, got %+v", p.Projected().Rules)
+		t.Fatalf("named rule must be present, rules=%+v", p.Projected().Rules)
 	}
-	if ra.Action != "quarantine" || ra.ManagedByPolicy {
-		t.Fatalf("operator-authored rule must be untouched and unmarked, got %+v", ra)
+	if len(ra.ApplyToTools) != 0 || len(ra.ExemptTools) != 0 {
+		t.Fatalf("named replace must clear scoped fields (apply_to_tools/exempt_tools), got %+v", ra)
+	}
+	if ra.Action != "block" || !ra.ManagedByPolicy {
+		t.Fatalf("named replace must write the signed global override marked, got %+v", ra)
 	}
 }
 

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -1,0 +1,951 @@
+package apply
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/policybundle"
+)
+
+// verifiedV2 wraps a PolicyBodyV2 as a (pre-)verified v2 bundle; the projector
+// operates on the verified body, so no signing is needed in these unit tests.
+func verifiedV2(b policybundle.PolicyBodyV2) *policybundle.VerifiedBundleV2 {
+	return &policybundle.VerifiedBundleV2{
+		Bundle:     &policybundle.PolicyBundleV2{PolicyHash: "sha256:deadbeef", Policy: b},
+		PolicyHash: "sha256:deadbeef",
+	}
+}
+
+// bodyV2 is a canonical-shape PolicyBodyV2 with every dimension unmanaged and
+// empty containers, mutated per test. Fleet scope by default.
+func bodyV2() policybundle.PolicyBodyV2 {
+	return policybundle.PolicyBodyV2{
+		PolicyID: "voice-ai-prod", PolicyVersion: "1", Mode: ModeEnforce,
+		Assignment: policybundle.AssignmentV2{
+			AssignmentID: "asg-1",
+			Target:       policybundle.TargetV2{Scope: "fleet"},
+			IssuedAt:     "2026-05-30T12:00:00Z",
+			Sequence:     1,
+		},
+		Rules:   policybundle.DimRulesV2{Mode: dimUnmanaged, Enabled: []string{}, Disabled: []string{}, Overrides: map[string]policybundle.PolicyRuleOverride{}},
+		Gateway: policybundle.DimGatewayV2{Mode: dimUnmanaged, ToolsAllowed: []string{}, ToolsDenied: []string{}},
+		Egress:  policybundle.DimEgressV2{Mode: dimUnmanaged, DomainsAllowed: []string{}, DomainsDenied: []string{}},
+		Governance: policybundle.GovernanceV2{
+			Server: policybundle.ServerGovernanceV2{Mode: dimUnmanaged},
+			Agents: []policybundle.AgentGovernanceV2{},
+		},
+		Redaction: policybundle.DimRedactionV2{Mode: dimUnmanaged, Level: "analyst"},
+		Metadata:  policybundle.PolicyMetadata{CreatedAt: "2026-05-30T12:00:00Z", CreatedBy: "alice", Reason: "test"},
+	}
+}
+
+// agentGovV2 returns a per-agent governance entry for name with all dimensions
+// unmanaged, mutated per test.
+func agentGovV2(name string) policybundle.AgentGovernanceV2 {
+	return policybundle.AgentGovernanceV2{
+		Selector:        policybundle.SelectorV2{Name: name},
+		ACLs:            policybundle.DimACLsV2{Mode: dimUnmanaged},
+		AllowedTools:    policybundle.DimStringSetV2{Mode: dimUnmanaged, Values: []string{}},
+		ToolPolicies:    policybundle.DimToolPoliciesV2{Mode: dimUnmanaged},
+		ToolConstraints: policybundle.DimToolConstraintsV2{Mode: dimUnmanaged},
+		ToolChainRules:  policybundle.DimToolChainRulesV2{Mode: dimUnmanaged},
+		BlockedContent:  policybundle.DimStringSetV2{Mode: dimUnmanaged, Values: []string{}},
+		ScanProfile:     policybundle.DimScalarStringV2{Mode: dimUnmanaged},
+		Suspended:       policybundle.DimScalarBoolV2{Mode: dimUnmanaged},
+		Egress:          policybundle.DimAgentEgressV2{Mode: dimUnmanaged, ScanRequests: "unset", ScanResponses: "unset"},
+	}
+}
+
+func hasChangeV2(p *PlanV2, kind, agent string) *ChangeV2 {
+	for i := range p.Changes {
+		if p.Changes[i].Kind == kind && (agent == "" || p.Changes[i].Agent == agent) {
+			return &p.Changes[i]
+		}
+	}
+	return nil
+}
+
+func hasUnsupportedV2(p *PlanV2, kind string) bool {
+	for _, u := range p.Unsupported {
+		if u.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// 1. unmanaged leaves the dimension untouched (no change).
+func TestV2_UnmanagedLeavesDimensionUntouched(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai") // all unmanaged
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if len(p.Changes) != 0 {
+		t.Fatalf("unmanaged dims must produce no changes, got %+v", p.Changes)
+	}
+	if p.Projected().Agents["voice-ai"].AllowedTools[0] != "old.tool" {
+		t.Fatal("unmanaged allowed_tools must be untouched")
+	}
+}
+
+// 2. replace replaces the dimension exactly.
+func TestV2_ReplaceReplacesExactly(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read", "mail.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("replace allowed_tools = %v", va.AllowedTools)
+	}
+}
+
+// 3. clear clears the dimension exactly (gateway tools clear -> zero callable).
+// 4. deny-all gateway tools IS representable through clear and applies.
+func TestV2_ClearGatewayToolsZeroAccess(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	if len(va.AllowedTools) != 1 || va.AllowedTools[0] != denyAllToolsSentinel {
+		t.Fatalf("clear must yield the zero-access sentinel, got %v", va.AllowedTools)
+	}
+	c := hasChangeV2(p, "agent_allowed_tools", "voice-ai")
+	if c == nil || c.DimMode != dimClear {
+		t.Fatalf("clear must emit a CLEAR change, got %+v", p.Changes)
+	}
+}
+
+// 5. empty list under replace is a hard error, never a silent no-op.
+func TestV2_EmptyReplaceIsHardError(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_empty_replace") {
+		t.Fatalf("expected empty-replace unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// 6. empty list under unmanaged never interpreted as all-allowed (no change).
+func TestV2_EmptyUnmanagedNotAllAllowed(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai") // allowed_tools unmanaged with empty values
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if hasChangeV2(p, "agent_allowed_tools", "") != nil {
+		t.Fatal("unmanaged empty allowed_tools must not change anything")
+	}
+}
+
+// 7. a replace that would resolve to Community "all" -> unsupported (same as #5
+// for gateway tools; the empty-replace guard IS the widening guard here).
+func TestV2_ReplaceResolvingToAllRefused(t *testing.T) {
+	// Covered by empty-replace; assert the explicit deny-all path works while an
+	// empty replace is refused, proving deny-all only flows through clear.
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	if _, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("empty replace (would widen to all) must be unsupported, got %v", err)
+	}
+}
+
+// 8. clear rejected for scalar fields where it widens (suspended->false).
+func TestV2_SuspendedClearWidensRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimClear}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_suspended_clear_widens") {
+		t.Fatalf("expected suspended-clear unsupported, got %+v", p.Unsupported)
+	}
+}
+
+func TestV2_ScanProfileClearRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.ScanProfile = policybundle.DimScalarStringV2{Mode: dimClear}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("scan_profile clear must be unsupported, got %v", err)
+	}
+}
+
+// Suspended replace works (the safe path).
+func TestV2_SuspendedReplaceApplies(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if !p.Projected().Agents["voice-ai"].Suspended {
+		t.Fatal("suspended replace=true must set Suspended")
+	}
+}
+
+// 9. merge -> unsupported (the verifier rejects it, but the projector defends).
+func TestV2_MergeModeUnsupported(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: "merge", Values: []string{"x"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("merge mode must be unsupported, got %v", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_mode_unsupported") {
+		t.Fatalf("expected merge-mode unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// 10. selector overlap on same dimension -> unsupported before writing.
+func TestV2_SelectorOverlapSameDimUnsupported(t *testing.T) {
+	b := bodyV2()
+	g1 := agentGovV2("voice-ai")
+	g1.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"a.read"}}
+	g2 := agentGovV2("voice-ai")
+	g2.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"b.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g1, g2}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_ambiguous_selector") {
+		t.Fatalf("expected ambiguous-selector unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// 11. unsupported dimension (governed but not implemented) -> refuses.
+func TestV2_GovernedUnimplementedDimRefuses(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.ACLs = policybundle.DimACLsV2{Mode: dimReplace, AllowedRecipients: []string{"x"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_acls_unsupported") {
+		t.Fatalf("expected acls unsupported, got %+v", p.Unsupported)
+	}
+}
+
+func TestV2_GovernedServerDimRefuses(t *testing.T) {
+	b := bodyV2()
+	b.Governance.Server = policybundle.ServerGovernanceV2{Mode: dimReplace, RequireIntent: true}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("governed server dim must be unsupported, got %v", err)
+	}
+}
+
+// 12. real apply is all-or-nothing (one unsupported dim -> nothing written).
+func TestV2_RealApplyAllOrNothing(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	orig, _ := os.ReadFile(path)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read"}}
+	g.ACLs = policybundle.DimACLsV2{Mode: dimReplace, AllowedRecipients: []string{"x"}} // unsupported
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+
+	plan, perr := DryRunV2(verifiedV2(b), cfg, "", path)
+	if !errors.Is(perr, ErrUnsupported) {
+		t.Fatalf("expected ErrUnsupported, got %v", perr)
+	}
+	// A real apply must not call CommitV2 on an unsupported plan; assert that
+	// committing it is refused at the command layer is covered elsewhere. Here,
+	// directly assert the config is still untouched (we never committed).
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("config must be untouched when a dim is unsupported")
+	}
+	_ = plan
+}
+
+// 13. dry-run reports the full patch without writing.
+func TestV2_DryRunReportsWithoutWriting(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	orig, _ := os.ReadFile(path)
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", path)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if len(p.Changes) == 0 {
+		t.Fatal("dry-run must report changes")
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(orig) {
+		t.Fatal("dry-run must not write")
+	}
+}
+
+// Commit + state helpers for the rollback tests.
+func commitV2Body(t *testing.T, path string, b policybundle.PolicyBodyV2, nodeID string) *PlanV2 {
+	t.Helper()
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p, err := DryRunV2(verifiedV2(b), cfg, nodeID, path)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	return p
+}
+
+// 14 + 21. sequence advances only after success; state file is 0600 + atomic.
+func TestV2_StateAdvancesAfterSuccessAndIs0600(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	b.Assignment.Sequence = 5
+
+	plan := commitV2Body(t, path, b, "")
+	if _, err := CommitV2(plan, path); err != nil {
+		t.Fatalf("CommitV2: %v", err)
+	}
+	st, _ := LoadPolicyState(path)
+	st.Record(plan.Scope, plan.NodeID, plan.AssignmentID, "2026-05-30T00:00:00Z", plan.Sequence)
+	if err := SavePolicyState(path, st); err != nil {
+		t.Fatalf("SavePolicyState: %v", err)
+	}
+	sp := PolicyStatePath(path)
+	info, err := os.Stat(sp)
+	if err != nil {
+		t.Fatalf("stat state: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state mode = %v, want 0600", info.Mode().Perm())
+	}
+	reloaded, err := LoadPolicyState(path)
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	rec := reloaded.Targets[TargetKey("fleet", "")]
+	if rec.LastSequence != 5 || rec.LastAssignmentID != "asg-1" {
+		t.Fatalf("state not recorded: %+v", rec)
+	}
+}
+
+// 15. stale sequence (<=last, no rollback_of) -> RollbackRefuse.
+func TestV2_StaleSequenceRefused(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	st.Record("fleet", "", "asg-old", "t", 10)
+	d := st.EvaluateRollback("fleet", "", "asg-new", "", 9)
+	if d != RollbackRefuse {
+		t.Fatalf("stale sequence must refuse, got %v", d)
+	}
+	dEq := st.EvaluateRollback("fleet", "", "asg-new", "", 10)
+	if dEq != RollbackRefuse {
+		t.Fatalf("equal sequence with no rollback must refuse, got %v", dEq)
+	}
+}
+
+// 16. signed rollback (rollback_of == current applied assignment) -> proceed.
+func TestV2_SignedRollbackAllowed(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	st.Record("fleet", "", "asg-current", "t", 10)
+	d := st.EvaluateRollback("fleet", "", "asg-rollback", "asg-current", 7)
+	if d != RollbackProceedSigned {
+		t.Fatalf("signed rollback must proceed, got %v", d)
+	}
+	// rollback_of naming a non-current assignment is refused.
+	d2 := st.EvaluateRollback("fleet", "", "asg-rollback", "asg-stale", 7)
+	if d2 != RollbackRefuse {
+		t.Fatalf("rollback_of not naming current must refuse, got %v", d2)
+	}
+}
+
+// The replay floor is monotonic: after a signed rollback to a lower sequence,
+// recording it must NOT lower the floor, so a stale apply at a sequence between
+// the rolled-back one and the previous floor is still refused.
+func TestV2_RollbackKeepsReplayFloorMonotonic(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	st.Record("fleet", "", "asg-10", "t", 10)
+	// Signed rollback to seq 7 of the current assignment is allowed...
+	if d := st.EvaluateRollback("fleet", "", "asg-rb", "asg-10", 7); d != RollbackProceedSigned {
+		t.Fatalf("signed rollback must proceed, got %v", d)
+	}
+	// ...and recording it keeps the replay floor at 10, not 7, while the applied
+	// sequence and assignment id reflect the rolled-back bundle.
+	st.Record("fleet", "", "asg-rb", "t", 7)
+	rec := st.Targets[TargetKey("fleet", "")]
+	if rec.ReplayFloor != 10 {
+		t.Fatalf("replay floor must stay 10 after a rollback to 7, got %d", rec.ReplayFloor)
+	}
+	if rec.LastSequence != 7 {
+		t.Fatalf("LastSequence must be the applied (rolled-back) seq 7, got %d", rec.LastSequence)
+	}
+	if rec.LastAssignmentID != "asg-rb" {
+		t.Fatal("LastAssignmentID must reflect the rolled-back assignment")
+	}
+	// A plain stale apply at seq 8 (below the floor, no rollback_of) is refused.
+	if d := st.EvaluateRollback("fleet", "", "asg-8", "", 8); d != RollbackRefuse {
+		t.Fatalf("stale seq-8 apply must be refused after the floor stayed at 10, got %v", d)
+	}
+	// A further signed rollback of the now-current rolled-back assignment works.
+	if d := st.EvaluateRollback("fleet", "", "asg-rb2", "asg-rb", 6); d != RollbackProceedSigned {
+		t.Fatalf("further signed rollback of the current assignment must proceed, got %v", d)
+	}
+	// An idempotent reapply of the rolled-back bundle (asg-rb at its own seq 7)
+	// must still be allowed even though the floor is 10.
+	if d := st.EvaluateRollback("fleet", "", "asg-rb", "", 7); d != RollbackProceedReapply {
+		t.Fatalf("idempotent reapply of the rolled-back bundle must proceed, got %v", d)
+	}
+}
+
+// An existing agent egress rate limit makes an egress restrict a partial
+// projection, so it fails closed.
+func TestV2_AgentEgressExistingRateLimitRefused(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.Egress = &config.EgressPolicy{AllowedDomains: []string{"api.openai.com"}, RateLimit: 10, RateWindow: 60}
+	cfg.Agents["voice-ai"] = va
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_allowed_not_restrictable") {
+		t.Fatalf("expected not-restrictable (rate limit), got %+v", p.Unsupported)
+	}
+}
+
+// 17. target.scope node + wrong node_id -> policy_target_mismatch, no plan.
+func TestV2_NodeTargetMismatchRefused(t *testing.T) {
+	b := bodyV2()
+	b.Assignment.Target = policybundle.TargetV2{Scope: "node", NodeID: "node-A"}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "node-B", targetPath)
+	if !errors.Is(err, ErrPolicyTargetMismatch) {
+		t.Fatalf("err = %v, want ErrPolicyTargetMismatch", err)
+	}
+}
+
+func TestV2_NodeTargetMissingNodeIDRefused(t *testing.T) {
+	b := bodyV2()
+	b.Assignment.Target = policybundle.TargetV2{Scope: "node", NodeID: "node-A"}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrPolicyTargetMismatch) {
+		t.Fatalf("missing node id must mismatch, got %v", err)
+	}
+}
+
+// 18. target.scope fleet -> applies on any node.
+func TestV2_FleetAppliesAnyNode(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "any-node-here", targetPath)
+	if err != nil {
+		t.Fatalf("fleet must apply on any node: %v", err)
+	}
+	if len(p.Changes) == 0 {
+		t.Fatal("fleet apply produced no changes")
+	}
+}
+
+func TestV2_NodeTargetMatchApplies(t *testing.T) {
+	b := bodyV2()
+	b.Assignment.Target = policybundle.TargetV2{Scope: "node", NodeID: "node-A"}
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	if _, err := DryRunV2(verifiedV2(b), baseConfig(), "node-A", targetPath); err != nil {
+		t.Fatalf("matching node must apply: %v", err)
+	}
+}
+
+// 19. first apply for a target (no state) -> proceeds.
+func TestV2_FirstApplyProceeds(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	if d := st.EvaluateRollback("fleet", "", "asg-1", "", 1); d != RollbackProceedFresh {
+		t.Fatalf("first apply must proceed fresh, got %v", d)
+	}
+	if d := st.EvaluateRollback("node", "node-A", "asg-1", "", 99); d != RollbackProceedFresh {
+		t.Fatalf("first node apply must proceed fresh, got %v", d)
+	}
+}
+
+// Fleet and node targets track independently.
+func TestV2_FleetAndNodeTracksSeparately(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	st.Record("fleet", "", "asg-fleet", "t", 10)
+	// A node target is still fresh despite the fleet record.
+	if d := st.EvaluateRollback("node", "node-A", "asg-node", "", 1); d != RollbackProceedFresh {
+		t.Fatalf("node target must be independent of fleet, got %v", d)
+	}
+}
+
+// blocked_content replace + clear.
+func TestV2_BlockedContentReplaceAndClear(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.BlockedContent = []string{"pii", "secrets"}
+	cfg.Agents["voice-ai"] = va
+
+	// replace
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.BlockedContent = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"pii"}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2 replace: %v", err)
+	}
+	if got := p.Projected().Agents["voice-ai"].BlockedContent; len(got) != 1 || got[0] != "pii" {
+		t.Fatalf("blocked_content replace = %v", got)
+	}
+
+	// clear -> empty
+	b2 := bodyV2()
+	g2 := agentGovV2("voice-ai")
+	g2.BlockedContent = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{}}
+	b2.Governance.Agents = []policybundle.AgentGovernanceV2{g2}
+	p2, err := DryRunV2(verifiedV2(b2), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2 clear: %v", err)
+	}
+	if len(p2.Projected().Agents["voice-ai"].BlockedContent) != 0 {
+		t.Fatalf("blocked_content clear must be empty, got %v", p2.Projected().Agents["voice-ai"].BlockedContent)
+	}
+}
+
+// scan_profile replace.
+func TestV2_ScanProfileReplace(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.ScanProfile = policybundle.DimScalarStringV2{Mode: dimReplace, Value: config.ScanProfileStrict}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if p.Projected().Agents["voice-ai"].ScanProfile != config.ScanProfileStrict {
+		t.Fatalf("scan_profile replace not applied")
+	}
+}
+
+// rules replace projected globally.
+func TestV2_RulesReplaceProjectedGlobally(t *testing.T) {
+	b := bodyV2()
+	b.Rules = policybundle.DimRulesV2{
+		Mode:      dimReplace,
+		Enabled:   []string{"IAP-003"},
+		Disabled:  []string{"IAP-002"},
+		Overrides: map[string]policybundle.PolicyRuleOverride{"IAP-003": {Action: "block"}},
+	}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	var sawBlock, sawIgnore bool
+	for _, c := range p.Changes {
+		if c.Kind == "rule_override" && c.ID == "IAP-003" && c.Action == "block" {
+			sawBlock = true
+		}
+		if c.Kind == "rule_override" && c.ID == "IAP-002" && c.Action == "ignore" {
+			sawIgnore = true
+		}
+	}
+	if !sawBlock || !sawIgnore {
+		t.Fatalf("rules not projected: %+v", p.Changes)
+	}
+}
+
+func TestV2_RulesClearUnsupported(t *testing.T) {
+	b := bodyV2()
+	b.Rules = policybundle.DimRulesV2{Mode: dimClear, Enabled: []string{}, Disabled: []string{}, Overrides: map[string]policybundle.PolicyRuleOverride{}}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("rules clear must be unsupported, got %v", err)
+	}
+}
+
+// CommitV2 writes governed agent fields and preserves unrelated content.
+func TestV2_CommitWritesAndPreserves(t *testing.T) {
+	path := writeOrigConfig(t, 0o600)
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read", "voice.dial"}}
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+
+	plan := commitV2Body(t, path, b, "")
+	backup, err := CommitV2(plan, path)
+	if err != nil {
+		t.Fatalf("CommitV2: %v", err)
+	}
+	if backup == "" {
+		t.Fatal("backup path empty")
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("written config must validate: %v", err)
+	}
+	va := cfg.Agents["voice-ai"]
+	if len(va.AllowedTools) != 2 || va.AllowedTools[0] != "calendar.read" {
+		t.Fatalf("allowed_tools not written: %v", va.AllowedTools)
+	}
+	if !va.Suspended {
+		t.Fatal("suspended not written")
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "operator config") {
+		t.Fatal("header comment dropped")
+	}
+}
+
+// A label-only selector (no name) is unsupported: the verifier requires a name,
+// and the projector enforces the same contract rather than silently matching all.
+func TestV2_LabelOnlySelectorUnsupported(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("")
+	g.Selector = policybundle.SelectorV2{Labels: map[string]string{"env": "prod"}}
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_selector_name_required") {
+		t.Fatalf("expected name-required unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// A named selector narrowed by labels matches only when the named agent carries
+// the labels; a label the agent lacks means no match (no change, no error).
+func TestV2_NamedSelectorLabelsNarrow(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.Tags = []string{"env=prod"}
+	cfg.Agents["voice-ai"] = va
+
+	// matching label -> applies
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Selector = policybundle.SelectorV2{Name: "voice-ai", Labels: map[string]string{"env": "prod"}}
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if !p.Projected().Agents["voice-ai"].Suspended {
+		t.Fatal("named selector with matching label must apply")
+	}
+
+	// non-matching label -> no change, no error
+	b2 := bodyV2()
+	g2 := agentGovV2("voice-ai")
+	g2.Selector = policybundle.SelectorV2{Name: "voice-ai", Labels: map[string]string{"env": "staging"}}
+	g2.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b2.Governance.Agents = []policybundle.AgentGovernanceV2{g2}
+	p2, err := DryRunV2(verifiedV2(b2), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if len(p2.Changes) != 0 {
+		t.Fatalf("non-matching label must produce no change, got %+v", p2.Changes)
+	}
+}
+
+// Idempotent reapply: the recorded assignment at its recorded sequence is
+// allowed again (retry / drift repair), not refused.
+func TestV2_IdempotentReapplyAllowed(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	st.Record("fleet", "", "asg-current", "t", 10)
+	if d := st.EvaluateRollback("fleet", "", "asg-current", "", 10); d != RollbackProceedReapply {
+		t.Fatalf("same assignment + same sequence must be an idempotent reapply, got %v", d)
+	}
+	// A different assignment at the same sequence is still refused.
+	if d := st.EvaluateRollback("fleet", "", "asg-other", "", 10); d != RollbackRefuse {
+		t.Fatalf("different assignment at recorded sequence must refuse, got %v", d)
+	}
+}
+
+// Egress replace additive-source widener: a global forward_proxy allowlist that
+// permits a domain outside the bundle's per-agent allowlist makes the restrict
+// unexpressible -> unsupported (mirrors v1).
+func TestV2_EgressReplaceAdditiveWidenerUnsupported(t *testing.T) {
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_allowed_not_restrictable") {
+		t.Fatalf("expected additive-widener unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// When the global allowlist is a subset of the bundle's, the union still equals
+// the policy, so egress replace is supported.
+func TestV2_EgressReplaceGlobalSubsetSupported(t *testing.T) {
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com", "github.com"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	if _, err := DryRunV2(verifiedV2(b), cfg, "", targetPath); err != nil {
+		t.Fatalf("global subset of policy must be supported: %v", err)
+	}
+}
+
+// Body-level gateway governance fails closed (global gateway not projected).
+func TestV2_BodyGatewayGovernedFailsClosed(t *testing.T) {
+	b := bodyV2()
+	b.Gateway = policybundle.DimGatewayV2{Mode: dimReplace, ToolsAllowed: []string{"x"}, ToolsDenied: []string{}}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("governed body gateway must be unsupported, got %v", err)
+	}
+	if !hasUnsupportedV2(p, "body_gateway") {
+		t.Fatalf("expected body_gateway unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// missing named agent -> ErrMissingAgent.
+func TestV2_MissingNamedAgent(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("ghost")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	_, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrMissingAgent) {
+		t.Fatalf("err = %v, want ErrMissingAgent", err)
+	}
+}
+
+
+// Reserved deny-all sentinel in a replace value is refused (P2 guard).
+func TestV2_ReservedToolSentinelInReplaceRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{denyAllToolsSentinel}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_reserved_value") {
+		t.Fatalf("expected reserved-value unsupported, got %+v", p.Unsupported)
+	}
+}
+
+func TestV2_ReservedDomainSentinelInReplaceRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{denyAllDomainsSentinel}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_reserved_value") {
+		t.Fatalf("expected reserved-domain unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// per-agent egress with unimplemented sub-fields fails closed.
+func TestV2_AgentEgressUnsupportedFields(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, ScanRequests: "true", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_unsupported_fields") {
+		t.Fatalf("expected egress-unsupported-fields, got %+v", p.Unsupported)
+	}
+}
+
+// per-agent egress allowed/blocked replace projects cleanly.
+func TestV2_AgentEgressReplaceProjects(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, BlockedDomains: []string{"evil.test"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	eg := p.Projected().Agents["voice-ai"].Egress
+	if eg == nil || len(eg.AllowedDomains) != 1 || eg.AllowedDomains[0] != "api.openai.com" {
+		t.Fatalf("egress allowed not projected: %+v", eg)
+	}
+	if len(eg.BlockedDomains) != 1 || eg.BlockedDomains[0] != "evil.test" {
+		t.Fatalf("egress blocked not projected: %+v", eg)
+	}
+}
+
+// per-agent egress clear yields the zero-egress sentinel when no additive
+// source remains.
+func TestV2_AgentEgressClearZeroEgress(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.Egress = &config.EgressPolicy{AllowedDomains: []string{"api.keep.com"}}
+	cfg.Agents["voice-ai"] = va
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimClear, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	eg := p.Projected().Agents["voice-ai"].Egress
+	if eg == nil || len(eg.AllowedDomains) != 1 || eg.AllowedDomains[0] != denyAllDomainsSentinel {
+		t.Fatalf("egress clear must yield zero-egress sentinel, got %+v", eg)
+	}
+}
+
+// egress clear with a global forward_proxy allowlist present cannot achieve zero
+// egress, so it fails closed.
+func TestV2_AgentEgressClearWithGlobalAllowlistRefused(t *testing.T) {
+	cfg := baseConfig()
+	cfg.ForwardProxy = config.ForwardProxyConfig{Enabled: true, AllowedDomains: []string{"github.com"}}
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimClear, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_clear_not_zeroable") {
+		t.Fatalf("expected clear-not-zeroable unsupported, got %+v", p.Unsupported)
+	}
+}
+
+// An existing agent egress scan override makes an egress restrict a partial
+// projection, so it fails closed.
+func TestV2_AgentEgressExistingScanOverrideRefused(t *testing.T) {
+	cfg := baseConfig()
+	tru := true
+	va := cfg.Agents["voice-ai"]
+	va.Egress = &config.EgressPolicy{AllowedDomains: []string{"api.openai.com"}, ScanRequests: &tru}
+	cfg.Agents["voice-ai"] = va
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_allowed_not_restrictable") {
+		t.Fatalf("expected not-restrictable (scan override), got %+v", p.Unsupported)
+	}
+}
+
+// An existing agent tool_restrictions entry is a widener: an egress restrict
+// (replace or clear) that only rewrites allowed_domains leaves the tool-scoped
+// domains reachable, so it fails closed.
+func TestV2_AgentEgressExistingToolRestrictionsWiden(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.Egress = &config.EgressPolicy{
+		AllowedDomains:   []string{"api.openai.com"},
+		ToolRestrictions: map[string][]string{"shell.exec": {"evil.com"}},
+	}
+	cfg.Agents["voice-ai"] = va
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_allowed_not_restrictable") {
+		t.Fatalf("expected not-restrictable (tool_restrictions widener), got %+v", p.Unsupported)
+	}
+}
+
+// P1: a no-op (zero-change) apply must record state so a later lower-sequence
+// real apply cannot sneak in. This asserts the state semantics the command's
+// no-op branch relies on (the command calls Record+SavePolicyState in that
+// branch; here we assert the EvaluateRollback consequence of that record).
+func TestV2_NoopAdvancesSequenceState(t *testing.T) {
+	st := &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}
+	// Recording a higher-sequence no-op assignment must make a later lower
+	// sequence refuse.
+	st.Record("fleet", "", "asg-noop", "2026-05-30T00:00:00Z", 20)
+	if d := st.EvaluateRollback("fleet", "", "asg-lower", "", 19); d != RollbackRefuse {
+		t.Fatalf("after a no-op recorded seq 20, a seq-19 apply must be refused, got %v", d)
+	}
+	if d := st.EvaluateRollback("fleet", "", "asg-higher", "", 21); d != RollbackProceedAdvance {
+		t.Fatalf("seq 21 must advance, got %v", d)
+	}
+}
+
+func TestV2_StateFileSuffixPathIsAdjacent(t *testing.T) {
+	got := PolicyStatePath("/etc/oktsec/oktsec.yaml")
+	want := "/etc/oktsec/oktsec.yaml" + PolicyStateFileSuffix
+	if got != want {
+		t.Fatalf("state path = %q, want %q", got, want)
+	}
+	if filepath.Dir(got) != "/etc/oktsec" {
+		t.Fatalf("state file not adjacent: %q", got)
+	}
+}

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -577,6 +577,13 @@ func TestV2_ScanProfileReplace(t *testing.T) {
 
 // rules replace projected globally.
 func TestV2_RulesReplaceProjectedGlobally(t *testing.T) {
+	// baseConfig seeds an unmarked KEEP-1 rule. Under the architect's fail-closed
+	// contract a v2 replace that does not name KEEP-1 would block it as unknown
+	// ownership, so this projection-mechanics test uses a config without any
+	// pre-existing local rule (the bundle's named set is then the whole governed
+	// set and no unowned rule can trip the fail-closed guard).
+	cfg := baseConfig()
+	cfg.Rules = nil
 	b := bodyV2()
 	b.Rules = policybundle.DimRulesV2{
 		Mode:      dimReplace,
@@ -584,7 +591,7 @@ func TestV2_RulesReplaceProjectedGlobally(t *testing.T) {
 		Disabled:  []string{"IAP-002"},
 		Overrides: map[string]policybundle.PolicyRuleOverride{"IAP-003": {Action: "block"}},
 	}
-	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
 	if err != nil {
 		t.Fatalf("DryRunV2: %v", err)
 	}

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -949,3 +949,224 @@ func TestV2_StateFileSuffixPathIsAdjacent(t *testing.T) {
 		t.Fatalf("state file not adjacent: %q", got)
 	}
 }
+
+// rulesReplaceBody builds a fleet bundle whose rules.mode is replace and which
+// governs exactly the given enabled ids with block overrides. Used by the honest
+// replace tests below.
+func rulesReplaceBody(enabled ...string) policybundle.PolicyBodyV2 {
+	b := bodyV2()
+	overrides := map[string]policybundle.PolicyRuleOverride{}
+	for _, id := range enabled {
+		overrides[id] = policybundle.PolicyRuleOverride{Action: "block"}
+	}
+	b.Rules = policybundle.DimRulesV2{
+		Mode:      dimReplace,
+		Enabled:   append([]string(nil), enabled...),
+		Disabled:  []string{},
+		Overrides: overrides,
+	}
+	return b
+}
+
+func ruleByID(cfg *config.Config, id string) (config.RuleAction, bool) {
+	for _, ra := range cfg.Rules {
+		if ra.ID == id {
+			return ra, true
+		}
+	}
+	return config.RuleAction{}, false
+}
+
+// FIX 1 test 1: replace with a PRIOR POLICY-OWNED rule (marked) absent from the
+// bundle -> it is REMOVED (honest replace reaps stale policy-owned overrides).
+func TestV2_RulesReplaceReapsStalePolicyOwnedRule(t *testing.T) {
+	cfg := baseConfig()
+	// A previously policy-owned override the new bundle no longer declares.
+	cfg.Rules = []config.RuleAction{
+		{ID: "STALE-1", Action: "ignore", Severity: "low", ManagedByPolicy: true},
+	}
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if _, ok := ruleByID(p.Projected(), "STALE-1"); ok {
+		t.Fatalf("stale policy-owned rule must be reaped, still present: %+v", p.Projected().Rules)
+	}
+	ra, ok := ruleByID(p.Projected(), "IAP-003")
+	if !ok || !ra.ManagedByPolicy || ra.Action != "block" {
+		t.Fatalf("governed rule must be written and marked, got %+v ok=%v", ra, ok)
+	}
+}
+
+// FIX 1 test 2: replace with an OPERATOR-AUTHORED rule (unmarked) absent from the
+// bundle -> it is PRESERVED, never touched.
+func TestV2_RulesReplacePreservesOperatorAuthoredRule(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Rules = []config.RuleAction{
+		{ID: "OPER-1", Action: "quarantine", Severity: "high"}, // no marker
+	}
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	ra, ok := ruleByID(p.Projected(), "OPER-1")
+	if !ok {
+		t.Fatalf("operator-authored rule must be preserved, got %+v", p.Projected().Rules)
+	}
+	if ra.Action != "quarantine" || ra.ManagedByPolicy {
+		t.Fatalf("operator-authored rule must be untouched and unmarked, got %+v", ra)
+	}
+}
+
+// FIX 1 test 3: reapplying the same bundle is a no-op (the marked governed set
+// already matches; no removal churn, no change entries).
+func TestV2_RulesReplaceReapplyIsNoop(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Rules = []config.RuleAction{
+		{ID: "IAP-003", Action: "block", Severity: "high", ManagedByPolicy: true},
+	}
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	for _, c := range p.Changes {
+		if c.Kind == "rule_override" || c.Kind == "rule_reset_default" {
+			t.Fatalf("reapply of the same bundle must be a rules no-op, got change %+v", c)
+		}
+	}
+	ra, ok := ruleByID(p.Projected(), "IAP-003")
+	if !ok || !ra.ManagedByPolicy || ra.Action != "block" {
+		t.Fatalf("reapply must keep the marked rule intact, got %+v ok=%v", ra, ok)
+	}
+}
+
+// FIX 1 test 4: drop an override from the bundle and reapply -> it DISAPPEARS
+// from the runtime (the previously-marked rule is reaped).
+func TestV2_RulesReplaceDroppedOverrideDisappears(t *testing.T) {
+	cfg := baseConfig()
+	// Two prior policy-owned overrides.
+	cfg.Rules = []config.RuleAction{
+		{ID: "IAP-003", Action: "block", Severity: "high", ManagedByPolicy: true},
+		{ID: "IAP-004", Action: "block", Severity: "high", ManagedByPolicy: true},
+	}
+	// New bundle only declares IAP-003: IAP-004 must be reaped.
+	b := rulesReplaceBody("IAP-003")
+	p, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	if _, ok := ruleByID(p.Projected(), "IAP-004"); ok {
+		t.Fatalf("dropped override must disappear, still present: %+v", p.Projected().Rules)
+	}
+	ra, ok := ruleByID(p.Projected(), "IAP-003")
+	if !ok || !ra.ManagedByPolicy {
+		t.Fatalf("retained override must stay marked, got %+v ok=%v", ra, ok)
+	}
+}
+
+// FIX 1 test 5: the marker round-trips through the YAML write path (Commit). After
+// a real apply, the written config has the governed rules marked and the operator
+// rules unmarked; loading it back preserves the distinction. Also proves the v1
+// rule the original config carried (KEEP-1, operator-authored) is preserved.
+func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
+	path := writeOrigConfig(t, 0o600) // carries operator rule KEEP-1 (unmarked)
+	b := rulesReplaceBody("IAP-003")
+	plan := commitV2Body(t, path, b, "")
+	if _, err := CommitV2(plan, path); err != nil {
+		t.Fatalf("CommitV2: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("written config must load: %v", err)
+	}
+	// Governed rule is marked.
+	ra, ok := ruleByID(cfg, "IAP-003")
+	if !ok || !ra.ManagedByPolicy {
+		t.Fatalf("governed rule must round-trip marked, got %+v ok=%v", ra, ok)
+	}
+	// Operator rule is preserved and stays unmarked.
+	keep, ok := ruleByID(cfg, "KEEP-1")
+	if !ok {
+		t.Fatalf("operator rule KEEP-1 must be preserved, rules=%+v", cfg.Rules)
+	}
+	if keep.ManagedByPolicy {
+		t.Fatalf("operator rule must stay unmarked through round-trip, got %+v", keep)
+	}
+	// The serialized YAML must carry the marker for the governed rule and NOT for
+	// the operator rule.
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "managed_by_policy: true") {
+		t.Fatalf("written YAML must carry the marker for the governed rule:\n%s", data)
+	}
+}
+
+// FIX 2 test 1a: a bundle whose allowed_tools value contains the sentinel is
+// refused (unsupported), no write, on the CLEAR path.
+func TestV2_SentinelInClearPathValueRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	// clear mode but the bundle still ships the sentinel as a value: refuse it.
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{denyAllToolsSentinel}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_reserved_value") {
+		t.Fatalf("expected reserved-value unsupported on clear path, got %+v", p.Unsupported)
+	}
+}
+
+// FIX 2 test 1b: the sentinel in a replace value is refused too (the original
+// guard, kept; reservation is now total across paths).
+func TestV2_SentinelInReplacePathValueRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimReplace, Values: []string{"calendar.read", denyAllToolsSentinel}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_allowed_tools_reserved_value") {
+		t.Fatalf("expected reserved-value unsupported on replace path, got %+v", p.Unsupported)
+	}
+}
+
+// FIX 2 test 2: apply where the agent's existing config allowed_tools already
+// contains the sentinel name -> fail closed (refuse, no write). A real tool named
+// the sentinel would make the deny-all clear form a silent bypass.
+func TestV2_SentinelInLocalConfigFailsClosed(t *testing.T) {
+	cfg := baseConfig()
+	va := cfg.Agents["voice-ai"]
+	va.AllowedTools = []string{denyAllToolsSentinel} // a real tool collides with the sentinel
+	cfg.Agents["voice-ai"] = va
+	b := bodyV2()
+	g := agentGovV2("other")
+	g.Suspended = policybundle.DimScalarBoolV2{Mode: dimReplace, Value: true}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	_, err := DryRunV2(verifiedV2(b), cfg, "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("collision in local config must fail closed with ErrUnsupported, got %v", err)
+	}
+}
+
+// FIX 2 test 3: deny-all via clear on a normal agent (no collision) still works:
+// the agent ends with the sentinel-based zero form (zero callable tools).
+func TestV2_DenyAllClearStillWorksWithoutCollision(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if err != nil {
+		t.Fatalf("DryRunV2: %v", err)
+	}
+	va := p.Projected().Agents["voice-ai"]
+	if len(va.AllowedTools) != 1 || va.AllowedTools[0] != denyAllToolsSentinel {
+		t.Fatalf("deny-all clear must yield the zero-access sentinel, got %v", va.AllowedTools)
+	}
+}

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -1143,17 +1143,19 @@ func TestV2_RulesReplaceDroppedOverrideDisappears(t *testing.T) {
 	}
 }
 
-// FIX 1 test 5: the marker round-trips through the YAML write path (Commit). After
-// a real apply, the written config has the governed rule marked and the operator
-// rule unmarked; loading it back preserves the distinction. Uses a config file
-// seeded with an operator-authored rule (OPER-1, no marker) so we prove operator
-// config is preserved through the real write path, not just in memory.
+// FIX 1 test 5: the marker round-trips through the YAML write path (Commit). A v2
+// replace claims the node's governed rule set, so the config is seeded with a
+// pre-existing rule the bundle NAMES (IAP-003, unmarked, as v1 would have written
+// it). After a real apply the bundle adopts that rule, marks it managed_by_policy,
+// and the marker survives a Commit + reload. This proves a v1-written (unmarked)
+// rule the bundle names is cleanly adopted through the real write path, and that
+// the resulting config is exactly the signed governed set.
 func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
-	// Reuse the proven-stable origConfigYAML fixture (identical to the reliable
-	// CommitV2 test) but with an operator-authored rule instead of an empty rules
-	// list, so the round-trip proves operator config survives the real write path.
+	// Reuse the proven-stable origConfigYAML fixture but seed a rule the bundle
+	// names so the replace is clean (no rule of unknown ownership to block) and it
+	// exercises the adopt+mark path through the real write path.
 	seeded := strings.Replace(origConfigYAML, "rules: []\n",
-		"rules:\n  - id: OPER-1\n    action: quarantine\n    severity: high\n", 1)
+		"rules:\n  - id: IAP-003\n    action: quarantine\n    severity: high\n", 1)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "oktsec.yaml")
 	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
@@ -1168,21 +1170,16 @@ func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("written config must load: %v", err)
 	}
-	// Governed rule is marked.
+	// Governed rule is adopted, set to the signed action, and marked.
 	ra, ok := ruleByID(cfg, "IAP-003")
-	if !ok || !ra.ManagedByPolicy {
-		t.Fatalf("governed rule must round-trip marked, got %+v ok=%v", ra, ok)
+	if !ok || !ra.ManagedByPolicy || ra.Action != "block" {
+		t.Fatalf("named rule must round-trip adopted+marked at the signed action, got %+v ok=%v", ra, ok)
 	}
-	// Operator rule is preserved and stays unmarked.
-	oper, ok := ruleByID(cfg, "OPER-1")
-	if !ok {
-		t.Fatalf("operator rule OPER-1 must be preserved, rules=%+v", cfg.Rules)
+	// The replace claims the governed set: only the signed rule remains.
+	if len(cfg.Rules) != 1 {
+		t.Fatalf("a clean replace must leave exactly the signed set, got %+v", cfg.Rules)
 	}
-	if oper.ManagedByPolicy {
-		t.Fatalf("operator rule must stay unmarked through round-trip, got %+v", oper)
-	}
-	// The serialized YAML must carry the marker for the governed rule and NOT for
-	// the operator rule.
+	// The serialized YAML must carry the marker for the governed rule.
 	data, _ := os.ReadFile(path)
 	if !strings.Contains(string(data), "managed_by_policy: true") {
 		t.Fatalf("written YAML must carry the marker for the governed rule:\n%s", data)

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -1068,11 +1068,22 @@ func TestV2_RulesReplaceDroppedOverrideDisappears(t *testing.T) {
 }
 
 // FIX 1 test 5: the marker round-trips through the YAML write path (Commit). After
-// a real apply, the written config has the governed rules marked and the operator
-// rules unmarked; loading it back preserves the distinction. Also proves the v1
-// rule the original config carried (KEEP-1, operator-authored) is preserved.
+// a real apply, the written config has the governed rule marked and the operator
+// rule unmarked; loading it back preserves the distinction. Uses a config file
+// seeded with an operator-authored rule (OPER-1, no marker) so we prove operator
+// config is preserved through the real write path, not just in memory.
 func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
-	path := writeOrigConfig(t, 0o600) // carries operator rule KEEP-1 (unmarked)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	const seeded = "# operator config\n" +
+		"server:\n  port: 8080\n" +
+		"identity:\n  require_signature: false\n" +
+		"agents:\n  voice-ai:\n    can_message: []\n    blocked_content: []\n" +
+		"rules:\n" +
+		"  - id: OPER-1\n    action: quarantine\n    severity: high\n"
+	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
 	b := rulesReplaceBody("IAP-003")
 	plan := commitV2Body(t, path, b, "")
 	if _, err := CommitV2(plan, path); err != nil {
@@ -1088,18 +1099,52 @@ func TestV2_RulesReplaceMarkerRoundTripsThroughCommit(t *testing.T) {
 		t.Fatalf("governed rule must round-trip marked, got %+v ok=%v", ra, ok)
 	}
 	// Operator rule is preserved and stays unmarked.
-	keep, ok := ruleByID(cfg, "KEEP-1")
+	oper, ok := ruleByID(cfg, "OPER-1")
 	if !ok {
-		t.Fatalf("operator rule KEEP-1 must be preserved, rules=%+v", cfg.Rules)
+		t.Fatalf("operator rule OPER-1 must be preserved, rules=%+v", cfg.Rules)
 	}
-	if keep.ManagedByPolicy {
-		t.Fatalf("operator rule must stay unmarked through round-trip, got %+v", keep)
+	if oper.ManagedByPolicy {
+		t.Fatalf("operator rule must stay unmarked through round-trip, got %+v", oper)
 	}
 	// The serialized YAML must carry the marker for the governed rule and NOT for
 	// the operator rule.
 	data, _ := os.ReadFile(path)
 	if !strings.Contains(string(data), "managed_by_policy: true") {
 		t.Fatalf("written YAML must carry the marker for the governed rule:\n%s", data)
+	}
+}
+
+// FIX 1 + FIX 2 reinforcement: deny-all clear is IDEMPOTENT through a real apply.
+// A first clear writes the lone sentinel; a second v2 apply over that config is
+// NOT refused as a sentinel collision (the lone sentinel is the canonical
+// deny-all form, not a real tool).
+func TestV2_DenyAllClearIsIdempotentAcrossApplies(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oktsec.yaml")
+	const seeded = "# operator config\n" +
+		"server:\n  port: 8080\n" +
+		"identity:\n  require_signature: false\n" +
+		"agents:\n  voice-ai:\n    can_message: []\n    blocked_content: []\n    allowed_tools: [old.tool]\n" +
+		"rules: []\n"
+	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	// First apply: clear -> lone sentinel written.
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.AllowedTools = policybundle.DimStringSetV2{Mode: dimClear, Values: []string{}}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	plan := commitV2Body(t, path, b, "")
+	if _, err := CommitV2(plan, path); err != nil {
+		t.Fatalf("first CommitV2: %v", err)
+	}
+	// Second apply over the produced config must NOT be refused as a collision.
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, err := DryRunV2(verifiedV2(b), cfg, "", path); err != nil {
+		t.Fatalf("deny-all clear must be idempotent (lone sentinel is not a collision), got %v", err)
 	}
 }
 
@@ -1142,7 +1187,9 @@ func TestV2_SentinelInReplacePathValueRefused(t *testing.T) {
 func TestV2_SentinelInLocalConfigFailsClosed(t *testing.T) {
 	cfg := baseConfig()
 	va := cfg.Agents["voice-ai"]
-	va.AllowedTools = []string{denyAllToolsSentinel} // a real tool collides with the sentinel
+	// A real tool collides with the sentinel: the sentinel appears ALONGSIDE
+	// another tool, so this is not the canonical lone-sentinel deny-all form.
+	va.AllowedTools = []string{"real.tool", denyAllToolsSentinel}
 	cfg.Agents["voice-ai"] = va
 	b := bodyV2()
 	g := agentGovV2("other")

--- a/internal/apply/state_v2.go
+++ b/internal/apply/state_v2.go
@@ -1,0 +1,240 @@
+package apply
+
+// Order 9A.2 anti-rollback state. The last-applied sequence per target is
+// persisted in a state file ADJACENT to the explicit config:
+// "<config>.policy-state.json", mode 0600, written atomically AFTER a
+// successful apply only. A failed write must NOT advance the sequence, so the
+// command reads the state before projection and writes it only after CommitV2
+// returns success.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oktsec/oktsec/internal/safefile"
+)
+
+// maxStateBytes caps the state file the rollback check reads.
+const maxStateBytes = 1 << 20 // 1 MiB
+
+// PolicyStateFileSuffix is appended to the explicit config path to form the
+// state file path. It is exported so the command help and tests can reference
+// the exact name.
+const PolicyStateFileSuffix = ".policy-state.json"
+
+// PolicyStateVersion tags the state file shape so a future change is detectable.
+const PolicyStateVersion = 1
+
+// TargetRecord is the per-target last-applied record.
+//
+// Two sequences are tracked on purpose:
+//   - ReplayFloor is the anti-rollback gate and is MONOTONIC: it never
+//     decreases, so a sequence at or below the highest ever applied can never be
+//     replayed as a plain apply (a signed rollback to a lower sequence does not
+//     re-open the sequences above it).
+//   - LastSequence is the sequence of the assignment CURRENTLY applied (which a
+//     signed rollback can lower below the floor). It pairs with LastAssignmentID
+//     so an idempotent reapply of the current bundle, and a further signed
+//     rollback of it, both work even after the floor moved ahead.
+type TargetRecord struct {
+	ReplayFloor      int64  `json:"replay_floor"`
+	LastSequence     int64  `json:"last_sequence"`
+	LastAssignmentID string `json:"last_assignment_id"`
+	AppliedAt        string `json:"applied_at"` // canonical UTC, set by the command
+}
+
+// PolicyState is the on-disk anti-rollback state: a map of target-key to the
+// last-applied record. Target-key separates fleet and node scopes so they track
+// independently (see TargetKey).
+type PolicyState struct {
+	Version int                     `json:"version"`
+	Targets map[string]TargetRecord `json:"targets"`
+}
+
+// TargetKey is the state map key for a (scope, node_id). Fleet and node
+// assignments track separately: a fleet apply never advances a node target's
+// sequence and vice versa.
+func TargetKey(scope, nodeID string) string {
+	if scope == "node" {
+		return "node:" + nodeID
+	}
+	return "fleet:"
+}
+
+// PolicyStatePath returns the state file path for an explicit config path.
+func PolicyStatePath(configPath string) string {
+	return configPath + PolicyStateFileSuffix
+}
+
+// LoadPolicyState reads the state file beside configPath. A missing file is not
+// an error: it returns an empty state (first apply for every target). The path
+// must not be a symlink (no write or read follows a link).
+func LoadPolicyState(configPath string) (*PolicyState, error) {
+	path := PolicyStatePath(configPath)
+	// A non-existent file is fine (first apply); only a real symlink is rejected
+	// so no read follows a link. ReadFileMax also uses O_NOFOLLOW.
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("policy state %q is a symlink (rejected for security)", path)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("policy state %q is not a regular file", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat policy state %q: %w", path, err)
+	}
+	data, err := safefile.ReadFileMax(path, maxStateBytes)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &PolicyState{Version: PolicyStateVersion, Targets: map[string]TargetRecord{}}, nil
+		}
+		return nil, fmt.Errorf("read policy state: %w", err)
+	}
+	var st PolicyState
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&st); err != nil {
+		return nil, fmt.Errorf("decode policy state %q: %w", path, err)
+	}
+	if st.Targets == nil {
+		st.Targets = map[string]TargetRecord{}
+	}
+	return &st, nil
+}
+
+// RollbackDecision is the outcome of the anti-rollback evaluation.
+type RollbackDecision int
+
+const (
+	// RollbackProceedFresh: no state for this target yet (first apply).
+	RollbackProceedFresh RollbackDecision = iota
+	// RollbackProceedAdvance: sequence strictly greater than last applied.
+	RollbackProceedAdvance
+	// RollbackProceedSigned: sequence <= last applied, but rollback_of names the
+	// currently-applied assignment for this target (an explicit signed rollback).
+	RollbackProceedSigned
+	// RollbackProceedReapply: the exact currently-applied assignment at its
+	// recorded sequence is being applied again (idempotent retry / drift repair).
+	RollbackProceedReapply
+	// RollbackRefuse: stale sequence with no valid rollback_of.
+	RollbackRefuse
+)
+
+// EvaluateRollback decides whether an assignment with the given sequence and
+// rollback_of may apply against the recorded state for its target. It does not
+// mutate state; the command records a new record only after CommitV2 succeeds.
+func (st *PolicyState) EvaluateRollback(scope, nodeID, assignmentID, rollbackOf string, sequence int64) RollbackDecision {
+	rec, ok := st.Targets[TargetKey(scope, nodeID)]
+	if !ok {
+		return RollbackProceedFresh
+	}
+	// Advance: strictly above the monotonic replay floor (the highest ever
+	// applied). This is the only path that may raise the floor.
+	if sequence > rec.ReplayFloor {
+		return RollbackProceedAdvance
+	}
+	// Idempotent reapply: the SAME assignment at the SAME sequence it was applied
+	// at is a retry or drift repair, not a rollback. This stays valid even after
+	// the floor moved past that sequence (e.g. a signed rollback whose bundle is
+	// re-applied), because it is keyed on the currently-applied assignment, not
+	// the floor.
+	if assignmentID == rec.LastAssignmentID && sequence == rec.LastSequence {
+		return RollbackProceedReapply
+	}
+	// sequence <= floor: only a signed rollback of the currently-applied
+	// assignment is allowed.
+	if rollbackOf != "" && rollbackOf == rec.LastAssignmentID {
+		return RollbackProceedSigned
+	}
+	return RollbackRefuse
+}
+
+// Record sets the last-applied record for a target. The caller persists via
+// SavePolicyState only after CommitV2 succeeds.
+//
+// ReplayFloor is monotonic (max of existing and the applied sequence), so a
+// signed rollback to a lower sequence never re-opens the sequences above it to a
+// plain apply. LastSequence/LastAssignmentID record the assignment now actually
+// applied (which a rollback can put below the floor), so an idempotent reapply
+// of it, and a further signed rollback of it, both still resolve correctly.
+func (st *PolicyState) Record(scope, nodeID, assignmentID, appliedAt string, sequence int64) {
+	if st.Targets == nil {
+		st.Targets = map[string]TargetRecord{}
+	}
+	st.Version = PolicyStateVersion
+	key := TargetKey(scope, nodeID)
+	floor := sequence
+	if prev, ok := st.Targets[key]; ok && prev.ReplayFloor > floor {
+		floor = prev.ReplayFloor
+	}
+	st.Targets[key] = TargetRecord{
+		ReplayFloor:      floor,
+		LastSequence:     sequence,
+		LastAssignmentID: assignmentID,
+		AppliedAt:        appliedAt,
+	}
+}
+
+// SavePolicyState writes the state beside configPath atomically with mode 0600:
+// write to an exclusive temp in the same dir, fsync, then rename over the state
+// file, then fsync the dir. It refuses to write through a symlink at the state
+// path. It is called ONLY after a successful CommitV2.
+func SavePolicyState(configPath string, st *PolicyState) error {
+	path := PolicyStatePath(configPath)
+	// Never write through a symlink at the state path.
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("policy state %q is a symlink (rejected for security)", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("policy state %q is not a regular file", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat policy state %q: %w", path, err)
+	}
+
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode policy state: %w", err)
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create state temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write state temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("fsync state temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close state temp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		cleanup()
+		return fmt.Errorf("chmod state temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("atomic replace state %q: %w", path, err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/internal/apply/state_v2.go
+++ b/internal/apply/state_v2.go
@@ -100,8 +100,19 @@ func LoadPolicyState(configPath string) (*PolicyState, error) {
 	if err := dec.Decode(&st); err != nil {
 		return nil, fmt.Errorf("decode policy state %q: %w", path, err)
 	}
+	// Fail closed on a PRESENT but malformed state file. Only a genuinely ABSENT
+	// file (handled above) may start fresh. Silently resetting a present file
+	// that decoded to the wrong version or has no targets map would treat every
+	// target as never-applied and re-open the anti-rollback gate, letting a stale
+	// lower sequence apply after an accidental or truncated state file. A
+	// truncated/garbage file already fails to decode above; here we additionally
+	// reject a well-formed JSON object that is not a valid state ("{}",
+	// "targets": null, or a wrong/missing version).
+	if st.Version != PolicyStateVersion {
+		return nil, fmt.Errorf("policy state %q has unexpected version %d (want %d); refusing to treat a malformed state as fresh", path, st.Version, PolicyStateVersion)
+	}
 	if st.Targets == nil {
-		st.Targets = map[string]TargetRecord{}
+		return nil, fmt.Errorf("policy state %q is missing its targets map; refusing to treat a malformed state as fresh", path)
 	}
 	return &st, nil
 }

--- a/internal/apply/write_v2.go
+++ b/internal/apply/write_v2.go
@@ -112,6 +112,77 @@ func CommitV2(plan *PlanV2, targetConfig string) (string, error) {
 	return backupPath, nil
 }
 
+// RestoreConfigV2FromBackup rolls targetConfig back to the exact bytes held in
+// backupPath (the backup CommitV2 just created from the original). It is the
+// recovery used when CommitV2 succeeded but the anti-rollback state then failed
+// to persist: restoring the config keeps config and state consistent at the
+// PRIOR sequence, so a later lower sequence can never win. It reuses the same
+// safety discipline as CommitV2 (refuse symlink / irregular target, validate
+// THROUGH the real load path, atomic rename, dir fsync) and never follows a
+// symlink at either path.
+func RestoreConfigV2FromBackup(targetConfig, backupPath string) error {
+	if backupPath == "" {
+		return errors.New("apply: cannot restore config without a backup path")
+	}
+	// Read the backup without following a symlink at the backup path.
+	if err := safefile.RejectSymlink(backupPath); err != nil {
+		return fmt.Errorf("apply: restore backup path not usable: %w", err)
+	}
+	orig, err := safefile.ReadFileMax(backupPath, maxConfigBytes)
+	if err != nil {
+		return fmt.Errorf("apply: read backup for restore: %w", err)
+	}
+
+	// Re-validate the target path right before writing: never follow a symlink,
+	// never write through a directory or irregular file.
+	info, err := os.Lstat(targetConfig)
+	if err != nil {
+		return fmt.Errorf("apply: stat config for restore %q: %w", targetConfig, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("apply: config %q is a symlink (rejected for security)", targetConfig)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("apply: config %q is not a regular file", targetConfig)
+	}
+	mode := info.Mode().Perm()
+
+	dir := filepath.Dir(targetConfig)
+	tmp, err := os.CreateTemp(dir, filepath.Base(targetConfig)+".restore-*")
+	if err != nil {
+		return fmt.Errorf("apply: create restore temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(orig); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("apply: write restore temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("apply: fsync restore temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("apply: close restore temp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return fmt.Errorf("apply: chmod restore temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, targetConfig); err != nil {
+		cleanup()
+		return fmt.Errorf("apply: atomic restore %q: %w", targetConfig, err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}
+
 // patchConfigYAMLV2 applies only the v2 plan's governed changes onto the
 // original YAML document, preserving every untouched field verbatim. It patches
 // the global rules section and, per changed agent, that agent's governed fields.

--- a/internal/apply/write_v2.go
+++ b/internal/apply/write_v2.go
@@ -1,0 +1,253 @@
+package apply
+
+// Order 9A.2 v2 commit. CommitV2 writes a verified v2 projection to the config
+// using the SAME safety protocol as v1 Commit (patch original YAML -> validate
+// via the real load path -> exclusive backup -> atomic rename -> dir fsync;
+// refuses symlink / read-only / anchored-YAML). It does NOT reimplement the
+// protocol: it reuses every helper from write.go (mapGet, mapSet, guardAnchored,
+// anchorReferenced, isExplicitMapping, backupOriginal, writeExclusive,
+// maxConfigBytes). The only v2-specific part is patch coverage: v2 can touch
+// rules (global) plus, per agent, allowed_tools, egress, suspended,
+// blocked_content, and scan_profile, across MULTIPLE agents (v1 scoped to one).
+//
+// CommitV2 does NOT write the anti-rollback state file; the command does that
+// only after CommitV2 returns success, so a failed write never advances the
+// sequence.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/safefile"
+	"gopkg.in/yaml.v3"
+)
+
+// CommitV2 writes the v2 plan's projected changes to targetConfig. Call it only
+// for a plan with changes and no unsupported items; it returns the backup path.
+func CommitV2(plan *PlanV2, targetConfig string) (string, error) {
+	if plan == nil || plan.projected == nil {
+		return "", ErrNoProjection
+	}
+
+	info, err := os.Lstat(targetConfig)
+	if err != nil {
+		return "", fmt.Errorf("apply: stat config %q: %w", targetConfig, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("apply: config %q is a symlink (rejected for security)", targetConfig)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("apply: config %q is not a regular file", targetConfig)
+	}
+	mode := info.Mode().Perm()
+
+	if probe, err := os.OpenFile(targetConfig, os.O_WRONLY, 0); err != nil {
+		return "", fmt.Errorf("apply: config %q is not writable: %w", targetConfig, err)
+	} else {
+		_ = probe.Close()
+	}
+
+	orig, err := safefile.ReadFileMax(targetConfig, maxConfigBytes)
+	if err != nil {
+		return "", fmt.Errorf("apply: read original config: %w", err)
+	}
+
+	patched, err := patchConfigYAMLV2(orig, plan)
+	if err != nil {
+		return "", fmt.Errorf("apply: %w", err)
+	}
+
+	dir := filepath.Dir(targetConfig)
+	tmp, err := os.CreateTemp(dir, filepath.Base(targetConfig)+".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("apply: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(patched); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", fmt.Errorf("apply: write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", fmt.Errorf("apply: fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: close temp: %w", err)
+	}
+	loaded, err := config.Load(tmpPath)
+	if err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: patched config does not load: %w", err)
+	}
+	if err := loaded.Validate(); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: patched config is invalid: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: chmod temp: %w", err)
+	}
+
+	backupPath, err := backupOriginal(targetConfig, orig, mode)
+	if err != nil {
+		cleanup()
+		return "", fmt.Errorf("apply: create backup: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, targetConfig); err != nil {
+		cleanup()
+		return backupPath, fmt.Errorf("apply: atomic replace %q (backup kept at %q): %w", targetConfig, backupPath, err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return backupPath, nil
+}
+
+// patchConfigYAMLV2 applies only the v2 plan's governed changes onto the
+// original YAML document, preserving every untouched field verbatim. It patches
+// the global rules section and, per changed agent, that agent's governed fields.
+func patchConfigYAMLV2(original []byte, plan *PlanV2) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(original, &doc); err != nil {
+		return nil, fmt.Errorf("parse original config: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("original config is not a YAML mapping")
+	}
+	root := doc.Content[0]
+
+	// Determine which sections changed. Track, per agent, which governed fields
+	// were touched so we patch only those keys.
+	var patchRules bool
+	agentFields := map[string]map[string]bool{} // agent -> field -> true
+	touch := func(agent, field string) {
+		m := agentFields[agent]
+		if m == nil {
+			m = map[string]bool{}
+			agentFields[agent] = m
+		}
+		m[field] = true
+	}
+	for _, c := range plan.Changes {
+		switch c.Kind {
+		case "rule_override", "rule_reset_default":
+			patchRules = true
+		case "agent_allowed_tools":
+			touch(c.Agent, "allowed_tools")
+		case "agent_egress_allowed_domains", "agent_egress_denied_domains":
+			touch(c.Agent, "egress")
+		case "agent_suspended":
+			touch(c.Agent, "suspended")
+		case "agent_blocked_content":
+			touch(c.Agent, "blocked_content")
+		case "agent_scan_profile":
+			touch(c.Agent, "scan_profile")
+		}
+	}
+
+	if patchRules {
+		if err := guardAnchored(&doc, mapGet(root, "rules"), "rules"); err != nil {
+			return nil, err
+		}
+		var n yaml.Node
+		if err := n.Encode(plan.projected.Rules); err != nil {
+			return nil, fmt.Errorf("encode rules: %w", err)
+		}
+		mapSet(root, "rules", &n)
+	}
+
+	if len(agentFields) > 0 {
+		agents := mapGet(root, "agents")
+		if agents == nil || agents.Kind != yaml.MappingNode {
+			// agents reachable only via alias/merge: materialize the whole resolved
+			// map (governed changes + others) so real apply matches dry-run.
+			var n yaml.Node
+			if err := n.Encode(plan.projected.Agents); err != nil {
+				return nil, fmt.Errorf("encode agents: %w", err)
+			}
+			mapSet(root, "agents", &n)
+		} else {
+			for agentName, fields := range agentFields {
+				proj, ok := plan.projected.Agents[agentName]
+				if !ok {
+					return nil, fmt.Errorf("agent %q not in projected config", agentName)
+				}
+				node := mapGet(agents, agentName)
+				if !isExplicitMapping(node) {
+					// Agent reachable only via alias/merge: materialize the fully
+					// resolved agent as an explicit key.
+					var n yaml.Node
+					if err := n.Encode(proj); err != nil {
+						return nil, fmt.Errorf("encode agent %q: %w", agentName, err)
+					}
+					mapSet(agents, agentName, &n)
+					continue
+				}
+				if node.Anchor != "" && anchorReferenced(&doc, node.Anchor) {
+					return nil, fmt.Errorf("agent %q has a YAML anchor %q referenced elsewhere; inline it before applying policy", agentName, node.Anchor)
+				}
+				if err := patchAgentFieldV2(&doc, node, agentName, fields, proj); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal patched config: %w", err)
+	}
+	return out, nil
+}
+
+// patchAgentFieldV2 patches the changed governed keys of one explicit agent
+// mapping in place, preserving its other fields and any merge. Each key is
+// anchor-guarded before replacement.
+func patchAgentFieldV2(doc *yaml.Node, node *yaml.Node, agentName string, fields map[string]bool, proj config.Agent) error {
+	set := func(key string, val any) error {
+		if err := guardAnchored(doc, mapGet(node, key), fmt.Sprintf("the agent's %s", key)); err != nil {
+			return err
+		}
+		var n yaml.Node
+		if err := n.Encode(val); err != nil {
+			return fmt.Errorf("encode %s for agent %q: %w", key, agentName, err)
+		}
+		mapSet(node, key, &n)
+		return nil
+	}
+	if fields["allowed_tools"] {
+		if err := set("allowed_tools", proj.AllowedTools); err != nil {
+			return err
+		}
+	}
+	if fields["egress"] {
+		if err := set("egress", proj.Egress); err != nil {
+			return err
+		}
+	}
+	if fields["suspended"] {
+		if err := set("suspended", proj.Suspended); err != nil {
+			return err
+		}
+	}
+	if fields["blocked_content"] {
+		if err := set("blocked_content", proj.BlockedContent); err != nil {
+			return err
+		}
+	}
+	if fields["scan_profile"] {
+		if err := set("scan_profile", proj.ScanProfile); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -381,10 +381,33 @@ type RuleAction struct {
 	// It is additive and omitempty so an operator config that never goes through v2
 	// apply is byte-unchanged (the field is absent at false) and the v1 apply path,
 	// which never sets it, is unaffected. v2 replace uses it to converge the
-	// GOVERNED rule subset to the signed desired state without clobbering
-	// operator-authored overrides: a marked rule absent from the new bundle is
-	// reaped; an unmarked rule is preserved.
+	// GOVERNED rule subset to the signed desired state: a marked rule absent from
+	// the new bundle is reaped; an UNMARKED local rule the bundle does not name is
+	// of unknown ownership and makes the apply FAIL CLOSED (never silently kept,
+	// never blindly deleted) so the operator reconciles it explicitly.
 	ManagedByPolicy bool `yaml:"managed_by_policy,omitempty"`
+}
+
+// DenyAllToolsSentinel is the reserved allowlist value that means "deny every
+// tool" for an agent. An empty AllowedTools list means "all tools allowed", so
+// zero access must be a non-empty list that matches no real tool. The lone
+// sentinel ([DenyAllToolsSentinel]) is the canonical deny-all form a v2 policy
+// apply writes (see internal/apply).
+//
+// The name is RESERVED end to end: it is never a callable tool. The runtime
+// allowlist enforcement (gateway and stdio proxy) special-cases it BEFORE name
+// matching so an agent whose allowlist is the lone sentinel is denied every
+// call, and a backend tool literally named the sentinel is rejected at
+// discovery and never registered. This keeps the deny-all representation
+// unspoofable.
+const DenyAllToolsSentinel = "__oktsec_deny_all__"
+
+// IsDenyAllTools reports whether an agent's AllowedTools is the canonical
+// deny-all form: exactly the lone reserved sentinel. This is the single runtime
+// predicate the gateway and stdio proxy consult before any normal tool-name
+// matching, so the sentinel can never be treated as a matchable name.
+func IsDenyAllTools(allowedTools []string) bool {
+	return len(allowedTools) == 1 && allowedTools[0] == DenyAllToolsSentinel
 }
 
 // ScanProfile constants.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -376,6 +376,15 @@ type RuleAction struct {
 	Template     string   `yaml:"template,omitempty"`       // webhook body template with {{RULE}}, {{ACTION}}, etc.
 	ApplyToTools []string `yaml:"apply_to_tools,omitempty"` // rule only enforced for these tools (empty = all)
 	ExemptTools  []string `yaml:"exempt_tools,omitempty"`   // rule NOT enforced for these tools
+	// ManagedByPolicy marks a rule override as owned by a signed policy_bundle.v2
+	// apply (rules.mode: replace), as opposed to one an operator authored by hand.
+	// It is additive and omitempty so an operator config that never goes through v2
+	// apply is byte-unchanged (the field is absent at false) and the v1 apply path,
+	// which never sets it, is unaffected. v2 replace uses it to converge the
+	// GOVERNED rule subset to the signed desired state without clobbering
+	// operator-authored overrides: a marked rule absent from the new bundle is
+	// reaped; an unmarked rule is preserved.
+	ManagedByPolicy bool `yaml:"managed_by_policy,omitempty"`
 }
 
 // ScanProfile constants.

--- a/internal/gateway/deny_all_test.go
+++ b/internal/gateway/deny_all_test.go
@@ -2,8 +2,8 @@ package gateway
 
 import (
 	"context"
-	"log/slog"
 	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,7 +30,7 @@ func denyAllCallIsError(t *testing.T, g *Gateway, agent, originalName string) bo
 	b := &Backend{Name: "backend1", Tools: []*mcp.Tool{{Name: originalName}}}
 	handler := g.makeHandler(toolMapping{Backend: b, OriginalName: originalName})
 	ctx := context.WithValue(context.Background(), agentContextKey, agent)
-	res, err := handler(ctx, &mcp.CallToolRequest{Params: &mcp.CallToolParams{Name: originalName}})
+	res, err := handler(ctx, makeHandlerRequest(originalName, map[string]any{"text": "x"}))
 	if err != nil {
 		t.Fatalf("handler returned transport error: %v", err)
 	}

--- a/internal/gateway/deny_all_test.go
+++ b/internal/gateway/deny_all_test.go
@@ -2,64 +2,70 @@ package gateway
 
 import (
 	"context"
+	"log/slog"
+	"io"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/oktsec/oktsec/internal/config"
+	"github.com/oktsec/oktsec/internal/engine"
 )
 
-// denyAllCallIsError drives a tool through the gateway handler and returns
-// whether it was denied. A policy denial returns a non-nil error result
-// (IsError) with err == nil, BEFORE the backend is ever contacted, so a
-// session-less stub backend is sufficient for the deny paths.
-func denyAllCallIsError(t *testing.T, g *Gateway, b *Backend, originalName string) bool {
+// denyAllGateway builds a minimal gateway (no real backends) for exercising the
+// handler's deny paths, which return BEFORE any backend session is contacted.
+func denyAllGateway(t *testing.T, cfg *config.Config) *Gateway {
 	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scanner := engine.NewScanner("")
+	t.Cleanup(scanner.Close)
+	return newGatewayForTest(cfg, scanner, nil, logger)
+}
+
+// denyAllCallIsError drives a tool through the gateway handler for principal
+// `agent` and reports whether it was denied. A policy denial returns a non-nil
+// error result (IsError) with err == nil, BEFORE the backend is contacted, so a
+// session-less stub backend is sufficient for the deny paths.
+func denyAllCallIsError(t *testing.T, g *Gateway, agent, originalName string) bool {
+	t.Helper()
+	b := &Backend{Name: "backend1", Tools: []*mcp.Tool{{Name: originalName}}}
 	handler := g.makeHandler(toolMapping{Backend: b, OriginalName: originalName})
-	req := &mcp.CallToolRequest{Params: &mcp.CallToolParams{Name: originalName, Arguments: map[string]any{"text": "x"}}}
-	result, err := handler(context.Background(), req)
+	ctx := context.WithValue(context.Background(), agentContextKey, agent)
+	res, err := handler(ctx, &mcp.CallToolRequest{Params: &mcp.CallToolParams{Name: originalName}})
 	if err != nil {
 		t.Fatalf("handler returned transport error: %v", err)
 	}
-	return result != nil && result.IsError
+	return res != nil && res.IsError
 }
 
 // FIX 2 gateway runtime test 2: with the deny-all allowlist (the lone sentinel),
 // any NORMAL tool call is blocked at runtime before reaching the backend.
 func TestGateway_DenyAllSentinelBlocksNormalTool(t *testing.T) {
-	g := newTestGateway(t)
-	g.cfg = &config.Config{Agents: map[string]config.Agent{
+	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
 		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
-	}}
-	b := newTestBackend("backend1", []*mcp.Tool{{Name: "search"}})
-	if !denyAllCallIsError(t, g, b, "search") {
+	}})
+	if !denyAllCallIsError(t, g, "agent1", "search") {
 		t.Fatalf("deny-all sentinel allowlist must block a normal tool call")
 	}
 }
 
 // FIX 2 gateway runtime test 3: with the deny-all allowlist, a backend tool
-// literally named the reserved sentinel is ALSO blocked. The sentinel is a
-// control marker, never a callable name.
+// literally named the reserved sentinel is ALSO blocked.
 func TestGateway_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
-	g := newTestGateway(t)
-	g.cfg = &config.Config{Agents: map[string]config.Agent{
+	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
 		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
-	}}
-	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
-	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+	}})
+	if !denyAllCallIsError(t, g, "agent1", config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must be blocked under a deny-all allowlist")
 	}
 }
 
 // FIX 2 reinforcement: a tool literally named the reserved sentinel is denied
-// even when the agent's allowlist is broad and NOT the deny-all form, because the
-// sentinel is never a callable name independent of allowlist contents.
+// even when the agent's allowlist is broad and NOT the deny-all form.
 func TestGateway_SentinelNamedToolBlockedEvenWithBroadAllowlist(t *testing.T) {
-	g := newTestGateway(t)
-	g.cfg = &config.Config{Agents: map[string]config.Agent{
+	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
 		"agent1": {AllowedTools: []string{"search", config.DenyAllToolsSentinel}},
-	}}
-	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
-	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+	}})
+	if !denyAllCallIsError(t, g, "agent1", config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must always be blocked")
 	}
 }
@@ -68,9 +74,8 @@ func TestGateway_SentinelNamedToolBlockedEvenWithBroadAllowlist(t *testing.T) {
 // an UNKNOWN principal with no agent config entry (the sentinel-name denial is
 // hoisted above the agent lookup).
 func TestGateway_SentinelNamedToolBlockedForUnknownPrincipal(t *testing.T) {
-	g := newTestGateway(t) // empty cfg: no agent entries
-	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
-	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+	g := denyAllGateway(t, &config.Config{}) // no agent entries
+	if !denyAllCallIsError(t, g, "ghost", config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must be blocked even for an unknown principal")
 	}
 }
@@ -78,12 +83,12 @@ func TestGateway_SentinelNamedToolBlockedForUnknownPrincipal(t *testing.T) {
 // FIX 2 discovery test 5: discovery containing the reserved tool name excludes it
 // (never registered as callable) while keeping normal tools.
 func TestGateway_DiscoveryExcludesReservedToolName(t *testing.T) {
-	g := newTestGateway(t)
+	g := denyAllGateway(t, &config.Config{})
 	g.backends = map[string]*Backend{
-		"backend1": newTestBackend("backend1", []*mcp.Tool{
+		"backend1": {Name: "backend1", Tools: []*mcp.Tool{
 			{Name: "search"},
 			{Name: config.DenyAllToolsSentinel}, // reserved: must be excluded
-		}),
+		}},
 	}
 	if err := g.buildToolMap(); err != nil {
 		t.Fatalf("buildToolMap: %v", err)
@@ -96,15 +101,22 @@ func TestGateway_DiscoveryExcludesReservedToolName(t *testing.T) {
 	}
 }
 
-// FIX 2 reinforcement: a normal allowlist still allows a permitted tool, proving
-// the sentinel special-case did not break normal allowlist matching.
-func TestGateway_NormalAllowlistStillAllows(t *testing.T) {
-	g := newTestGateway(t)
-	g.cfg = &config.Config{Agents: map[string]config.Agent{
-		"agent1": {AllowedTools: []string{"search"}},
-	}}
-	b := newTestBackend("backend1", []*mcp.Tool{{Name: "search"}})
-	if denyAllCallIsError(t, g, b, "search") {
-		t.Fatalf("a permitted tool must not be blocked by the sentinel special-case")
+// FIX 2 discovery: a NAMESPACED frontend name that collides with the reserved
+// sentinel is also excluded. Backend "__oktsec" + a conflicting tool "deny_all__"
+// would namespace to "__oktsec_deny_all__" (the sentinel); it must not register.
+func TestGateway_DiscoveryExcludesNamespacedSentinelCollision(t *testing.T) {
+	g := denyAllGateway(t, &config.Config{})
+	g.backends = map[string]*Backend{
+		"__oktsec": {Name: "__oktsec", Tools: []*mcp.Tool{{Name: "deny_all__"}}},
+		"other":    {Name: "other", Tools: []*mcp.Tool{{Name: "deny_all__"}}},
+	}
+	if err := g.buildToolMap(); err != nil {
+		t.Fatalf("buildToolMap: %v", err)
+	}
+	if _, ok := g.toolMap[config.DenyAllToolsSentinel]; ok {
+		t.Fatalf("namespaced name colliding with the sentinel must be excluded, toolMap=%v", g.toolMap)
+	}
+	if _, ok := g.toolMap["other_deny_all__"]; !ok {
+		t.Fatalf("the non-colliding conflicted tool must still register, toolMap=%v", g.toolMap)
 	}
 }

--- a/internal/gateway/deny_all_test.go
+++ b/internal/gateway/deny_all_test.go
@@ -4,33 +4,45 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/oktsec/oktsec/internal/audit"
 	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
+	"github.com/stretchr/testify/require"
 )
 
-// denyAllGateway builds a minimal gateway (no real backends) for exercising the
-// handler's deny paths, which return BEFORE any backend session is contacted.
-func denyAllGateway(t *testing.T, cfg *config.Config) *Gateway {
+// discoveryGateway builds a gateway with synthetic (non-connected) backends for
+// exercising buildToolMap discovery directly. Unlike newTestGateway it does not
+// require live in-process backends, so callers can stuff arbitrary tool names
+// (including the reserved sentinel) into g.backends before building the tool map.
+func discoveryGateway(t *testing.T, backends map[string]*Backend) *Gateway {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	scanner := engine.NewScanner("")
-	t.Cleanup(scanner.Close)
-	return newGatewayForTest(cfg, scanner, nil, logger)
+	auditStore, err := audit.NewStore(filepath.Join(t.TempDir(), "audit.db"), logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		scanner.Close()
+		_ = auditStore.Close()
+	})
+	g := newGatewayForTest(defaultGatewayConfig(), scanner, auditStore, logger)
+	g.backends = backends
+	return g
 }
 
 // denyAllCallIsError drives a tool through the gateway handler for principal
-// `agent` and reports whether it was denied. A policy denial returns a non-nil
-// error result (IsError) with err == nil, BEFORE the backend is contacted, so a
-// session-less stub backend is sufficient for the deny paths.
-func denyAllCallIsError(t *testing.T, g *Gateway, agent, originalName string) bool {
+// `agent` via the given mapping and reports whether it was denied. A policy
+// denial returns a non-nil error result (IsError) with err == nil. The gateway
+// is built with the full newTestGateway harness so g.audit and the real backend
+// session are wired (the handler logs audit and may forward on the allow path).
+func denyAllCallIsError(t *testing.T, g *Gateway, agent string, m toolMapping, callName string) bool {
 	t.Helper()
-	b := &Backend{Name: "backend1", Tools: []*mcp.Tool{{Name: originalName}}}
-	handler := g.makeHandler(toolMapping{Backend: b, OriginalName: originalName})
+	handler := g.makeHandler(m)
 	ctx := context.WithValue(context.Background(), agentContextKey, agent)
-	res, err := handler(ctx, makeHandlerRequest(originalName, map[string]any{"text": "x"}))
+	res, err := handler(ctx, makeHandlerRequest(callName, map[string]any{"text": "x"}))
 	if err != nil {
 		t.Fatalf("handler returned transport error: %v", err)
 	}
@@ -38,23 +50,27 @@ func denyAllCallIsError(t *testing.T, g *Gateway, agent, originalName string) bo
 }
 
 // FIX 2 gateway runtime test 2: with the deny-all allowlist (the lone sentinel),
-// any NORMAL tool call is blocked at runtime before reaching the backend.
+// any NORMAL tool call is blocked at runtime.
 func TestGateway_DenyAllSentinelBlocksNormalTool(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
-		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
-	}})
-	if !denyAllCallIsError(t, g, "agent1", "search") {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{AllowedTools: []string{config.DenyAllToolsSentinel}}
+	g := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	if !denyAllCallIsError(t, g, "test-agent", g.toolMap["echo"], "echo") {
 		t.Fatalf("deny-all sentinel allowlist must block a normal tool call")
 	}
 }
 
 // FIX 2 gateway runtime test 3: with the deny-all allowlist, a backend tool
-// literally named the reserved sentinel is ALSO blocked.
+// literally named the reserved sentinel is ALSO blocked. The handler keys
+// deny-all on OriginalName, so we route to the real echo backend (for a non-nil
+// audit/session) but present the sentinel as the original tool name.
 func TestGateway_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
-		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
-	}})
-	if !denyAllCallIsError(t, g, "agent1", config.DenyAllToolsSentinel) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{AllowedTools: []string{config.DenyAllToolsSentinel}}
+	g := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	m := g.toolMap["echo"]
+	m.OriginalName = config.DenyAllToolsSentinel
+	if !denyAllCallIsError(t, g, "test-agent", m, config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must be blocked under a deny-all allowlist")
 	}
 }
@@ -62,10 +78,12 @@ func TestGateway_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
 // FIX 2 reinforcement: a tool literally named the reserved sentinel is denied
 // even when the agent's allowlist is broad and NOT the deny-all form.
 func TestGateway_SentinelNamedToolBlockedEvenWithBroadAllowlist(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{Agents: map[string]config.Agent{
-		"agent1": {AllowedTools: []string{"search", config.DenyAllToolsSentinel}},
-	}})
-	if !denyAllCallIsError(t, g, "agent1", config.DenyAllToolsSentinel) {
+	cfg := defaultGatewayConfig()
+	cfg.Agents["test-agent"] = config.Agent{AllowedTools: []string{"echo", config.DenyAllToolsSentinel}}
+	g := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	m := g.toolMap["echo"]
+	m.OriginalName = config.DenyAllToolsSentinel
+	if !denyAllCallIsError(t, g, "test-agent", m, config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must always be blocked")
 	}
 }
@@ -74,8 +92,11 @@ func TestGateway_SentinelNamedToolBlockedEvenWithBroadAllowlist(t *testing.T) {
 // an UNKNOWN principal with no agent config entry (the sentinel-name denial is
 // hoisted above the agent lookup).
 func TestGateway_SentinelNamedToolBlockedForUnknownPrincipal(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{}) // no agent entries
-	if !denyAllCallIsError(t, g, "ghost", config.DenyAllToolsSentinel) {
+	cfg := defaultGatewayConfig() // no agent entries
+	g := newTestGateway(t, cfg, map[string]*mcp.Server{"echo": echoServer()})
+	m := g.toolMap["echo"]
+	m.OriginalName = config.DenyAllToolsSentinel
+	if !denyAllCallIsError(t, g, "ghost", m, config.DenyAllToolsSentinel) {
 		t.Fatalf("a tool named the deny-all sentinel must be blocked even for an unknown principal")
 	}
 }
@@ -83,13 +104,12 @@ func TestGateway_SentinelNamedToolBlockedForUnknownPrincipal(t *testing.T) {
 // FIX 2 discovery test 5: discovery containing the reserved tool name excludes it
 // (never registered as callable) while keeping normal tools.
 func TestGateway_DiscoveryExcludesReservedToolName(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{})
-	g.backends = map[string]*Backend{
+	g := discoveryGateway(t, map[string]*Backend{
 		"backend1": {Name: "backend1", Tools: []*mcp.Tool{
 			{Name: "search"},
 			{Name: config.DenyAllToolsSentinel}, // reserved: must be excluded
 		}},
-	}
+	})
 	if err := g.buildToolMap(); err != nil {
 		t.Fatalf("buildToolMap: %v", err)
 	}
@@ -105,11 +125,10 @@ func TestGateway_DiscoveryExcludesReservedToolName(t *testing.T) {
 // sentinel is also excluded. Backend "__oktsec" + a conflicting tool "deny_all__"
 // would namespace to "__oktsec_deny_all__" (the sentinel); it must not register.
 func TestGateway_DiscoveryExcludesNamespacedSentinelCollision(t *testing.T) {
-	g := denyAllGateway(t, &config.Config{})
-	g.backends = map[string]*Backend{
+	g := discoveryGateway(t, map[string]*Backend{
 		"__oktsec": {Name: "__oktsec", Tools: []*mcp.Tool{{Name: "deny_all__"}}},
 		"other":    {Name: "other", Tools: []*mcp.Tool{{Name: "deny_all__"}}},
-	}
+	})
 	if err := g.buildToolMap(); err != nil {
 		t.Fatalf("buildToolMap: %v", err)
 	}

--- a/internal/gateway/deny_all_test.go
+++ b/internal/gateway/deny_all_test.go
@@ -1,0 +1,110 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// denyAllCallIsError drives a tool through the gateway handler and returns
+// whether it was denied. A policy denial returns a non-nil error result
+// (IsError) with err == nil, BEFORE the backend is ever contacted, so a
+// session-less stub backend is sufficient for the deny paths.
+func denyAllCallIsError(t *testing.T, g *Gateway, b *Backend, originalName string) bool {
+	t.Helper()
+	handler := g.makeHandler(toolMapping{Backend: b, OriginalName: originalName})
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParams{Name: originalName, Arguments: map[string]any{"text": "x"}}}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	return result != nil && result.IsError
+}
+
+// FIX 2 gateway runtime test 2: with the deny-all allowlist (the lone sentinel),
+// any NORMAL tool call is blocked at runtime before reaching the backend.
+func TestGateway_DenyAllSentinelBlocksNormalTool(t *testing.T) {
+	g := newTestGateway(t)
+	g.cfg = &config.Config{Agents: map[string]config.Agent{
+		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
+	}}
+	b := newTestBackend("backend1", []*mcp.Tool{{Name: "search"}})
+	if !denyAllCallIsError(t, g, b, "search") {
+		t.Fatalf("deny-all sentinel allowlist must block a normal tool call")
+	}
+}
+
+// FIX 2 gateway runtime test 3: with the deny-all allowlist, a backend tool
+// literally named the reserved sentinel is ALSO blocked. The sentinel is a
+// control marker, never a callable name.
+func TestGateway_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
+	g := newTestGateway(t)
+	g.cfg = &config.Config{Agents: map[string]config.Agent{
+		"agent1": {AllowedTools: []string{config.DenyAllToolsSentinel}},
+	}}
+	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
+	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+		t.Fatalf("a tool named the deny-all sentinel must be blocked under a deny-all allowlist")
+	}
+}
+
+// FIX 2 reinforcement: a tool literally named the reserved sentinel is denied
+// even when the agent's allowlist is broad and NOT the deny-all form, because the
+// sentinel is never a callable name independent of allowlist contents.
+func TestGateway_SentinelNamedToolBlockedEvenWithBroadAllowlist(t *testing.T) {
+	g := newTestGateway(t)
+	g.cfg = &config.Config{Agents: map[string]config.Agent{
+		"agent1": {AllowedTools: []string{"search", config.DenyAllToolsSentinel}},
+	}}
+	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
+	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+		t.Fatalf("a tool named the deny-all sentinel must always be blocked")
+	}
+}
+
+// FIX 2 defense in depth: a tool named the reserved sentinel is denied even for
+// an UNKNOWN principal with no agent config entry (the sentinel-name denial is
+// hoisted above the agent lookup).
+func TestGateway_SentinelNamedToolBlockedForUnknownPrincipal(t *testing.T) {
+	g := newTestGateway(t) // empty cfg: no agent entries
+	b := newTestBackend("backend1", []*mcp.Tool{{Name: config.DenyAllToolsSentinel}})
+	if !denyAllCallIsError(t, g, b, config.DenyAllToolsSentinel) {
+		t.Fatalf("a tool named the deny-all sentinel must be blocked even for an unknown principal")
+	}
+}
+
+// FIX 2 discovery test 5: discovery containing the reserved tool name excludes it
+// (never registered as callable) while keeping normal tools.
+func TestGateway_DiscoveryExcludesReservedToolName(t *testing.T) {
+	g := newTestGateway(t)
+	g.backends = map[string]*Backend{
+		"backend1": newTestBackend("backend1", []*mcp.Tool{
+			{Name: "search"},
+			{Name: config.DenyAllToolsSentinel}, // reserved: must be excluded
+		}),
+	}
+	if err := g.buildToolMap(); err != nil {
+		t.Fatalf("buildToolMap: %v", err)
+	}
+	if _, ok := g.toolMap[config.DenyAllToolsSentinel]; ok {
+		t.Fatalf("reserved sentinel tool must be excluded from discovery, toolMap=%v", g.toolMap)
+	}
+	if _, ok := g.toolMap["search"]; !ok {
+		t.Fatalf("normal tool must still be discovered alongside an excluded reserved tool, toolMap=%v", g.toolMap)
+	}
+}
+
+// FIX 2 reinforcement: a normal allowlist still allows a permitted tool, proving
+// the sentinel special-case did not break normal allowlist matching.
+func TestGateway_NormalAllowlistStillAllows(t *testing.T) {
+	g := newTestGateway(t)
+	g.cfg = &config.Config{Agents: map[string]config.Agent{
+		"agent1": {AllowedTools: []string{"search"}},
+	}}
+	b := newTestBackend("backend1", []*mcp.Tool{{Name: "search"}})
+	if denyAllCallIsError(t, g, b, "search") {
+		t.Fatalf("a permitted tool must not be blocked by the sentinel special-case")
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -569,16 +569,29 @@ func (g *Gateway) buildToolMap() error {
 		return fmt.Errorf("no backends connected")
 	}
 
-	// Count tool name occurrences to detect conflicts
+	// Count tool name occurrences to detect conflicts. A backend tool whose name
+	// is the reserved deny-all sentinel is NEVER registered: the sentinel is a
+	// control marker, not a callable tool, and registering it would let a backend
+	// smuggle in a callable tool with the reserved name (defeating the deny-all
+	// representation). Reject it here at the single discovery chokepoint with an
+	// explicit warning so it is excluded, never silently callable.
 	nameCounts := make(map[string]int)
 	for _, b := range g.backends {
 		for _, t := range b.Tools {
+			if t.Name == config.DenyAllToolsSentinel {
+				continue
+			}
 			nameCounts[t.Name]++
 		}
 	}
 
 	for backendName, b := range g.backends {
 		for _, t := range b.Tools {
+			if t.Name == config.DenyAllToolsSentinel {
+				g.logger.Warn("backend tool uses reserved deny-all sentinel name; excluding from gateway",
+					"backend", backendName, "tool", t.Name)
+				continue
+			}
 			frontendName := t.Name
 			if nameCounts[t.Name] > 1 {
 				frontendName = backendName + "_" + t.Name
@@ -736,11 +749,28 @@ func (g *Gateway) makeHandler(m toolMapping) mcp.ToolHandler {
 		}
 		defer release()
 
-		// 3. Tool allowlist check
+		// 3. Tool allowlist check.
+		// The reserved deny-all sentinel is never a callable tool name, for ANY
+		// principal (even one with no agent config). Deny it unconditionally before
+		// the agent lookup so a sentinel-named tool can never execute. Gateway
+		// discovery already excludes such a backend tool, so this is defense in
+		// depth that also closes the no-agent-config path.
+		if m.OriginalName == config.DenyAllToolsSentinel {
+			g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionToolNotAllowed, "[]", toolArgs, sessionID, start)
+			return toolError(fmt.Sprintf("tool %q not allowed for agent %q", m.OriginalName, agent)), nil
+		}
 		if agentCfg, ok := g.cfg.Agents[policyAgent]; ok {
 			if agentCfg.Suspended {
 				g.logAudit(msgID, id, m.OriginalName, audit.StatusRejected, audit.DecisionAgentSuspended, "[]", toolArgs, sessionID, start)
 				return toolError("agent suspended"), nil
+			}
+			// Deny-all sentinel allowlist is special-cased BEFORE name matching so it
+			// can never execute as a tool: when the agent's allowlist is the lone
+			// deny-all sentinel, deny EVERY call (the sentinel is a control marker,
+			// never a matchable name).
+			if config.IsDenyAllTools(agentCfg.AllowedTools) {
+				g.logAudit(msgID, id, m.OriginalName, audit.StatusBlocked, audit.DecisionToolNotAllowed, "[]", toolArgs, sessionID, start)
+				return toolError(fmt.Sprintf("tool %q not allowed for agent %q", m.OriginalName, agent)), nil
 			}
 			if len(agentCfg.AllowedTools) > 0 {
 				allowed := false

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -596,6 +596,15 @@ func (g *Gateway) buildToolMap() error {
 			if nameCounts[t.Name] > 1 {
 				frontendName = backendName + "_" + t.Name
 			}
+			// A namespaced frontend name could ALSO collide with the reserved
+			// sentinel (e.g. backend "__oktsec" + tool "deny_all__" -> the sentinel).
+			// The handler keys deny-all on OriginalName, so a sentinel-named frontend
+			// would still be callable; exclude it here too.
+			if frontendName == config.DenyAllToolsSentinel {
+				g.logger.Warn("namespaced tool name collides with reserved deny-all sentinel; excluding from gateway",
+					"backend", backendName, "tool", t.Name, "frontend", frontendName)
+				continue
+			}
 			g.toolMap[frontendName] = toolMapping{
 				BackendName:    backendName,
 				OriginalName:   t.Name,

--- a/internal/proxy/stdio.go
+++ b/internal/proxy/stdio.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
 	"github.com/oktsec/oktsec/internal/engine"
 	"github.com/oktsec/oktsec/internal/verdict"
 )
@@ -232,10 +233,15 @@ func (p *StdioProxy) inspectAndDecide(line []byte, from, to string) (bool, json.
 		return false, nil, ""
 	}
 
-	// Tool allowlist check: block tools/call for tools not in the allowlist
+	// Tool allowlist check: block tools/call for tools not in the allowlist.
+	// The deny-all sentinel is special-cased BEFORE name matching so it can never
+	// execute as a tool: when the allowlist is the lone sentinel every call is
+	// denied (including a call to a tool literally named the sentinel), and a tool
+	// whose name IS the reserved sentinel is denied regardless of the allowlist.
 	if p.enforce && msg.Method == "tools/call" && len(p.allowedTools) > 0 {
 		toolName := extractToolName(msg)
-		if toolName != "" && !p.allowedTools[toolName] {
+		denyAll := len(p.allowedTools) == 1 && p.allowedTools[config.DenyAllToolsSentinel]
+		if toolName != "" && (denyAll || toolName == config.DenyAllToolsSentinel || !p.allowedTools[toolName]) {
 			p.logger.Warn("tool not allowed",
 				"tool", toolName,
 				"agent", p.agent,

--- a/internal/proxy/stdio.go
+++ b/internal/proxy/stdio.go
@@ -235,13 +235,18 @@ func (p *StdioProxy) inspectAndDecide(line []byte, from, to string) (bool, json.
 
 	// Tool allowlist check: block tools/call for tools not in the allowlist.
 	// The deny-all sentinel is special-cased BEFORE name matching so it can never
-	// execute as a tool: when the allowlist is the lone sentinel every call is
-	// denied (including a call to a tool literally named the sentinel), and a tool
-	// whose name IS the reserved sentinel is denied regardless of the allowlist.
-	if p.enforce && msg.Method == "tools/call" && len(p.allowedTools) > 0 {
+	// execute as a tool. Three denials, evaluated in this order:
+	//   - the requested tool name IS the reserved sentinel -> deny UNCONDITIONALLY,
+	//     even with an empty allowlist (an empty allowlist means "all tools", but
+	//     the sentinel is never a callable tool name);
+	//   - the allowlist is the lone deny-all sentinel -> deny EVERY call;
+	//   - a non-empty allowlist that does not list the tool -> deny.
+	if p.enforce && msg.Method == "tools/call" {
 		toolName := extractToolName(msg)
-		denyAll := len(p.allowedTools) == 1 && p.allowedTools[config.DenyAllToolsSentinel]
-		if toolName != "" && (denyAll || toolName == config.DenyAllToolsSentinel || !p.allowedTools[toolName]) {
+		denyAllList := len(p.allowedTools) == 1 && p.allowedTools[config.DenyAllToolsSentinel]
+		sentinelName := toolName == config.DenyAllToolsSentinel
+		notAllowed := len(p.allowedTools) > 0 && !p.allowedTools[toolName]
+		if toolName != "" && (sentinelName || denyAllList || notAllowed) {
 			p.logger.Warn("tool not allowed",
 				"tool", toolName,
 				"agent", p.agent,

--- a/internal/proxy/stdio_deny_all_test.go
+++ b/internal/proxy/stdio_deny_all_test.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// FIX 2 stdio runtime test: with the deny-all allowlist (the lone sentinel), any
+// NORMAL tool call is blocked at the stdio proxy enforcement point.
+func TestStdioProxy_DenyAllSentinelBlocksNormalTool(t *testing.T) {
+	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p.SetAllowedTools([]string{config.DenyAllToolsSentinel})
+	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, "weather"), "agent1", "server")
+	if !blocked {
+		t.Fatalf("deny-all sentinel allowlist must block a normal tool call")
+	}
+}
+
+// FIX 2 stdio runtime test: with the deny-all allowlist, a tool literally named
+// the reserved sentinel is ALSO blocked.
+func TestStdioProxy_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
+	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p.SetAllowedTools([]string{config.DenyAllToolsSentinel})
+	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, config.DenyAllToolsSentinel), "agent1", "server")
+	if !blocked {
+		t.Fatalf("a tool named the deny-all sentinel must be blocked under a deny-all allowlist")
+	}
+}
+
+// FIX 2 stdio reinforcement: a tool literally named the reserved sentinel is
+// denied even when the allowlist is broad and not the deny-all form.
+func TestStdioProxy_SentinelNamedToolBlockedWithBroadAllowlist(t *testing.T) {
+	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p.SetAllowedTools([]string{"calculator", config.DenyAllToolsSentinel})
+	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, config.DenyAllToolsSentinel), "agent1", "server")
+	if !blocked {
+		t.Fatalf("a tool named the deny-all sentinel must always be blocked")
+	}
+}
+
+// FIX 2 stdio reinforcement: a normal allowlist still permits a listed tool, so
+// the sentinel special-case did not break normal matching.
+func TestStdioProxy_NormalAllowlistStillAllows(t *testing.T) {
+	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p.SetAllowedTools([]string{"calculator"})
+	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, "calculator"), "agent1", "server")
+	if blocked {
+		t.Fatalf("a permitted tool must not be blocked by the sentinel special-case")
+	}
+}

--- a/internal/proxy/stdio_deny_all_test.go
+++ b/internal/proxy/stdio_deny_all_test.go
@@ -1,19 +1,22 @@
 package proxy
 
 import (
-	"io"
-	"log/slog"
 	"testing"
 
 	"github.com/oktsec/oktsec/internal/config"
 )
 
+// denyAllToolCall builds a JSON-RPC tools/call frame for the given tool name.
+func denyAllToolCall(toolName string) []byte {
+	return []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + toolName + `","arguments":{}}}`)
+}
+
 // FIX 2 stdio runtime test: with the deny-all allowlist (the lone sentinel), any
 // NORMAL tool call is blocked at the stdio proxy enforcement point.
 func TestStdioProxy_DenyAllSentinelBlocksNormalTool(t *testing.T) {
-	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p := newStdioTestSetup(t, true)
 	p.SetAllowedTools([]string{config.DenyAllToolsSentinel})
-	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, "weather"), "agent1", "server")
+	blocked, _, _ := p.inspectAndDecide(denyAllToolCall("weather"), "test-agent", "server")
 	if !blocked {
 		t.Fatalf("deny-all sentinel allowlist must block a normal tool call")
 	}
@@ -22,20 +25,32 @@ func TestStdioProxy_DenyAllSentinelBlocksNormalTool(t *testing.T) {
 // FIX 2 stdio runtime test: with the deny-all allowlist, a tool literally named
 // the reserved sentinel is ALSO blocked.
 func TestStdioProxy_DenyAllSentinelBlocksSentinelNamedTool(t *testing.T) {
-	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p := newStdioTestSetup(t, true)
 	p.SetAllowedTools([]string{config.DenyAllToolsSentinel})
-	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, config.DenyAllToolsSentinel), "agent1", "server")
+	blocked, _, _ := p.inspectAndDecide(denyAllToolCall(config.DenyAllToolsSentinel), "test-agent", "server")
 	if !blocked {
 		t.Fatalf("a tool named the deny-all sentinel must be blocked under a deny-all allowlist")
+	}
+}
+
+// FIX 2 stdio: the sentinel tool name is blocked UNCONDITIONALLY, even with an
+// empty allowlist (which otherwise means "all tools allowed"). The sentinel is
+// never a callable tool name.
+func TestStdioProxy_SentinelNamedToolBlockedWithEmptyAllowlist(t *testing.T) {
+	p := newStdioTestSetup(t, true)
+	// No SetAllowedTools call: empty allowlist == all tools allowed for normal names.
+	blocked, _, _ := p.inspectAndDecide(denyAllToolCall(config.DenyAllToolsSentinel), "test-agent", "server")
+	if !blocked {
+		t.Fatalf("a tool named the deny-all sentinel must be blocked even with an empty allowlist")
 	}
 }
 
 // FIX 2 stdio reinforcement: a tool literally named the reserved sentinel is
 // denied even when the allowlist is broad and not the deny-all form.
 func TestStdioProxy_SentinelNamedToolBlockedWithBroadAllowlist(t *testing.T) {
-	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p := newStdioTestSetup(t, true)
 	p.SetAllowedTools([]string{"calculator", config.DenyAllToolsSentinel})
-	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, config.DenyAllToolsSentinel), "agent1", "server")
+	blocked, _, _ := p.inspectAndDecide(denyAllToolCall(config.DenyAllToolsSentinel), "test-agent", "server")
 	if !blocked {
 		t.Fatalf("a tool named the deny-all sentinel must always be blocked")
 	}
@@ -44,9 +59,9 @@ func TestStdioProxy_SentinelNamedToolBlockedWithBroadAllowlist(t *testing.T) {
 // FIX 2 stdio reinforcement: a normal allowlist still permits a listed tool, so
 // the sentinel special-case did not break normal matching.
 func TestStdioProxy_NormalAllowlistStillAllows(t *testing.T) {
-	p := NewStdioProxy("agent1", newScanner(t), newStore(t), slog.New(slog.NewTextHandler(io.Discard, nil)), true)
+	p := newStdioTestSetup(t, true)
 	p.SetAllowedTools([]string{"calculator"})
-	blocked, _, _ := p.inspectAndDecide(buildToolCall(t, "calculator"), "agent1", "server")
+	blocked, _, _ := p.inspectAndDecide(denyAllToolCall("calculator"), "test-agent", "server")
 	if blocked {
 		t.Fatalf("a permitted tool must not be blocked by the sentinel special-case")
 	}


### PR DESCRIPTION
## What

Projects a verified `policy_bundle.v2` onto the local Oktsec config, safely. Builds on the v2 verification foundation (#198). The v1 apply path is unchanged; this adds a separate v2 projector dispatched by `schema_version`.

## Apply semantics

- **Per-dimension modes** `unmanaged | replace | clear`. `unmanaged` (the only meaning of "not governed") never touches config. `replace` sets the dimension to exactly the bundle value. `clear` is the explicit deny-all form. `merge` is rejected (deferred).
- **No silent widening.** An empty `replace` that would resolve to the runtime's "all allowed" is refused, never emitted; deny-all goes through `clear`, rendered as the genuine zero-access form. Scalar `clear` that would widen (un-suspend, remove a spend cap) is forbidden; the operator must use an explicit `replace` with the value.
- **Selectors** match agents by name/labels. Two governance entries matching the same agent on the same dimension fail closed before any write.
- **Target binding.** A node-scoped bundle applies only on the matching node id (via `--node-id`); a fleet-scoped bundle applies anywhere. Mismatch refuses before projection, with no write or backup.
- **Anti-rollback.** Last-applied sequence is persisted per target in `<config>.policy-state.json` (0600, written atomically only after a successful apply). A non-increasing sequence is refused unless an explicit signed rollback names the currently-applied assignment. The replay floor is monotonic and tracked separately from the applied sequence.
- **No partial apply.** Dry-run reports the full patch and any unsupported dimensions without writing; a real apply refuses entirely if any dimension is unsupported. Backup, validate-via-real-load, atomic replace, and dir fsync are preserved from the v1 path.

## Dimensions

Projected in this PR: rules (global), gateway tools, egress domains, agent suspension, blocked-content categories, scan profile. The richer dimensions (ACLs, tool policies, tool constraints, tool chain rules, server governance) FAIL CLOSED as unsupported when governed - never silently ignored.

## Tests

Full contract coverage: every mode per dimension, the widening guard (empty-replace refused, deny-all via clear, scalar-clear-widens forbidden), selector overlap, unsupported-fail-closed, no-partial, sequence advance-only-on-success, stale-sequence and signed-rollback, target binding, the 0600 atomic state file, and a v1 regression. `make build`, `make test` (race), `make lint`, `make vet` all green.

## Scope boundary

Local apply only. No node contact, no remote execution. Distribution (pull) is a later slice.