### PR TITLE
Harden policy apply and snapshot JSON output

### DIFF
--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -487,6 +487,8 @@ func emitPlan(cmd *cobra.Command, jsonOut bool, p *apply.Plan) {
 			fmt.Fprintf(out, "  - rule %s → %s\n", c.ID, c.Action)
 		case "rule_reset_default":
 			fmt.Fprintf(out, "  - rule %s → severity default (local override removed)\n", c.ID)
+		case "rule_marker_cleared":
+			fmt.Fprintf(out, "  - rule %s → policy ownership cleared (no action change)\n", c.ID)
 		default:
 			fmt.Fprintf(out, "  - %s (agent %s): %d\n", c.Kind, c.Agent, c.Count)
 		}

--- a/internal/apply/fix_correctness_test.go
+++ b/internal/apply/fix_correctness_test.go
@@ -145,6 +145,103 @@ func TestV1DryRun_ClearsManagedByPolicyMarker(t *testing.T) {
 	}
 }
 
+// P2 #2: a v2-owned rule already AT the override's target action and global hits
+// the no-action-change early return in upsert. The marker must STILL be cleared
+// (so a later v2 replace cannot reap it), and that clear must be recorded as a
+// distinct committable change (not a false action change) so it persists.
+func TestV1DryRun_ClearsManagedByPolicyMarker_NoActionChange(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 8080},
+		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
+		Rules: []config.RuleAction{
+			// already global, already at the override target action ("block"),
+			// and v2-owned: the upsert no-action-change early-return path.
+			{ID: "IAP-001", Action: "block", ManagedByPolicy: true},
+		},
+	}
+	plan, err := DryRun(verified(v1OverrideBody("IAP-001")), cfg, "voice-ai", "/tmp/x.yaml")
+	if err != nil {
+		t.Fatalf("v1 dry-run: %v", err)
+	}
+	proj := plan.Projected()
+	if proj == nil {
+		t.Fatalf("expected a projected config")
+	}
+	var got *config.RuleAction
+	for i := range proj.Rules {
+		if proj.Rules[i].ID == "IAP-001" {
+			got = &proj.Rules[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("IAP-001 should still exist")
+	}
+	if got.ManagedByPolicy {
+		t.Fatalf("marker must be cleared even when the action already matches")
+	}
+	// The clear is recorded as a marker-cleared change (so Commit runs and the
+	// rules section is re-encoded) but never as a false rule_override.
+	var markerCleared, falseOverride bool
+	for _, c := range plan.Changes {
+		if c.ID == "IAP-001" {
+			switch c.Kind {
+			case "rule_marker_cleared":
+				markerCleared = true
+			case "rule_override":
+				falseOverride = true
+			}
+		}
+	}
+	if !markerCleared {
+		t.Fatalf("expected a rule_marker_cleared change for IAP-001, got %+v", plan.Changes)
+	}
+	if falseOverride {
+		t.Fatalf("must not report a false rule_override for an already-matching global rule")
+	}
+}
+
+// P2 #2 (persistence): the marker clear must survive a real Commit even when it
+// is the ONLY change. Without recording it as a committable change, the CLI skips
+// Commit on an empty change set and the marker lingers on disk, leaving the
+// v2-reap hazard in place. This is the end-to-end gap a projection-only test misses.
+func TestV1Commit_PersistsMarkerClear_WhenOnlyChange(t *testing.T) {
+	start := &config.Config{
+		Version: "1",
+		Server:  config.ServerConfig{Port: 8080},
+		Agents:  map[string]config.Agent{"voice-ai": {AllowedTools: []string{"a"}}},
+		Rules: []config.RuleAction{
+			// already at the override target action, global, v2-owned: marker clear
+			// is the sole change.
+			{ID: "IAP-001", Action: "block", ManagedByPolicy: true},
+		},
+	}
+	cfgPath := saveTestConfig(t, start)
+	c, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	plan, err := DryRun(verified(v1OverrideBody("IAP-001")), c, "voice-ai", cfgPath)
+	if err != nil {
+		t.Fatalf("v1 dry-run: %v", err)
+	}
+	if len(plan.Changes) == 0 {
+		t.Fatalf("marker-only clear must produce a committable change so Commit is not skipped")
+	}
+	if _, err := Commit(plan, cfgPath); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	after, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, r := range after.Rules {
+		if r.ID == "IAP-001" && r.ManagedByPolicy {
+			t.Fatalf("v1 commit must persist the cleared marker on disk, found managed_by_policy still set")
+		}
+	}
+}
+
 // TestV1ThenV2Replace_DoesNotReapV1OwnedRule asserts the end-to-end FIX C
 // invariant: a rule first marked by v2, then rewritten by a v1 apply (which
 // clears the marker and Commit-writes it), is NOT silently reaped by a later v2

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -171,21 +171,34 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 	// rule already global on this action shows none.
 	upsert := func(id, action string) {
 		if i, ok := idx[id]; ok {
+			// v1 is marker-agnostic by design: it never SETS ManagedByPolicy, but
+			// when it rewrites (or re-confirms) a rule that a prior v2 apply owned,
+			// that rule becomes operator/v1-owned, which under v2 means unowned.
+			// Clear the marker so a later v2 replace fails closed on it (treats it
+			// as unowned/local) instead of reaping a v1-applied override as
+			// policy-owned. This MUST run before the no-change early return below:
+			// a v2-owned rule already at the target action would otherwise retain
+			// ownership through a v1 apply. The cleared YAML stays externally
+			// stable: ManagedByPolicy is omitempty, so false is absent, exactly as
+			// for any rule v1 writes itself.
+			clearedMarker := target.Rules[i].ManagedByPolicy
+			target.Rules[i].ManagedByPolicy = false
 			scoped := len(target.Rules[i].ApplyToTools) > 0 || len(target.Rules[i].ExemptTools) > 0
 			if target.Rules[i].Action == action && !scoped {
-				return // already global on policy — no change
+				// No action change. But clearing a v2 ownership marker IS a real
+				// on-disk change (managed_by_policy is removed), so it must reach
+				// Commit/patchConfigYAML or the marker survives on disk and a later
+				// v2 replace can reap the rule. Record it as a distinct, committable
+				// change — not a false action change. If nothing was owned, there is
+				// genuinely no change to report.
+				if clearedMarker {
+					plan.Changes = append(plan.Changes, Change{Kind: "rule_marker_cleared", ID: id})
+				}
+				return
 			}
 			target.Rules[i].Action = action
 			target.Rules[i].ApplyToTools = nil
 			target.Rules[i].ExemptTools = nil
-			// v1 is marker-agnostic by design: it never SETS ManagedByPolicy, but
-			// when it rewrites a rule that a prior v2 apply owned, that rule becomes
-			// operator/v1-owned, which under v2 means unowned. Clear the marker so a
-			// later v2 replace fails closed on it (treats it as unowned/local)
-			// instead of reaping a v1-applied override as policy-owned. This does NOT
-			// change v1's externally-observable YAML: ManagedByPolicy is omitempty,
-			// so false is absent, exactly as for any rule v1 writes itself.
-			target.Rules[i].ManagedByPolicy = false
 		} else {
 			target.Rules = append(target.Rules, config.RuleAction{ID: id, Action: action})
 			idx[id] = len(target.Rules) - 1

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -685,6 +685,19 @@ func projectAgentEgressV2(plan *PlanV2, target *config.Config, agent *config.Age
 			})
 			return
 		}
+		// The deny-all sentinel is RESERVED on EVERY domain path, not just
+		// allowed_domains. Placed in blocked_domains it is written verbatim and
+		// matches no real host (deny-all.invalid), so it silently blocks nothing
+		// while reading as a deny-all. Refuse fail-closed rather than let a bundle
+		// smuggle a misleading no-op block. (mirrors the allowed_tools sentinel,
+		// which is reserved on every path.)
+		if slices.Contains(eg.BlockedDomains, denyAllDomainsSentinel) {
+			plan.Unsupported = append(plan.Unsupported, Unsupported{
+				Kind:   "agent_egress_reserved_value",
+				Detail: fmt.Sprintf("agent %q egress blocked_domains contains the reserved sentinel %q, which matches no real host and blocks nothing; remove it (use allowed_domains clear for zero egress)", name, denyAllDomainsSentinel),
+			})
+			return
+		}
 		// Additive-source guard (mirrors v1): the egress resolver UNIONS the
 		// agent's allowed_domains with the global forward_proxy allowlist and any
 		// integration presets the agent already carries. Setting the agent's list

--- a/internal/apply/projection_v2_test.go
+++ b/internal/apply/projection_v2_test.go
@@ -811,6 +811,30 @@ func TestV2_ReservedDomainSentinelInReplaceRefused(t *testing.T) {
 	}
 }
 
