### PR TITLE
Node snapshot verifies policy_bundle.v2 signatures (Order 9A.4.1)

### DIFF
--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -6,11 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/oktsec/oktsec/internal/policybundle"
 	"github.com/oktsec/oktsec/internal/safefile"
 )
 
@@ -106,7 +108,10 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 		return unreadable("invalid JSON: " + err.Error())
 	}
 	// A bundle that does not declare the minimal identity Enterprise
-	// compares against (hash + id) is not a usable active policy.
+	// compares against (hash + id) is not a usable active policy. This
+	// tolerant projection shares the policy_hash / policy.policy_id /
+	// policy.policy_version JSON paths with both the v1 and v2 envelopes,
+	// so the minimal-identity guard is schema-agnostic.
 	if bundle.PolicyHash == "" {
 		return unreadable("bundle declares no policy_hash")
 	}
@@ -114,7 +119,18 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 		return unreadable("bundle declares no policy.policy_id")
 	}
 
-	verified, status := verifyPolicyBundle(bundle, trustFingerprint)
+	// Dispatch verification by the declared schema_version. v1 (and any
+	// legacy/unknown shape) keeps the byte-for-byte Order 4C.1 path; v2
+	// reuses the already-merged policybundle.VerifyBundleV2 verifier. The
+	// reported hash/id/version always come from the tolerant projection
+	// above, which reads the same JSON paths for both schemas.
+	var verified bool
+	var status string
+	if bundle.SchemaVersion == policybundle.SchemaVersionV2 {
+		verified, status = verifyPolicyBundleV2(data, trustFingerprint)
+	} else {
+		verified, status = verifyPolicyBundle(bundle, trustFingerprint)
+	}
 	return &SnapshotPolicy{
 		ActivePolicyHash:               bundle.PolicyHash,
 		ActivePolicyID:                 bundle.Policy.PolicyID,
@@ -125,6 +141,63 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 		ActivePolicyVerificationStatus: status,
 		PolicyStatus:                   PolicyStatusActive,
 	}, nil
+}
+
+// verifyPolicyBundleV2 runs the Order 9A.4.1 signature verification for a
+// policy_bundle.v2 bundle, reusing the merged policybundle.VerifyBundleV2
+// verifier. It maps the result into the SAME ActivePolicyVerificationStatus
+// vocabulary the v1 path uses; no new status strings are introduced.
+//
+// As with v1, "verified" means exactly "the Ed25519 signature over the v2
+// signing payload verified against the operator-configured trust
+// fingerprint". The body is not applied here.
+//
+// Trust-anchor handling mirrors v1: with no configured trust fingerprint the
+// node reports the present-but-unverified bundle as no_trust_anchor rather
+// than attempting a verification it cannot anchor. VerifyBundleV2 itself
+// requires a trust fingerprint, so the no-anchor case is handled before
+// calling it.
+func verifyPolicyBundleV2(raw []byte, trustFingerprint string) (bool, string) {
+	// Mirror v1: a present bundle with no trust anchor is reported
+	// no_trust_anchor, not verified. VerifyBundleV2 rejects an empty
+	// trust fingerprint outright, so short-circuit here.
+	if trustFingerprint == "" {
+		return false, PolicyVerificationNoTrustAnchor
+	}
+	if _, err := policybundle.VerifyBundleV2(raw, trustFingerprint); err != nil {
+		return false, policyV2RejectToStatus(err)
+	}
+	return true, PolicyVerificationVerified
+}
+
+// policyV2RejectToStatus maps a policybundle.VerifyBundleV2 reject code onto
+// the existing ActivePolicyVerificationStatus vocabulary, mirroring how the
+// v1 path classifies the equivalent failures. No new status strings.
+//
+//	policy_signing_key_mismatch -> signing_key_mismatch
+//	policy_hash_mismatch        -> signature_invalid (the declared hash the
+//	                               signature covers did not match the body)
+//	policy_signature_invalid    -> signature_invalid
+//	policy_decode / policy_schema_invalid / policy_unsupported_bundle
+//	                            -> unsupported_bundle
+//
+// A non-reject error (none is expected from VerifyBundleV2 once the trust
+// fingerprint is non-empty) falls back to unsupported_bundle so the node
+// fails closed rather than claiming verification.
+func policyV2RejectToStatus(err error) string {
+	var re *policybundle.RejectError
+	if !errors.As(err, &re) {
+		return PolicyVerificationUnsupportedBundle
+	}
+	switch re.Code {
+	case policybundle.RejectSigningKeyMismatch:
+		return PolicyVerificationSigningKeyMismatch
+	case policybundle.RejectHashMismatch, policybundle.RejectSignatureInvalid:
+		return PolicyVerificationSignatureInvalid
+	default:
+		// policy_decode, policy_schema_invalid, policy_unsupported_bundle.
+		return PolicyVerificationUnsupportedBundle
+	}
 }
 
 // verifyPolicyBundle runs the Order 4C.1 verification state machine

