### PR TITLE
Add policy pull: fetch and apply a signed bundle from an operator store

### DIFF
--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -27,6 +27,7 @@ func newPolicyCmd() *cobra.Command {
 		Short: "Apply signed policy bundles to the local Oktsec runtime config",
 	}
 	cmd.AddCommand(newPolicyApplyCmd())
+	cmd.AddCommand(newPolicyPullCmd())
 	return cmd
 }
 

--- a/cmd/oktsec/commands/policy_pull.go
+++ b/cmd/oktsec/commands/policy_pull.go
@@ -1,0 +1,246 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/netutil"
+	"github.com/oktsec/oktsec/internal/policybundle"
+	"github.com/oktsec/oktsec/internal/safefile"
+	"github.com/spf13/cobra"
+)
+
+// maxPullObjectBytes caps every object the pull fetches (index, sig, bundle).
+const maxPullObjectBytes = 1 << 20 // 1 MiB
+
+// pullHTTPTimeout bounds an HTTPS fetch of a single store object.
+const pullHTTPTimeout = 15 * time.Second
+
+// newPolicyPullCmd builds `oktsec policy pull` (Order 9C). The node fetches a
+// signed pull store from an operator-controlled source, verifies the index
+// signature against its pinned trust fingerprint, selects the bundle for its
+// target, and routes that bundle through the SAME verify + target-binding +
+// anti-rollback + apply pipeline `policy apply` uses. Enterprise never contacts
+// the node; the node initiates everything here.
+func newPolicyPullCmd() *cobra.Command {
+	var (
+		source  string
+		nodeID  string
+		trustFP string
+		dryRun  bool
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: "Fetch a signed policy bundle from an operator store and apply it locally",
+		Long: "Fetch index.json + index.json.sig from --source (a local directory, a file:// " +
+			"URL, or an https:// URL), verify the index signature against --trust-fingerprint, " +
+			"select the bundle for --node-id (the node-scoped entry if present, else the fleet " +
+			"entry), fetch it, and run the same verification + target binding + anti-rollback + " +
+			"apply pipeline as `policy apply`. With --dry-run it writes nothing. The bundle's own " +
+			"signature is the final authority; a signed index only decides which bundle to fetch.",
+		Example: "  oktsec policy pull --source file:///srv/oktsec-store --node-id node_abc \\\n" +
+			"    --trust-fingerprint sha256:<policy-key-fp> --config oktsec.yaml --dry-run --json",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if source == "" {
+				return fmt.Errorf("--source <path-or-url> is required")
+			}
+			if trustFP == "" {
+				return fmt.Errorf("--trust-fingerprint sha256:<fp> is required")
+			}
+			if nodeID == "" {
+				return fmt.Errorf("--node-id <id> is required (selects this node's target and binds a node-scoped bundle)")
+			}
+
+			fetch, err := newStoreFetcher(source)
+			if err != nil {
+				return fmt.Errorf("--source: %w", err)
+			}
+
+			// 1. Fetch + signature-verify the index BEFORE trusting any entry.
+			indexBytes, err := fetch("index.json")
+			if err != nil {
+				return fmt.Errorf("fetch index.json: %w", err)
+			}
+			sigBytes, err := fetch("index.json.sig")
+			if err != nil {
+				return fmt.Errorf("fetch index.json.sig: %w", err)
+			}
+			if err := policybundle.VerifyPullIndexSig(indexBytes, sigBytes, trustFP); err != nil {
+				return emitApplyFailure(cmd, jsonOut, dryRun, err)
+			}
+			idx, err := policybundle.ParsePullIndex(indexBytes)
+			if err != nil {
+				return emitApplyFailure(cmd, jsonOut, dryRun, err)
+			}
+
+			// 2. Select this node's target entry.
+			entry, ok := policybundle.SelectPullEntry(idx, nodeID)
+			if !ok {
+				if jsonOut {
+					enc := json.NewEncoder(cmd.OutOrStdout())
+					enc.SetIndent("", "  ")
+					return enc.Encode(map[string]any{
+						"pulled": false, "source": source, "node_id": nodeID,
+						"reason": "no_target_entry",
+					})
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "no bundle to pull: the store index targets neither node %q nor the fleet\n", nodeID)
+				return nil
+			}
+
+			// 3. Fetch the selected bundle from a store-contained relative path.
+			if err := safeStoreRelPath(entry.BundleFile); err != nil {
+				return fmt.Errorf("index bundle_file %q: %w", entry.BundleFile, err)
+			}
+			bundleRaw, err := fetch(entry.BundleFile)
+			if err != nil {
+				return fmt.Errorf("fetch bundle %q: %w", entry.BundleFile, err)
+			}
+
+			// 4. The bundle is the authority: verify it and route through the
+			// existing v2 apply pipeline (target binding + anti-rollback + write).
+			res, verr := policybundle.Verify(bundleRaw, trustFP)
+			if verr != nil {
+				return emitApplyFailure(cmd, jsonOut, dryRun, verr)
+			}
+			if res.SchemaVersion != policybundle.SchemaVersionV2 {
+				return fmt.Errorf("pull supports policy_bundle.v2 only; store bundle is %q", res.SchemaVersion)
+			}
+			// Bind the fetched bundle to the SIGNED index entry. Without this, an
+			// attacker who can swap the bundle file (but not the signed index)
+			// could serve a different validly-signed bundle — e.g. an older one
+			// signed by the same key — and a fresh node with no anti-rollback
+			// floor would apply it. The signed index names exactly one bundle;
+			// the fetched bytes must be that bundle.
+			a := res.V2.Bundle.Policy.Assignment
+			if res.V2.Bundle.PolicyHash != entry.PolicyHash ||
+				a.AssignmentID != entry.AssignmentID ||
+				a.Sequence != entry.Sequence ||
+				a.Target.Scope != entry.TargetScope ||
+				a.Target.NodeID != entry.TargetNodeID {
+				return fmt.Errorf("fetched bundle does not match the signed index entry "+
+					"(index hash=%s seq=%d assignment=%s target=%s/%s; bundle hash=%s seq=%d assignment=%s target=%s/%s)",
+					entry.PolicyHash, entry.Sequence, entry.AssignmentID, entry.TargetScope, entry.TargetNodeID,
+					res.V2.Bundle.PolicyHash, a.Sequence, a.AssignmentID, a.Target.Scope, a.Target.NodeID)
+			}
+			return runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, false)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&source, "source", "", "pull store: a local directory, a file:// URL, or an https:// URL")
+	f.StringVar(&nodeID, "node-id", "", "this node's id (selects its target entry; bound against the bundle's target)")
+	f.StringVar(&trustFP, "trust-fingerprint", "", "sha256:<fp> the index and bundle signing key must match")
+	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing")
+	f.BoolVar(&jsonOut, "json", false, "emit result as JSON")
+	return cmd
+}
+
+// newStoreFetcher returns a function that reads a store object by its relative
+// path. Local directories and file:// URLs read the filesystem through
+// safefile (symlink-rejecting, size-capped); https:// URLs fetch over an
+// SSRF-guarded client. http:// is allowed too (operator-chosen plaintext store)
+// but runs through the same SSRF guard.
+func newStoreFetcher(source string) (func(rel string) ([]byte, error), error) {
+	// Only route RECOGNIZED URL schemes through the URL branch. Anything else —
+	// no scheme, or a Windows drive path like `C:\store` that url.Parse reads as
+	// scheme "c" — is a local filesystem path.
+	if u, err := url.Parse(source); err == nil {
+		switch u.Scheme {
+		case "file":
+			if u.Host != "" && u.Host != "localhost" {
+				return nil, fmt.Errorf("file:// URL must be local (no host), got host %q", u.Host)
+			}
+			return localFetcher(u.Path), nil
+		case "http", "https":
+			return httpFetcher(source), nil
+		}
+	}
+	return localFetcher(source), nil
+}
+
+func localFetcher(root string) func(rel string) ([]byte, error) {
+	return func(rel string) ([]byte, error) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := safefile.RejectSymlink(p); err != nil {
+			return nil, err
+		}
+		return safefile.ReadFileMax(p, maxPullObjectBytes)
+	}
+}
+
+// pullDialContext is the dialer the HTTPS store fetcher uses. It defaults to the
+// SSRF-guarded dialer (blocks loopback, link-local, and cloud metadata IPs);
+// tests override it to reach a local test server, which the guard would
+// otherwise (correctly) refuse.
+var pullDialContext = netutil.SafeDialContext
+
+func httpFetcher(base string) func(rel string) ([]byte, error) {
+	client := &http.Client{
+		Timeout:   pullHTTPTimeout,
+		Transport: &http.Transport{DialContext: pullDialContext},
+	}
+	return func(rel string) ([]byte, error) {
+		u, err := url.Parse(base)
+		if err != nil {
+			return nil, err
+		}
+		// Join the relative object onto the base URL path without letting it
+		// escape the base (path.Join cleans, and safeStoreRelPath already
+		// rejected traversal for the bundle path).
+		u.Path = path.Join(u.Path, rel)
+		ctx, cancel := context.WithTimeout(context.Background(), pullHTTPTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET %s -> %d", rel, resp.StatusCode)
+		}
+		// Read one byte past the cap so an over-large object is REJECTED (the
+		// local read path already errors past the cap); silently verifying a
+		// truncated prefix of the served bytes would be wrong.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxPullObjectBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(body)) > maxPullObjectBytes {
+			return nil, fmt.Errorf("object %s exceeds %d bytes", rel, maxPullObjectBytes)
+		}
+		return body, nil
+	}
+}
+
+// safeStoreRelPath rejects a bundle_file path that is absolute or escapes the
+// store root, so a tampered index cannot redirect the fetch outside the store.
+func safeStoreRelPath(rel string) error {
+	if rel == "" {
+		return fmt.Errorf("empty path")
+	}
+	if strings.ContainsRune(rel, '\\') {
+		return fmt.Errorf("backslash not allowed")
+	}
+	if path.IsAbs(rel) || strings.HasPrefix(rel, "/") {
+		return fmt.Errorf("must be relative")
+	}
+	cleaned := path.Clean(rel)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || cleaned != rel {
+		return fmt.Errorf("must be a clean relative path with no traversal")
+	}
+	return nil
+}