+// P2 #4: the reserved deny-all sentinel in blocked_domains is refused
+// fail-closed too. Placed there it is written verbatim and matches no real host,
+// so it would silently block nothing while reading as a deny-all. The sentinel
+// is reserved on EVERY domain path, not just allowed_domains.
+func TestV2_ReservedDomainSentinelInBlockedRefused(t *testing.T) {
+	b := bodyV2()
+	g := agentGovV2("voice-ai")
+	g.Egress = policybundle.DimAgentEgressV2{Mode: dimReplace, AllowedDomains: []string{"api.openai.com"}, BlockedDomains: []string{denyAllDomainsSentinel}, ScanRequests: "unset", ScanResponses: "unset"}
+	b.Governance.Agents = []policybundle.AgentGovernanceV2{g}
+	p, err := DryRunV2(verifiedV2(b), baseConfig(), "", targetPath)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported", err)
+	}
+	if !hasUnsupportedV2(p, "agent_egress_reserved_value") {
+		t.Fatalf("expected reserved-domain unsupported, got %+v", p.Unsupported)
+	}
+	// Fail-closed before any mutation: the agent's egress is left untouched.
+	if proj := p.Projected(); proj != nil {
+		if eg := proj.Agents["voice-ai"].Egress; eg != nil && len(eg.BlockedDomains) > 0 {
+			t.Fatalf("blocked_domains must not be projected when the sentinel is refused, got %+v", eg)
+		}
+	}
+}
+
 // per-agent egress with unimplemented sub-fields fails closed.
 func TestV2_AgentEgressUnsupportedFields(t *testing.T) {
 	b := bodyV2()

--- a/internal/apply/write.go
+++ b/internal/apply/write.go
@@ -150,7 +150,7 @@ func patchConfigYAML(original []byte, plan *Plan) ([]byte, error) {
 	var patchRules, patchTools, patchEgress bool
 	for _, c := range plan.Changes {
 		switch c.Kind {
-		case "rule_override", "rule_reset_default":
+		case "rule_override", "rule_reset_default", "rule_marker_cleared":
 			patchRules = true
 		case "agent_allowed_tools":
 			patchTools = true

--- a/internal/node/redact_test.go
+++ b/internal/node/redact_test.go
@@ -101,3 +101,25 @@ func TestRedactMCPServerConfig(t *testing.T) {
 		}
 	}
 }
+
+// P2 #1: args_count must always be present in --json, including an explicit 0,
+// so "0 args configured" is distinguishable from "field absent". This mirrors
+// env_count, which already always emits its 0.
+func TestRedactMCPServerConfig_ArgsCountZeroEmitted(t *testing.T) {
+	in := config.MCPServerConfig{
+		Transport: "stdio",
+		Command:   "/usr/bin/server", // no Args, no Env
+	}
+	got := RedactMCPServerConfig("backend", in)
+	if got.ArgsCount != 0 {
+		t.Fatalf("expected args count 0, got %d", got.ArgsCount)
+	}
+	raw, _ := toJSON(got)
+	if !strings.Contains(raw, `"args_count":0`) {
+		t.Errorf("expected explicit args_count:0 in JSON, got %s", raw)
+	}
+	// env_count already always emits; assert the two ints are now symmetric.
+	if !strings.Contains(raw, `"env_count":0`) {
+		t.Errorf("expected explicit env_count:0 in JSON, got %s", raw)
+	}
+}

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -269,7 +269,7 @@ type InventoryMCPServer struct {
 	Name        string `json:"name"`
 	Transport   string `json:"transport"`
 	CommandTail string `json:"command_tail,omitempty"`
-	ArgsCount   int    `json:"args_count,omitempty"`
+	ArgsCount   int    `json:"args_count"`
 	URLHostHash string `json:"url_host_hash,omitempty"`
 	EnvCount    int    `json:"env_count"`
 }


### PR DESCRIPTION
Closes four residual correctness gaps in policy apply and snapshot output.

## Changes

**node snapshot: always emit `args_count`**
`InventoryMCPServer.ArgsCount` dropped its `omitempty`, so a server with zero args now serializes `"args_count":0` instead of omitting the field. Consumers can distinguish "0 args configured" from "field absent", matching the sibling `env_count`.

**v1 apply: clear and persist `ManagedByPolicy` on re-confirmed rules**
When a v1 apply re-confirms a rule a prior v2 apply owned (already global, already at the target action), it now clears the policy-ownership marker and records a `rule_marker_cleared` change so the clear reaches `Commit` and is written to disk, even when it is the only change. Previously the marker was cleared in the in-memory projection but lost on commit (the empty change set skipped the write), leaving the marker on disk where a later v2 replace could reap the rule. The clear is not reported as an action change.

**policy_bundle.v2 apply: reject the reserved deny-all sentinel in `blocked_domains`**
The reserved zero-egress sentinel is already refused in `allowed_domains`; it is now also refused fail-closed in `blocked_domains`, where it would otherwise be written verbatim as a literal that matches no real host (a silent no-op block that reads as a deny-all). The sentinel is reserved on every domain path.

## Tests
- snapshot JSON includes `args_count:0` for a zero-arg server (symmetric with `env_count`).
- v2-owned rule already at the target action: marker is cleared and recorded as `rule_marker_cleared`, never as a false action change.
- marker-only clear persists through a real `Commit` to disk.
- `blocked_domains` containing the sentinel returns Unsupported / reserved value and projects nothing.

`make build && make test && make lint && make vet` all green.