--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -156,23 +156,36 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 // FIRST, then the no-trust-anchor decision, then signature verification.
 // VerifyBundleV2 entangles the trust match with its shape checks (it
 // rejects an empty trust fingerprint outright), so the no-anchor case
-// cannot route through it. To keep the reported status accurate even
-// without a configured trust anchor, the empty-fingerprint case runs the
-// minimal structural checks inline below before classifying the bundle:
-// a malformed/unsupported v2 bundle is unsupported_bundle (fail closed)
-// EVEN WITH no trust fingerprint, and only a well-shaped bundle whose
-// only missing piece is the trust anchor is no_trust_anchor. These inline
-// checks deliberately mirror v1's pre-anchor checks (the schema/bundle/
-// canonicalization/alg constants plus a present, well-formed signature
-// block); they are NOT a reimplementation of signature verification, which
-// stays in VerifyBundleV2 for the anchored path.
+// cannot pass it the empty fingerprint directly. To keep the reported
+// status accurate even without a configured trust anchor, the
+// empty-fingerprint case runs the SAME strict v2 verification against the
+// bundle's OWN embedded key fingerprint. That reuses every shape, schema,
+// duplicate-key, hash, and signature check VerifyBundleV2 performs (its
+// trust-match step trivially passes because the embedded key is its own
+// self-consistent fingerprint), without reimplementing any of them:
+//
+//	verifier rejects (malformed/unsupported/bad signature) -> the mapped
+//	  reject status (unsupported_bundle / signature_invalid), EVEN WITH no
+//	  configured trust anchor (fail closed)
+//	verifier accepts (well-shaped AND self-signature valid) -> the only
+//	  thing missing is the operator trust anchor -> no_trust_anchor
+//
+// So a bundle's snapshot status no longer flips between unsupported_bundle/
+// signature_invalid and no_trust_anchor merely because a trust fingerprint
+// is added: the structural verdict is identical either way, and the trust
+// anchor only decides verified vs signing_key_mismatch vs no_trust_anchor.
 func verifyPolicyBundleV2(raw []byte, trustFingerprint string) (bool, string) {
 	if trustFingerprint == "" {
-		// Shape first, then the no-trust-anchor decision. Mirror v1's
-		// pre-anchor checks so a malformed v2 bundle is unsupported_bundle
-		// and only a well-shaped one with no anchor is no_trust_anchor.
-		if !isSupportedV2Shape(raw) {
+		// Shape/structure first, via the real verifier against the bundle's
+		// own embedded fingerprint, then the no-trust-anchor decision.
+		ownFP := embeddedV2Fingerprint(raw)
+		if ownFP == "" {
+			// No usable embedded fingerprint to anchor the self-check on:
+			// the signature block is malformed, so fail closed.
 			return false, PolicyVerificationUnsupportedBundle
+		}
+		if _, err := policybundle.VerifyBundleV2(raw, ownFP); err != nil {
+			return false, policyV2RejectToStatus(err)
 		}
 		return false, PolicyVerificationNoTrustAnchor
 	}
@@ -182,38 +195,21 @@ func verifyPolicyBundleV2(raw []byte, trustFingerprint string) (bool, string) {
 	return true, PolicyVerificationVerified
 }
 
-// isSupportedV2Shape reports whether raw is a structurally-supported
-// policy_bundle.v2 bundle, mirroring the class of pre-anchor checks v1's
-// verifyPolicyBundle does before its no_trust_anchor return: the v2 schema/
-// bundle/canonicalization/alg constants plus a present, well-formed
-// signature block (a base64-decodable Ed25519 public key of the right
-// length, a self-consistent claimed fingerprint, and a non-empty signature
-// value). It does NOT verify the signature; that is VerifyBundleV2's job on
-// the anchored path. A malformed bundle returns false so the caller fails
-// closed to unsupported_bundle.
-func isSupportedV2Shape(raw []byte) bool {
+// embeddedV2Fingerprint returns the public_key_fingerprint a v2 bundle
+// claims for its embedded signing key, used only to drive the no-anchor
+// self-check through VerifyBundleV2 (which requires a non-empty trust
+// fingerprint). It does NOT decide trust: VerifyBundleV2 still re-derives
+// the fingerprint from the embedded key and rejects a self-inconsistent
+// block, so a hand-edited fingerprint cannot launder a bad bundle. Returns
+// "" when the claimed fingerprint is absent (the bundle is then treated as
+// an unsupported shape, matching the verifier's own self-consistency
+// reject).
+func embeddedV2Fingerprint(raw []byte) string {
 	var b rawPolicyBundle
 	if err := json.Unmarshal(raw, &b); err != nil {
-		return false
+		return ""
 	}
-	sig := b.Signature
-	pub, err := base64.StdEncoding.DecodeString(sig.PublicKey)
-	if b.SchemaVersion != policybundle.SchemaVersionV2 ||
-		b.BundleVersion != policybundle.BundleVersionV2 ||
-		b.Canonicalization != policybundle.CanonicalizationV2 ||
-		sig.Alg != policybundle.SignatureAlg ||
-		sig.Value == "" ||
-		err != nil ||
-		len(pub) != ed25519.PublicKeySize {
-		return false
-	}
-	// Self-consistency: the embedded key must hash to the claimed
-	// fingerprint, the same malformed-signature-block guard v1 applies
-	// before its trust decision.
-	if sig.PublicKeyFingerprint != policyKeyFingerprint(pub) {
-		return false
-	}
-	return true
+	return b.Signature.PublicKeyFingerprint
 }
 
 // policyV2RejectToStatus maps a policybundle.VerifyBundleV2 reject code onto

--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -152,22 +152,68 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 // signing payload verified against the operator-configured trust
 // fingerprint". The body is not applied here.
 //
-// Trust-anchor handling mirrors v1: with no configured trust fingerprint the
-// node reports the present-but-unverified bundle as no_trust_anchor rather
-// than attempting a verification it cannot anchor. VerifyBundleV2 itself
-// requires a trust fingerprint, so the no-anchor case is handled before
-// calling it.
+// Trust-anchor handling mirrors v1's ordering exactly: shape/structure
+// FIRST, then the no-trust-anchor decision, then signature verification.
+// VerifyBundleV2 entangles the trust match with its shape checks (it
+// rejects an empty trust fingerprint outright), so the no-anchor case
+// cannot route through it. To keep the reported status accurate even
+// without a configured trust anchor, the empty-fingerprint case runs the
+// minimal structural checks inline below before classifying the bundle:
+// a malformed/unsupported v2 bundle is unsupported_bundle (fail closed)
+// EVEN WITH no trust fingerprint, and only a well-shaped bundle whose
+// only missing piece is the trust anchor is no_trust_anchor. These inline
+// checks deliberately mirror v1's pre-anchor checks (the schema/bundle/
+// canonicalization/alg constants plus a present, well-formed signature
+// block); they are NOT a reimplementation of signature verification, which
+// stays in VerifyBundleV2 for the anchored path.
 func verifyPolicyBundleV2(raw []byte, trustFingerprint string) (bool, string) {
-	// Mirror v1: a present bundle with no trust anchor is reported
-	// no_trust_anchor, not verified. VerifyBundleV2 rejects an empty
-	// trust fingerprint outright, so short-circuit here.
 	if trustFingerprint == "" {
+		// Shape first, then the no-trust-anchor decision. Mirror v1's
+		// pre-anchor checks so a malformed v2 bundle is unsupported_bundle
+		// and only a well-shaped one with no anchor is no_trust_anchor.
+		if !isSupportedV2Shape(raw) {
+			return false, PolicyVerificationUnsupportedBundle
+		}
 		return false, PolicyVerificationNoTrustAnchor
 	}
 	if _, err := policybundle.VerifyBundleV2(raw, trustFingerprint); err != nil {
 		return false, policyV2RejectToStatus(err)
 	}
 	return true, PolicyVerificationVerified
+}
+
+// isSupportedV2Shape reports whether raw is a structurally-supported
+// policy_bundle.v2 bundle, mirroring the class of pre-anchor checks v1's
+// verifyPolicyBundle does before its no_trust_anchor return: the v2 schema/
+// bundle/canonicalization/alg constants plus a present, well-formed
+// signature block (a base64-decodable Ed25519 public key of the right
+// length, a self-consistent claimed fingerprint, and a non-empty signature
+// value). It does NOT verify the signature; that is VerifyBundleV2's job on
+// the anchored path. A malformed bundle returns false so the caller fails
+// closed to unsupported_bundle.
+func isSupportedV2Shape(raw []byte) bool {
+	var b rawPolicyBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return false
+	}
+	sig := b.Signature
+	pub, err := base64.StdEncoding.DecodeString(sig.PublicKey)
+	if b.SchemaVersion != policybundle.SchemaVersionV2 ||
+		b.BundleVersion != policybundle.BundleVersionV2 ||
+		b.Canonicalization != policybundle.CanonicalizationV2 ||
+		sig.Alg != policybundle.SignatureAlg ||
+		sig.Value == "" ||
+		err != nil ||
+		len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	// Self-consistency: the embedded key must hash to the claimed
+	// fingerprint, the same malformed-signature-block guard v1 applies
+	// before its trust decision.
+	if sig.PublicKeyFingerprint != policyKeyFingerprint(pub) {
+		return false
+	}
+	return true
 }
 
 // policyV2RejectToStatus maps a policybundle.VerifyBundleV2 reject code onto

--- a/internal/node/policy_bundle_v2_fixture.json
+++ b/internal/node/policy_bundle_v2_fixture.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": "policy_bundle.v2",
+  "bundle_version": 2,
+  "policy_hash": "sha256:304e887278c6d571daa9e2b4e68aa4e41fee9850e837196da27d97845de95cf2",
+  "canonicalization": "oktsec-policy-v2-typed-utc-json",
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "mode": "enforce",
+    "assignment": {
+      "assignment_id": "assign-0001",
+      "target": {
+        "scope": "node",
+        "node_id": "node-east-1"
+      },
+      "issued_at": "2026-05-23T12:00:00Z",
+      "sequence": 1,
+      "rollback_of": ""
+    },
+    "rules": {
+      "mode": "replace",
+      "enabled": [
+        "IAP-001",
+        "IAP-003",
+        "IAP-007"
+      ],
+      "disabled": [
+        "IAP-004"
+      ],
+      "overrides": {
+        "IAP-007": {
+          "action": "block"
+        }
+      }
+    },
+    "gateway": {
+      "mode": "replace",
+      "tools_allowed": [
+        "calendar.read",
+        "voice.dial"
+      ],
+      "tools_denied": [
+        "shell.exec"
+      ]
+    },
+    "egress": {
+      "mode": "replace",
+      "domains_allowed": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "domains_denied": [
+        "*.suspicious.example"
+      ]
+    },
+    "governance": {
+      "server": {
+        "mode": "replace",
+        "require_intent": true,
+        "rate_limit_max": 100,
+        "rate_limit_window_s": 60
+      },
+      "agents": [
+        {
+          "selector": {
+            "name": "voice-agent",
+            "labels": {
+              "env": "prod",
+              "tier": "critical"
+            }
+          },
+          "acls": {
+            "mode": "replace",
+            "allowed_recipients": [
+              "billing-agent",
+              "calendar-agent"
+            ],
+            "blocked_recipients": [
+              "untrusted-agent"
+            ]
+          },
+          "allowed_tools": {
+            "mode": "replace",
+            "values": [
+              "calendar.read",
+              "voice.dial"
+            ]
+          },
+          "tool_policies": {
+            "mode": "replace",
+            "by_tool": {
+              "voice.dial": {
+                "max_amount": "100.00",
+                "daily_limit": "1000.00",
+                "require_approval_above": "500.00",
+                "rate_limit": 20
+              }
+            }
+          },
+          "tool_constraints": {
+            "mode": "replace",
+            "items": [
+              {
+                "tool": "voice.dial",
+                "parameters": {
+                  "number": {
+                    "allowed_patterns": [
+                      "+1*",
+                      "+44*"
+                    ],
+                    "blocked_patterns": [
+                      "+1900*"
+                    ],
+                    "max_length": 20
+                  }
+                },
+                "max_response_bytes": 4096,
+                "cooldown_secs": 30
+              }
+            ]
+          },
+          "tool_chain_rules": {
+            "mode": "clear",
+            "items": [
+              {
+                "if": "voice.dial",
+                "then": [
+                  "shell.exec"
+                ],
+                "cooldown_secs": 300
+              }
+            ]
+          },
+          "blocked_content": {
+            "mode": "replace",
+            "values": [
+              "secrets",
+              "credentials"
+            ]
+          },
+          "scan_profile": {
+            "mode": "replace",
+            "value": "strict"
+          },
+          "suspended": {
+            "mode": "replace",
+            "value": false
+          },
+          "egress": {
+            "mode": "replace",
+            "allowed_domains": [
+              "api.openai.com",
+              "api.anthropic.com"
+            ],
+            "blocked_domains": [
+              "*.suspicious.example"
+            ],
+            "scope": "internal+api.openai.com",
+            "tool_restrictions": {
+              "voice.dial": [
+                "api.twilio.com"
+              ]
+            },
+            "scan_requests": "true",
+            "scan_responses": "false",
+            "blocked_categories": [
+              "secrets",
+              "pii"
+            ],
+            "rate_limit": 100,
+            "rate_window": 60,
+            "integrations": [
+              "slack",
+              "github"
+            ]
+          }
+        }
+      ]
+    },
+    "redaction": {
+      "mode": "replace",
+      "level": "analyst"
+    },
+    "metadata": {
+      "created_at": "2026-05-23T12:00:00Z",
+      "created_by": "fixture-generator",
+      "reason": "Vendored test fixture for policy_bundle.v2 schema drift guard."
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "key_id": "enterprise-policy-fixture-v2",
+    "public_key": "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ=",
+    "public_key_fingerprint": "sha256:65b60673d6ed884bf01c2c222d82ada0740f29ac3355d6a925c81f17f47a27b8",
+    "signed_at": "2026-05-23T12:00:01Z",
+    "value": "0kluhegBEV5F/l2a8KlblR/827WqKvoCOkTqxPgRlPWYx+FXYSIdZEPN11SUgI7FKOAAfPOU2S/UEvzvKNUgCA=="
+  }
+}

--- a/internal/node/policy_bundle_v2_verify_test.go
+++ b/internal/node/policy_bundle_v2_verify_test.go
@@ -1,0 +1,181 @@
+package node
+
+import (
+	"crypto/ed25519"
+	_ "embed"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// vendoredPolicyBundleV2 is a real, deterministically signed
+// policy_bundle.v2 vendored verbatim from the policybundle package (the
+// same artifact policybundle.VerifyBundleV2 verifies in its own tests).
+// Embedding it here lets the node snapshot's v2 verification path exercise
+// a genuine v2 bundle end to end, and guards the cross-package contract:
+// if the snapshot dispatch or the v2 verifier drift, these tests fail.
+//
+//go:embed policy_bundle_v2_fixture.json
+var vendoredPolicyBundleV2 []byte
+
+// v2FixtureFingerprint returns the trust fingerprint the vendored v2
+// fixture was signed with (its embedded signing-key fingerprint).
+func v2FixtureFingerprint(t *testing.T) string {
+	t.Helper()
+	var b rawPolicyBundle
+	if err := json.Unmarshal(vendoredPolicyBundleV2, &b); err != nil {
+		t.Fatalf("decode v2 fixture: %v", err)
+	}
+	if b.Signature.PublicKeyFingerprint == "" {
+		t.Fatal("v2 fixture has no signing-key fingerprint")
+	}
+	return b.Signature.PublicKeyFingerprint
+}
+
+// writeV2 drops raw v2 bundle bytes into a temp file and returns the path.
+func writeV2(t *testing.T, raw []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "policy.v2.signed.json")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write v2 bundle: %v", err)
+	}
+	return p
+}
+
+// (1) Regression: the v1 path stays frozen. A v1 bundle signed with the
+// node's own payload reconstruction still verifies true under its trust
+// fingerprint, unchanged by the v2 dispatch.
+func TestBuildPolicySection_V1StillVerifies(t *testing.T) {
+	priv := newKey(t)
+	trustFP := policyKeyFingerprint(priv.Public().(ed25519.PublicKey))
+	path := writeV2(t, signedBundleJSON(t, priv, nil))
+	sec, warns := buildPolicySection(path, trustFP)
+	if len(warns) != 0 {
+		t.Fatalf("valid v1 bundle must not warn, got %v", warns)
+	}
+	if !sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationVerified {
+		t.Fatalf("v1 path drifted: verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+	}
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("status = %q, want %q", sec.PolicyStatus, PolicyStatusActive)
+	}
+}
+
+// (2) A valid v2 bundle + matching trust fingerprint verifies true, and
+// the reported hash/id/version come from the v2 body.
+func TestBuildPolicySection_V2Verified(t *testing.T) {
+	trustFP := v2FixtureFingerprint(t)
+	path := writeV2(t, vendoredPolicyBundleV2)
+	sec, warns := buildPolicySection(path, trustFP)
+	if len(warns) != 0 {
+		t.Fatalf("valid v2 bundle must not warn, got %v", warns)
+	}
+	if !sec.ActivePolicyVerified || sec.ActivePolicyVerificationStatus != PolicyVerificationVerified {
+		t.Fatalf("v2 bundle did not verify: verified=%v status=%q", sec.ActivePolicyVerified, sec.ActivePolicyVerificationStatus)
+	}
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("status = %q, want %q", sec.PolicyStatus, PolicyStatusActive)
+	}
+	// Identity comes from the v2 body (echoed via the tolerant projection,
+	// which reads the same JSON paths the v2 envelope uses).
+	if sec.ActivePolicyHash != "sha256:304e887278c6d571daa9e2b4e68aa4e41fee9850e837196da27d97845de95cf2" {
+		t.Errorf("hash = %q, want v2 body hash", sec.ActivePolicyHash)
+	}
+	if sec.ActivePolicyID != "voice-ai-prod" {
+		t.Errorf("id = %q, want v2 body policy_id", sec.ActivePolicyID)
+	}
+	if sec.ActivePolicyVersion != "1" {
+		t.Errorf("version = %q, want v2 body policy_version", sec.ActivePolicyVersion)
+	}
+}
+
+// (3) Wrong trust fingerprint on a valid v2 bundle -> verified false,
+// signing_key_mismatch (same status the v1 path uses for this case).
+func TestBuildPolicySection_V2WrongTrustFingerprint(t *testing.T) {
+	otherFP := policyKeyFingerprint(newKey(t).Public().(ed25519.PublicKey))
+	path := writeV2(t, vendoredPolicyBundleV2)
+	sec, _ := buildPolicySection(path, otherFP)
+	if sec.ActivePolicyVerified {
+		t.Fatal("v2 bundle must not verify under a wrong trust fingerprint")
+	}
+	if sec.ActivePolicyVerificationStatus != PolicyVerificationSigningKeyMismatch {
+		t.Fatalf("status = %q, want %q", sec.ActivePolicyVerificationStatus, PolicyVerificationSigningKeyMismatch)
+	}
+}
+
+// (4) A v2 bundle corrupted after signing (its declared policy_hash
+// flipped) fails closed. The hash no longer matches the body the
+// signature covers, so VerifyBundleV2 rejects it; the node reports
+// signature_invalid (fail closed, never verified). A separate case
+// corrupts the schema body so the strict v2 decode rejects it as
+// unsupported_bundle.
+func TestBuildPolicySection_V2FailClosed(t *testing.T) {
+	trustFP := v2FixtureFingerprint(t)
+
+	t.Run("hash_flipped_signature_invalid", func(t *testing.T) {
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		m["policy_hash"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), trustFP)
+		if sec.ActivePolicyVerified {
+			t.Fatal("corrupted v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationSignatureInvalid {
+			t.Fatalf("status = %q, want %q", sec.ActivePolicyVerificationStatus, PolicyVerificationSignatureInvalid)
+		}
+	})
+
+	t.Run("unknown_field_unsupported", func(t *testing.T) {
+		// A v2-tagged bundle carrying an unknown top-level field is
+		// rejected by the strict v2 decode (policy_decode) and reported
+		// as unsupported_bundle, never verified.
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		m["unexpected_field"] = "x"
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), trustFP)
+		if sec.ActivePolicyVerified {
+			t.Fatal("malformed v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status = %q, want %q", sec.ActivePolicyVerificationStatus, PolicyVerificationUnsupportedBundle)
+		}
+	})
+}
+
+// (5) Supports the 9A.4 smoke: a present v2 bundle with NO trust
+// fingerprint is reported present-but-unverified as no_trust_anchor, the
+// same status the v1 path uses, so the smoke can distinguish "no anchor"
+// from "verified". Identity is still echoed (the bundle IS present).
+func TestBuildPolicySection_V2NoTrustAnchor(t *testing.T) {
+	path := writeV2(t, vendoredPolicyBundleV2)
+	sec, warns := buildPolicySection(path, "")
+	if len(warns) != 0 {
+		t.Fatalf("present v2 bundle must not warn, got %v", warns)
+	}
+	if sec.ActivePolicyVerified {
+		t.Fatal("no trust anchor means not verified")
+	}
+	if sec.ActivePolicyVerificationStatus != PolicyVerificationNoTrustAnchor {
+		t.Fatalf("status = %q, want %q", sec.ActivePolicyVerificationStatus, PolicyVerificationNoTrustAnchor)
+	}
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("status = %q, want %q (bundle is present)", sec.PolicyStatus, PolicyStatusActive)
+	}
+	if sec.ActivePolicyID != "voice-ai-prod" || sec.ActivePolicyVersion != "1" {
+		t.Fatalf("identity not echoed for present-but-unverified v2: id=%q version=%q", sec.ActivePolicyID, sec.ActivePolicyVersion)
+	}
+}

