### PR TITLE
Add `oktsec cloud`: enroll, sync and status against an Oktsec Cloud control plane

### DIFF
--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -161,16 +161,32 @@ func newCloudEnrollCmd() *cobra.Command {
 				return fmt.Errorf("register failed: HTTP %d", status)
 			}
 
-			// Trust fingerprint: explicit flag wins; else Cloud's answer
-			// (newer Clouds include it once custody is configured).
+			// Merge, never wipe: explicit flags win, then Cloud's
+			// register response, then whatever a previous enroll
+			// stored — so an idempotent re-enroll without --pull-url
+			// cannot silently disable policy pulls.
+			prev, _ := store.LoadCloudState() // nil on first enroll
 			if trustFP == "" {
 				trustFP, _ = body["trust_fingerprint"].(string)
+			}
+			if pullURL == "" {
+				pullURL, _ = body["pull_url"].(string)
+			}
+			enrolledAt := time.Now().UTC().Format(time.RFC3339)
+			if prev != nil {
+				if trustFP == "" {
+					trustFP = prev.TrustFingerprint
+				}
+				if pullURL == "" {
+					pullURL = prev.PullURL
+				}
+				enrolledAt = prev.EnrolledAt
 			}
 			st := &node.CloudState{
 				URL:              base,
 				PullURL:          pullURL,
 				TrustFingerprint: trustFP,
-				EnrolledAt:       time.Now().UTC().Format(time.RFC3339),
+				EnrolledAt:       enrolledAt,
 			}
 			if err := store.SaveCloudState(st); err != nil {
 				return err
@@ -201,6 +217,12 @@ func normalizeCloudURL(raw string) (string, error) {
 	u, err := url.Parse(strings.TrimRight(raw, "/"))
 	if err != nil || u.Host == "" || (u.Scheme != "https" && u.Scheme != "http") {
 		return "", fmt.Errorf("--url must be an http(s) base URL, got %q", raw)
+	}
+	// Bearer tokens travel in every Cloud call: plaintext HTTP would
+	// leak them to any on-path network. https only, with an explicit
+	// dev-only escape for local test servers.
+	if u.Scheme == "http" && os.Getenv("OKTSEC_CLOUD_INSECURE_HTTP") != "1" {
+		return "", fmt.Errorf("--url must be https (set OKTSEC_CLOUD_INSECURE_HTTP=1 only for local development)")
 	}
 	return u.String(), nil
 }

--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -67,7 +67,7 @@ func cloudPost(client *http.Client, rawURL, bearer string, body []byte) (int, ma
 	if err != nil {
 		return 0, nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return resp.StatusCode, nil, err

--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -1,0 +1,441 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/netutil"
+	"github.com/oktsec/oktsec/internal/node"
+	"github.com/spf13/cobra"
+)
+
+// `oktsec cloud` connects this node to an Oktsec Cloud control plane.
+// The trust model is the node's, unchanged: the node INITIATES every
+// exchange (register, report, pull); Cloud never reaches in. Apply runs
+// through the exact same verify + target-binding + anti-rollback
+// pipeline as `policy apply` / `policy pull` — these commands only
+// orchestrate steps that already exist.
+//
+// State lives beside the node identity (0600):
+//
+//	cloud.json   — url, pull store URL, trust fingerprint, sync stamps
+//	cloud-token  — the node's bearer token (secret; never printed)
+
+const cloudHTTPTimeout = 30 * time.Second
+
+// cloudDialContext is the dialer for Cloud API calls. SSRF-guarded by
+// default (loopback, link-local and metadata IPs refused); tests
+// override it to reach a local test server.
+var cloudDialContext = netutil.SafeDialContext
+
+// cloudMinInterval keeps daemon mode polite (Cloud rate limits are
+// generous, but a sub-minute loop is never needed).
+const cloudMinInterval = time.Minute
+
+// cloudHTTPClient builds the SSRF-guarded client for Cloud API calls.
+// Daemon mode constructs it ONCE per run (keep-alive across ticks);
+// the seam stays a var so tests can point it at a local server.
+func cloudHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   cloudHTTPTimeout,
+		Transport: &http.Transport{DialContext: cloudDialContext},
+	}
+}
+
+// cloudPost sends JSON with a bearer token and decodes the JSON reply.
+// The response body is returned for error detail; bearer secrets never
+// appear in errors.
+func cloudPost(client *http.Client, rawURL, bearer string, body []byte) (int, map[string]any, error) {
+	req, err := http.NewRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	out := map[string]any{}
+	if len(raw) > 0 {
+		// Tolerate non-JSON error bodies; the status code still tells
+		// the caller what happened.
+		_ = json.Unmarshal(raw, &out)
+	}
+	return resp.StatusCode, out, nil
+}
+
+func newCloudCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Connect this node to an Oktsec Cloud control plane",
+		Long: "Enroll this node with Oktsec Cloud, then keep it in sync: report signed " +
+			"evidence and pull + verify + apply the signed policy published for it. The node " +
+			"initiates everything; Cloud has no way to reach in.",
+	}
+	cmd.AddCommand(newCloudEnrollCmd(), newCloudSyncCmd(), newCloudStatusCmd())
+	return cmd
+}
+
+// --- enroll -----------------------------------------------------------
+
+func newCloudEnrollCmd() *cobra.Command {
+	var (
+		cloudURL string
+		token    string
+		pullURL  string
+		trustFP  string
+	)
+	cmd := &cobra.Command{
+		Use:   "enroll",
+		Short: "Register this node with Oktsec Cloud",
+		Long: "Registers this node's identity with Cloud using an enrollment token and stores " +
+			"the connection state beside the node identity. The pull store URL and policy trust " +
+			"fingerprint are taken from Cloud's response when available, or from flags.",
+		Example:      "  oktsec cloud enroll --url https://cloud.oktsec.com --token <enrollment-token>",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cloudURL == "" || token == "" {
+				return fmt.Errorf("--url and --token are required")
+			}
+			base, err := normalizeCloudURL(cloudURL)
+			if err != nil {
+				return err
+			}
+			store := nodeStoreForTest()
+			id, err := store.Load()
+			if err != nil {
+				if node.IsErrIdentityMissing(err) {
+					return fmt.Errorf("no node identity yet — run `oktsec node init` first")
+				}
+				return err
+			}
+
+			payload, err := json.Marshal(map[string]string{
+				"node_id":                id.NodeID,
+				"public_key_fingerprint": id.PublicKeyFingerprint,
+			})
+			if err != nil {
+				return err
+			}
+			client := cloudHTTPClient()
+			status, body, err := cloudPost(client, base+"/v1/node/register", token, payload)
+			if err != nil {
+				return fmt.Errorf("register with %s: %w", base, err)
+			}
+			switch status {
+			case http.StatusCreated:
+				nodeToken, _ := body["token"].(string)
+				if nodeToken == "" {
+					return fmt.Errorf("register succeeded but no node token was returned")
+				}
+				if err := store.SaveCloudToken(nodeToken); err != nil {
+					return err
+				}
+			case http.StatusOK:
+				// Idempotent re-register: no new token. Keep the stored one.
+				if _, err := store.LoadCloudToken(); err != nil {
+					return fmt.Errorf("node already registered but no local token is stored — rotate it from Cloud and re-enroll: %w", err)
+				}
+			case http.StatusUnauthorized:
+				return fmt.Errorf("enrollment token rejected (expired or revoked)")
+			case http.StatusConflict:
+				return fmt.Errorf("registration conflicts with Cloud's state for this node (identity pin mismatch)")
+			default:
+				return fmt.Errorf("register failed: HTTP %d", status)
+			}
+
+			// Trust fingerprint: explicit flag wins; else Cloud's answer
+			// (newer Clouds include it once custody is configured).
+			if trustFP == "" {
+				trustFP, _ = body["trust_fingerprint"].(string)
+			}
+			st := &node.CloudState{
+				URL:              base,
+				PullURL:          pullURL,
+				TrustFingerprint: trustFP,
+				EnrolledAt:       time.Now().UTC().Format(time.RFC3339),
+			}
+			if err := store.SaveCloudState(st); err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Enrolled node %s with %s\n", id.NodeID, base)
+			switch {
+			case st.PullURL == "":
+				fmt.Fprintln(out, "No pull store URL configured yet: `cloud sync` will report evidence only.")
+				fmt.Fprintln(out, "Add it with: oktsec cloud enroll --url ... --token ... --pull-url <capability URL>")
+			case st.TrustFingerprint == "":
+				fmt.Fprintln(out, "No policy trust fingerprint yet: pulls stay disabled until one is set (--trust-fingerprint).")
+			default:
+				fmt.Fprintln(out, "Policy pull configured. Run: oktsec cloud sync --interval 5m")
+			}
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cloudURL, "url", "", "Cloud base URL (https://cloud.example.com)")
+	f.StringVar(&token, "token", "", "enrollment token issued by Cloud (shown once at creation)")
+	f.StringVar(&pullURL, "pull-url", "", "this fleet's pull store URL (from the Cloud console)")
+	f.StringVar(&trustFP, "trust-fingerprint", "", "policy signing trust fingerprint sha256:<hex> (defaults to Cloud's answer)")
+	return cmd
+}
+
+func normalizeCloudURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimRight(raw, "/"))
+	if err != nil || u.Host == "" || (u.Scheme != "https" && u.Scheme != "http") {
+		return "", fmt.Errorf("--url must be an http(s) base URL, got %q", raw)
+	}
+	return u.String(), nil
+}
+
+// --- sync -------------------------------------------------------------
+
+func newCloudSyncCmd() *cobra.Command {
+	var (
+		once     bool
+		interval time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Pull + apply published policy, then report signed evidence",
+		Long: "One full cycle: fetch the signed pull store (when configured), verify and apply " +
+			"the bundle published for this node through the standard pipeline, then build, sign " +
+			"and report a snapshot so the evidence reflects the post-apply state. --interval runs " +
+			"the cycle continuously; --once runs it a single time with distinct exit codes " +
+			"(2 = pull/apply failed, 3 = evidence report failed).",
+		Example: "  oktsec cloud sync --once --config oktsec.yaml\n" +
+			"  oktsec cloud sync --interval 5m --config oktsec.yaml",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if once == (interval != 0) {
+				return fmt.Errorf("pass exactly one of --once or --interval")
+			}
+			store := nodeStoreForTest()
+			client := cloudHTTPClient()
+			if once {
+				return runCloudSyncOnce(cmd, store, client)
+			}
+			if interval < cloudMinInterval {
+				return fmt.Errorf("--interval must be at least %s", cloudMinInterval)
+			}
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+			out := cmd.ErrOrStderr()
+			fmt.Fprintf(out, "cloud sync: every %s (±10%% jitter); SIGTERM to stop\n", interval)
+			for {
+				if err := runCloudSyncOnce(cmd, store, client); err != nil {
+					fmt.Fprintf(out, "cloud sync: %v\n", err)
+				}
+				jitter := time.Duration(rand.Int63n(int64(interval) / 5))
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(interval - interval/10 + jitter):
+				}
+			}
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVar(&once, "once", false, "run one sync cycle and exit")
+	f.DurationVar(&interval, "interval", 0, "run continuously with this period (min 1m)")
+	return cmd
+}
+
+// cloudSyncError tags a sync failure with its --once exit code
+// (2 = pull/apply, 3 = evidence report), surfaced via ExitCode so
+// main can map it for systemd-style operators.
+type cloudSyncError struct {
+	stage string
+	code  int
+	err   error
+}
+
+func (e *cloudSyncError) Error() string { return e.stage + ": " + e.err.Error() }
+func (e *cloudSyncError) Unwrap() error { return e.err }
+
+// ExitCode lets main map sync failures to distinct process exit codes.
+func (e *cloudSyncError) ExitCode() int { return e.code }
+
+// stampSync records the cycle result in cloud.json (best effort on
+// failure paths; the ok path surfaces the write error).
+func stampSync(store node.IdentityStore, st *node.CloudState, result string) error {
+	st.LastSyncAt = time.Now().UTC().Format(time.RFC3339)
+	st.LastSyncResult = result
+	return store.SaveCloudState(st)
+}
+
+func runCloudSyncOnce(cmd *cobra.Command, store node.IdentityStore, client *http.Client) error {
+	st, err := store.LoadCloudState()
+	if err != nil {
+		return err
+	}
+	token, err := store.LoadCloudToken()
+	if err != nil {
+		return err
+	}
+	id, err := store.Load()
+	if err != nil {
+		return err
+	}
+
+	// 1. Pull + apply FIRST so the snapshot reports post-apply state.
+	// Real apply mutates the config, so the same explicit---config rule
+	// as `policy apply`/`policy pull` holds.
+	if st.PullURL != "" && st.TrustFingerprint != "" {
+		if !cfgFileExplicit {
+			return &cloudSyncError{stage: "pull/apply", code: 2,
+				err: fmt.Errorf("policy pull is configured: pass an explicit --config <path> (the file the applied policy mutates)")}
+		}
+		if err := cloudPullApply(cmd, store, st, id.NodeID); err != nil {
+			_ = stampSync(store, st, "pull_failed")
+			return &cloudSyncError{stage: "pull/apply", code: 2, err: err}
+		}
+	}
+
+	// 2. Snapshot reflecting the (possibly just-applied) active policy.
+	opts := node.Options{
+		ConfigPath:    cfgFile,
+		DBPath:        nodeSnapshotDBPathOverride,
+		IdentityStore: store,
+		OktsecVersion: version,
+		OktsecCommit:  commit,
+	}
+	if _, err := os.Stat(store.CloudBundlePath()); err == nil {
+		opts.PolicyBundlePath = store.CloudBundlePath()
+		opts.PolicyTrustFingerprint = st.TrustFingerprint
+	}
+	snap, err := node.Build(context.Background(), opts)
+	if err != nil {
+		return &cloudSyncError{stage: "snapshot", code: 3, err: err}
+	}
+	env, err := node.SealSnapshotEnvelope(store, snap, time.Now().UTC())
+	if err != nil {
+		return &cloudSyncError{stage: "sign", code: 3, err: err}
+	}
+	envRaw, err := json.Marshal(env)
+	if err != nil {
+		return &cloudSyncError{stage: "sign", code: 3, err: err}
+	}
+
+	// 3. Report.
+	status, body, err := cloudPost(client, st.URL+"/v1/evidence/envelope", token, envRaw)
+	if err != nil {
+		return &cloudSyncError{stage: "report", code: 3, err: err}
+	}
+	result, _ := body["status"].(string)
+	switch result {
+	case "accepted", "accepted_signed", "idempotent":
+		if err := stampSync(store, st, "ok"); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "sync ok (evidence %s)\n", result)
+		return nil
+	default:
+		_ = stampSync(store, st, "report_failed")
+		code, _ := body["code"].(string)
+		if code == "" {
+			code = fmt.Sprintf("http_%d", status)
+		}
+		return &cloudSyncError{stage: "report", code: 3, err: fmt.Errorf("evidence refused (%s)", code)}
+	}
+}
+
+// cloudPullApply runs the SHARED pull pipeline (pullVerifiedBundle:
+// signed index -> entry -> bundle -> binding) and applies through the
+// standard v2 pipeline. The verified bundle bytes are cached so
+// snapshots echo the active policy. A store with no entry for this
+// node is a clean no-op.
+func cloudPullApply(cmd *cobra.Command, store node.IdentityStore, st *node.CloudState, nodeID string) error {
+	raw, res, entry, found, perr := pullVerifiedBundle(st.PullURL, nodeID, st.TrustFingerprint)
+	if perr != nil {
+		return perr.err
+	}
+	if !found {
+		return nil // nothing published for this node yet
+	}
+
+	// Apply via the standard pipeline; output stays quiet (a no-op
+	// apply is healthy), the structured outcome says what happened.
+	applyCmd := &cobra.Command{}
+	applyCmd.SetOut(io.Discard)
+	applyCmd.SetErr(io.Discard)
+	applied, err := runPolicyApplyV2(applyCmd, res.V2, nodeID, false, true, false)
+	if err != nil {
+		return fmt.Errorf("apply: %w", err)
+	}
+	if applied {
+		fmt.Fprintf(cmd.OutOrStdout(), "applied policy %s (sequence %d)\n", entry.PolicyID, entry.Sequence)
+	}
+
+	// Cache the verified bundle bytes for snapshot echoing.
+	return store.SaveCloudBundle(raw)
+}
+
+// --- status -----------------------------------------------------------
+
+func newCloudStatusCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:          "status",
+		Short:        "Show this node's Cloud connection state",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := nodeStoreForTest()
+			st, err := store.LoadCloudState()
+			if err != nil {
+				return err
+			}
+			_, tokenErr := store.LoadCloudToken()
+			tokenState := "configured"
+			if tokenErr != nil {
+				tokenState = "MISSING"
+			}
+			pullConfigured := st.PullURL != "" && st.TrustFingerprint != ""
+
+			out := cmd.OutOrStdout()
+			if jsonOut {
+				enc := json.NewEncoder(out)
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"url":               st.URL,
+					"enrolled_at":       st.EnrolledAt,
+					"node_token":        tokenState,
+					"pull_configured":   pullConfigured,
+					"trust_fingerprint": st.TrustFingerprint,
+					"last_sync_at":      st.LastSyncAt,
+					"last_sync_result":  st.LastSyncResult,
+				})
+			}
+			fmt.Fprintf(out, "cloud:             %s\n", st.URL)
+			fmt.Fprintf(out, "enrolled:          %s\n", st.EnrolledAt)
+			fmt.Fprintf(out, "node token:        %s\n", tokenState)
+			fmt.Fprintf(out, "policy pull:       %v\n", pullConfigured)
+			if st.TrustFingerprint != "" {
+				fmt.Fprintf(out, "trust fingerprint: %s\n", st.TrustFingerprint)
+			}
+			if st.LastSyncAt != "" {
+				fmt.Fprintf(out, "last sync:         %s (%s)\n", st.LastSyncAt, st.LastSyncResult)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON")
+	return cmd
+}

