### PR TITLE
Snapshot echoes the active v2 policy assignment binding

### DIFF
--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -48,6 +48,17 @@ type rawPolicyBundle struct {
 	Policy           struct {
 		PolicyID      string `json:"policy_id"`
 		PolicyVersion string `json:"policy_version"`
+		// Assignment is the v2 signed assignment binding. Read via the
+		// tolerant projection but echoed by buildPolicySection ONLY when
+		// schema_version is policy_bundle.v2 (the v1 signing payload does
+		// not bind it, so it is not trustworthy on a v1 bundle). Only
+		// assignment_id + sequence are read; the snapshot echoes them so
+		// Enterprise can compare the exact assignment, not just the hash
+		// (Order 9B).
+		Assignment struct {
+			AssignmentID string `json:"assignment_id"`
+			Sequence     int64  `json:"sequence"`
+		} `json:"assignment"`
 	} `json:"policy"`
 	Signature struct {
 		Alg                  string `json:"alg"`
@@ -126,8 +137,19 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 	// above, which reads the same JSON paths for both schemas.
 	var verified bool
 	var status string
+	var assignmentID string
+	var appliedSeq int64
 	if bundle.SchemaVersion == policybundle.SchemaVersionV2 {
 		verified, status = verifyPolicyBundleV2(data, trustFingerprint)
+		// Echo the assignment binding ONLY for v2: the v2 signing payload
+		// binds policy.assignment, so it is covered by the same signature
+		// ActivePolicyVerified reflects. The v1 signing payload does NOT bind
+		// assignment, so a v1 bundle with an injected policy.assignment object
+		// still verifies under v1 — echoing it would present forged, unsigned
+		// assignment metadata next to verified=true. Leave the fields absent
+		// for v1/legacy/unknown schemas regardless of what the JSON carries.
+		assignmentID = bundle.Policy.Assignment.AssignmentID
+		appliedSeq = bundle.Policy.Assignment.Sequence
 	} else {
 		verified, status = verifyPolicyBundle(bundle, trustFingerprint)
 	}
@@ -139,6 +161,8 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 		ActivePolicyLoadedAt:           policyBundleLoadedAt(bundlePath),
 		ActivePolicyVerified:           verified,
 		ActivePolicyVerificationStatus: status,
+		AppliedAssignmentID:            assignmentID,
+		AppliedSequence:                appliedSeq,
 		PolicyStatus:                   PolicyStatusActive,
 	}, nil
 }