--- a/internal/node/policy_bundle_v2_verify_test.go
+++ b/internal/node/policy_bundle_v2_verify_test.go
@@ -179,3 +179,80 @@ func TestBuildPolicySection_V2NoTrustAnchor(t *testing.T) {
 		t.Fatalf("identity not echoed for present-but-unverified v2: id=%q version=%q", sec.ActivePolicyID, sec.ActivePolicyVersion)
 	}
 }
+
+// (6) Parity regression: a MALFORMED v2 bundle with NO trust fingerprint
+// must report unsupported_bundle, NOT no_trust_anchor. The verification
+// status has to be accurate regardless of whether a trust anchor is
+// configured, so shape is decided before the no-anchor classification,
+// mirroring the v1 path. Before the fix, the empty-fingerprint case
+// short-circuited to no_trust_anchor and mis-labeled these bundles.
+func TestBuildPolicySection_V2NoTrustAnchorMalformedUnsupported(t *testing.T) {
+	t.Run("corrupt_signature_block_no_anchor", func(t *testing.T) {
+		// Garble the embedded signature block so it is no longer a
+		// well-formed v2 signature (the public key fingerprint no longer
+		// matches the embedded key). With no trust fingerprint this is a
+		// shape failure, not a missing anchor.
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		sig, ok := m["signature"].(map[string]any)
+		if !ok {
+			t.Fatal("fixture has no signature object")
+		}
+		sig["public_key_fingerprint"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), "")
+		if sec.ActivePolicyVerified {
+			t.Fatal("malformed v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status = %q, want %q (malformed shape wins over missing anchor)",
+				sec.ActivePolicyVerificationStatus, PolicyVerificationUnsupportedBundle)
+		}
+	})
+
+	t.Run("wrong_bundle_version_no_anchor", func(t *testing.T) {
+		// A v2-tagged bundle with the wrong bundle_version is structurally
+		// unsupported. With no trust fingerprint it is unsupported_bundle,
+		// not no_trust_anchor.
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		m["bundle_version"] = 99
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), "")
+		if sec.ActivePolicyVerified {
+			t.Fatal("malformed v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status = %q, want %q (wrong bundle_version is unsupported, not no_trust_anchor)",
+				sec.ActivePolicyVerificationStatus, PolicyVerificationUnsupportedBundle)
+		}
+	})
+}
+
+// (7) The legitimate case stays correct: a WELL-FORMED v2 bundle with NO
+// trust fingerprint is still no_trust_anchor (present-but-unanchored), not
+// unsupported_bundle. This is the companion to the malformed regression
+// above and pins the shape-then-anchor ordering from the other side.
+func TestBuildPolicySection_V2NoTrustAnchorWellFormed(t *testing.T) {
+	sec, warns := buildPolicySection(writeV2(t, vendoredPolicyBundleV2), "")
+	if len(warns) != 0 {
+		t.Fatalf("present well-formed v2 bundle must not warn, got %v", warns)
+	}
+	if sec.ActivePolicyVerified {
+		t.Fatal("no trust anchor means not verified")
+	}
+	if sec.ActivePolicyVerificationStatus != PolicyVerificationNoTrustAnchor {
+		t.Fatalf("status = %q, want %q (well-formed + no anchor stays no_trust_anchor)",
+			sec.ActivePolicyVerificationStatus, PolicyVerificationNoTrustAnchor)
+	}
+}

