### PR TITLE
cloud sync ships redacted audit events to the control plane

### DIFF
--- a/cmd/oktsec/commands/cloud.go
+++ b/cmd/oktsec/commands/cloud.go
@@ -405,10 +405,22 @@ func runCloudSyncOnce(cmd *cobra.Command, store node.IdentityStore, client *http
 	result, _ := body["status"].(string)
 	switch result {
 	case "accepted", "accepted_signed", "idempotent":
+		// 4. Ship new audit events (redacted; metadata only). Best
+		// effort: live telemetry must never fail the evidence cycle —
+		// the cursor only advances on an accepted batch, so anything
+		// missed ships next cycle.
+		shipped, serr := shipCloudEvents(client, store, st, id.NodeID, token)
+		if serr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "cloud sync: events: %v\n", serr)
+		}
 		if err := stampSync(store, st, "ok"); err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "sync ok (evidence %s)\n", result)
+		if shipped > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "sync ok (evidence %s, %d event(s) shipped)\n", result, shipped)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "sync ok (evidence %s)\n", result)
+		}
 		return nil
 	default:
 		_ = stampSync(store, st, "report_failed")
@@ -417,6 +429,45 @@ func runCloudSyncOnce(cmd *cobra.Command, store node.IdentityStore, client *http
 			code = fmt.Sprintf("http_%d", status)
 		}
 		return &cloudSyncError{stage: "report", code: 3, err: fmt.Errorf("evidence refused (%s)", code)}
+	}
+}
+
+// shipCloudEvents sends audit entries newer than the cursor, in one
+// bounded batch per cycle (the next cycle picks up the rest). The
+// cursor advances ONLY after the control plane accepted the batch.
+func shipCloudEvents(client *http.Client, store node.IdentityStore, st *node.CloudState, nodeID, token string) (int, error) {
+	const batchLimit = 500
+	entries, next, err := node.CollectRecentEvents(cfgFile, nodeSnapshotDBPathOverride, st.EventsCursor, batchLimit)
+	if err != nil {
+		return 0, err
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	payload, err := json.Marshal(node.EventsBatch{
+		SchemaVersion: node.SchemaEvents, NodeID: nodeID, Entries: entries,
+	})
+	if err != nil {
+		return 0, err
+	}
+	status, body, err := cloudPost(client, st.URL+"/v1/evidence/events", token, payload)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case status == http.StatusNotFound:
+		// An older control plane without the events endpoint: skip
+		// quietly, never advance the cursor.
+		return 0, nil
+	case status >= 200 && status < 300:
+		st.EventsCursor = next
+		return len(entries), nil
+	default:
+		code, _ := body["code"].(string)
+		if code == "" {
+			code = fmt.Sprintf("http_%d", status)
+		}
+		return 0, fmt.Errorf("events refused (%s)", code)
 	}
 }
 

--- a/internal/node/cloud_state.go
+++ b/internal/node/cloud_state.go
@@ -37,6 +37,9 @@ type CloudState struct {
 	EnrolledAt       string `json:"enrolled_at"`
 	LastSyncAt       string `json:"last_sync_at,omitempty"`
 	LastSyncResult   string `json:"last_sync_result,omitempty"`
+	// EventsCursor is the timestamp of the last audit entry shipped to
+	// the control plane (additive local state; absent on old files).
+	EventsCursor string `json:"events_cursor,omitempty"`
 }
 
 func (s IdentityStore) cloudStatePath() string { return filepath.Join(s.Dir, "cloud.json") }

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/oktsec/oktsec/internal/audit"
@@ -28,15 +29,24 @@ type EventsBatch struct {
 	Entries       []audit.RedactedEntry `json:"entries"`
 }
 
