### PR TITLE
Neutral wording for the public client and evidence contracts

### DIFF
--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// `oktsec cloud` connects this node to an Oktsec Cloud control plane.
+// `oktsec cloud` connects this node to an operator control plane.
 // The trust model is the node's, unchanged: the node INITIATES every
-// exchange (register, report, pull); Cloud never reaches in. Apply runs
+// exchange (register, report, pull); the plane never reaches in. Apply runs
 // through the exact same verify + target-binding + anti-rollback
 // pipeline as `policy apply` / `policy pull` — these commands only
 // orchestrate steps that already exist.
@@ -47,7 +47,7 @@ const cloudMinInterval = time.Minute
 // cloudDial picks the dialer for one cloud command invocation. When
 // OKTSEC_CLOUD_INSECURE_HTTP=1 — the same dev-only escape that admits
 // a plaintext --url — it returns a plain dialer, because a local or
-// LAN test Cloud sits in address ranges the SSRF guard refuses by
+// LAN test plane sits in address ranges the SSRF guard refuses by
 // design and the escape already declares "this is a development
 // environment". The choice is per-call and mutates nothing: `policy
 // pull` invocations and every server-side surface keep the hard guard
@@ -100,10 +100,10 @@ func cloudPost(client *http.Client, rawURL, bearer string, body []byte) (int, ma
 func newCloudCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
-		Short: "Connect this node to an Oktsec Cloud control plane",
-		Long: "Enroll this node with Oktsec Cloud, then keep it in sync: report signed " +
+		Short: "Connect this node to a control plane",
+		Long: "Enroll this node with a control plane, then keep it in sync: report signed " +
 			"evidence and pull + verify + apply the signed policy published for it. The node " +
-			"initiates everything; Cloud has no way to reach in.",
+			"initiates everything; the control plane has no way to reach in.",
 	}
 	cmd.AddCommand(newCloudEnrollCmd(), newCloudSyncCmd(), newCloudStatusCmd())
 	return cmd
@@ -120,11 +120,11 @@ func newCloudEnrollCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "enroll",
-		Short: "Register this node with Oktsec Cloud",
-		Long: "Registers this node's identity with Cloud using an enrollment token and stores " +
+		Short: "Register this node with the control plane",
+		Long: "Registers this node's identity with the control plane using an enrollment token and stores " +
 			"the connection state beside the node identity. The pull store URL and policy trust " +