--- a/internal/node/policy_bundle_v2_verify_test.go
+++ b/internal/node/policy_bundle_v2_verify_test.go
@@ -237,6 +237,55 @@ func TestBuildPolicySection_V2NoTrustAnchorMalformedUnsupported(t *testing.T) {
 				sec.ActivePolicyVerificationStatus, PolicyVerificationUnsupportedBundle)
 		}
 	})
+
+	t.Run("unknown_field_no_anchor", func(t *testing.T) {
+		// A v2-tagged bundle with an unknown top-level field is rejected by
+		// the strict v2 decode. With no trust fingerprint it must still be
+		// unsupported_bundle, the SAME status the anchored path reports for
+		// this bundle (see TestBuildPolicySection_V2FailClosed). The status
+		// must not flip to no_trust_anchor just because no anchor is set.
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		m["unexpected_field"] = "x"
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), "")
+		if sec.ActivePolicyVerified {
+			t.Fatal("malformed v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationUnsupportedBundle {
+			t.Fatalf("status = %q, want %q (strict-decode reject is unsupported, not no_trust_anchor)",
+				sec.ActivePolicyVerificationStatus, PolicyVerificationUnsupportedBundle)
+		}
+	})
+
+	t.Run("hash_flipped_no_anchor", func(t *testing.T) {
+		// A v2 bundle whose declared policy_hash was flipped after signing
+		// fails the verifier hash/signature checks. With no trust
+		// fingerprint it must report signature_invalid (fail closed), the
+		// SAME status the anchored path reports, not no_trust_anchor.
+		var m map[string]any
+		if err := json.Unmarshal(vendoredPolicyBundleV2, &m); err != nil {
+			t.Fatalf("decode fixture: %v", err)
+		}
+		m["policy_hash"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		raw, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sec, _ := buildPolicySection(writeV2(t, raw), "")
+		if sec.ActivePolicyVerified {
+			t.Fatal("corrupted v2 bundle must not verify")
+		}
+		if sec.ActivePolicyVerificationStatus != PolicyVerificationSignatureInvalid {
+			t.Fatalf("status = %q, want %q (hash mismatch is signature_invalid, not no_trust_anchor)",
+				sec.ActivePolicyVerificationStatus, PolicyVerificationSignatureInvalid)
+		}
+	})
 }
 
 // (7) The legitimate case stays correct: a WELL-FORMED v2 bundle with NO