-// CollectRecentEvents reads audit entries strictly newer than the
-// cursor (RFC3339; "" = everything), redacted for export. It returns
-// the entries and the new cursor (the last entry's timestamp).
+// CollectRecentEvents reads audit entries past the cursor, redacted
+// for export, and returns them with the new cursor. The cursor is
+// "timestamp|id" of the last shipped entry ("" = everything): the id
+// tiebreak makes same-second batches safe — a 500-row batch cutting
+// through a busy second, or a late row in an already-shipped second,
+// ships on the next cycle instead of being skipped forever.
 // A missing or unreadable audit database is a clean no-op: nodes
 // without a proxy runtime have no events, not an error.
 func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]audit.RedactedEntry, string, error) {
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		// No config = no proxy = no events.
+		return nil, cursor, nil
+	}
+	// Same guard as the snapshot builder: a Postgres-backed install
+	// must not have a stale local SQLite file shipped as live
+	// telemetry.
+	if cfg != nil && strings.EqualFold(cfg.DBBackend, "postgres") {
 		return nil, cursor, nil
 	}
 	dbPath := dbPathOverride
@@ -61,8 +71,12 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 
 	where, args := "", []any{}
 	if cursor != "" {
-		where = "WHERE timestamp > ?"
-		args = append(args, cursor)
+		curTS, curID := cursor, ""
+		if i := strings.IndexByte(cursor, '|'); i >= 0 {
+			curTS, curID = cursor[:i], cursor[i+1:]
+		}
+		where = "WHERE (timestamp > ? OR (timestamp = ? AND id > ?))"
+		args = append(args, curTS, curTS, curID)
 	}
 	args = append(args, limit)
 	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
@@ -90,7 +104,7 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 		e.SignatureVerified = int(sigVerified.Int64)
 		e.LatencyMs = latency.Int64
 		out = append(out, audit.Redact(e, audit.RedactAnalyst))