--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -173,7 +173,12 @@ func newCloudEnrollCmd() *cobra.Command {
 				pullURL, _ = body["pull_url"].(string)
 			}
 			enrolledAt := time.Now().UTC().Format(time.RFC3339)
-			if prev != nil {
+			// Previous settings are only trustworthy for the SAME
+			// control plane: carrying the old Cloud's pull capability
+			// and trust anchor into an enrollment against a different
+			// URL would leave the node reporting to one Cloud while
+			// applying the other's policy.
+			if prev != nil && prev.URL == base {
 				if trustFP == "" {
 					trustFP = prev.TrustFingerprint
 				}
@@ -292,8 +297,11 @@ type cloudSyncError struct {
 func (e *cloudSyncError) Error() string { return e.stage + ": " + e.err.Error() }
 func (e *cloudSyncError) Unwrap() error { return e.err }
 
-// ExitCode lets main map sync failures to distinct process exit codes.
-func (e *cloudSyncError) ExitCode() int { return e.code }
+// CommandExitCode lets main map sync failures to distinct process
+// exit codes. Deliberately NOT named ExitCode: os/exec.ExitError has
+// that method, and wrapped subprocess errors must not leak a child's
+// exit code as ours.
+func (e *cloudSyncError) CommandExitCode() int { return e.code }
 
 // stampSync records the cycle result in cloud.json (best effort on
 // failure paths; the ok path surfaces the write error).

--- a/cmd/oktsec/commands/cloud_test.go
+++ b/cmd/oktsec/commands/cloud_test.go
@@ -149,6 +149,17 @@ func TestCloudEnrollPersistsStateAndIsIdempotent(t *testing.T) {
 	if st3.PullURL != st2.PullURL || st3.TrustFingerprint == "" {
 		t.Fatalf("re-enroll wiped pull state: %+v", st3)
 	}
+
+	// Enrolling against a DIFFERENT Cloud must NOT inherit the old
+	// plane's pull capability or trust anchor.
+	srv2, _ := fakeCloud(t)
+	if _, err := runCloud(t, "enroll", "--url", srv2.URL, "--token", "enroll-secret"); err != nil {
+		t.Fatalf("enroll new cloud: %v", err)
+	}
+	st4, _ := store.LoadCloudState()
+	if st4.PullURL == st2.PullURL {
+		t.Fatalf("pull state must reset when the Cloud URL changes: %+v", st4)
+	}
 }
 
 func TestCloudEnrollRefusesPlaintextHTTP(t *testing.T) {

--- a/cmd/oktsec/commands/cloud_test.go
+++ b/cmd/oktsec/commands/cloud_test.go
@@ -1,0 +1,290 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oktsec/oktsec/internal/node"
+)
+
+// runCloud executes `oktsec cloud <args...>` through the real root
+// command, returning combined stdout and the error.
+func runCloud(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	root := NewRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(append([]string{"cloud"}, args...))
+	err := root.Execute()
+	return out.String(), err
+}
+
+// withLocalCloudDialer lets the SSRF-guarded client reach a local
+// httptest server (which the guard would otherwise correctly refuse).
+func withLocalCloudDialer(t *testing.T) {
+	t.Helper()
+	prev := cloudDialContext
+	cloudDialContext = (&net.Dialer{}).DialContext
+	t.Cleanup(func() { cloudDialContext = prev })
+}
+
+// fakeCloud is a minimal Cloud: register issues a token once, evidence
+// accepts signed envelopes.
+func fakeCloud(t *testing.T) (*httptest.Server, *struct {
+	Registers, Evidence int
+	LastEvidence        map[string]any
+}) {
+	t.Helper()
+	state := &struct {
+		Registers, Evidence int
+		LastEvidence        map[string]any
+	}{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/node/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer enroll-secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		state.Registers++
+		w.Header().Set("Content-Type", "application/json")
+		if state.Registers == 1 {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": "node-token-secret", "pinned": true,
+				"trust_fingerprint": "sha256:" + strings.Repeat("ab", 32),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"pinned": true})
+	})
+	mux.HandleFunc("POST /v1/evidence/envelope", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer node-token-secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var env map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&env)
+		state.Evidence++
+		state.LastEvidence = env
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "accepted_signed"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, state
+}
+
+func TestCloudEnrollPersistsStateAndIsIdempotent(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	withLocalCloudDialer(t)
+	srv, state := fakeCloud(t)
+
+	out, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret")
+	if err != nil {
+		t.Fatalf("enroll: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Enrolled node node_") {
+		t.Fatalf("enroll output: %s", out)
+	}
+	if strings.Contains(out, "node-token-secret") || strings.Contains(out, "enroll-secret") {
+		t.Fatal("enroll output must never contain secrets")
+	}
+
+	// State files exist with owner-only permissions.
+	for _, p := range []string{filepath.Join(store.Dir, "cloud.json"), filepath.Join(store.Dir, "cloud-token")} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("missing %s: %v", p, err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s permissions = %v, want 0600", p, info.Mode().Perm())
+		}
+	}
+	st, err := store.LoadCloudState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.TrustFingerprint != "sha256:"+strings.Repeat("ab", 32) {
+		t.Fatalf("trust fingerprint not taken from Cloud's answer: %q", st.TrustFingerprint)
+	}
+
+	// Re-enroll: idempotent (server answers 200, no new token), token kept.
+	if _, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret"); err != nil {
+		t.Fatalf("re-enroll: %v", err)
+	}
+	if tok, err := store.LoadCloudToken(); err != nil || tok != "node-token-secret" {
+		t.Fatalf("token must survive re-enroll: %q %v", tok, err)
+	}
+	if state.Registers != 2 {
+		t.Fatalf("registers = %d", state.Registers)
+	}
+}
+
+func TestCloudSyncOnceReportsEvidence(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	withLocalCloudDialer(t)
+	srv, state := fakeCloud(t)
+	_, configPath := writeV2ApplyConfig(t)
+	withTestCfgFile(t, configPath)
+	withTestSnapshotDBPath(t, filepath.Join(t.TempDir(), "absent-audit.db"))
+
+	if _, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret"); err != nil {
+		t.Fatalf("enroll: %v", err)
+	}
+	out, err := runCloud(t, "sync", "--once")
+	if err != nil {
+		t.Fatalf("sync: %v\n%s", err, out)
+	}
+	if state.Evidence != 1 {
+		t.Fatalf("evidence posts = %d, want 1", state.Evidence)
+	}
+	// The reported envelope is a real signed envelope for THIS node.
+	sig, _ := state.LastEvidence["signature"].(map[string]any)
+	if sig["value"] == "" || state.LastEvidence["node_id"] == "" {
+		t.Fatalf("evidence is not a signed envelope: %v", state.LastEvidence)
+	}
+}
+
+func TestCloudSyncPullsAppliesThenReports(t *testing.T) {
+	store := withTestNodeStore(t)
+	id, err := store.Init("dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	withLocalCloudDialer(t)
+	srv, state := fakeCloud(t)
+	_, configPath := writeV2ApplyConfig(t)
+	withTestCfgFile(t, configPath)
+	withTestSnapshotDBPath(t, filepath.Join(t.TempDir(), "absent-audit.db"))
+
+	// A signed pull store targeting this node, served from a local dir.
+	raw, fp := signV2Bundle(t, supportedAgentBodyV2("node", id.NodeID))
+	pullDir := writePullStore(t, raw, "node", id.NodeID, "bundles/b.json")
+
+	if _, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret",
+		"--pull-url", fileURL(pullDir), "--trust-fingerprint", fp); err != nil {
+		t.Fatalf("enroll: %v", err)
+	}
+	out, err := runCloud(t, "sync", "--once", "--config", configPath)
+	if err != nil {
+		t.Fatalf("sync: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "applied policy") {
+		t.Fatalf("sync must report the apply: %s", out)
+	}
+	// The bundle cache exists so snapshots echo the active policy...
+	if _, err := os.Stat(store.CloudBundlePath()); err != nil {
+		t.Fatalf("bundle cache missing: %v", err)
+	}
+	// ...and the reported snapshot carries the applied policy block.
+	snap, _ := state.LastEvidence["snapshot"].(map[string]any)
+	pol, _ := snap["policy"].(map[string]any)
+	if pol == nil || pol["policy_status"] != "active" {
+		t.Fatalf("reported snapshot must echo the applied policy, got %v", pol)
+	}
+	if pol["applied_sequence"] == nil {
+		t.Fatalf("policy block missing assignment echo: %v", pol)
+	}
+
+	// Second sync: pull is a clean no-op, evidence still reported.
+	if _, err := runCloud(t, "sync", "--once", "--config", configPath); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if state.Evidence != 2 {
+		t.Fatalf("evidence posts = %d, want 2", state.Evidence)
+	}
+}
+
+func TestCloudSyncExitStagesAndValidation(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	withLocalCloudDialer(t)
+
+	// Not enrolled: clear remediation error.
+	if _, err := runCloud(t, "sync", "--once"); err == nil ||
+		!strings.Contains(err.Error(), "not enrolled") {
+		t.Fatalf("unenrolled sync must say so: %v", err)
+	}
+	// Exactly one of --once / --interval.
+	if _, err := runCloud(t, "sync"); err == nil {
+		t.Fatal("sync without mode must fail")
+	}
+	if _, err := runCloud(t, "sync", "--once", "--interval", "5m"); err == nil {
+		t.Fatal("sync with both modes must fail")
+	}
+	// Interval floor.
+	st := &node.CloudState{URL: "https://cloud.example.com", EnrolledAt: "2026-06-10T00:00:00Z"}
+	if err := store.SaveCloudState(st); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCloud(t, "sync", "--interval", "5s"); err == nil ||
+		!strings.Contains(err.Error(), "at least") {
+		t.Fatalf("sub-minute interval must be refused: %v", err)
+	}
+
+	// Pull failure carries the stage exit code.
+	if err := store.SaveCloudToken("tok"); err != nil {
+		t.Fatal(err)
+	}
+	st.PullURL = fileURL(t.TempDir()) // empty store: index fetch fails
+	st.TrustFingerprint = "sha256:" + strings.Repeat("cd", 32)
+	if err := store.SaveCloudState(st); err != nil {
+		t.Fatal(err)
+	}
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "oktsec.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runCloud(t, "sync", "--once", "--config", cfgPath)
+	var syncErr *cloudSyncError
+	if !errors.As(err, &syncErr) || syncErr.code != 2 {
+		t.Fatalf("pull failure must carry exit code 2: %v", err)
+	}
+}
+
+func TestCloudStatusShowsNoSecrets(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	st := &node.CloudState{
+		URL: "https://cloud.example.com", EnrolledAt: "2026-06-10T00:00:00Z",
+		PullURL: "https://cloud.example.com/pull/x/y/SECRETCAP/", TrustFingerprint: "sha256:" + strings.Repeat("ef", 32),
+	}
+	if err := store.SaveCloudState(st); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveCloudToken("node-token-secret"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runCloud(t, "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if strings.Contains(out, "node-token-secret") || strings.Contains(out, "SECRETCAP") {
+		t.Fatalf("status must not print secrets:\n%s", out)
+	}
+	if !strings.Contains(out, "configured") || !strings.Contains(out, "true") {
+		t.Fatalf("status must show connection state:\n%s", out)
+	}
+}

--- a/cmd/oktsec/commands/cloud_test.go
+++ b/cmd/oktsec/commands/cloud_test.go
@@ -35,6 +35,8 @@ func withLocalCloudDialer(t *testing.T) {
 	prev := cloudDialContext
 	cloudDialContext = (&net.Dialer{}).DialContext
 	t.Cleanup(func() { cloudDialContext = prev })
+	// httptest serves plain http; the product default refuses it.
+	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "1")
 }
 
 // fakeCloud is a minimal Cloud: register issues a token once, evidence
@@ -131,6 +133,33 @@ func TestCloudEnrollPersistsStateAndIsIdempotent(t *testing.T) {
 	}
 	if state.Registers != 2 {
 		t.Fatalf("registers = %d", state.Registers)
+	}
+
+	// Re-enroll WITHOUT flags must not wipe previously stored pull
+	// settings (flags > response > existing state).
+	st2, _ := store.LoadCloudState()
+	st2.PullURL = "https://cloud.example.com/pull/o/f/cap/"
+	if err := store.SaveCloudState(st2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret"); err != nil {
+		t.Fatalf("third enroll: %v", err)
+	}
+	st3, _ := store.LoadCloudState()
+	if st3.PullURL != st2.PullURL || st3.TrustFingerprint == "" {
+		t.Fatalf("re-enroll wiped pull state: %+v", st3)
+	}
+}
+
+func TestCloudEnrollRefusesPlaintextHTTP(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "0")
+	_, err := runCloud(t, "enroll", "--url", "http://cloud.example.com", "--token", "x")
+	if err == nil || !strings.Contains(err.Error(), "https") {
+		t.Fatalf("plaintext URL must be refused: %v", err)
 	}
 }
 