-			"fingerprint are taken from Cloud's response when available, or from flags.",
-		Example:      "  oktsec cloud enroll --url https://cloud.oktsec.com --token <enrollment-token>",
+			"fingerprint are taken from the control plane's response when available, or from flags.",
+		Example:      "  oktsec cloud enroll --url https://cloud.example.com --token <enrollment-token>",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cloudURL == "" || token == "" {
@@ -167,17 +167,17 @@ func newCloudEnrollCmd() *cobra.Command {
 			case http.StatusOK:
 				// Idempotent re-register: no new token. Keep the stored one.
 				if _, err := store.LoadCloudToken(); err != nil {
-					return fmt.Errorf("node already registered but no local token is stored — rotate it from Cloud and re-enroll: %w", err)
+					return fmt.Errorf("node already registered but no local token is stored — rotate it from the control plane and re-enroll: %w", err)
 				}
 			case http.StatusUnauthorized:
 				return fmt.Errorf("enrollment token rejected (expired or revoked)")
 			case http.StatusConflict:
-				return fmt.Errorf("registration conflicts with Cloud's state for this node (identity pin mismatch)")
+				return fmt.Errorf("registration conflicts with the control plane's state for this node (identity pin mismatch)")
 			default:
 				return fmt.Errorf("register failed: HTTP %d", status)
 			}
 
-			// Merge, never wipe: explicit flags win, then Cloud's
+			// Merge, never wipe: explicit flags win, then the plane's
 			// register response, then whatever a previous enroll
 			// stored — so an idempotent re-enroll without --pull-url
 			// cannot silently disable policy pulls.
@@ -190,9 +190,9 @@ func newCloudEnrollCmd() *cobra.Command {
 			}
 			enrolledAt := time.Now().UTC().Format(time.RFC3339)
 			// Previous settings are only trustworthy for the SAME
-			// control plane: carrying the old Cloud's pull capability
+			// control plane: carrying the old plane's pull capability
 			// and trust anchor into an enrollment against a different
-			// URL would leave the node reporting to one Cloud while
+			// URL would leave the node reporting to one plane while
 			// applying the other's policy.
 			if prev != nil && prev.URL == base {
 				if trustFP == "" {
@@ -228,9 +228,9 @@ func newCloudEnrollCmd() *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVar(&cloudURL, "url", "", "Cloud base URL (https://cloud.example.com)")
-	f.StringVar(&token, "token", "", "enrollment token issued by Cloud (shown once at creation)")
-	f.StringVar(&pullURL, "pull-url", "", "this fleet's pull store URL (from the Cloud console)")
-	f.StringVar(&trustFP, "trust-fingerprint", "", "policy signing trust fingerprint sha256:<hex> (defaults to Cloud's answer)")
+	f.StringVar(&token, "token", "", "enrollment token (shown once at creation)")
+	f.StringVar(&pullURL, "pull-url", "", "this fleet's pull store URL (shown once at capability creation)")
+	f.StringVar(&trustFP, "trust-fingerprint", "", "policy signing trust fingerprint sha256:<hex> (defaults to the control plane's answer)")
 	return cmd
 }
 
@@ -239,7 +239,7 @@ func normalizeCloudURL(raw string) (string, error) {
 	if err != nil || u.Host == "" || (u.Scheme != "https" && u.Scheme != "http") {
 		return "", fmt.Errorf("--url must be an http(s) base URL, got %q", raw)
 	}
-	// Bearer tokens travel in every Cloud call: plaintext HTTP would
+	// Bearer tokens travel in every call: plaintext HTTP would
 	// leak them to any on-path network. https only, with an explicit
 	// dev-only escape for local test servers.
 	if u.Scheme == "http" && os.Getenv("OKTSEC_CLOUD_INSECURE_HTTP") != "1" {
@@ -440,7 +440,7 @@ func newCloudStatusCmd() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:          "status",
-		Short:        "Show this node's Cloud connection state",
+		Short:        "Show this node's control plane connection state",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := nodeStoreForTest()

--- a/cmd/oktsec/commands/node.go
+++ b/cmd/oktsec/commands/node.go
@@ -17,8 +17,8 @@ import (
 
 // newNodeCmd builds the `oktsec node` command group. Order 1 shipped
 // init / status / snapshot; Phase 5 Order 3A adds sign-snapshot for
-// producing signed envelopes that downstream consumers (e.g.
-// `oktsec-enterprise ingest`) can verify against the local node key.
+// producing signed envelopes that downstream consumers (e.g. a
+// fleet ingest tool) can verify against the local node key.
 // All subcommands are local-only and read-only with respect to the
 // Oktsec runtime — none of them open a network socket or modify
 // running enforcement.

--- a/cmd/oktsec/commands/policy_pull.go
+++ b/cmd/oktsec/commands/policy_pull.go
@@ -29,7 +29,7 @@ const pullHTTPTimeout = 15 * time.Second
 // signed pull store from an operator-controlled source, verifies the index
 // signature against its pinned trust fingerprint, selects the bundle for its
 // target, and routes that bundle through the SAME verify + target-binding +
-// anti-rollback + apply pipeline `policy apply` uses. Enterprise never contacts
+// anti-rollback + apply pipeline `policy apply` uses. The store operator never contacts
 // the node; the node initiates everything here.
 func newPolicyPullCmd() *cobra.Command {
 	var (

--- a/internal/apply/projection.go
+++ b/internal/apply/projection.go
@@ -10,8 +10,8 @@
 // subset that would change runtime meaning are reported as unsupported and
 // refused by default — never silently applied or ignored.
 //
-// The signed bundle carries the Enterprise policy vocabulary
-// (flag/quarantine/block); the Enterprise→Community action mapping happens
+// The signed bundle carries the control-plane policy vocabulary
+// (flag/quarantine/block); the bundle→Community action mapping happens
 // here, at projection time, NOT in the bundle.
 package apply
 
@@ -50,12 +50,12 @@ var (
 	ErrPolicyRollbackRefused = errors.New("apply: policy_rollback_refused")
 )
 
-// mapAction maps an Enterprise override action to a Community rule action.
-// Returns ok=false for an action outside the Enterprise vocabulary (a
+// mapAction maps a bundle override action to a Community rule action.
+// Returns ok=false for an action outside the bundle vocabulary (a
 // verified bundle never carries one, but the projection refuses rather than
 // silently mis-mapping).
-func mapAction(enterprise string) (string, bool) {
-	switch enterprise {
+func mapAction(action string) (string, bool) {
+	switch action {
 	case "flag":
 		return "allow-and-flag", true
 	case "quarantine":
@@ -398,7 +398,7 @@ func DryRun(verified *policybundle.VerifiedBundle, cfg *config.Config, agentName
 
 	target.Agents[agentName] = agent
 
-	// redaction.level and metadata are Enterprise report/display + audit
+	// redaction.level and metadata are control-plane report/display + audit
 	// concerns, not Community runtime settings — intentionally not projected,
 	// and NOT "unsupported": they do not change runtime meaning here.
 

--- a/internal/apply/projection_v2.go
+++ b/internal/apply/projection_v2.go
@@ -21,7 +21,7 @@ package apply
 // governed (mode != unmanaged) but not yet implemented:
 //   - body-level egress (fleet/global forward-proxy domain lists)
 //   - server governance (require_intent, rate limits)
-//   - redaction (Enterprise report concern, but a managed mode is refused so it
+//   - redaction (control-plane report concern, but a managed mode is refused so it
 //     is never silently dropped)
 //   - per-agent acls, tool_policies, tool_constraints, tool_chain_rules, and
 //     per-agent egress fields beyond allowed/blocked domains (scope,
@@ -210,7 +210,7 @@ func DryRunV2(verified *policybundle.VerifiedBundleV2, cfg *config.Config, nodeI
 	failClosedIfManaged(plan, "server_governance", body.Governance.Server.Mode,
 		"server governance (require_intent, rate limits) is not projected by Community apply in this PR")
 	failClosedIfManaged(plan, "redaction", body.Redaction.Mode,
-		"redaction is an Enterprise report concern and is not projected onto Community runtime")
+		"redaction is a control-plane report concern and is not projected onto Community runtime")
 
 	// --- Per-agent governance via selectors. Selector overlap on the SAME
 	// dimension fails closed; matched agents are projected. ---

--- a/internal/node/cloud_state.go
+++ b/internal/node/cloud_state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oktsec/oktsec/internal/safefile"
 )
 
-// Cloud connection state lives beside the node identity and goes
+// Control plane connection state lives beside the node identity and goes
 // through the SAME file discipline the identity uses: reads open with
 // O_NOFOLLOW (safefile), writes are atomic tmp+rename and refuse
 // pre-planted symlinks (writeFileSafe). cloud.json carries the policy
@@ -53,7 +53,7 @@ func (s IdentityStore) LoadCloudState() (*CloudState, error) {
 	raw, err := safefile.ReadFileMax(p, maxCloudStateBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("this node is not enrolled with a Cloud (run `oktsec cloud enroll --url <cloud> --token <enrollment-token>`)")
+			return nil, fmt.Errorf("this node is not enrolled with a control plane (run `oktsec cloud enroll --url <url> --token <enrollment-token>`)")
 		}
 		return nil, err
 	}

--- a/internal/node/envelope.go
+++ b/internal/node/envelope.go
@@ -13,28 +13,28 @@ import (
 )
 
 // Stable envelope schema version. Bumping is a contract break and
-// must come with a coordinated Enterprise-side release; this constant
+// must come with a coordinated consumer-side release; this constant
 // is the single source of truth on the Community side and the value
-// Enterprise vendors into its JSON Schema fixtures.
+// downstream verifiers vendor into their JSON Schema fixtures.
 const SchemaSnapshotEnvelope = "node_snapshot_envelope.v1"
 
 // EnvelopeVersion is the integer envelope-shape version. Distinct
 // from SchemaSnapshotEnvelope so a future field-only addition can
 // bump the integer without rotating the schema name; current
-// Enterprise verifiers should still accept it under the same
+// verifiers should still accept it under the same
 // schema string, refusing fields they do not understand.
 const EnvelopeVersion = 1
 
 // CanonicalizationTag identifies the exact canonicalization
 // algorithm used to compute the snapshot hash that goes into the
-// envelope. Enterprise must verify against this exact tag so an
+// envelope. Verifiers must check this exact tag so an
 // untagged or differently-tagged envelope is rejected outright.
 const CanonicalizationTag = "node_snapshot.v1.canonical_json.utc_minified"
 
 // SnapshotSignature is the cryptographic-evidence half of the
 // envelope. The public key is carried in raw base64 form because
 // node_identity.v1 only exposes the fingerprint; without the raw
-// bytes Enterprise cannot verify the Ed25519 signature.
+// bytes a verifier cannot check the Ed25519 signature.
 type SnapshotSignature struct {
 	Alg                  string `json:"alg"`
 	KeyID                string `json:"key_id"`
@@ -64,7 +64,7 @@ type SnapshotEnvelope struct {
 	Snapshot              Snapshot          `json:"snapshot"`
 }
 
-// CanonicalSnapshotBytes returns the bytes Enterprise must reproduce
+// CanonicalSnapshotBytes returns the bytes a verifier must reproduce
 // to verify the signature. The contract:
 //
 //  1. RFC3339 timestamps that the snapshot uses for time bounds
@@ -101,7 +101,7 @@ func CanonicalSnapshotBytes(s Snapshot) ([]byte, error) {
 
 // SnapshotSHA256 returns the lowercase-hex SHA-256 of the canonical
 // snapshot bytes, paired with those bytes. The hash has NO sha256:
-// prefix because Enterprise's snapshots.id already uses raw hex; the
+// prefix because consumer snapshot IDs already use raw hex; the
 // fingerprint prefix is reserved for identity-shaped values.
 func SnapshotSHA256(s Snapshot) (string, []byte, error) {
 	canon, err := CanonicalSnapshotBytes(s)
@@ -218,11 +218,11 @@ func SealSnapshotEnvelope(store IdentityStore, snap Snapshot, signedAt time.Time
 	return env, nil
 }
 
-// verifyEnvelopeSelf runs the same Ed25519 verification a future
-// Enterprise verifier would run, against the IdentityStore's
+// verifyEnvelopeSelf runs the same Ed25519 verification a
+// downstream verifier would run, against the IdentityStore's
 // current public key. It catches an entire class of subtle
 // breakage (mismatched key files, accidental key rotation
-// mid-process) without depending on Enterprise being installed.
+// mid-process) without depending on any external verifier.
 func verifyEnvelopeSelf(env *SnapshotEnvelope, pub ed25519.PublicKey) error {
 	sigBytes, err := base64.StdEncoding.DecodeString(env.Signature.Value)
 	if err != nil {

--- a/internal/node/errors.go
+++ b/internal/node/errors.go
@@ -1,6 +1,6 @@
 // Package node implements the local node identity and read-only
 // snapshot contract for Phase 5 Order 1. Community owns the local
-// runtime node; Enterprise will consume the JSON artifacts this
+// runtime node; downstream verifiers consume the JSON artifacts this
 // package emits without importing internal/ Go code.
 //
 // Everything in this package must remain additive and read-only.
@@ -20,7 +20,7 @@ type Warning struct {
 }
 
 // Stable warning codes. New codes may be appended; existing codes must
-// not change spelling, because Enterprise consumers and Order 2 evidence
+// not change spelling, because downstream consumers and Order 2 evidence
 // checkpoints branch on them.
 const (
 	WarnNodeIdentityMissing      = "node_identity_missing"

--- a/internal/node/identity_store.go
+++ b/internal/node/identity_store.go
@@ -130,7 +130,7 @@ func (s IdentityStore) Init(profile string) (*Identity, error) {
 // Load reads identity.json AND verifies that node.key + node.pub
 // exist and are consistent with the fingerprint in identity.json.
 //
-// The signed-checkpoint contract that future Enterprise depends on
+// The signed-checkpoint contract downstream verifiers depend on
 // requires all three to be usable together: identity.json on its own
 // (without keys, or with mismatched keys) must not be reported as
 // present. If only identity.json exists, Load returns a real error

--- a/internal/node/policy_bundle.go
+++ b/internal/node/policy_bundle.go
@@ -53,7 +53,7 @@ type rawPolicyBundle struct {
 		// schema_version is policy_bundle.v2 (the v1 signing payload does
 		// not bind it, so it is not trustworthy on a v1 bundle). Only
 		// assignment_id + sequence are read; the snapshot echoes them so
-		// Enterprise can compare the exact assignment, not just the hash
+		// a verifier can compare the exact assignment, not just the hash
 		// (Order 9B).
 		Assignment struct {
 			AssignmentID string `json:"assignment_id"`
@@ -118,7 +118,7 @@ func buildPolicySection(bundlePath, trustFingerprint string) (*SnapshotPolicy, [
 	if err := json.Unmarshal(data, &bundle); err != nil {
 		return unreadable("invalid JSON: " + err.Error())
 	}
-	// A bundle that does not declare the minimal identity Enterprise
+	// A bundle that does not declare the minimal identity a verifier
 	// compares against (hash + id) is not a usable active policy. This
 	// tolerant projection shares the policy_hash / policy.policy_id /
 	// policy.policy_version JSON paths with both the v1 and v2 envelopes,

--- a/internal/node/schema.go
+++ b/internal/node/schema.go
@@ -1,7 +1,7 @@
 package node
 
 // Stable schema versions emitted in JSON output. Bumping a version is a
-// breaking-change signal to Enterprise consumers and must be done in a
+// breaking-change signal to downstream consumers and must be done in a
 // dedicated PR with a migration note.
 const (
 	SchemaIdentity = "node_identity.v1"
@@ -65,7 +65,7 @@ const (
 	PolicyStatusNone = "none"
 	// PolicyStatusUnreadable: a path was supplied but the bundle could
 	// not be read or parsed, or it lacked the minimal fields. Distinct
-	// from PolicyStatusNone so Enterprise does not mistake "I could not
+	// from PolicyStatusNone so a consumer does not mistake "I could not
 	// read it" for "there is no policy here".
 	PolicyStatusUnreadable = "unreadable"
 )
@@ -145,7 +145,7 @@ type SnapshotPolicy struct {
 	ActivePolicyVerificationStatus string `json:"active_policy_verification_status,omitempty"`
 	// AppliedAssignmentID / AppliedSequence echo the active v2 bundle's
 	// signed assignment binding (policybundle.AssignmentV2). They let
-	// Enterprise compare the exact assignment the node carries, not just
+	// a verifier compare the exact assignment the node carries, not just
 	// the policy hash (Order 9B observed-vs-desired). Both are omitempty
 	// because a v1 (or no-assignment) bundle has no assignment block: an
 	// empty id / zero sequence means "absent", never a meaningful zero
@@ -195,8 +195,8 @@ type SnapshotConfig struct {
 }
 
 // SnapshotSurfaces is the per-surface configured/observed view used by
-// the dashboard coverage matrix and by the planned Enterprise fleet
-// report. Booleans are conservative: false when the section cannot
+// the dashboard coverage matrix and by downstream fleet
+// reports. Booleans are conservative: false when the section cannot
 // prove the affirmative.
 type SnapshotSurfaces struct {
 	MCPGateway      SurfaceGateway  `json:"mcp_gateway"`
@@ -339,7 +339,7 @@ type PostureCounts struct {
 // proxy_signature AND every one of those signatures verified
 // against the configured proxy public key. Anything weaker —
 // no key reachable, no signed rows, or mixed signed/unsigned
-// coverage — leaves this field false. Enterprise compliance
+// coverage — leaves this field false. Compliance
 // evidence must read both fields together: AuditChainVerified
 // tells you nothing tampered; AuditChainSignaturesChecked tells
 // you the proxy actually signed every row in scope.

--- a/internal/node/snapshot.go
+++ b/internal/node/snapshot.go
@@ -259,7 +259,7 @@ func Build(ctx context.Context, opts Options) (Snapshot, error) {
 		//
 		//   partial coverage: at least one row carries a
 		//   signature, but the scope also contains unsigned rows.
-		//   Calling this "signed" would overclaim — Enterprise
+		//   Calling this "signed" would overclaim — compliance
 		//   evidence needs a separate code so the consumer can
 		//   distinguish "no key reachable" from "mixed coverage".
 		//

--- a/internal/policybundle/pull_index.go
+++ b/internal/policybundle/pull_index.go
@@ -21,7 +21,7 @@ import (
 // truncated index (e.g. one hiding the newest bundle) is refused rather than
 // silently followed. The signature is detached and covers the LITERAL index
 // bytes (not a re-canonicalization), so no shared JSON canonicalizer is needed
-// between the signer (Enterprise) and this verifier — byte-exactness is the
+// between the signer and this verifier — byte-exactness is the
 // file's own bytes. The bundle's own signature remains the final authority for
 // what is applied; the index only decides which bundle the node fetches.
 

--- a/internal/policybundle/pull_index_test.go
+++ b/internal/policybundle/pull_index_test.go
@@ -21,7 +21,7 @@ func pullTestKey(t *testing.T) (ed25519.PrivateKey, string) {
 }
 
 // signIndexForTest builds a valid index.json.sig for the given index bytes,
-// mirroring exactly what the Enterprise publisher must produce.
+// mirroring exactly what a store publisher must produce.
 func signIndexForTest(t *testing.T, key ed25519.PrivateKey, indexBytes []byte, signedAt, fp string) []byte {
 	t.Helper()
 	sum := sha256.Sum256(indexBytes)


### PR DESCRIPTION
Comments, help text and user-facing strings now describe the consumer side of the node's contracts generically — control plane, downstream verifier, store publisher — instead of naming specific products, and command examples use a placeholder domain.

No behavior change: one parameter rename (`mapAction`), one error-string wording change (`redaction is a control-plane report concern...`, not pinned by any test), everything else is comments and help text. The `enterprise` deployment profile keeps its name throughout — it is a shipped flag value (`--profile enterprise`), not a product reference.