-		last = e.Timestamp
+		last = e.Timestamp + "|" + e.ID
 	}
 	if err := rows.Err(); err != nil {
 		return nil, cursor, err

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -46,7 +46,8 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 	// Same guard as the snapshot builder: a Postgres-backed install
 	// must not have a stale local SQLite file shipped as live
 	// telemetry.
-	if cfg != nil && strings.EqualFold(cfg.DBBackend, "postgres") {
+	if cfg != nil && strings.HasPrefix(strings.ToLower(cfg.DBBackend), "postgres") {
+		// Covers both supported aliases (postgres, postgresql).
 		return nil, cursor, nil
 	}
 	dbPath := dbPathOverride
@@ -60,7 +61,7 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 	if err != nil {
 		return nil, cursor, nil
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -71,32 +72,36 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 
 	where, args := "", []any{}
 	if cursor != "" {
-		curTS, curID := cursor, ""
+		curTS, curRow := cursor, "0"
 		if i := strings.IndexByte(cursor, '|'); i >= 0 {
-			curTS, curID = cursor[:i], cursor[i+1:]
+			curTS, curRow = cursor[:i], cursor[i+1:]
 		}
-		where = "WHERE (timestamp > ? OR (timestamp = ? AND id > ?))"
-		args = append(args, curTS, curTS, curID)
+		// rowid is SQLite's monotonic insertion key: a same-second row
+		// committed after the last sync always has a larger rowid, so
+		// nothing is skipped (audit IDs are random UUIDs and would be).
+		where = "WHERE (timestamp > ? OR (timestamp = ? AND rowid > ?))"
+		args = append(args, curTS, curTS, curRow)
 	}
 	args = append(args, limit)
 	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
-		SELECT id, timestamp, COALESCE(from_agent,''), COALESCE(to_agent,''),
+		SELECT rowid, id, timestamp, COALESCE(from_agent,''), COALESCE(to_agent,''),
 		       COALESCE(content_hash,''), COALESCE(signature_verified,0),
 		       COALESCE(status,''), COALESCE(rules_triggered,''),
 		       COALESCE(policy_decision,''), COALESCE(latency_ms,0)
-		FROM audit_log %s ORDER BY timestamp ASC, id ASC LIMIT ?`, where), args...)
+		FROM audit_log %s ORDER BY timestamp ASC, rowid ASC LIMIT ?`, where), args...)
 	if err != nil {
 		return nil, cursor, fmt.Errorf("events query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []audit.RedactedEntry
 	last := cursor
 	for rows.Next() {
 		var e audit.Entry
+		var rowid int64
 		var sigVerified sql.NullInt64
 		var latency sql.NullInt64
-		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent,
+		if err := rows.Scan(&rowid, &e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent,
 			&e.ContentHash, &sigVerified, &e.Status, &e.RulesTriggered,
 			&e.PolicyDecision, &latency); err != nil {
 			return nil, cursor, fmt.Errorf("events scan: %w", err)
@@ -104,7 +109,7 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 		e.SignatureVerified = int(sigVerified.Int64)
 		e.LatencyMs = latency.Int64
 		out = append(out, audit.Redact(e, audit.RedactAnalyst))
-		last = e.Timestamp + "|" + e.ID
+		last = fmt.Sprintf("%s|%d", e.Timestamp, rowid)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, cursor, err

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -1,0 +1,99 @@
+package node
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/oktsec/oktsec/internal/audit"
+	"github.com/oktsec/oktsec/internal/config"
+)
+
+// Event shipping: the node's audit trail is the live record of what
+// the proxy actually did. `cloud sync` ships NEW entries to the
+// control plane in batches, REDACTED at the analyst level: agent
+// names, verdicts, redacted rule findings, latency — never message
+// content, tool arguments, intents or delegation chains. The cursor
+// is the last shipped timestamp; overlap at the boundary is fine
+// because the receiver dedupes on entry ID.
+
+// SchemaEvents freezes the events batch shape.
+const SchemaEvents = "node_events.v1"
+
+// EventsBatch is the wire shape POSTed to the control plane.
+type EventsBatch struct {
+	SchemaVersion string                `json:"schema_version"`
+	NodeID        string                `json:"node_id"`
+	Entries       []audit.RedactedEntry `json:"entries"`
+}
+
+// CollectRecentEvents reads audit entries strictly newer than the
+// cursor (RFC3339; "" = everything), redacted for export. It returns
+// the entries and the new cursor (the last entry's timestamp).
+// A missing or unreadable audit database is a clean no-op: nodes
+// without a proxy runtime have no events, not an error.
+func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]audit.RedactedEntry, string, error) {
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		// No config = no proxy = no events.
+		return nil, cursor, nil
+	}
+	dbPath := dbPathOverride
+	if dbPath == "" {
+		dbPath = resolveSnapshotDBPath(cfg)
+	}
+	if avail := inspectSQLiteAvailability(dbPath); !avail.Available {
+		return nil, cursor, nil
+	}
+	db, err := openSQLiteReadOnly(dbPath)
+	if err != nil {
+		return nil, cursor, nil
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	exists, err := sqliteTableExists(ctx, db, "audit_log")
+	if err != nil || !exists {
+		return nil, cursor, nil
+	}
+
+	where, args := "", []any{}
+	if cursor != "" {
+		where = "WHERE timestamp > ?"
+		args = append(args, cursor)
+	}
+	args = append(args, limit)
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, timestamp, COALESCE(from_agent,''), COALESCE(to_agent,''),
+		       COALESCE(content_hash,''), COALESCE(signature_verified,0),
+		       COALESCE(status,''), COALESCE(rules_triggered,''),
+		       COALESCE(policy_decision,''), COALESCE(latency_ms,0)
+		FROM audit_log %s ORDER BY timestamp ASC, id ASC LIMIT ?`, where), args...)
+	if err != nil {
+		return nil, cursor, fmt.Errorf("events query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []audit.RedactedEntry
+	last := cursor
+	for rows.Next() {
+		var e audit.Entry
+		var sigVerified sql.NullInt64
+		var latency sql.NullInt64
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.FromAgent, &e.ToAgent,
+			&e.ContentHash, &sigVerified, &e.Status, &e.RulesTriggered,
+			&e.PolicyDecision, &latency); err != nil {
+			return nil, cursor, fmt.Errorf("events scan: %w", err)
+		}
+		e.SignatureVerified = int(sigVerified.Int64)
+		e.LatencyMs = latency.Int64
+		out = append(out, audit.Redact(e, audit.RedactAnalyst))
+		last = e.Timestamp
+	}
+	if err := rows.Err(); err != nil {
+		return nil, cursor, err
+	}
+	return out, last, nil
+}

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,6 +76,12 @@ func CollectRecentEvents(cfgPath, dbPathOverride, cursor string, limit int) ([]a
 		curTS, curRow := cursor, "0"
 		if i := strings.IndexByte(cursor, '|'); i >= 0 {
 			curTS, curRow = cursor[:i], cursor[i+1:]
+		}
+		// A malformed or foreign tiebreak (this field has only ever
+		// held a rowid, but be safe) degrades to 0: the same-second
+		// set re-ships and the receiver dedupes by entry ID.
+		if _, perr := strconv.ParseInt(curRow, 10, 64); perr != nil {
+			curRow = "0"
 		}
 		// rowid is SQLite's monotonic insertion key: a same-second row
 		// committed after the last sync always has a larger rowid, so

--- a/internal/node/events_test.go
+++ b/internal/node/events_test.go
@@ -1,0 +1,84 @@
+package node
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// CollectRecentEvents reads strictly past the cursor, in order,
+// bounded, redacted for export (no intent, no delegation, redacted
+// rule findings), and a missing database is a clean no-op.
+func TestCollectRecentEvents(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "oktsec.yaml")
+	if err := os.WriteFile(cfgPath, []byte("agents: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "audit.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE audit_log (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		from_agent TEXT NOT NULL,
+		to_agent TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		status TEXT NOT NULL,
+		rules_triggered TEXT DEFAULT '',
+		policy_decision TEXT NOT NULL,
+		latency_ms INTEGER,
+		signature_verified INTEGER
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	for i, status := range []string{"delivered", "blocked", "delivered"} {
+		if _, err := db.Exec(`INSERT INTO audit_log
+			(id, timestamp, from_agent, to_agent, content_hash, status, rules_triggered, policy_decision, latency_ms, signature_verified)
+			VALUES (?, ?, 'agent-a', 'agent-b', 'h', ?, '[]', 'allow', 3, 1)`,
+			"e"+string(rune('1'+i)), base.Add(time.Duration(i)*time.Minute).Format(time.RFC3339), status); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = db.Close()
+
+	entries, cursor, err := CollectRecentEvents(cfgPath, dbPath, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 || entries[1].Status != "blocked" {
+		t.Fatalf("entries: %+v", entries)
+	}
+	if cursor != base.Add(2*time.Minute).Format(time.RFC3339) {
+		t.Fatalf("cursor: %s", cursor)
+	}
+
+	// Strictly newer than the cursor: nothing left.
+	rest, next, err := CollectRecentEvents(cfgPath, dbPath, cursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rest) != 0 || next != cursor {
+		t.Fatalf("rest: %d next: %s", len(rest), next)
+	}
+
+	// Bounded batch: limit 2 returns the first two and a mid cursor.
+	two, mid, err := CollectRecentEvents(cfgPath, dbPath, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(two) != 2 || mid != base.Add(time.Minute).Format(time.RFC3339) {
+		t.Fatalf("batch: %d mid: %s", len(two), mid)
+	}
+
+	// A missing database is a no-op, never an error.
+	none, same, err := CollectRecentEvents(cfgPath, filepath.Join(dir, "absent.db"), "x", 10)
+	if err != nil || len(none) != 0 || same != "x" {
+		t.Fatalf("missing db: %v %d %s", err, len(none), same)
+	}
+}

--- a/internal/node/events_test.go
+++ b/internal/node/events_test.go
@@ -14,7 +14,7 @@ import (
 func TestCollectRecentEvents(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "oktsec.yaml")
-	if err := os.WriteFile(cfgPath, []byte("agents: []\n"), 0o600); err != nil {
+	if err := os.WriteFile(cfgPath, []byte("agents: {}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	dbPath := filepath.Join(dir, "audit.db")
@@ -54,7 +54,7 @@ func TestCollectRecentEvents(t *testing.T) {
 	if len(entries) != 3 || entries[1].Status != "blocked" {
 		t.Fatalf("entries: %+v", entries)
 	}
-	if cursor != base.Add(2*time.Minute).Format(time.RFC3339) {
+	if cursor != base.Add(2*time.Minute).Format(time.RFC3339)+"|e3" {
 		t.Fatalf("cursor: %s", cursor)
 	}
 
@@ -72,8 +72,29 @@ func TestCollectRecentEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(two) != 2 || mid != base.Add(time.Minute).Format(time.RFC3339) {
+	if len(two) != 2 || mid != base.Add(time.Minute).Format(time.RFC3339)+"|e2" {
 		t.Fatalf("batch: %d mid: %s", len(two), mid)
+	}
+
+	// Same-second tiebreak: rows sharing the last shipped timestamp but
+	// with later ids still ship.
+	db2, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db2.Exec(`INSERT INTO audit_log
+		(id, timestamp, from_agent, to_agent, content_hash, status, rules_triggered, policy_decision, latency_ms, signature_verified)
+		VALUES ('e4', ?, 'agent-a', 'agent-b', 'h', 'delivered', '[]', 'allow', 1, 1)`,
+		base.Add(2*time.Minute).Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+	_ = db2.Close()
+	tie, _, err := CollectRecentEvents(cfgPath, dbPath, cursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tie) != 1 || tie[0].ID != "e4" {
+		t.Fatalf("same-second tiebreak: %+v", tie)
 	}
 
 	// A missing database is a no-op, never an error.

--- a/internal/node/events_test.go
+++ b/internal/node/events_test.go
@@ -54,7 +54,7 @@ func TestCollectRecentEvents(t *testing.T) {
 	if len(entries) != 3 || entries[1].Status != "blocked" {
 		t.Fatalf("entries: %+v", entries)
 	}
-	if cursor != base.Add(2*time.Minute).Format(time.RFC3339)+"|e3" {
+	if cursor != base.Add(2*time.Minute).Format(time.RFC3339)+"|3" {
 		t.Fatalf("cursor: %s", cursor)
 	}
 
@@ -72,7 +72,7 @@ func TestCollectRecentEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(two) != 2 || mid != base.Add(time.Minute).Format(time.RFC3339)+"|e2" {
+	if len(two) != 2 || mid != base.Add(time.Minute).Format(time.RFC3339)+"|2" {
 		t.Fatalf("batch: %d mid: %s", len(two), mid)
 	}
 


### PR DESCRIPTION
Operators need to see what their nodes' proxies are actually doing — the audit trail has the answer, locally. After each accepted evidence report, `cloud sync` now ships audit entries newer than its cursor in one bounded batch (500/cycle) to `POST /v1/evidence/events` (`node_events.v1`).

**Privacy**: entries are redacted at the analyst level — agent names, verdicts, redacted rule findings, latency. Message content, tool arguments, intents and delegation chains never leave the node.

**Reliability**: the cursor (additive `cloud.json` field) advances only when the control plane accepted the batch — failures re-ship next cycle; boundary overlap dedupes downstream on entry ID. A 404 from an older control plane skips quietly; event shipping is best-effort and never fails the evidence cycle. Audit DB opens read-only (mode=ro + query_only), same discipline as snapshots; a missing DB is a no-op.

Tests: cursor semantics (strictly-newer, bounded batches, mid-cursor), missing-DB no-op.