--- a/cmd/oktsec/commands/policy.go
+++ b/cmd/oktsec/commands/policy.go
@@ -83,7 +83,8 @@ func newPolicyApplyCmd() *cobra.Command {
 				return emitApplyFailure(cmd, jsonOut, dryRun, verr)
 			}
 			if res.SchemaVersion == policybundle.SchemaVersionV2 {
-				return runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, allowPartial)
+				_, err := runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, allowPartial)
+				return err
 			}
 
 			if agent == "" {
@@ -168,16 +169,16 @@ func newPolicyApplyCmd() *cobra.Command {
 // projection, anti-rollback against the adjacent state file, no-partial apply,
 // and the post-success state write. Same flag contract as v1 (--dry-run,
 // --allow-partial dry-run only, --json), plus --node-id for target binding.
-func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, nodeID string, dryRun, jsonOut, allowPartial bool) error {
+func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, nodeID string, dryRun, jsonOut, allowPartial bool) (applied bool, err error) {
 	if cfgFile == "" {
-		return fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
+		return false, fmt.Errorf("could not resolve a config path (set --config or $OKTSEC_CONFIG)")
 	}
 	if !dryRun {
 		if !cfgFileExplicit {
-			return fmt.Errorf("real apply requires an explicit, non-empty --config <path> (refusing to mutate a cascaded default config)")
+			return false, fmt.Errorf("real apply requires an explicit, non-empty --config <path> (refusing to mutate a cascaded default config)")
 		}
 		if err := ensureWritableConfigPath(cfgFile); err != nil {
-			return emitApplyFailure(cmd, jsonOut, false, err)
+			return false, emitApplyFailure(cmd, jsonOut, false, err)
 		}
 	}
 	// --- Dry-run path: project against the current config and report, writing
@@ -187,30 +188,30 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	if dryRun {
 		cfg, err := config.Load(cfgFile)
 		if err != nil {
-			return fmt.Errorf("load config %q: %w", cfgFile, err)
+			return false, fmt.Errorf("load config %q: %w", cfgFile, err)
 		}
 		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
+			return false, fmt.Errorf("current config %q is invalid: %w", cfgFile, err)
 		}
 		// Target binding (scope/node_id) is checked inside DryRunV2 before any
 		// work, so a mismatch yields no plan and no write.
 		plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
 		if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
 			// Target mismatch, missing agent, or invalid projected config: no plan.
-			return emitApplyFailure(cmd, jsonOut, true, perr)
+			return false, emitApplyFailure(cmd, jsonOut, true, perr)
 		}
 		// Some ErrUnsupported failures occur BEFORE a plan is built (the deny-all
 		// sentinel collision fails closed in DryRunV2 and returns nil,
 		// ErrUnsupported). Route a nil plan through emitApplyFailure so the plan
 		// emitters never dereference nil.
 		if plan == nil {
-			return emitApplyFailure(cmd, jsonOut, true, perr)
+			return false, emitApplyFailure(cmd, jsonOut, true, perr)
 		}
 		emitPlanV2(cmd, jsonOut, plan)
 		if errors.Is(perr, apply.ErrUnsupported) && !allowPartial {
-			return perr
+			return false, perr
 		}
-		return nil
+		return false, nil
 	}
 
 	// --- Real apply path. The lock must cover the FULL critical section: load