--- a/internal/node/policy_bundle_test.go
+++ b/internal/node/policy_bundle_test.go
@@ -83,6 +83,80 @@ func TestBuildPolicySection_ValidBundle(t *testing.T) {
 	if sec.ActivePolicyVerified {
 		t.Error("verified must be false in 4B even for a parseable bundle")
 	}
+	// v1 bundle carries no assignment block: the 9B fields stay absent.
+	if sec.AppliedAssignmentID != "" {
+		t.Errorf("v1 bundle must not echo an assignment_id, got %q", sec.AppliedAssignmentID)
+	}
+	if sec.AppliedSequence != 0 {
+		t.Errorf("v1 bundle must not echo a sequence, got %d", sec.AppliedSequence)
+	}
+}
+
+// v2BundleJSON is a policy_bundle.v2-shaped bundle carrying the signed
+// assignment binding the snapshot must echo (Order 9B). Verification is
+// exercised elsewhere; buildPolicySection echoes the assignment fields from the
+// tolerant projection regardless of verified, exactly as it does the hash/id.
+const v2BundleJSON = `{
+  "schema_version": "policy_bundle.v2",
+  "bundle_version": 1,
+  "policy_hash": "sha256:cafef00d",
+  "signature": {"alg": "Ed25519", "value": "ignored-here"},
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "2",
+    "assignment": {"assignment_id": "assign-0007", "sequence": 7}
+  }
+}`
+
+// v1WithInjectedAssignmentJSON is a v1-shaped bundle (no v2 schema_version)
+// that carries a forged policy.assignment object. The v1 signing payload does
+// not bind assignment, so a v1 bundle could be locally edited to add one; the
+// snapshot must NOT echo it (it would read as signed evidence next to
+// verified=true). Regression for the trust-boundary P1.
+const v1WithInjectedAssignmentJSON = `{
+  "schema_version": "policy_bundle_envelope.v1",
+  "bundle_version": 1,
+  "policy_hash": "sha256:deadbeef",
+  "signature": {"alg": "Ed25519", "value": "ignored-in-4b"},
+  "policy": {
+    "policy_id": "voice-ai-prod",
+    "policy_version": "1",
+    "assignment": {"assignment_id": "forged-9999", "sequence": 9999}
+  }
+}`
+
+func TestBuildPolicySection_V1IgnoresInjectedAssignment(t *testing.T) {
+	path := writePolicyBundle(t, v1WithInjectedAssignmentJSON)
+	sec, _ := buildPolicySection(path, "")
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("status = %q, want %q", sec.PolicyStatus, PolicyStatusActive)
+	}
+	if sec.AppliedAssignmentID != "" {
+		t.Errorf("v1 bundle must not echo an injected assignment_id, got %q", sec.AppliedAssignmentID)
+	}
+	if sec.AppliedSequence != 0 {
+		t.Errorf("v1 bundle must not echo an injected sequence, got %d", sec.AppliedSequence)
+	}
+}
+
+func TestBuildPolicySection_V2BundleEchoesAssignment(t *testing.T) {
+	path := writePolicyBundle(t, v2BundleJSON)
+	sec, warns := buildPolicySection(path, "")
+	if len(warns) != 0 {
+		t.Errorf("valid v2 bundle must not warn, got %v", warns)
+	}
+	if sec.PolicyStatus != PolicyStatusActive {
+		t.Fatalf("status = %q, want %q", sec.PolicyStatus, PolicyStatusActive)
+	}
+	if sec.ActivePolicyHash != "sha256:cafef00d" {
+		t.Errorf("hash = %q, want echoed bundle hash", sec.ActivePolicyHash)
+	}
+	if sec.AppliedAssignmentID != "assign-0007" {
+		t.Errorf("applied_assignment_id = %q, want echoed assignment id", sec.AppliedAssignmentID)
+	}
+	if sec.AppliedSequence != 7 {
+		t.Errorf("applied_sequence = %d, want 7", sec.AppliedSequence)
+	}
 }
 
 func TestBuildPolicySection_Unreadable(t *testing.T) {
@@ -203,10 +277,12 @@ func TestSealSnapshotEnvelope_WithPolicyBlock(t *testing.T) {
 	snap.Policy = &SnapshotPolicy{
 		ActivePolicyHash:     "sha256:deadbeef",
 		ActivePolicyID:       "voice-ai-prod",
-		ActivePolicyVersion:  "1",
+		ActivePolicyVersion:  "2",
 		ActivePolicySource:   PolicySourceLocalFile,
 		ActivePolicyLoadedAt: "2026-05-24T12:00:00Z",
 		ActivePolicyVerified: false,
+		AppliedAssignmentID:  "assign-0007",
+		AppliedSequence:      7,
 		PolicyStatus:         PolicyStatusActive,
 	}
 	env, err := SealSnapshotEnvelope(store, snap, time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC))
@@ -216,11 +292,18 @@ func TestSealSnapshotEnvelope_WithPolicyBlock(t *testing.T) {
 	if env.Snapshot.Policy == nil || env.Snapshot.Policy.PolicyStatus != PolicyStatusActive {
 		t.Fatalf("policy block did not survive into the envelope snapshot")
 	}
+	if env.Snapshot.Policy.AppliedAssignmentID != "assign-0007" || env.Snapshot.Policy.AppliedSequence != 7 {
+		t.Fatalf("assignment binding did not survive into the envelope snapshot: %+v", env.Snapshot.Policy)
+	}
 	canon, err := CanonicalSnapshotBytes(snap)
 	if err != nil {
 		t.Fatalf("canonicalize: %v", err)
 	}
 	if !strings.Contains(string(canon), `"policy":`) {
 		t.Fatalf("populated policy block must appear in canonical bytes")
+	}
+	if !strings.Contains(string(canon), `"applied_assignment_id":"assign-0007"`) ||
+		!strings.Contains(string(canon), `"applied_sequence":7`) {
+		t.Fatalf("assignment binding must appear in the signed canonical bytes; got:\n%s", canon)
 	}
 }

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -143,6 +143,16 @@ type SnapshotPolicy struct {
 	// signing_key_mismatch / signature_invalid / bundle_unreadable /
 	// unsupported_bundle. Omitted when no bundle path was supplied.
 	ActivePolicyVerificationStatus string `json:"active_policy_verification_status,omitempty"`
+	// AppliedAssignmentID / AppliedSequence echo the active v2 bundle's
+	// signed assignment binding (policybundle.AssignmentV2). They let
+	// Enterprise compare the exact assignment the node carries, not just
+	// the policy hash (Order 9B observed-vs-desired). Both are omitempty
+	// because a v1 (or no-assignment) bundle has no assignment block: an
+	// empty id / zero sequence means "absent", never a meaningful zero
+	// (v2 sequence is contractually >= 1), so omitting them keeps v1 and
+	// pre-9B snapshots byte-identical and their signed envelopes verifying.
+	AppliedAssignmentID string `json:"applied_assignment_id,omitempty"`
+	AppliedSequence     int64  `json:"applied_sequence,omitempty"`
 	// PolicyStatus is one of active / none / unreadable.
 	PolicyStatus string `json:"policy_status"`
 }


### PR DESCRIPTION
The node snapshot policy block now echoes `applied_assignment_id` and `applied_sequence` from the active `policy_bundle.v2`'s signed assignment. A control plane can confirm the node carries the exact signed assignment it expects, not just a matching policy hash.

## Changes
- `SnapshotPolicy` gains `applied_assignment_id` + `applied_sequence`, sourced from the active bundle's signed assignment block via the existing tolerant projection (same place hash/id/version come from).
- Echoed **only for `policy_bundle.v2`**, where the v2 signing payload binds the assignment. v1/legacy bundles never echo it: the v1 signing payload does not cover `policy.assignment`, so a v1 bundle with an injected assignment object still verifies and would otherwise present forged, unsigned metadata next to `verified=true`.
- Both fields are `omitempty`: an absent assignment means empty id / zero sequence (v2 sequence is contractually `>= 1`), so omitting them keeps v1 and pre-existing snapshots byte-identical and their signed envelopes verifying.

## Tests
- v2 bundle echoes the assignment binding.
- v1 bundle omits it; a v1 bundle with an injected `policy.assignment` is ignored (trust-boundary regression).
- The signed envelope seals, self-verifies, and carries the binding in its canonical bytes.

`make build && make test && make lint && make vet` green.