### PR TITLE
cloud: dev escape also relaxes the SSRF dial guard

### DIFF
--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -42,6 +43,24 @@ var cloudDialContext = netutil.SafeDialContext
 // cloudMinInterval keeps daemon mode polite (Cloud rate limits are
 // generous, but a sub-minute loop is never needed).
 const cloudMinInterval = time.Minute
+
+// cloudApplyDevDialEscape relaxes the SSRF dial guard for the running
+// `cloud` command when OKTSEC_CLOUD_INSECURE_HTTP=1 — the same
+// dev-only escape that admits a plaintext --url. A local or LAN test
+// Cloud sits in address ranges the guard refuses by design, so the
+// escape that already declares "this is a development environment"
+// covers both relaxations. It mutates the dial seams of THIS process
+// only, from `cloud` entry points only: `policy pull` invocations and
+// every server-side surface keep the hard guard regardless of
+// environment.
+func cloudApplyDevDialEscape() {
+	if os.Getenv("OKTSEC_CLOUD_INSECURE_HTTP") != "1" {
+		return
+	}
+	plain := (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+	cloudDialContext = plain
+	pullDialContext = plain
+}
 
 // cloudHTTPClient builds the SSRF-guarded client for Cloud API calls.
 // Daemon mode constructs it ONCE per run (keep-alive across ticks);
@@ -114,6 +133,7 @@ func newCloudEnrollCmd() *cobra.Command {
 			if cloudURL == "" || token == "" {
 				return fmt.Errorf("--url and --token are required")
 			}
+			cloudApplyDevDialEscape()
 			base, err := normalizeCloudURL(cloudURL)
 			if err != nil {
 				return err
@@ -254,6 +274,7 @@ func newCloudSyncCmd() *cobra.Command {
 			if once == (interval != 0) {
 				return fmt.Errorf("pass exactly one of --once or --interval")
 			}
+			cloudApplyDevDialEscape()
 			store := nodeStoreForTest()
 			client := cloudHTTPClient()
 			if once {

--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -44,22 +44,19 @@ var cloudDialContext = netutil.SafeDialContext
 // generous, but a sub-minute loop is never needed).
 const cloudMinInterval = time.Minute
 
-// cloudApplyDevDialEscape relaxes the SSRF dial guard for the running
-// `cloud` command when OKTSEC_CLOUD_INSECURE_HTTP=1 — the same
-// dev-only escape that admits a plaintext --url. A local or LAN test
-// Cloud sits in address ranges the guard refuses by design, so the
-// escape that already declares "this is a development environment"
-// covers both relaxations. It mutates the dial seams of THIS process
-// only, from `cloud` entry points only: `policy pull` invocations and
-// every server-side surface keep the hard guard regardless of
-// environment.
-func cloudApplyDevDialEscape() {
-	if os.Getenv("OKTSEC_CLOUD_INSECURE_HTTP") != "1" {
-		return
+// cloudDial picks the dialer for one cloud command invocation. When
+// OKTSEC_CLOUD_INSECURE_HTTP=1 — the same dev-only escape that admits
+// a plaintext --url — it returns a plain dialer, because a local or
+// LAN test Cloud sits in address ranges the SSRF guard refuses by
+// design and the escape already declares "this is a development
+// environment". The choice is per-call and mutates nothing: `policy
+// pull` invocations and every server-side surface keep the hard guard
+// regardless of environment.
+func cloudDial() dialContextFunc {
+	if os.Getenv("OKTSEC_CLOUD_INSECURE_HTTP") == "1" {
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext
 	}
-	plain := (&net.Dialer{Timeout: 5 * time.Second}).DialContext
-	cloudDialContext = plain
-	pullDialContext = plain
+	return cloudDialContext
 }
 
 // cloudHTTPClient builds the SSRF-guarded client for Cloud API calls.
@@ -68,7 +65,7 @@ func cloudApplyDevDialEscape() {
 func cloudHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout:   cloudHTTPTimeout,
-		Transport: &http.Transport{DialContext: cloudDialContext},
+		Transport: &http.Transport{DialContext: cloudDial()},
 	}
 }
 
@@ -133,7 +130,6 @@ func newCloudEnrollCmd() *cobra.Command {
 			if cloudURL == "" || token == "" {
 				return fmt.Errorf("--url and --token are required")
 			}
-			cloudApplyDevDialEscape()
 			base, err := normalizeCloudURL(cloudURL)
 			if err != nil {
 				return err
@@ -274,7 +270,6 @@ func newCloudSyncCmd() *cobra.Command {
 			if once == (interval != 0) {
 				return fmt.Errorf("pass exactly one of --once or --interval")
 			}
-			cloudApplyDevDialEscape()
 			store := nodeStoreForTest()
 			client := cloudHTTPClient()
 			if once {
@@ -414,7 +409,7 @@ func runCloudSyncOnce(cmd *cobra.Command, store node.IdentityStore, client *http
 // snapshots echo the active policy. A store with no entry for this
 // node is a clean no-op.
 func cloudPullApply(cmd *cobra.Command, store node.IdentityStore, st *node.CloudState, nodeID string) error {
-	raw, res, entry, found, perr := pullVerifiedBundle(st.PullURL, nodeID, st.TrustFingerprint)
+	raw, res, entry, found, perr := pullVerifiedBundle(st.PullURL, nodeID, st.TrustFingerprint, cloudDial())
 	if perr != nil {
 		return perr.err
 	}

--- a/cmd/oktsec/commands/cloud_test.go
+++ b/cmd/oktsec/commands/cloud_test.go
@@ -32,12 +32,9 @@ func runCloud(t *testing.T, args ...string) (string, error) {
 // httptest server (which the guard would otherwise correctly refuse).
 func withLocalCloudDialer(t *testing.T) {
 	t.Helper()
-	prevCloud, prevPull := cloudDialContext, pullDialContext
+	prev := cloudDialContext
 	cloudDialContext = (&net.Dialer{}).DialContext
-	// Restore BOTH seams: the dev dial escape inside the command also
-	// mutates pullDialContext, and a leak across tests would silently
-	// change later tests' guard assumptions.
-	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
+	t.Cleanup(func() { cloudDialContext = prev })
 	// httptest serves plain http; the product default refuses it.
 	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "1")
 }
@@ -313,8 +310,6 @@ func TestCloudDevEscapeReachesLoopback(t *testing.T) {
 	if _, err := store.Init("dev"); err != nil {
 		t.Fatal(err)
 	}
-	prevCloud, prevPull := cloudDialContext, pullDialContext
-	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
 	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "1")
 	srv, _ := fakeCloud(t)
 
@@ -327,13 +322,10 @@ func TestCloudDevEscapeReachesLoopback(t *testing.T) {
 	}
 }
 
-// Without the env escape the SSRF guard stays in force: the escape
-// helper is a no-op and loopback dials are refused.
+// Without the env escape the SSRF guard stays in force: cloudDial
+// returns the guarded dialer and loopback dials are refused.
 func TestCloudDevEscapeNoOpWithoutEnv(t *testing.T) {
-	prevCloud, prevPull := cloudDialContext, pullDialContext
-	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
 	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "")
-	cloudApplyDevDialEscape()
 
 	srv, _ := fakeCloud(t)
 	_, err := cloudHTTPClient().Get(srv.URL + "/v1/node/register")

--- a/cmd/oktsec/commands/cloud_test.go
+++ b/cmd/oktsec/commands/cloud_test.go
@@ -32,9 +32,12 @@ func runCloud(t *testing.T, args ...string) (string, error) {
 // httptest server (which the guard would otherwise correctly refuse).
 func withLocalCloudDialer(t *testing.T) {
 	t.Helper()
-	prev := cloudDialContext
+	prevCloud, prevPull := cloudDialContext, pullDialContext
 	cloudDialContext = (&net.Dialer{}).DialContext
-	t.Cleanup(func() { cloudDialContext = prev })
+	// Restore BOTH seams: the dev dial escape inside the command also
+	// mutates pullDialContext, and a leak across tests would silently
+	// change later tests' guard assumptions.
+	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
 	// httptest serves plain http; the product default refuses it.
 	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "1")
 }
@@ -299,6 +302,43 @@ func TestCloudSyncExitStagesAndValidation(t *testing.T) {
 	var syncErr *cloudSyncError
 	if !errors.As(err, &syncErr) || syncErr.code != 2 {
 		t.Fatalf("pull failure must carry exit code 2: %v", err)
+	}
+}
+
+// The dev escape alone (no test dialer seam) must let `cloud enroll`
+// reach a loopback Cloud — this is exactly what a real-binary smoke
+// against a local server relies on.
+func TestCloudDevEscapeReachesLoopback(t *testing.T) {
+	store := withTestNodeStore(t)
+	if _, err := store.Init("dev"); err != nil {
+		t.Fatal(err)
+	}
+	prevCloud, prevPull := cloudDialContext, pullDialContext
+	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
+	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "1")
+	srv, _ := fakeCloud(t)
+
+	out, err := runCloud(t, "enroll", "--url", srv.URL, "--token", "enroll-secret")
+	if err != nil {
+		t.Fatalf("enroll through the dev escape: %v\n%s", err, out)
+	}
+	if _, err := store.LoadCloudToken(); err != nil {
+		t.Fatalf("token not persisted: %v", err)
+	}
+}
+
+// Without the env escape the SSRF guard stays in force: the escape
+// helper is a no-op and loopback dials are refused.
+func TestCloudDevEscapeNoOpWithoutEnv(t *testing.T) {
+	prevCloud, prevPull := cloudDialContext, pullDialContext
+	t.Cleanup(func() { cloudDialContext, pullDialContext = prevCloud, prevPull })
+	t.Setenv("OKTSEC_CLOUD_INSECURE_HTTP", "")
+	cloudApplyDevDialEscape()
+
+	srv, _ := fakeCloud(t)
+	_, err := cloudHTTPClient().Get(srv.URL + "/v1/node/register")
+	if err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("loopback must stay blocked without the escape: %v", err)
 	}
 }
 

--- a/cmd/oktsec/commands/policy_pull.go
+++ b/cmd/oktsec/commands/policy_pull.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -61,7 +62,7 @@ func newPolicyPullCmd() *cobra.Command {
 				return fmt.Errorf("--node-id <id> is required (selects this node's target and binds a node-scoped bundle)")
 			}
 
-			raw, res, _, found, perr := pullVerifiedBundle(source, nodeID, trustFP)
+			raw, res, _, found, perr := pullVerifiedBundle(source, nodeID, trustFP, pullDialContext)
 			_ = raw
 			if perr != nil {
 				if perr.verifyStage {
@@ -112,12 +113,14 @@ func (e *pullStageError) Unwrap() error { return e.err }
 // and bind it to the signed entry. The ordering is part of the security
 // contract: signature before parse, path check before fetch, bind
 // before any apply. found=false means the store publishes nothing for
-// this node (a clean no-op for callers).
-func pullVerifiedBundle(source, nodeID, trustFP string) (raw []byte, res *policybundle.VerifyResult, entry policybundle.PullIndexEntry, found bool, perr *pullStageError) {
+// this node (a clean no-op for callers). dial is the dialer an https
+// source fetches through — each caller passes its own guard so no
+// caller's relaxation can leak into another's.
+func pullVerifiedBundle(source, nodeID, trustFP string, dial dialContextFunc) (raw []byte, res *policybundle.VerifyResult, entry policybundle.PullIndexEntry, found bool, perr *pullStageError) {
 	fail := func(verify bool, err error) ([]byte, *policybundle.VerifyResult, policybundle.PullIndexEntry, bool, *pullStageError) {
 		return nil, nil, policybundle.PullIndexEntry{}, false, &pullStageError{err: err, verifyStage: verify}
 	}
-	fetch, err := newStoreFetcher(source)
+	fetch, err := newStoreFetcher(source, dial)
 	if err != nil {
 		return fail(false, fmt.Errorf("--source: %w", err))
 	}
@@ -196,7 +199,7 @@ func bindPulledBundle(res *policybundle.VerifyResult, entry policybundle.PullInd
 // safefile (symlink-rejecting, size-capped); https:// URLs fetch over an
 // SSRF-guarded client. http:// is allowed too (operator-chosen plaintext store)
 // but runs through the same SSRF guard.
-func newStoreFetcher(source string) (func(rel string) ([]byte, error), error) {
+func newStoreFetcher(source string, dial dialContextFunc) (func(rel string) ([]byte, error), error) {
 	// Only route RECOGNIZED URL schemes through the URL branch. Anything else —
 	// no scheme, or a Windows drive path like `C:\store` that url.Parse reads as
 	// scheme "c" — is a local filesystem path.
@@ -208,7 +211,7 @@ func newStoreFetcher(source string) (func(rel string) ([]byte, error), error) {
 			}
 			return localFetcher(u.Path), nil
 		case "http", "https":
-			return httpFetcher(source), nil
+			return httpFetcher(source, dial), nil
 		}
 	}
 	return localFetcher(source), nil
@@ -224,16 +227,19 @@ func localFetcher(root string) func(rel string) ([]byte, error) {
 	}
 }
 
-// pullDialContext is the dialer the HTTPS store fetcher uses. It defaults to the
-// SSRF-guarded dialer (blocks loopback, link-local, and cloud metadata IPs);
-// tests override it to reach a local test server, which the guard would
-// otherwise (correctly) refuse.
-var pullDialContext = netutil.SafeDialContext
+// dialContextFunc is the dial signature the URL fetchers take.
+type dialContextFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
 
-func httpFetcher(base string) func(rel string) ([]byte, error) {
+// pullDialContext is the dialer `policy pull` fetches HTTPS stores through.
+// It defaults to the SSRF-guarded dialer (blocks loopback, link-local, and
+// cloud metadata IPs); tests override it to reach a local test server, which
+// the guard would otherwise (correctly) refuse.
+var pullDialContext dialContextFunc = netutil.SafeDialContext
+
+func httpFetcher(base string, dial dialContextFunc) func(rel string) ([]byte, error) {
 	client := &http.Client{
 		Timeout:   pullHTTPTimeout,
-		Transport: &http.Transport{DialContext: pullDialContext},
+		Transport: &http.Transport{DialContext: dial},
 	}
 	return func(rel string) ([]byte, error) {
 		u, err := url.Parse(base)


### PR DESCRIPTION
## What

`OKTSEC_CLOUD_INSECURE_HTTP=1` (the existing dev-only escape that admits a plaintext `--url`) now also swaps the SSRF-guarded dialer for a plain one in `cloud enroll` and `cloud sync`.

## Why

A local test Cloud sits on loopback or a private range, which `SafeDialContext` refuses by design. Without this, no end-to-end exercise of `cloud enroll` + `cloud sync` with real binaries against a local server is possible. The env var already declares "this is a development environment"; the dial relaxation follows from the same trust statement.

## Scope

- Applied only at the `cloud` command entry points of the running process. `policy pull` invocations and all server-side surfaces keep the hard guard regardless of environment.
- Default behavior unchanged: without the env var, loopback and private ranges stay blocked.

## Tests

- `TestCloudDevEscapeReachesLoopback`: enroll succeeds against a loopback server through the escape alone (no test dialer seam).
- `TestCloudDevEscapeNoOpWithoutEnv`: without the env var the helper is a no-op and loopback dials stay blocked.
- Test helper now saves/restores both dial seams so the escape cannot leak across tests.