@@ -231,7 +232,7 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	// in every path (success, refusal, error) via defer. ---
 	lock, lerr := apply.AcquireApplyLock(cfgFile)
 	if lerr != nil {
-		return emitApplyFailure(cmd, jsonOut, false, lerr)
+		return false, emitApplyFailure(cmd, jsonOut, false, lerr)
 	}
 	defer func() { _ = lock.Release() }()
 
@@ -239,10 +240,10 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	// config the projection and the no-op decision are computed against.
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
-		return emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("load config %q: %w", cfgFile, err))
+		return false, emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("load config %q: %w", cfgFile, err))
 	}
 	if err := cfg.Validate(); err != nil {
-		return emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("current config %q is invalid: %w", cfgFile, err))
+		return false, emitApplyFailure(cmd, jsonOut, false, fmt.Errorf("current config %q is invalid: %w", cfgFile, err))
 	}
 
 	// Authoritative projection under the lock. Target binding (scope/node_id) is
@@ -251,17 +252,17 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	plan, perr := apply.DryRunV2(v, cfg, nodeID, cfgFile)
 	if perr != nil && !errors.Is(perr, apply.ErrUnsupported) {
 		// Target mismatch, missing agent, or invalid projected config: no plan.
-		return emitApplyFailure(cmd, jsonOut, false, perr)
+		return false, emitApplyFailure(cmd, jsonOut, false, perr)
 	}
 	// A nil plan (e.g. the deny-all sentinel collision fails closed in DryRunV2)
 	// must not reach the plan emitters; route it through emitApplyFailure.
 	if plan == nil {
-		return emitApplyFailure(cmd, jsonOut, false, perr)
+		return false, emitApplyFailure(cmd, jsonOut, false, perr)
 	}
 	// Unsupported semantics always fail with no write.
 	if errors.Is(perr, apply.ErrUnsupported) {
 		emitApplyResultV2(cmd, jsonOut, plan, "", false)
-		return perr
+		return false, perr
 	}
 
 	// Anti-rollback: read state AFTER the lock is held (never a pre-lock