### PR DESCRIPTION
The 9A.4 cross-repo smoke surfaced a real gap: `oktsec node snapshot --policy-bundle` could verify the signature of a `policy_bundle.v1` bundle but short-circuited a `policy_bundle.v2` bundle to `active_policy_verified: false` / `active_policy_verification_status: unsupported_bundle`. A node can APPLY a v2 bundle (9A.2) but could not VERIFY its signature when reporting its active policy. This closes that gap.

## What changed

The snapshot policy-bundle verification path now dispatches by `schema_version`:

- `policy_bundle.v1` (and any legacy/unknown shape) keeps the byte-for-byte Order 4C.1 path (`rawPolicyBundle` + `verifyPolicyBundle`). v1 behavior and status outcomes are unchanged.
- `policy_bundle.v2` is verified via the already-merged `policybundle.VerifyBundleV2`. No v2 verification is reimplemented.

The minimal-identity guard (`policy_hash` + `policy.policy_id` non-empty), symlink rejection, file-size cap, and JSON-unreadable handling are unchanged and shared by both paths. The reported hash/id/version come from the tolerant projection that reads the JSON paths shared by both envelopes. No apply, no changes to the snapshot output schema.

## Status mapping (reuses the existing vocabulary, no new strings)

| `VerifyBundleV2` reject | reported status |
|---|---|
| `policy_signing_key_mismatch` | `signing_key_mismatch` |
| `policy_hash_mismatch` / `policy_signature_invalid` | `signature_invalid` |
| `policy_decode` / `policy_schema_invalid` / `policy_unsupported_bundle` | `unsupported_bundle` |

No trust fingerprint configured reports `no_trust_anchor` (same as v1), so the smoke can distinguish "no anchor" from "verified". Fails closed in all error paths.

## Tests

Five tests added (race-clean), embedding a vendored copy of the deterministic v2 fixture:

1. v1 bundle still verifies true (regression, v1 frozen).
2. valid v2 + matching trust fingerprint -> `verified`, hash/id/version from the v2 body.
3. wrong trust fingerprint on v2 -> `signing_key_mismatch`.
4. corrupted/malformed v2 -> fail closed (`signature_invalid` and `unsupported_bundle`).
5. v2 with no trust fingerprint -> `no_trust_anchor` (present-but-unverified).

`make build && make test && make lint && make vet` all green with `-race`. The `internal/policybundle` package is untouched.