--- a/cmd/oktsec/commands/policy_pull_test.go
+++ b/cmd/oktsec/commands/policy_pull_test.go
@@ -1,0 +1,354 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/policybundle"
+)
+
+func runPolicyPull(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	root := NewRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs(append([]string{"policy", "pull"}, args...))
+	err := root.Execute()
+	var got map[string]any
+	if out.Len() > 0 {
+		_ = json.Unmarshal(out.Bytes(), &got)
+	}
+	return got, err
+}
+
+// signPullIndex builds a valid index.json.sig over indexBytes using the same
+// deterministic key signV2Bundle uses, so one trust fingerprint verifies both
+// the index and the bundles.
+func signPullIndex(t *testing.T, indexBytes []byte) []byte {
+	t.Helper()
+	priv, fp := v2SignerKey(t)
+	sum := sha256.Sum256(indexBytes)
+	payload := policybundle.PullIndexSigningPayload("2026-06-01T12:00:00Z", hex.EncodeToString(sum[:]))
+	sig := ed25519.Sign(priv, payload)
+	out, err := json.Marshal(policybundle.PullIndexSig{
+		SchemaVersion:        policybundle.PullIndexSigSchemaVersion,
+		Alg:                  "Ed25519",
+		PublicKey:            base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey)),
+		PublicKeyFingerprint: fp,
+		SignedAt:             "2026-06-01T12:00:00Z",
+		Value:                base64.StdEncoding.EncodeToString(sig),
+	})
+	if err != nil {
+		t.Fatalf("marshal index sig: %v", err)
+	}
+	return out
+}
+
+// writePullStore lays out <dir>/bundles/<name>.json + index.json + index.json.sig
+// for one entry, and returns the store dir. entryNodeID/"" selects the entry's
+// scope (node vs fleet). indexMut lets a test corrupt the index before signing.
+func writePullStore(t *testing.T, bundleRaw []byte, entryScope, entryNodeID, bundleFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "bundles"), 0o700); err != nil {
+		t.Fatalf("mkdir bundles: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(bundleFile)), bundleRaw, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	// Derive the index entry from the bundle so the signed index BINDS the exact
+	// bundle (hash + assignment + sequence). The caller's entryScope/entryNodeID
+	// is the entry's CLAIMED target, which a test can deliberately set to differ
+	// from the bundle's to exercise the binding check.
+	var b policybundle.PolicyBundleV2
+	if err := json.Unmarshal(bundleRaw, &b); err != nil {
+		t.Fatalf("unmarshal bundle for index: %v", err)
+	}
+	idx, err := json.Marshal(policybundle.PullIndex{
+		SchemaVersion: policybundle.PullIndexSchemaVersion,
+		GeneratedAt:   "2026-06-01T12:00:00Z",
+		Entries: []policybundle.PullIndexEntry{{
+			TargetScope: entryScope, TargetNodeID: entryNodeID, BundleFile: bundleFile,
+			PolicyHash: b.PolicyHash, PolicyID: b.Policy.PolicyID, PolicyVersion: b.Policy.PolicyVersion,
+			AssignmentID: b.Policy.Assignment.AssignmentID, Sequence: b.Policy.Assignment.Sequence,
+			PublicKeyFingerprint: b.Signature.PublicKeyFingerprint,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), idx, 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.json.sig"), signPullIndex(t, idx), 0o600); err != nil {
+		t.Fatalf("write index sig: %v", err)
+	}
+	return dir
+}
+
+func fileURL(dir string) string { return "file://" + dir }
+
+func TestPolicyPull_FetchesAndApplies(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", "node_x"))
+	store := writePullStore(t, raw, "node", "node_x", "bundles/b.json")
+
+	// Dry-run writes nothing.
+	before, _ := os.ReadFile(configPath)
+	if _, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--dry-run", "--json"); err != nil {
+		t.Fatalf("dry-run pull: %v", err)
+	}
+	after, _ := os.ReadFile(configPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("dry-run must not write the config")
+	}
+
+	// Real apply writes the config + records state.
+	got, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json")
+	if err != nil {
+		t.Fatalf("apply pull: %v", err)
+	}
+	if got["applied"] != true {
+		t.Fatalf("expected applied=true, got %v", got)
+	}
+	if _, err := os.Stat(statePath(configPath)); err != nil {
+		t.Fatalf("anti-rollback state must be written: %v", err)
+	}
+}
+
+func TestPolicyPull_StaleSequenceRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	// Bundle at sequence 2 applies and sets the anti-rollback floor.
+	hi := supportedAgentBodyV2("node", "node_x")
+	hi.Assignment.Sequence = 2
+	hi.Assignment.AssignmentID = "assign-2"
+	rawHi, fp := signV2Bundle(t, hi)
+	storeHi := writePullStore(t, rawHi, "node", "node_x", "bundles/hi.json")
+	if got, err := runPolicyPull(t, "--source", fileURL(storeHi), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err != nil || got["applied"] != true {
+		t.Fatalf("seq2 must apply: err=%v got=%v", err, got)
+	}
+
+	// A store offering sequence 1 for the same target must be refused.
+	lo := supportedAgentBodyV2("node", "node_x")
+	lo.Assignment.Sequence = 1
+	lo.Assignment.AssignmentID = "assign-1"
+	rawLo, _ := signV2Bundle(t, lo)
+	storeLo := writePullStore(t, rawLo, "node", "node_x", "bundles/lo.json")
+	if _, err := runPolicyPull(t, "--source", fileURL(storeLo), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("a stale (lower-sequence) bundle must be refused by anti-rollback")
+	}
+}
+
+func TestPolicyPull_WrongTargetRejected(t *testing.T) {
+	// The index entry claims node_x, but the bundle is bound to node_other.
+	// The bundle is the authority: pull --node-id node_x must fail target binding.
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", "node_other"))
+	store := writePullStore(t, raw, "node", "node_x", "bundles/b.json")
+
+	got, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json")
+	if err == nil {
+		t.Fatal("a bundle bound to a different node must be refused")
+	}
+	if got["applied"] == true {
+		t.Fatalf("must not apply a wrong-target bundle: %v", got)
+	}
+}
+
+func TestPolicyPull_SubstitutedBundleRejected(t *testing.T) {
+	// The signed index names bundle A, but the file at that path is a DIFFERENT
+	// validly-signed bundle B (same key). Even on a fresh node with no
+	// anti-rollback floor, the signed index must bind the exact bundle: B is
+	// refused because it does not match the entry A names.
+	_, configPath := writeV2ApplyConfig(t)
+	rawA, fp := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	bodyB := supportedAgentBodyV2("fleet", "")
+	bodyB.PolicyVersion = "2"
+	bodyB.Assignment.AssignmentID = "assign-B"
+	rawB, _ := signV2Bundle(t, bodyB)
+
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "bundles"), 0o700)
+	var a policybundle.PolicyBundleV2
+	if err := json.Unmarshal(rawA, &a); err != nil {
+		t.Fatalf("unmarshal A: %v", err)
+	}
+	idx, _ := json.Marshal(policybundle.PullIndex{
+		SchemaVersion: policybundle.PullIndexSchemaVersion,
+		GeneratedAt:   "2026-06-01T12:00:00Z",
+		Entries: []policybundle.PullIndexEntry{{
+			TargetScope: "fleet", BundleFile: "bundles/b.json",
+			PolicyHash: a.PolicyHash, PolicyID: a.Policy.PolicyID, PolicyVersion: a.Policy.PolicyVersion,
+			AssignmentID: a.Policy.Assignment.AssignmentID, Sequence: a.Policy.Assignment.Sequence,
+		}},
+	})
+	_ = os.WriteFile(filepath.Join(dir, "index.json"), idx, 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "index.json.sig"), signPullIndex(t, idx), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "bundles", "b.json"), rawB, 0o600) // substituted
+
+	if _, err := runPolicyPull(t, "--source", fileURL(dir), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("a bundle not matching the signed index entry must be refused")
+	}
+}
+
+func TestPolicyPull_TamperedBundleRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	// Build the (signed) index from the valid bundle, then corrupt the bundle
+	// bytes on disk so its signature no longer verifies.
+	store := writePullStore(t, raw, "fleet", "", "bundles/b.json")
+	bundlePath := filepath.Join(store, "bundles", "b.json")
+	tampered := append([]byte(nil), raw...)
+	tampered[len(tampered)/2] ^= 0x01
+	if err := os.WriteFile(bundlePath, tampered, 0o600); err != nil {
+		t.Fatalf("rewrite tampered bundle: %v", err)
+	}
+
+	if _, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("a tampered bundle must be refused")
+	}
+}
+
+func TestPolicyPull_TamperedIndexRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	store := writePullStore(t, raw, "fleet", "", "bundles/b.json")
+	// Flip a byte of index.json AFTER it was signed.
+	idxPath := filepath.Join(store, "index.json")
+	idx, _ := os.ReadFile(idxPath)
+	idx[len(idx)/2] ^= 0x01
+	if err := os.WriteFile(idxPath, idx, 0o600); err != nil {
+		t.Fatalf("rewrite tampered index: %v", err)
+	}
+	if _, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("a tampered index must be refused before any bundle fetch")
+	}
+}
+
+func TestPolicyPull_WrongIndexSigningKeyRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, _ := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	store := writePullStore(t, raw, "fleet", "", "bundles/b.json")
+	// Pin a trust fingerprint that does not match the signing key.
+	if _, err := runPolicyPull(t, "--source", fileURL(store), "--node-id", "node_x",
+		"--trust-fingerprint", "sha256:"+hex.EncodeToString(make([]byte, 32)),
+		"--config", configPath, "--json"); err == nil {
+		t.Fatal("an index signed by a non-pinned key must be refused")
+	}
+}
+
+func TestPolicyPull_PathTraversalBundleFileRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("fleet", ""))
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "bundles"), 0o700)
+	_ = os.WriteFile(filepath.Join(dir, "bundles", "b.json"), raw, 0o600)
+	idx, _ := json.Marshal(policybundle.PullIndex{
+		SchemaVersion: policybundle.PullIndexSchemaVersion,
+		GeneratedAt:   "2026-06-01T12:00:00Z",
+		Entries: []policybundle.PullIndexEntry{
+			{TargetScope: "fleet", BundleFile: "../escape.json", PolicyHash: "sha256:x", Sequence: 1},
+		},
+	})
+	_ = os.WriteFile(filepath.Join(dir, "index.json"), idx, 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "index.json.sig"), signPullIndex(t, idx), 0o600)
+
+	if _, err := runPolicyPull(t, "--source", fileURL(dir), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("a traversal bundle_file must be refused")
+	}
+}
+
+func TestPolicyPull_NoTargetEntry(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	dir := t.TempDir()
+	idx, _ := json.Marshal(policybundle.PullIndex{
+		SchemaVersion: policybundle.PullIndexSchemaVersion,
+		GeneratedAt:   "2026-06-01T12:00:00Z",
+		Entries:       []policybundle.PullIndexEntry{}, // nothing for anyone
+	})
+	_ = os.WriteFile(filepath.Join(dir, "index.json"), idx, 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "index.json.sig"), signPullIndex(t, idx), 0o600)
+	_, fp := v2SignerKey(t)
+
+	got, err := runPolicyPull(t, "--source", fileURL(dir), "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json")
+	if err != nil {
+		t.Fatalf("empty index is not an error: %v", err)
+	}
+	if got["pulled"] != false {
+		t.Fatalf("expected pulled=false for no target, got %v", got)
+	}
+}
+
+func TestPolicyPull_HTTPSFetch(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", "node_x"))
+	store := writePullStore(t, raw, "node", "node_x", "bundles/b.json")
+	srv := httptest.NewServer(http.FileServer(http.Dir(store)))
+	defer srv.Close()
+
+	// SafeDialContext blocks loopback, so point the fetcher's dialer at the
+	// local test server for this case (prod keeps SafeDialContext).
+	orig := pullDialContext
+	pullDialContext = (&net.Dialer{}).DialContext
+	defer func() { pullDialContext = orig }()
+
+	got, err := runPolicyPull(t, "--source", srv.URL, "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json")
+	if err != nil {
+		t.Fatalf("https pull: %v", err)
+	}
+	if got["applied"] != true {
+		t.Fatalf("expected applied=true over https, got %v", got)
+	}
+}
+
+func TestPolicyPull_HTTPOverlargeObjectRejected(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	_, fp := v2SignerKey(t)
+	// Serve an index.json larger than the cap; the fetch must reject it rather
+	// than verify a truncated prefix.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("a"), (1<<20)+10))
+	}))
+	defer srv.Close()
+	orig := pullDialContext
+	pullDialContext = (&net.Dialer{}).DialContext
+	defer func() { pullDialContext = orig }()
+
+	if _, err := runPolicyPull(t, "--source", srv.URL, "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json"); err == nil {
+		t.Fatal("an over-cap HTTP object must be rejected, not truncated")
+	}
+}
+
+func TestPolicyPull_SSRFGuardBlocksLoopback(t *testing.T) {
+	_, configPath := writeV2ApplyConfig(t)
+	_, fp := v2SignerKey(t)
+	// Default dialer (SafeDialContext) must refuse a loopback store URL.
+	_, err := runPolicyPull(t, "--source", "http://127.0.0.1:9/", "--node-id", "node_x",
+		"--trust-fingerprint", fp, "--config", configPath, "--json")
+	if err == nil {
+		t.Fatal("the SSRF guard must refuse a loopback source")
+	}
+}