@@ -269,7 +270,7 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	// after a successful write.
 	state, serr := apply.LoadPolicyState(cfgFile)
 	if serr != nil {
-		return emitApplyFailure(cmd, jsonOut, false, serr)
+		return false, emitApplyFailure(cmd, jsonOut, false, serr)
 	}
 	switch state.EvaluateRollback(plan.Scope, plan.NodeID, plan.AssignmentID, plan.RollbackOf, plan.Sequence) {
 	case apply.RollbackRefuse:
@@ -277,7 +278,7 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 		// --json stdout stays one JSON document.
 		err := fmt.Errorf("%w: sequence %d is not greater than the last applied sequence for this target and rollback_of does not name the current assignment",
 			apply.ErrPolicyRollbackRefused, plan.Sequence)
-		return emitApplyFailure(cmd, jsonOut, false, err)
+		return false, emitApplyFailure(cmd, jsonOut, false, err)
 	default:
 		// fresh, advance, signed rollback, or idempotent reapply: proceed.
 	}
@@ -293,16 +294,16 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 	if len(plan.Changes) == 0 {
 		state.Record(plan.Scope, plan.NodeID, plan.AssignmentID, time.Now().UTC().Format(time.RFC3339), plan.Sequence)
 		if err := apply.SavePolicyState(cfgFile, state); err != nil {
-			return emitApplyFailure(cmd, jsonOut, false,
+			return false, emitApplyFailure(cmd, jsonOut, false,
 				fmt.Errorf("no config change, but anti-rollback state write failed: %w", err))
 		}
 		emitApplyResultV2(cmd, jsonOut, plan, "", false)
-		return nil
+		return false, nil
 	}
 
 	backupPath, cerr := apply.CommitV2(plan, cfgFile)
 	if cerr != nil {
-		return emitApplyFailure(cmd, jsonOut, false, cerr)
+		return false, emitApplyFailure(cmd, jsonOut, false, cerr)
 	}
 
 	// Advance the anti-rollback state ONLY after CommitV2 succeeded.
@@ -316,14 +317,14 @@ func runPolicyApplyV2(cmd *cobra.Command, v *policybundle.VerifiedBundleV2, node
 		// no lower sequence can ever win. Whatever the outcome, never report
 		// success: return a non-nil error naming the inconsistency.
 		if rerr := apply.RestoreConfigV2FromBackup(cfgFile, backupPath); rerr != nil {
-			return emitApplyFailure(cmd, jsonOut, false,
+			return false, emitApplyFailure(cmd, jsonOut, false,
 				fmt.Errorf("anti-rollback state write failed (%v) AND config rollback failed (%v): config and apply state are inconsistent; restore config from backup %q manually", err, rerr, backupPath))
 		}
-		return emitApplyFailure(cmd, jsonOut, false,
+		return false, emitApplyFailure(cmd, jsonOut, false,
 			fmt.Errorf("anti-rollback state write failed; config rolled back to the prior sequence from backup %q: %w", backupPath, err))
 	}
 	emitApplyResultV2(cmd, jsonOut, plan, backupPath, true)
-	return nil
+	return true, nil
 }
 
 // savePolicyStateAfterCommit persists the v2 anti-rollback state on the

--- a/cmd/oktsec/commands/policy_pull.go
+++ b/cmd/oktsec/commands/policy_pull.go
@@ -61,31 +61,15 @@ func newPolicyPullCmd() *cobra.Command {
 				return fmt.Errorf("--node-id <id> is required (selects this node's target and binds a node-scoped bundle)")
 			}
 
-			fetch, err := newStoreFetcher(source)
-			if err != nil {
-				return fmt.Errorf("--source: %w", err)
+			raw, res, _, found, perr := pullVerifiedBundle(source, nodeID, trustFP)
+			_ = raw
+			if perr != nil {
+				if perr.verifyStage {
+					return emitApplyFailure(cmd, jsonOut, dryRun, perr.err)
+				}
+				return perr.err
 			}
-
-			// 1. Fetch + signature-verify the index BEFORE trusting any entry.
-			indexBytes, err := fetch("index.json")
-			if err != nil {
-				return fmt.Errorf("fetch index.json: %w", err)
-			}
-			sigBytes, err := fetch("index.json.sig")
-			if err != nil {
-				return fmt.Errorf("fetch index.json.sig: %w", err)
-			}
-			if err := policybundle.VerifyPullIndexSig(indexBytes, sigBytes, trustFP); err != nil {
-				return emitApplyFailure(cmd, jsonOut, dryRun, err)
-			}
-			idx, err := policybundle.ParsePullIndex(indexBytes)
-			if err != nil {
-				return emitApplyFailure(cmd, jsonOut, dryRun, err)
-			}
-
-			// 2. Select this node's target entry.
-			entry, ok := policybundle.SelectPullEntry(idx, nodeID)
-			if !ok {
+			if !found {
 				if jsonOut {
 					enc := json.NewEncoder(cmd.OutOrStdout())
 					enc.SetIndent("", "  ")
@@ -97,43 +81,8 @@ func newPolicyPullCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "no bundle to pull: the store index targets neither node %q nor the fleet\n", nodeID)
 				return nil
 			}
-
-			// 3. Fetch the selected bundle from a store-contained relative path.
-			if err := safeStoreRelPath(entry.BundleFile); err != nil {
-				return fmt.Errorf("index bundle_file %q: %w", entry.BundleFile, err)
-			}
-			bundleRaw, err := fetch(entry.BundleFile)
-			if err != nil {
-				return fmt.Errorf("fetch bundle %q: %w", entry.BundleFile, err)
-			}
-
-			// 4. The bundle is the authority: verify it and route through the
-			// existing v2 apply pipeline (target binding + anti-rollback + write).
-			res, verr := policybundle.Verify(bundleRaw, trustFP)
-			if verr != nil {
-				return emitApplyFailure(cmd, jsonOut, dryRun, verr)
-			}
-			if res.SchemaVersion != policybundle.SchemaVersionV2 {
-				return fmt.Errorf("pull supports policy_bundle.v2 only; store bundle is %q", res.SchemaVersion)
-			}
-			// Bind the fetched bundle to the SIGNED index entry. Without this, an
-			// attacker who can swap the bundle file (but not the signed index)
-			// could serve a different validly-signed bundle — e.g. an older one
-			// signed by the same key — and a fresh node with no anti-rollback
-			// floor would apply it. The signed index names exactly one bundle;
-			// the fetched bytes must be that bundle.
-			a := res.V2.Bundle.Policy.Assignment
-			if res.V2.Bundle.PolicyHash != entry.PolicyHash ||
-				a.AssignmentID != entry.AssignmentID ||
-				a.Sequence != entry.Sequence ||
-				a.Target.Scope != entry.TargetScope ||
-				a.Target.NodeID != entry.TargetNodeID {
-				return fmt.Errorf("fetched bundle does not match the signed index entry "+
-					"(index hash=%s seq=%d assignment=%s target=%s/%s; bundle hash=%s seq=%d assignment=%s target=%s/%s)",
-					entry.PolicyHash, entry.Sequence, entry.AssignmentID, entry.TargetScope, entry.TargetNodeID,
-					res.V2.Bundle.PolicyHash, a.Sequence, a.AssignmentID, a.Target.Scope, a.Target.NodeID)
-			}
-			return runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, false)
+			_, err := runPolicyApplyV2(cmd, res.V2, nodeID, dryRun, jsonOut, false)
+			return err
 		},
 	}
 	f := cmd.Flags()
@@ -143,6 +92,103 @@ func newPolicyPullCmd() *cobra.Command {
 	f.BoolVar(&dryRun, "dry-run", false, "compute and print the projection without writing")
 	f.BoolVar(&jsonOut, "json", false, "emit result as JSON")
 	return cmd
+}
+
+// pullStageError distinguishes verification failures (which `policy
+// pull --json` routes through emitApplyFailure for a structured JSON
+// document) from plain fetch/transport failures.
+type pullStageError struct {
+	err         error
+	verifyStage bool
+}
+
+func (e *pullStageError) Error() string { return e.err.Error() }
+func (e *pullStageError) Unwrap() error { return e.err }
+
+// pullVerifiedBundle is the SINGLE pull pipeline shared by
+// `policy pull` and `cloud sync`: fetch index.json + signature, verify
+// the index signature against the trust fingerprint, select nodeID's
+// entry, fetch the named bundle from a store-contained path, verify it,
+// and bind it to the signed entry. The ordering is part of the security
+// contract: signature before parse, path check before fetch, bind
+// before any apply. found=false means the store publishes nothing for
+// this node (a clean no-op for callers).
+func pullVerifiedBundle(source, nodeID, trustFP string) (raw []byte, res *policybundle.VerifyResult, entry policybundle.PullIndexEntry, found bool, perr *pullStageError) {
+	fail := func(verify bool, err error) ([]byte, *policybundle.VerifyResult, policybundle.PullIndexEntry, bool, *pullStageError) {
+		return nil, nil, policybundle.PullIndexEntry{}, false, &pullStageError{err: err, verifyStage: verify}
+	}
+	fetch, err := newStoreFetcher(source)
+	if err != nil {
+		return fail(false, fmt.Errorf("--source: %w", err))
+	}
+
+	// 1. Fetch + signature-verify the index BEFORE trusting any entry.
+	indexBytes, err := fetch("index.json")
+	if err != nil {
+		return fail(false, fmt.Errorf("fetch index.json: %w", err))
+	}
+	sigBytes, err := fetch("index.json.sig")
+	if err != nil {
+		return fail(false, fmt.Errorf("fetch index.json.sig: %w", err))
+	}
+	if err := policybundle.VerifyPullIndexSig(indexBytes, sigBytes, trustFP); err != nil {
+		return fail(true, err)
+	}
+	idx, err := policybundle.ParsePullIndex(indexBytes)
+	if err != nil {
+		return fail(true, err)
+	}
+
+	// 2. Select this node's target entry.
+	entry, ok := policybundle.SelectPullEntry(idx, nodeID)
+	if !ok {
+		return nil, nil, policybundle.PullIndexEntry{}, false, nil
+	}
+
+	// 3. Fetch the selected bundle from a store-contained relative path.
+	if err := safeStoreRelPath(entry.BundleFile); err != nil {
+		return fail(false, fmt.Errorf("index bundle_file %q: %w", entry.BundleFile, err))
+	}
+	raw, err = fetch(entry.BundleFile)
+	if err != nil {
+		return fail(false, fmt.Errorf("fetch bundle %q: %w", entry.BundleFile, err))
+	}
+
+	// 4. The bundle is the authority: verify it, then bind it to the
+	// SIGNED index entry. Without the binding, an attacker who can swap
+	// the bundle file (but not the signed index) could serve a different
+	// validly-signed bundle — e.g. an older one signed by the same key —
+	// and a fresh node with no anti-rollback floor would apply it.
+	res, verr := policybundle.Verify(raw, trustFP)
+	if verr != nil {
+		return fail(true, verr)
+	}
+	if err := bindPulledBundle(res, entry); err != nil {
+		return fail(true, err)
+	}
+	return raw, res, entry, true, nil
+}
+
+// bindPulledBundle is the single source of the fetched-bundle-vs-signed-
+// index-entry binding check, shared by `policy pull` and `cloud sync`:
+// the verified bundle's hash and full assignment binding must equal the
+// entry the SIGNED index named. v2-only is enforced here too.
+func bindPulledBundle(res *policybundle.VerifyResult, entry policybundle.PullIndexEntry) error {
+	if res.SchemaVersion != policybundle.SchemaVersionV2 {
+		return fmt.Errorf("pull supports policy_bundle.v2 only; store bundle is %q", res.SchemaVersion)
+	}
+	a := res.V2.Bundle.Policy.Assignment
+	if res.V2.Bundle.PolicyHash != entry.PolicyHash ||
+		a.AssignmentID != entry.AssignmentID ||
+		a.Sequence != entry.Sequence ||
+		a.Target.Scope != entry.TargetScope ||
+		a.Target.NodeID != entry.TargetNodeID {
+		return fmt.Errorf("fetched bundle does not match the signed index entry "+
+			"(index hash=%s seq=%d assignment=%s target=%s/%s; bundle hash=%s seq=%d assignment=%s target=%s/%s)",
+			entry.PolicyHash, entry.Sequence, entry.AssignmentID, entry.TargetScope, entry.TargetNodeID,
+			res.V2.Bundle.PolicyHash, a.Sequence, a.AssignmentID, a.Target.Scope, a.Target.NodeID)
+	}
+	return nil
 }
 
 // newStoreFetcher returns a function that reads a store object by its relative

--- a/cmd/oktsec/commands/root.go
+++ b/cmd/oktsec/commands/root.go
@@ -94,6 +94,7 @@ func NewRoot() *cobra.Command {
 		newScanOpenClawCmd(),
 		newTokensCmd(),
 		newNodeCmd(),
+		newCloudCmd(),
 	)
 
 	// Internal/advanced commands — hidden from help

--- a/cmd/oktsec/main.go
+++ b/cmd/oktsec/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,6 +11,13 @@ import (
 func main() {
 	if err := commands.NewRoot().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		// Commands may tag failures with a distinct exit code (e.g.
+		// `cloud sync --once`: 2 = pull/apply, 3 = report) so systemd
+		// units and scripts can branch on the failing stage.
+		var coded interface{ ExitCode() int }
+		if errors.As(err, &coded) {
+			os.Exit(coded.ExitCode())
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/oktsec/main.go
+++ b/cmd/oktsec/main.go
@@ -14,9 +14,9 @@ func main() {
 		// Commands may tag failures with a distinct exit code (e.g.
 		// `cloud sync --once`: 2 = pull/apply, 3 = report) so systemd
 		// units and scripts can branch on the failing stage.
-		var coded interface{ ExitCode() int }
+		var coded interface{ CommandExitCode() int }
 		if errors.As(err, &coded) {
-			os.Exit(coded.ExitCode())
+			os.Exit(coded.CommandExitCode())
 		}
 		os.Exit(1)
 	}

--- a/internal/node/cloud_state.go
+++ b/internal/node/cloud_state.go
@@ -1,0 +1,101 @@
+package node
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oktsec/oktsec/internal/safefile"
+)
+
+// Cloud connection state lives beside the node identity and goes
+// through the SAME file discipline the identity uses: reads open with
+// O_NOFOLLOW (safefile), writes are atomic tmp+rename and refuse
+// pre-planted symlinks (writeFileSafe). cloud.json carries the policy
+// trust fingerprint — the node's trust anchor — so a torn or redirected
+// write of it is security-relevant state corruption.
+//
+//	cloud.json        — url, pull store URL, trust fingerprint, stamps
+//	cloud-token       — the node's bearer token (secret, own file)
+//	cloud-bundle.json — the last verified+applied bundle (for snapshots)
+
+// CloudStateSchemaVersion freezes the cloud.json shape.
+const CloudStateSchemaVersion = "oktsec_cloud_state.v1"
+
+// maxCloudStateBytes bounds the state/token files on read.
+const maxCloudStateBytes = 1 << 20
+
+// CloudState is cloud.json. No secrets here: the node token has its
+// own file so this state can be displayed by `cloud status`.
+type CloudState struct {
+	SchemaVersion    string `json:"schema_version"`
+	URL              string `json:"url"`
+	PullURL          string `json:"pull_url,omitempty"`
+	TrustFingerprint string `json:"trust_fingerprint,omitempty"`
+	EnrolledAt       string `json:"enrolled_at"`
+	LastSyncAt       string `json:"last_sync_at,omitempty"`
+	LastSyncResult   string `json:"last_sync_result,omitempty"`
+}
+
+func (s IdentityStore) cloudStatePath() string { return filepath.Join(s.Dir, "cloud.json") }
+func (s IdentityStore) cloudTokenPath() string { return filepath.Join(s.Dir, "cloud-token") }
+
+// CloudBundlePath is where `cloud sync` caches the last verified bundle
+// so snapshots can echo the active policy.
+func (s IdentityStore) CloudBundlePath() string { return filepath.Join(s.Dir, "cloud-bundle.json") }
+
+// LoadCloudState reads cloud.json. A missing file is reported with the
+// enroll remediation, distinct from a corrupt one.
+func (s IdentityStore) LoadCloudState() (*CloudState, error) {
+	p := s.cloudStatePath()
+	raw, err := safefile.ReadFileMax(p, maxCloudStateBytes)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("this node is not enrolled with a Cloud (run `oktsec cloud enroll --url <cloud> --token <enrollment-token>`)")
+		}
+		return nil, err
+	}
+	var st CloudState
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", p, err)
+	}
+	if st.SchemaVersion != CloudStateSchemaVersion {
+		return nil, fmt.Errorf("%s has schema %q, want %q", p, st.SchemaVersion, CloudStateSchemaVersion)
+	}
+	return &st, nil
+}
+
+// SaveCloudState writes cloud.json atomically (0600).
+func (s IdentityStore) SaveCloudState(st *CloudState) error {
+	st.SchemaVersion = CloudStateSchemaVersion
+	raw, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileSafe(s.cloudStatePath(), raw, 0o600)
+}
+
+// LoadCloudToken reads the node's Cloud bearer token.
+func (s IdentityStore) LoadCloudToken() (string, error) {
+	raw, err := safefile.ReadFileMax(s.cloudTokenPath(), maxCloudStateBytes)
+	if err != nil {
+		return "", fmt.Errorf("node token missing (re-run `oktsec cloud enroll`): %w", err)
+	}
+	token := string(bytes.TrimSpace(raw))
+	if token == "" {
+		return "", fmt.Errorf("node token file is empty (re-run `oktsec cloud enroll`)")
+	}
+	return token, nil
+}
+
+// SaveCloudToken writes the node's Cloud bearer token atomically (0600).
+func (s IdentityStore) SaveCloudToken(token string) error {
+	return writeFileSafe(s.cloudTokenPath(), []byte(token), 0o600)
+}
+
+// SaveCloudBundle caches the last verified bundle bytes atomically.
+func (s IdentityStore) SaveCloudBundle(raw []byte) error {
+	return writeFileSafe(s.CloudBundlePath(), raw, 0o600)
+}


### PR DESCRIPTION
Connect a node to Oktsec Cloud with two commands:

```
oktsec cloud enroll --url https://cloud.example.com --token <enrollment-token>
oktsec cloud sync --interval 5m --config oktsec.yaml
```

**enroll** registers the node's identity (explicit fingerprint pin) and stores the connection state beside the node identity: `cloud.json` (URL, pull store URL, policy trust fingerprint, sync stamps) plus the node token in its own 0600 file. Idempotent re-enroll keeps the existing token. The trust fingerprint is taken from Cloud's register response when present, or from `--trust-fingerprint`; the pull store URL travels via `--pull-url` (it is a capability secret Cloud stores only as a hash, so it cannot be re-issued later).

**sync** runs the full loop — pull first, so evidence always reflects the post-apply state: fetch the signed pull store → verify the index signature against the pinned trust fingerprint → select this node's entry → verify the bundle and bind it to the signed entry → apply through the standard v2 pipeline (target binding + anti-rollback) → build, sign and report a snapshot. `--once` exits with distinct codes per failing stage (2 pull/apply, 3 report) for systemd units; `--interval` loops with jitter (min 1m) and clean SIGTERM shutdown. A store with nothing published for the node is a quiet no-op.

**status** shows the connection state without ever printing secrets.

### Shared, not duplicated

- `pullVerifiedBundle` extracts the pull verification pipeline (index signature → entry → bundle → binding, order preserved) as the **single implementation** used by both `policy pull` and `cloud sync` — no second copy of a security path to drift.
- `runPolicyApplyV2` now also returns the applied outcome, so callers consume a typed result instead of parsing CLI output. Its emit behavior is unchanged.
- Cloud connection state lives in `internal/node` beside the identity store and inherits its file discipline: O_NOFOLLOW reads, atomic symlink-refusing 0600 writes (cloud.json carries the policy trust anchor).
- All Cloud API calls go through the SSRF-guarded dialer (same policy as the pull fetcher); the daemon reuses one HTTP client across ticks. `main` honors command-tagged exit codes via an `ExitCode` interface.

### Trust model unchanged

The node initiates everything (register, report, pull); there is no inbound channel and no remote execution. Apply is exactly the existing pipeline — these commands only orchestrate steps that already ship.

### Tests

Enroll persistence (0600, idempotency, no secrets in output), sync end-to-end against a fake control plane (signed envelope reported; pull → apply → snapshot echoes the applied assignment; second sync is a clean no-op), stage exit codes and flag validation, status redaction. Full suite green with the race detector.