--- a/internal/policybundle/pull_index.go
+++ b/internal/policybundle/pull_index.go
@@ -1,0 +1,193 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+// Order 9C pull distribution. A node fetches an operator-published pull store:
+//
+//	index.json      - oktsec_pull_index.v1 (data: one entry per target)
+//	index.json.sig  - oktsec_pull_index_sig.v1 (detached Ed25519 over index.json)
+//	bundles/<hash>.json - the exact signed policy_bundle.v2 bytes
+//
+// The index is a convenience pointer, but it is SIGNED so a tampered or
+// truncated index (e.g. one hiding the newest bundle) is refused rather than
+// silently followed. The signature is detached and covers the LITERAL index
+// bytes (not a re-canonicalization), so no shared JSON canonicalizer is needed
+// between the signer (Enterprise) and this verifier — byte-exactness is the
+// file's own bytes. The bundle's own signature remains the final authority for
+// what is applied; the index only decides which bundle the node fetches.
+
+const (
+	// PullIndexSchemaVersion / PullIndexSigSchemaVersion are frozen schema tags.
+	PullIndexSchemaVersion    = "oktsec_pull_index.v1"
+	PullIndexSigSchemaVersion = "oktsec_pull_index_sig.v1"
+	// pullIndexSigDomain is the domain-separation prefix of the signing payload,
+	// so an index signature can never be confused with a bundle or snapshot one.
+	pullIndexSigDomain = "oktsec.pull_index.v1"
+)
+
+// Pull-index reject codes, distinct from the bundle codes so an operator can
+// tell an index problem from a bundle problem.
+const (
+	RejectPullIndexDecode      RejectCode = "pull_index_decode"
+	RejectPullIndexSigInvalid  RejectCode = "pull_index_signature_invalid"
+	RejectPullIndexKeyMismatch RejectCode = "pull_index_signing_key_mismatch"
+)
+
+// PullIndex is the data half (index.json). Entries map a target to the bundle
+// file the node should fetch for it.
+type PullIndex struct {
+	SchemaVersion string           `json:"schema_version"`
+	GeneratedAt   string           `json:"generated_at"`
+	Entries       []PullIndexEntry `json:"entries"`
+}
+
+// PullIndexEntry points at one target's current bundle. The hash / sequence /
+// fingerprint fields are hints the node cross-checks against the verified
+// bundle; the bundle signature is the authority, so a lying entry cannot make
+// the node apply something the bundle does not itself prove.
+type PullIndexEntry struct {
+	TargetScope          string `json:"target_scope"` // "fleet" | "node"
+	TargetNodeID         string `json:"target_node_id"`
+	BundleFile           string `json:"bundle_file"` // relative to the store root
+	PolicyHash           string `json:"policy_hash"`
+	PolicyID             string `json:"policy_id"`
+	PolicyVersion        string `json:"policy_version"`
+	AssignmentID         string `json:"assignment_id"`
+	Sequence             int64  `json:"sequence"`
+	PublicKeyFingerprint string `json:"public_key_fingerprint"`
+}
+
+// PullIndexSig is the detached signature half (index.json.sig).
+type PullIndexSig struct {
+	SchemaVersion        string `json:"schema_version"`
+	Alg                  string `json:"alg"`
+	PublicKey            string `json:"public_key"`
+	PublicKeyFingerprint string `json:"public_key_fingerprint"`
+	SignedAt             string `json:"signed_at"`
+	Value                string `json:"value"`
+}
+
+// PullIndexSigningPayload is the single source of truth for the bytes an index
+// signature covers. It binds the signing time and the exact index bytes (by
+// their SHA-256) under a domain-separation prefix. The signer and this verifier
+// MUST build it identically; a cross-repo fixture guards against drift.
+func PullIndexSigningPayload(signedAt, indexSHA256Hex string) []byte {
+	return []byte(pullIndexSigDomain + "\n" +
+		"signed_at:" + signedAt + "\n" +
+		"index_sha256:" + indexSHA256Hex)
+}
+
+// ParsePullIndex strictly decodes index.json bytes: unknown keys and trailing
+// content are rejected so a node never silently ignores a field it does not
+// understand.
+func ParsePullIndex(raw []byte) (*PullIndex, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var idx PullIndex
+	if err := dec.Decode(&idx); err != nil {
+		return nil, reject(RejectPullIndexDecode, "decode index: %s", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
+		return nil, reject(RejectPullIndexDecode, "trailing content after index object")
+	}
+	if idx.SchemaVersion != PullIndexSchemaVersion {
+		return nil, reject(RejectPullIndexDecode, "schema_version=%q, want %q", idx.SchemaVersion, PullIndexSchemaVersion)
+	}
+	return &idx, nil
+}
+
+// VerifyPullIndexSig verifies the detached signature over the literal index
+// bytes against the operator-pinned trust fingerprint. Order mirrors the bundle
+// verifier: decode the sig, check the key shape, prove the key is
+// self-consistent (sha256(public_key)==claimed fingerprint), match the pinned
+// trust fingerprint, then Ed25519-verify the domain-separated payload that binds
+// the index sha256 + signed_at. The pinned fingerprint is the only trust anchor;
+// nothing here is taken from the index itself.
+func VerifyPullIndexSig(indexBytes, sigBytes []byte, trustFingerprint string) error {
+	if trustFingerprint == "" {
+		return reject(RejectPullIndexKeyMismatch, "a trust fingerprint is required to verify the pull index")
+	}
+	dec := json.NewDecoder(bytes.NewReader(sigBytes))
+	dec.DisallowUnknownFields()
+	var sig PullIndexSig
+	if err := dec.Decode(&sig); err != nil {
+		return reject(RejectPullIndexDecode, "decode index signature: %s", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
+		return reject(RejectPullIndexDecode, "trailing content after index signature object")
+	}
+	if sig.SchemaVersion != PullIndexSigSchemaVersion {
+		return reject(RejectPullIndexDecode, "sig schema_version=%q, want %q", sig.SchemaVersion, PullIndexSigSchemaVersion)
+	}
+	if sig.Alg != "Ed25519" {
+		return reject(RejectPullIndexDecode, "sig alg=%q, want Ed25519", sig.Alg)
+	}
+	pub, err := base64.StdEncoding.DecodeString(sig.PublicKey)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return reject(RejectPullIndexKeyMismatch, "sig public_key is not a valid Ed25519 key")
+	}
+	derivedFP := publicKeyFingerprint(ed25519.PublicKey(pub))
+	if derivedFP != sig.PublicKeyFingerprint {
+		return reject(RejectPullIndexKeyMismatch,
+			"sig public_key_fingerprint claimed=%s computed=%s", sig.PublicKeyFingerprint, derivedFP)
+	}
+	if derivedFP != trustFingerprint {
+		return reject(RejectPullIndexKeyMismatch,
+			"index signing key %s does not match trust fingerprint %s", derivedFP, trustFingerprint)
+	}
+	sigVal, err := base64.StdEncoding.DecodeString(sig.Value)
+	if err != nil || len(sigVal) != ed25519.SignatureSize {
+		return reject(RejectPullIndexSigInvalid, "sig value is not a valid Ed25519 signature")
+	}
+	sum := sha256.Sum256(indexBytes)
+	payload := PullIndexSigningPayload(sig.SignedAt, hex.EncodeToString(sum[:]))
+	if !ed25519.Verify(ed25519.PublicKey(pub), payload, sigVal) {
+		return reject(RejectPullIndexSigInvalid, "index signature does not verify over the pull-index signing payload")
+	}
+	return nil
+}
+
+// SelectPullEntry picks the entry a node with nodeID should pull: the
+// node-scoped entry if one exists, else the fleet entry. ok is false when the
+// index targets neither (nothing to pull). A node-scoped entry is only eligible
+// when its target_node_id equals nodeID; the bundle's own target binding is
+// re-checked at apply time regardless.
+func SelectPullEntry(idx *PullIndex, nodeID string) (PullIndexEntry, bool) {
+	var fleet *PullIndexEntry
+	for i := range idx.Entries {
+		e := &idx.Entries[i]
+		switch e.TargetScope {
+		case "node":
+			if nodeID != "" && e.TargetNodeID == nodeID {
+				return *e, true
+			}
+		case "fleet":
+			if fleet == nil {
+				fleet = e
+			}
+		}
+	}
+	if fleet != nil {
+		return *fleet, true
+	}
+	return PullIndexEntry{}, false
+}
+
+// AsRejectError unwraps a *RejectError so callers can surface its stable code.
+// Returns ("", false) for a non-reject error.
+func AsRejectError(err error) (RejectCode, bool) {
+	var re *RejectError
+	if errors.As(err, &re) {
+		return re.Code, true
+	}
+	return "", false
+}

--- a/internal/policybundle/pull_index_test.go
+++ b/internal/policybundle/pull_index_test.go
@@ -1,0 +1,172 @@
+package policybundle
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// pullTestKey returns a deterministic Ed25519 key + its fingerprint for index
+// signing tests.
+func pullTestKey(t *testing.T) (ed25519.PrivateKey, string) {
+	t.Helper()
+	seed := sha256.Sum256([]byte("oktsec/pull-index-test-key/v1"))
+	key := ed25519.NewKeyFromSeed(seed[:])
+	fp := publicKeyFingerprint(key.Public().(ed25519.PublicKey))
+	return key, fp
+}
+
+// signIndexForTest builds a valid index.json.sig for the given index bytes,
+// mirroring exactly what the Enterprise publisher must produce.
+func signIndexForTest(t *testing.T, key ed25519.PrivateKey, indexBytes []byte, signedAt, fp string) []byte {
+	t.Helper()
+	sum := sha256.Sum256(indexBytes)
+	payload := PullIndexSigningPayload(signedAt, hex.EncodeToString(sum[:]))
+	sig := ed25519.Sign(key, payload)
+	out, err := json.Marshal(PullIndexSig{
+		SchemaVersion:        PullIndexSigSchemaVersion,
+		Alg:                  "Ed25519",
+		PublicKey:            base64.StdEncoding.EncodeToString(key.Public().(ed25519.PublicKey)),
+		PublicKeyFingerprint: fp,
+		SignedAt:             signedAt,
+		Value:                base64.StdEncoding.EncodeToString(sig),
+	})
+	if err != nil {
+		t.Fatalf("marshal sig: %v", err)
+	}
+	return out
+}
+
+func sampleIndexBytes(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(PullIndex{
+		SchemaVersion: PullIndexSchemaVersion,
+		GeneratedAt:   "2026-06-01T12:00:00Z",
+		Entries: []PullIndexEntry{
+			{TargetScope: "fleet", BundleFile: "bundles/aaaa.json", PolicyHash: "sha256:aaaa", Sequence: 5},
+			{TargetScope: "node", TargetNodeID: "node_x", BundleFile: "bundles/bbbb.json", PolicyHash: "sha256:bbbb", Sequence: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+	return raw
+}
+
+func TestVerifyPullIndexSig_HappyPath(t *testing.T) {
+	key, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	sig := signIndexForTest(t, key, idx, "2026-06-01T12:00:00Z", fp)
+	if err := VerifyPullIndexSig(idx, sig, fp); err != nil {
+		t.Fatalf("valid index signature must verify: %v", err)
+	}
+}
+
+func TestVerifyPullIndexSig_TamperedIndexFails(t *testing.T) {
+	key, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	sig := signIndexForTest(t, key, idx, "2026-06-01T12:00:00Z", fp)
+	// Flip one byte of the index after signing.
+	tampered := append([]byte(nil), idx...)
+	tampered[len(tampered)/2] ^= 0x01
+	err := VerifyPullIndexSig(tampered, sig, fp)
+	if code, ok := AsRejectError(err); !ok || code != RejectPullIndexSigInvalid {
+		t.Fatalf("tampered index must fail with %q, got %v", RejectPullIndexSigInvalid, err)
+	}
+}
+
+func TestVerifyPullIndexSig_WrongTrustFingerprint(t *testing.T) {
+	key, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	sig := signIndexForTest(t, key, idx, "2026-06-01T12:00:00Z", fp)
+	err := VerifyPullIndexSig(idx, sig, "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+	if code, ok := AsRejectError(err); !ok || code != RejectPullIndexKeyMismatch {
+		t.Fatalf("wrong trust fingerprint must fail with %q, got %v", RejectPullIndexKeyMismatch, err)
+	}
+}
+
+func TestVerifyPullIndexSig_KeySelfInconsistent(t *testing.T) {
+	key, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	// Claim a fingerprint that does not match the embedded key.
+	sig := signIndexForTest(t, key, idx, "2026-06-01T12:00:00Z",
+		"sha256:1111111111111111111111111111111111111111111111111111111111111111")
+	// The pinned fingerprint matches the bogus claim, but self-consistency
+	// (sha256(public_key) == claimed) must still fail first.
+	err := VerifyPullIndexSig(idx, sig, "sha256:1111111111111111111111111111111111111111111111111111111111111111")
+	if code, ok := AsRejectError(err); !ok || code != RejectPullIndexKeyMismatch {
+		t.Fatalf("self-inconsistent key must fail with %q, got %v", RejectPullIndexKeyMismatch, err)
+	}
+	_ = fp
+}
+
+func TestParsePullIndex_StrictAndSchema(t *testing.T) {
+	if _, err := ParsePullIndex([]byte(`{"schema_version":"wrong","entries":[]}`)); err == nil {
+		t.Fatal("wrong schema_version must be rejected")
+	}
+	if _, err := ParsePullIndex([]byte(`{"schema_version":"oktsec_pull_index.v1","bogus":1,"entries":[]}`)); err == nil {
+		t.Fatal("unknown field must be rejected")
+	}
+	// Trailing content after the object must be rejected (strict EOF), so a
+	// signature over only the leading object cannot cover a smuggled tail.
+	tail := append(append([]byte(nil), sampleIndexBytes(t)...), []byte(`{"x":1}`)...)
+	if _, err := ParsePullIndex(tail); err == nil {
+		t.Fatal("trailing content after the index object must be rejected")
+	}
+	idx, err := ParsePullIndex(sampleIndexBytes(t))
+	if err != nil {
+		t.Fatalf("valid index must parse: %v", err)
+	}
+	if len(idx.Entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(idx.Entries))
+	}
+}
+
+func TestVerifyPullIndexSig_TrailingContentRejected(t *testing.T) {
+	key, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	sig := signIndexForTest(t, key, idx, "2026-06-01T12:00:00Z", fp)
+	tail := append(append([]byte(nil), sig...), []byte(`garbage`)...)
+	if err := VerifyPullIndexSig(idx, tail, fp); err == nil {
+		t.Fatal("trailing content after the signature object must be rejected")
+	}
+}
+
+func TestSelectPullEntry(t *testing.T) {
+	idx, err := ParsePullIndex(sampleIndexBytes(t))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// Node-scoped entry wins for its node.
+	e, ok := SelectPullEntry(idx, "node_x")
+	if !ok || e.TargetScope != "node" || e.TargetNodeID != "node_x" {
+		t.Fatalf("node_x must select its node entry, got %+v ok=%v", e, ok)
+	}
+	// A different node falls back to the fleet entry.
+	e, ok = SelectPullEntry(idx, "node_other")
+	if !ok || e.TargetScope != "fleet" {
+		t.Fatalf("node_other must fall back to fleet, got %+v ok=%v", e, ok)
+	}
+	// No fleet entry + no matching node => nothing to pull.
+	fleetless := &PullIndex{SchemaVersion: PullIndexSchemaVersion, Entries: []PullIndexEntry{
+		{TargetScope: "node", TargetNodeID: "node_x", BundleFile: "b"},
+	}}
+	if _, ok := SelectPullEntry(fleetless, "node_other"); ok {
+		t.Fatal("node_other with no fleet entry must select nothing")
+	}
+}
+
+func TestVerifyPullIndexSig_MalformedSigRejected(t *testing.T) {
+	_, fp := pullTestKey(t)
+	idx := sampleIndexBytes(t)
+	if err := VerifyPullIndexSig(idx, []byte(`{not json`), fp); err == nil {
+		t.Fatal("malformed sig must be rejected")
+	}
+	if !strings.HasPrefix(string(sampleIndexBytes(t)), "{") {
+		t.Fatal("sanity: index is JSON object")
+	}
+}


### PR DESCRIPTION
A node can fetch a signed `policy_bundle.v2` from an operator-controlled pull store and apply it locally. Enterprise never contacts the node; the node initiates the pull and the bundle's own signature stays the final authority (Order 9C, node side).

## Command
`oktsec policy pull --source <path|file://|https://> --node-id <id> --trust-fingerprint sha256:<fp> [--dry-run] [--json]`
1. Fetch `index.json` + `index.json.sig`; verify the index signature against the pinned `--trust-fingerprint`.
2. Select this node's target entry (node-scoped wins, else fleet).
3. Fetch that bundle (containment-checked relative path).
4. Verify it, **bind it to the signed index entry** (hash + assignment_id + sequence + target must match), then route through the EXISTING verify + target-binding + anti-rollback + apply pipeline. No change to apply/state.

## Trust / safety
- New signed-pointer contract `oktsec_pull_index.v1` + detached `oktsec_pull_index_sig.v1`. The signature covers the literal index bytes (sha256 + signed_at under a domain prefix), so no shared JSON canonicalizer is needed between signer and verifier. Strict EOF on both index and sig.
- Source fetch: local / `file://` via `safefile` (symlink-reject, 1 MiB cap); `http(s)://` via `netutil.SafeDialContext` (SSRF/loopback/metadata guarded), over-cap responses rejected (parity with local). Windows drive paths handled as local.
- The pinned fingerprint is the only trust anchor. The signed index binds the exact bundle, so a swapped-but-validly-signed bundle is refused even on a fresh node.

## Tests
pull+apply (file:// and https via injected dialer); dry-run writes nothing; stale sequence, wrong target, tampered bundle, **substituted (validly-signed but wrong) bundle**, tampered index, wrong index-signing-key, traversal `bundle_file`, over-cap HTTP object, trailing-content index/sig all refused; SSRF guard refuses loopback; no-target index is a clean no-op.

`make build && make test && make lint && make vet` green.